### PR TITLE
Fix CommandLineChoiceParameter error when alternatives array contains a single value

### DIFF
--- a/common/changes/@microsoft/ts-command-line/keco-choice-alternatives-length_2019-10-17-23-12.json
+++ b/common/changes/@microsoft/ts-command-line/keco-choice-alternatives-length_2019-10-17-23-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Fix Choice parameter error when only one alternative value is provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/libraries/ts-command-line/src/CommandLineParameter.ts
+++ b/libraries/ts-command-line/src/CommandLineParameter.ts
@@ -209,7 +209,7 @@ export class CommandLineChoiceParameter extends CommandLineParameter {
   constructor(definition: ICommandLineChoiceDefinition) {
     super(definition);
 
-    if (definition.alternatives.length <= 1) {
+    if (definition.alternatives.length < 1) {
       throw new Error(`When defining a choice parameter, the alternatives list must contain at least one value.`);
     }
     if (definition.defaultValue && definition.alternatives.indexOf(definition.defaultValue) === -1) {


### PR DESCRIPTION
Fixes an issue where an error is thrown if the supplied alternative values array contains only a single value. This scenario is supported in the schema.