### PR TITLE
[rush] Fix PNPM 4 incompatibility with --no-prefer-frozen-shrinkwrap

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1161,7 +1161,11 @@ export class InstallManager {
 
       // Ensure that Rush's tarball dependencies get synchronized properly with the pnpm-lock.yaml file.
       // See this GitHub issue: https://github.com/pnpm/pnpm/issues/1342
-      args.push('--no-prefer-frozen-shrinkwrap');
+      if (semver.gte(this._rushConfiguration.packageManagerToolVersion, '3.0.0')) {
+        args.push('--no-prefer-frozen-lockfile');
+      } else {
+        args.push('--no-prefer-frozen-shrinkwrap');
+      }
 
       if (options.collectLogFile) {
         args.push('--reporter', 'ndjson');

--- a/common/changes/@microsoft/rush/octogonz-rush-prefer-frozen-shrinkwrap_2019-10-08-23-10.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-prefer-frozen-shrinkwrap_2019-10-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix compatibility issue where PNPM 4 requires --no-prefer-frozen-lockfile instead of --no-prefer-frozen-shrinkwrap",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
In [Gitter chatroom](https://gitter.im/rushstack/rushstack?at=5d9bee8fb385bf2cc6919ece), @sadsa reported:

> After running `rush update` after updating PNPM to 4.0.0-7, I get 
> ```ERROR  Unknown option 'prefer-frozen-shrinkwrap'```

