### PR TITLE
render remarks at page start for class, interface, package and namespace

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -207,6 +207,17 @@ export class MarkdownDocumenter {
       }
     }
 
+    let appendRemarks: boolean = true;
+    switch (apiItem.kind) {
+      case ApiItemKind.Class:
+      case ApiItemKind.Interface:
+      case ApiItemKind.Namespace:
+      case ApiItemKind.Package:
+        this._writeRemarksSection(output, apiItem);
+        appendRemarks = false;
+        break;
+    }
+
     switch (apiItem.kind) {
       case ApiItemKind.Class:
         this._writeClassTables(output, apiItem as ApiClass);
@@ -244,31 +255,8 @@ export class MarkdownDocumenter {
         throw new Error('Unsupported API item kind: ' + apiItem.kind);
     }
 
-    if (apiItem instanceof ApiDocumentedItem) {
-      const tsdocComment: DocComment | undefined = apiItem.tsdocComment;
-
-      if (tsdocComment) {
-        // Write the @remarks block
-        if (tsdocComment.remarksBlock) {
-          output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: 'Remarks' }));
-          this._appendSection(output, tsdocComment.remarksBlock.content);
-        }
-
-        // Write the @example blocks
-        const exampleBlocks: DocBlock[] = tsdocComment.customBlocks.filter(x => x.blockTag.tagNameWithUpperCase
-          === StandardTags.example.tagNameWithUpperCase);
-
-        let exampleNumber: number = 1;
-        for (const exampleBlock of exampleBlocks) {
-          const heading: string = exampleBlocks.length > 1 ? `Example ${exampleNumber}` : 'Example';
-
-          output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: heading }));
-
-          this._appendSection(output, exampleBlock.content);
-
-          ++exampleNumber;
-        }
-      }
+    if (appendRemarks) {
+    this._writeRemarksSection(output, apiItem);
     }
 
     const filename: string = path.join(this._outputFolder, this._getFilenameForApiItem(apiItem));
@@ -299,6 +287,35 @@ export class MarkdownDocumenter {
     FileSystem.writeFile(filename, pageContent, {
       convertLineEndings: NewlineKind.CrLf
     });
+  }
+
+  private _writeRemarksSection(output: DocSection, apiItem: ApiItem): void {
+    if (apiItem instanceof ApiDocumentedItem) {
+      const tsdocComment: DocComment | undefined = apiItem.tsdocComment;
+
+      if (tsdocComment) {
+        // Write the @remarks block
+        if (tsdocComment.remarksBlock) {
+          output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: 'Remarks' }));
+          this._appendSection(output, tsdocComment.remarksBlock.content);
+        }
+
+        // Write the @example blocks
+        const exampleBlocks: DocBlock[] = tsdocComment.customBlocks.filter(x => x.blockTag.tagNameWithUpperCase
+          === StandardTags.example.tagNameWithUpperCase);
+
+        let exampleNumber: number = 1;
+        for (const exampleBlock of exampleBlocks) {
+          const heading: string = exampleBlocks.length > 1 ? `Example ${exampleNumber}` : 'Example';
+
+          output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: heading }));
+
+          this._appendSection(output, exampleBlock.content);
+
+          ++exampleNumber;
+        }
+      }
+    }
   }
 
   /**

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
@@ -12,6 +12,12 @@ This is an example class.
 export declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 
 ```
 
+## Remarks
+
+These are some remarks.
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.
+
 ## Events
 
 |  Property | Modifiers | Type | Description |
@@ -35,10 +41,4 @@ export declare class DocClass1 extends DocBaseClass implements IDocInterface1, I
 |  [interestingEdgeCases()](./api-documenter-test.docclass1.interestingedgecases.md) |  | Example: "<!-- -->{ \\<!-- -->"maxItemsToShow<!-- -->\\<!-- -->": 123 }<!-- -->"<!-- -->The regular expression used to validate the constraints is /^\[a-zA-Z0-9<!-- -->\\<!-- -->-\_\]+$/ |
 |  [sumWithExample(x, y)](./api-documenter-test.docclass1.sumwithexample.md) | <code>static</code> | Returns the sum of two numbers. |
 |  [tableExample()](./api-documenter-test.docclass1.tableexample.md) |  | An example with tables: |
-
-## Remarks
-
-These are some remarks.
-
-The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.
 

--- a/common/changes/@microsoft/api-documenter/master_2019-10-05-23-26.json
+++ b/common/changes/@microsoft/api-documenter/master_2019-10-05-23-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "For the markdown target, reorder the \"Remarks\" section to appear before the members for classes, interfaces, namespaces, and packages (GitHub #1550)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "giniedp@users.noreply.github.com"
+}


### PR DESCRIPTION
This commit changes the markdown documenter output logic, so that the remarks section appears on the top of the page for classes, interfaces, packages and namespaces. See https://github.com/microsoft/rushstack/issues/1550