### PR TITLE
Update preferred versions when version bumped and add warning on rush check when internal projects are preferred

### DIFF
--- a/apps/rush-lib/src/api/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/api/VersionMismatchFinder.ts
@@ -74,6 +74,10 @@ export class VersionMismatchFinder {
 
     commonVersions.getAllPreferredVersions().forEach((version: string, dependency: string) => {
       allPreferredVersions[dependency] = version;
+      if (rushConfiguration.getProjectByName(dependency)) {
+        console.warn(colors.red('Internal project ' + dependency + ' specified in preferred versions. '
+          + 'If this is a cyclic dependency, it should be set in rush.json instead.'));
+      }
     });
 
     // Create a fake project for the purposes of reporting conflicts with preferredVersions

--- a/apps/rush-lib/src/logic/VersionManager.ts
+++ b/apps/rush-lib/src/logic/VersionManager.ts
@@ -230,6 +230,7 @@ export class VersionManager {
       return false;
     }
     let updated: boolean = false;
+    let preferredVersionChange: boolean = false;
     this._updatedProjects.forEach((updatedDependentProject, updatedDependentProjectName) => {
       if (dependencies[updatedDependentProjectName]) {
         if (rushProject.cyclicDependencyProjects.has(updatedDependentProjectName)) {
@@ -255,9 +256,17 @@ export class VersionManager {
             );
           }
           dependencies[updatedDependentProjectName] = newDependencyVersion;
+          const preferredVersions: Map<string, string> = this._rushConfiguration.getCommonVersions().preferredVersions;
+          if (preferredVersions.has(updatedDependentProjectName)) {
+            preferredVersions[updatedDependentProjectName] = newDependencyVersion;
+            preferredVersionChange = true;
+          }
         }
       }
     });
+    if (preferredVersionChange) {
+      this._rushConfiguration.getCommonVersions().save();
+    }
     return updated;
   }
 

--- a/common/changes/@microsoft/rush/kelin-temp_2019-07-03-02-48.json
+++ b/common/changes/@microsoft/rush/kelin-temp_2019-07-03-02-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update preferred versions when version bumped and add warning on rush check when internal projects are preferred.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "lincoded@users.noreply.github.com"
+}


### PR DESCRIPTION
WIP pr while I get tests working.