### PR TITLE
[rush-lib]  Add optional 'commonFolder' configuration setting to control the common folder location

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -19,6 +19,12 @@
   "rushVersion": "[%RUSH_VERSION%]",
 
   /**
+   * The folder name where Rush's common data will be stored.
+   * assumes 'common' if not specified.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "commonFolder": "common",
+
+  /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
    * is fully isolated from whatever tools are present in the local environment.

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -110,6 +110,7 @@ export interface IRushVariantOptionsJson {
  */
 export interface IRushConfigurationJson {
   $schema: string;
+  commonFolder?: string;
   npmVersion?: string;
   pnpmVersion?: string;
   yarnVersion?: string;
@@ -1029,7 +1030,8 @@ export class RushConfiguration {
     this._rushJsonFile = rushJsonFilename;
     this._rushJsonFolder = path.dirname(rushJsonFilename);
 
-    this._commonFolder = path.resolve(path.join(this._rushJsonFolder, RushConstants.commonFolderName));
+    this._commonFolder = path.resolve(path.join(this._rushJsonFolder, rushConfigurationJson.commonFolder ||
+      RushConstants.commonFolderName));
 
     this._commonRushConfigFolder = path.join(this._commonFolder, 'config', 'rush');
 

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -16,6 +16,11 @@
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
 
+    "commonFolder": {
+      "description": "If Specified, the folder name ('common') where Rush's common data will be stored.  Example: \"common\"",
+      "type": "string"
+    },
+
     "pnpmVersion": {
       "description": "If specified, selects PNPM as the package manager and specifies the deterministic version to be installed by Rush.",
       "type": "string",

--- a/common/changes/@microsoft/rush/master_2019-09-05-16-23.json
+++ b/common/changes/@microsoft/rush/master_2019-09-05-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "add optional 'commonFolder' configuration setting to control the common folder location",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "fearthecowboy@users.noreply.github.com"
+}


### PR DESCRIPTION
Discussion started with @octogonz  in gitter -- created discussion here: https://github.com/microsoft/rushjs.io-website/issues/36

This PR contains the proposed changes to support `commonFolder` as a configuration in `rush.json`