### PR TITLE
[rush] Fix install-run-rush handling of spaces in paths

### DIFF
--- a/common/changes/@microsoft/rush/path-spaces_2018-12-20-21-57.json
+++ b/common/changes/@microsoft/rush/path-spaces_2018-12-20-21-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix install-run-rush handling of spaces in paths",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "ecraig12345@users.noreply.github.com"
+}


### PR DESCRIPTION
On Windows, if the user puts their Git repo in a path with spaces (as in OfficeDev/office-ui-fabric-react#7508) and tries to use the `install-run-rush.js` script, it will fail. For whatever reason, paths with spaces work fine on Macs.

Fix is to wrap the path in quotes if it contains any spaces, then spawn the child process in a shell so the quotes are interpreted properly (as suggested by https://github.com/nodejs/node/issues/7367#issuecomment-229721296). My current implementation only uses quotes and a shell when necessary, but it could be changed to always do so.