### PR TITLE
Bump cyclic dependencies

### DIFF
--- a/apps/api-extractor-model/package.json
+++ b/apps/api-extractor-model/package.json
@@ -18,8 +18,8 @@
     "@microsoft/tsdoc": "0.12.14"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@types/jest": "23.3.11",
     "@types/node": "8.10.54",
     "gulp": "~4.0.2",

--- a/apps/api-extractor-model/src/model/DeserializerContext.ts
+++ b/apps/api-extractor-model/src/model/DeserializerContext.ts
@@ -44,7 +44,7 @@ export enum ApiJsonSchemaVersion {
   /**
    * Used to assign `IApiPackageMetadataJson.oldestForwardsCompatibleVersion`.
    *
-   * This value must be <= `ApiJsonSchemaVersion.LATEST`.  It must be reset to the `LATEST` value
+   * This value must be \<= `ApiJsonSchemaVersion.LATEST`.  It must be reset to the `LATEST` value
    * if the older library would not be able to deserialize your new file format.  Adding a nonessential field
    * is generally okay.  Removing, modifying, or reinterpreting existing fields is NOT safe.
    */

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -43,8 +43,8 @@
     "typescript": "~3.5.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@types/jest": "23.3.11",
     "@types/lodash": "4.14.116",
     "@types/node": "8.10.54",

--- a/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/node-core-library/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.4",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.7",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.8",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.9",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.0",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.1",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.2",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.4",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.5",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/octogonz-bump-cyclics_2019-10-21-06-40.json
+++ b/common/changes/@microsoft/ts-command-line/octogonz-bump-cyclics_2019-10-21-06-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
-  '@microsoft/node-library-build': 6.1.2
-  '@microsoft/rush-stack-compiler-3.4': 0.1.15
+  '@microsoft/node-library-build': 6.3.0
+  '@microsoft/rush-stack-compiler-3.4': 0.3.0
   '@microsoft/teams-js': 1.3.0-beta.4
   '@microsoft/tsdoc': 0.12.14
   '@pnpm/link-bins': 1.0.3
@@ -207,20 +207,19 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
-  /@microsoft/api-extractor-model/7.3.1:
+  /@microsoft/api-extractor-model/7.5.1:
     dependencies:
-      '@microsoft/node-core-library': 3.13.0
-      '@microsoft/tsdoc': 0.12.12
-      '@types/node': 8.5.8
+      '@microsoft/node-core-library': 3.15.1
+      '@microsoft/tsdoc': 0.12.14
     dev: false
     resolution:
-      integrity: sha512-1HlhnAYCkc7tPrDFq7s5WpZGEn/NPhpchep6761BMhshN7HIVWKJrmnsEIsjGh6wMOgCF/l9a0q1k4xWRyVgZQ==
-  /@microsoft/api-extractor/7.3.6:
+      integrity: sha512-qzgmJeoqpJqYDS1yj9YTPdd/+9OWGFwfzGFyr6kVarexomdPSltcoQYIS5JnrB/RFNeUgTNUlwn5mYdyp2Xv6A==
+  /@microsoft/api-extractor/7.5.1:
     dependencies:
-      '@microsoft/api-extractor-model': 7.3.1
-      '@microsoft/node-core-library': 3.13.0
-      '@microsoft/ts-command-line': 4.2.6
-      '@microsoft/tsdoc': 0.12.12
+      '@microsoft/api-extractor-model': 7.5.1
+      '@microsoft/node-core-library': 3.15.1
+      '@microsoft/ts-command-line': 4.3.3
+      '@microsoft/tsdoc': 0.12.14
       colors: 1.2.5
       lodash: 4.17.15
       resolve: 1.8.1
@@ -229,36 +228,36 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-NIKk6da6z7wXQ+Ur+Rxq/CdDe0Hcz1VtG7iPhjvsLob99eoo6KVA3DTZciXBSIJToQFZgKoGTl8xkBAEsLemOQ==
-  /@microsoft/gulp-core-build-mocha/3.6.1:
+      integrity: sha512-pUMrXO+nW31piHhmBznlBdYEiemSOQ8sYcEm8T6tfDvAQdPxg3oaHfrau/DseUY5haAFh+2hY+rl0GUl5CEKbQ==
+  /@microsoft/gulp-core-build-mocha/3.7.1:
     dependencies:
-      '@microsoft/gulp-core-build': 3.11.0
-      '@types/node': 8.5.8
+      '@microsoft/gulp-core-build': 3.12.1
+      '@types/node': 8.10.54
       glob: 7.0.6
       gulp: 4.0.2
       gulp-istanbul: 0.10.4
       gulp-mocha: 6.0.0
     dev: false
     resolution:
-      integrity: sha512-Hr0G+rLJnfN4tANf3y3GhVr00GAfrfSFGZLucezkxCNr3ThrWBmbBbeswGzNFvG/XuhDEkXD4QARqhLIQX07hg==
-  /@microsoft/gulp-core-build-typescript/8.1.26:
+      integrity: sha512-0o9jG7L3DVDZxsSFmgCj4pivGidduQ9wwJthK8sO8XIn9m9bqGzXH8q8ClVZjucT+fdiIC9UQulrxJvSdusVJQ==
+  /@microsoft/gulp-core-build-typescript/8.3.0:
     dependencies:
-      '@microsoft/gulp-core-build': 3.11.0
-      '@microsoft/node-core-library': 3.13.0
-      '@types/node': 8.5.8
+      '@microsoft/gulp-core-build': 3.12.1
+      '@microsoft/node-core-library': 3.15.1
+      '@types/node': 8.10.54
       decomment: 0.9.2
       glob: 7.0.6
       glob-escape: 0.0.2
       resolve: 1.8.1
     dev: false
     resolution:
-      integrity: sha512-dc7HA4l75VlaXnAUs1MwvAiH/uANGBwwmp/nyJFPP5nXxJ/ahA3F2/X7p97EAtnzCYcVIou2ERtisZicdTNg1w==
-  /@microsoft/gulp-core-build/3.11.0:
+      integrity: sha512-u2EOiwXgYjoUEZf1kA6KCFyHJnAmmfgsBh3EHavaFmz6FJY2BEyuRRCt27JP/bTHcyQPTFXlIterrRGo3mYJXw==
+  /@microsoft/gulp-core-build/3.12.1:
     dependencies:
-      '@microsoft/node-core-library': 3.13.0
+      '@microsoft/node-core-library': 3.15.1
       '@types/chalk': 0.4.31
       '@types/gulp': 4.0.6
-      '@types/node': 8.5.8
+      '@types/node': 8.10.54
       '@types/node-notifier': 0.0.28
       '@types/orchestrator': 0.0.30
       '@types/semver': 5.3.33
@@ -291,60 +290,54 @@ packages:
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha512-vDlJTvJ2QJez//5wSNm23y8HPvGVTnaPNPXkcjYEsll6q5MZafhzrdqE+mq79FEJ2aw83T75dXrxpNRLEBBljQ==
-  /@microsoft/node-core-library/3.13.0:
+      integrity: sha512-npDc1oWEXZpRrLrJvTxENI7q3h8/I6PPt58ZnGVzke0AfIIcPHdsqjDrO37nCRbOwuLJC/M1lTS+pB83TPmPeA==
+  /@microsoft/node-core-library/3.15.1:
     dependencies:
-      '@types/fs-extra': 5.0.4
-      '@types/jju': 1.4.1
-      '@types/node': 8.5.8
-      '@types/z-schema': 3.16.31
+      '@types/node': 8.10.54
       colors: 1.2.5
       fs-extra: 7.0.1
       jju: 1.4.0
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha512-mnsL/1ikVWHl8sPNssavaAgtUaIM3hkQ8zeySuApU5dNmsMPzovJPfx9m5JGiMvs1v5QNAIVeiS9jnWwe/7anw==
-  /@microsoft/node-library-build/6.1.2:
+      integrity: sha512-fUrcgu+w40k2GW8fiOUFby7jaKAAuDKaTrQuFQ3j+0Pg3ANnJ2uKtVf3bgFiNu+uVKpwVtLo4CPS8TwFduJRow==
+  /@microsoft/node-library-build/6.3.0:
     dependencies:
-      '@microsoft/gulp-core-build': 3.11.0
-      '@microsoft/gulp-core-build-mocha': 3.6.1
-      '@microsoft/gulp-core-build-typescript': 8.1.26
+      '@microsoft/gulp-core-build': 3.12.1
+      '@microsoft/gulp-core-build-mocha': 3.7.1
+      '@microsoft/gulp-core-build-typescript': 8.3.0
       '@types/gulp': 4.0.6
-      '@types/node': 8.5.8
+      '@types/node': 8.10.54
       gulp: 4.0.2
     dev: false
     resolution:
-      integrity: sha512-j7MGoBr5XVpnnkSElfQ4SrAsZWyMaN8ut5I8SUBXGQqpyF5zBxVrSEztQ3Ui06hTuqHT5amykelnpVKjwPnE2g==
-  /@microsoft/rush-stack-compiler-3.4/0.1.15:
+      integrity: sha512-N7wQOvWIuXw8bdLGaCYTScwfBOWFYBgLhT+ce/PGfakRr4BnV1cmgBa0mKKIeA96KmBS2eUB0V0vfLEKKC1bTg==
+  /@microsoft/rush-stack-compiler-3.4/0.3.0:
     dependencies:
-      '@microsoft/api-extractor': 7.3.6
-      '@microsoft/node-core-library': 3.13.0
-      '@types/node': 8.5.8
+      '@microsoft/api-extractor': 7.5.1
+      '@microsoft/node-core-library': 3.15.1
+      '@rushstack/eslint-config': 0.4.0_eslint@6.5.1+typescript@3.4.5
+      '@types/node': 8.10.54
+      eslint: 6.5.1
       tslint: 5.12.1
       tslint-microsoft-contrib: 5.2.1_tslint@5.12.1
       typescript: 3.4.5
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-gdfi1Ea48mey5rsu0qj0pFUq8Csi2lYgnKoHcrTc5JJN1QHcQqZK/ppPuM2LjK4oWEuWGxdxWihNVSws8bMpWA==
+      integrity: sha512-TnVl59wEz9OOdxJO5eaciZBEDyQxrPzsAvqd2+1WtJbTJn0L3rYdDzB0PbPURzVbaVlnZUYR0WZNby9ZsWEKaw==
   /@microsoft/teams-js/1.3.0-beta.4:
     dev: false
     resolution:
       integrity: sha512-AxDfMpiVqh3hsqTxMEYtQoz866WB/sw/Jl0pgTLh6sMHHmIBNMd+E0pVcP9WNk8zTkr9LCphJ5SziU1C8BgZMA==
-  /@microsoft/ts-command-line/4.2.6:
+  /@microsoft/ts-command-line/4.3.3:
     dependencies:
       '@types/argparse': 1.0.33
-      '@types/node': 8.5.8
       argparse: 1.0.10
       colors: 1.2.5
     dev: false
     resolution:
-      integrity: sha512-GFLPg9Z5yiNca3di/V6Zt3tAvj1de9EK0eL88tE+1eckQSH405UQcm7D+H8LbEhRpqpG+ZqN9LXCAEw4L5uchg==
-  /@microsoft/tsdoc/0.12.12:
-    dev: false
-    resolution:
-      integrity: sha512-5EzH1gHIonvvgA/xWRmVAJmRkTQj/yayUXyr66hFwNZiFE4j7lP8is9YQeXhwxGZEjO1PVMblAmFF0CyjNtPGw==
+      integrity: sha512-dzAdHwmw0p0T2Nra91nPd5n57fw5bRQEWGPe5iZOsqoLpjU/NCgBpmBdbvx1Oy3+YRnrV4lSeSbN6C7sSniwmQ==
   /@microsoft/tsdoc/0.12.14:
     dev: false
     resolution:
@@ -421,6 +414,23 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NsEzBVa5aMgn/n79piyJtpUQFzJ97tB2R2r8PSJlLnMA6LJmchKuv7ATN+/nZH/3QRd/+uFXEq07/i/ajsqVGQ==
+  /@rushstack/eslint-config/0.4.0_eslint@6.5.1+typescript@3.4.5:
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 2.3.3_e4f20efab8ef9037bea9f2d5cf7da5d2
+      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/typescript-estree': 2.3.3
+      eslint: 6.5.1
+      eslint-plugin-promise: 4.2.1
+      eslint-plugin-react: 7.16.0_eslint@6.5.1
+      eslint-plugin-security: 1.4.0
+      typescript: 3.4.5
+    dev: false
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '>=3.0.0'
+    resolution:
+      integrity: sha512-gbqdY0TKZsl/PTKz+LBK5TWwLGXw3NXLaWpz5mBX5WEaMjfchtCEZW52YbvtTgtYfhKAGRM5gXeBpxQDYcXbrw==
   /@types/anymatch/1.3.1:
     dev: false
     resolution:
@@ -622,10 +632,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==
-  /@types/node/8.5.8:
-    dev: false
-    resolution:
-      integrity: sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==
   /@types/orchestrator/0.0.30:
     dependencies:
       '@types/q': 1.5.2
@@ -853,7 +859,7 @@ packages:
   /@typescript-eslint/eslint-plugin/2.3.3:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.3.3
-      eslint-utils: 1.4.2
+      eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
       tsutils: 3.17.1
@@ -871,10 +877,29 @@ packages:
       '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
       '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
       eslint: 6.5.1
-      eslint-utils: 1.4.2
+      eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
       tsutils: 3.17.1_typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
+  /@typescript-eslint/eslint-plugin/2.3.3_e4f20efab8ef9037bea9f2d5cf7da5d2:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
+      eslint: 6.5.1
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1_typescript@3.4.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -1437,7 +1462,7 @@ packages:
   /autoprefixer/9.1.5:
     dependencies:
       browserslist: 4.7.1
-      caniuse-lite: 1.0.30000999
+      caniuse-lite: 1.0.30001002
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 7.0.5
@@ -1874,8 +1899,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/4.7.1:
     dependencies:
-      caniuse-lite: 1.0.30000999
-      electron-to-chromium: 1.3.286
+      caniuse-lite: 1.0.30001002
+      electron-to-chromium: 1.3.289
       node-releases: 1.1.36
     dev: false
     hasBin: true
@@ -1998,10 +2023,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-lite/1.0.30000999:
+  /caniuse-lite/1.0.30001002:
     dev: false
     resolution:
-      integrity: sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==
+      integrity: sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==
   /capture-exit/1.2.0:
     dependencies:
       rsvp: 3.6.2
@@ -2832,10 +2857,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.286:
+  /electron-to-chromium/1.3.289:
     dev: false
     resolution:
-      integrity: sha512-gPvrdAHxCdF2IxCeGEIJdXmor32Czae8+ZLOMsk/qmGAfIgtH7BfXiaBHZHVVHz6L2ouAdR377lzPuOE5wJFZg==
+      integrity: sha512-39GEOWgTxtMDk/WjIQLg4W/l1s4FZdiMCqUBLjd92tAXsBPDFLwuwCba5OGhuTdVYm6E128TZIqSnMpeocUlCQ==
   /elliptic/6.5.1:
     dependencies:
       bn.js: 4.11.8
@@ -3118,14 +3143,14 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
-  /eslint-utils/1.4.2:
+  /eslint-utils/1.4.3:
     dependencies:
       eslint-visitor-keys: 1.1.0
     dev: false
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+      integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
   /eslint-visitor-keys/1.1.0:
     dev: false
     engines:
@@ -3141,9 +3166,9 @@ packages:
       debug: 4.1.1
       doctrine: 3.0.0
       eslint-scope: 5.0.0
-      eslint-utils: 1.4.2
+      eslint-utils: 1.4.3
       eslint-visitor-keys: 1.1.0
-      espree: 6.1.1
+      espree: 6.1.2
       esquery: 1.0.1
       esutils: 2.0.3
       file-entry-cache: 5.0.1
@@ -3177,7 +3202,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
-  /espree/6.1.1:
+  /espree/6.1.2:
     dependencies:
       acorn: 7.1.0
       acorn-jsx: 5.1.0_acorn@7.1.0
@@ -3186,7 +3211,7 @@ packages:
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==
+      integrity: sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
   /esprima/1.2.5:
     dev: false
     engines:
@@ -4297,7 +4322,7 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
-  /handlebars/4.4.3:
+  /handlebars/4.4.5:
     dependencies:
       neo-async: 2.6.1
       optimist: 0.6.1
@@ -4309,7 +4334,7 @@ packages:
     optionalDependencies:
       uglify-js: 3.6.3
     resolution:
-      integrity: sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
+      integrity: sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==
   /har-schema/2.0.0:
     dev: false
     engines:
@@ -4482,7 +4507,7 @@ packages:
       depd: 1.1.2
       inherits: 2.0.3
       setprototypeof: 1.1.0
-      statuses: 1.4.0
+      statuses: 1.5.0
     dev: false
     engines:
       node: '>= 0.6'
@@ -5130,7 +5155,7 @@ packages:
       integrity: sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==
   /istanbul-reports/1.5.1:
     dependencies:
-      handlebars: 4.4.3
+      handlebars: 4.4.5
     dev: false
     resolution:
       integrity: sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
@@ -5148,7 +5173,7 @@ packages:
       escodegen: 1.7.1
       esprima: 2.5.0
       fileset: 0.2.1
-      handlebars: 4.4.3
+      handlebars: 4.4.5
       js-yaml: 3.13.1
       mkdirp: 0.5.1
       nopt: 3.0.6
@@ -5172,7 +5197,7 @@ packages:
       escodegen: 1.8.1
       esprima: 2.7.3
       glob: 5.0.15
-      handlebars: 4.4.3
+      handlebars: 4.4.5
       js-yaml: 3.13.1
       mkdirp: 0.5.1
       nopt: 3.0.6
@@ -9255,6 +9280,17 @@ packages:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
       integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  /tsutils/3.17.1_typescript@3.4.5:
+    dependencies:
+      tslib: 1.10.0
+      typescript: 3.4.5
+    dev: false
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tsutils/3.17.1_typescript@3.5.3:
     dependencies:
       tslib: 1.10.0
@@ -10060,7 +10096,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-L7h159/9UesRSi205ipj70H7fv+JWz+R0Wp5tmVvYmdyHYPPXdxVoWgXRm/Bzd/ZTzHPDrcwBYHANsYmRgkzvA==
+      integrity: sha512-wHF/gbHQRg81HGCkUxwe2zq5A2p9K8Mk2DsU7NnB+A6pB+yfH0LZ2SAC7IQnmo/voSMh5GaleOLUI5xS61Jw9g==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -10078,7 +10114,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-DTpotAQo5NcjJLEokNPrPJmRFwUBNS4VY94vyC2sFBOYBQFcKH/nw+XRNUMh8MukriPBS2YoGL2sOvZ+dyRsug==
+      integrity: sha512-sNZ/rBz4697CNSaE8auLpJN/YmTiLPrAToCy/2fBIqu6ZST+j2O8PIKQ7MtJiE/ZSmg88NjoDFKnjBg39xnJMQ==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -10119,8 +10155,8 @@ packages:
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@microsoft/tsdoc': 0.12.14
       '@types/jest': 23.3.11
       '@types/node': 8.10.54
@@ -10129,7 +10165,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-B2yPT4JYXWXEeyuL1udqkFiEFWRRTDh+RQ26k3w++4E0OLmPt5TfNUU1FCENNuUPFV/qvaTqiBo5Idg3yG1/FA==
+      integrity: sha512-u7Wz4J9lRW4+5FZnbbCvdptzIPjIOPldgtWnbYDi7F9ZOiQxgc3RlGtx3whB+xM9qvBo5crmP3N9cS3adk3uRQ==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -10197,8 +10233,8 @@ packages:
     version: 0.0.0
   'file:projects/api-extractor.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@microsoft/tsdoc': 0.12.14
       '@types/jest': 23.3.11
       '@types/lodash': 4.14.116
@@ -10212,7 +10248,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-IIIC6IHuqwSrr7tA0zc7IS69KDrq0eLTDkSxehNiFQ+n3jWuZGi8Auj+rXsNYLvIXH0/zlD22oL8M4hxfpHkqw==
+      integrity: sha512-zcsd9A4SX55wymlTxfT1lYGN12oj0Sh2RsHOFJgdwbKMDMGYI/lL2X+LTZ7wEIiwxzYYfwQIvZB2n+WeSW5FMA==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/doc-plugin-rush-stack.tgz':
@@ -10225,7 +10261,7 @@ packages:
     dev: false
     name: '@rush-temp/doc-plugin-rush-stack'
     resolution:
-      integrity: sha512-Djrn6qxik1ZaLeW0U8EfstQSH7eP5bHdDXjhokxrFATyNjlY+cSWiys3MMILgbyZ3aRY50b4AGoCQb62jyDlEQ==
+      integrity: sha512-V+jkI9jx/PCVWHSgi/y2nRWrtNgU1it2AH9l2/Z4/NssgmUk214jyNLWuD+aTQirAW8WwY3rOeXyzNQlmPz3mQ==
       tarball: 'file:projects/doc-plugin-rush-stack.tgz'
     version: 0.0.0
   'file:projects/eslint-config.tgz':
@@ -10249,12 +10285,12 @@ packages:
     dev: false
     name: '@rush-temp/generate-api-docs'
     resolution:
-      integrity: sha512-Ij2IVC8Uke0amAz8VTs0zH0AL4LxXpCM6KpUkS9TxFIcgO+OguEiZWEWDBz1vSuscMiFZuI11LbmWct7efzXog==
+      integrity: sha512-0U/GsVTkSBtAIZlxFA0rpT456d2+wQrfKpP8VTl2j5PRXIMdvcehwPMdQCJ52tRb0UQFLXrk8RJAGQ9DfmWHRw==
       tarball: 'file:projects/generate-api-docs.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
     dependencies:
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/glob': 5.0.30
       '@types/gulp': 4.0.6
       '@types/gulp-istanbul': 0.9.30
@@ -10269,7 +10305,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-YrbnNJpSFqBheD3z3Q1Fx9X7Tbn5HL2aWRTIofbGRyncsZmGF2qBTWfCwvRg4WGyPPXgF83mdiXG7AvweVTNqg==
+      integrity: sha512-49N4JbnInae3iG9RoyoChJ5OYJTEwPwmAbhfxeCycVPbXQl3YAnjpBdgfqF2+R/b7fHSVttPCKCVh40V9N6NAw==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -10291,7 +10327,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-w2PU1N/ciNb3WT1TZuHyVKQghVf1nJamwY0Yaca/DdqsyflD3PKEVQAYHNx2pysvbkZDoeVuMapDAOXFJcUtFg==
+      integrity: sha512-iMfL6hgxazN1Put8Z3vvTGSOpfQLy3BACi0C0t13m9Ykn4+9p+CzJ3wY+nuws/8+wUgeVDWgAhSpfobFRU5WmA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10317,13 +10353,13 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-F+151qLRhwcK3ywNWiq+JUWLnUjuBlhmhawwQbLHVSmaWp5afgw1TyNlz17XGXznZ5bL2kJbsOWYRlOLRd2jiA==
+      integrity: sha512-m/aIx7SoqkLJg0jPTzILFmB9RYwpvFz3X5qJ3HlQKNj8LuZQIKTNLCeVSC7Gu7kdsUUP0rIAWI49dMSQqLR9vw==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/glob': 5.0.30
       '@types/node': 8.10.54
       '@types/resolve': 0.0.8
@@ -10337,7 +10373,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-0uZ7YGPWenJJh54Re8D/Un2o+6r5TRMnpWrykX05Z5t6GR18c8he0cVeUKVblVLPDAdgAWCOf79/3n+7SIumog==
+      integrity: sha512-j5sQTbVSWxiX9WeLrUUOb+UnFaDgK0A/LlaF2kXSFoCqmDvNpU9JFqPXzXLSjf4w7WO9zN+SdXgyHUrBRR5cwg==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10355,13 +10391,13 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-kzRDzngM3Nw1lB1rjJ47jNIYO7aeEicvML5Pp9YeiaNvdnqp++vaQXzbO1t0NUDx9W97f6shYKMYNCu8yKu6lg==
+      integrity: sha512-tcXGkjqSE9+ToUJL7S3sZuUiDJG0gA1Wh7MV+ETBiTREAPAOohzPZC2zvYkc47hBFoBrTttjAB79f+gZFCIZaQ==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/chai': 3.4.34
       '@types/chalk': 0.4.31
       '@types/gulp': 4.0.6
@@ -10402,7 +10438,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-BnzfQhiY4CiGyvpAVxWWNJaqlo6iR4e3abTCjaXAnI2QQhhA511DvE6DaNQwtgEnYA0zY9I48ytHt64afj5Qaw==
+      integrity: sha512-gIthIir60JTf6orNk/UyPVkAW0CZPJmd/dbfHH703cnEkuZZv1CuJ6iu8YhXjQUhXc4Dad5mXeVddkC7QK7DNw==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10415,7 +10451,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-0TUTwFNkNaoBAfyT6BFqNH9jZmbeW0Ks0m+ZJS+ncC22BuXtLSDwTAQNf1N75ym0qUUcI5/6hvq4aNszmfLYow==
+      integrity: sha512-Pxz3b7AY2jtRA3ftMsqIcQlNkOHU8jhoCnA3qfXklB2sl0LWEjVmKmyLK6v5LYsPUBbntJKCwRP/FedYbvtZcQ==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10430,7 +10466,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-a9ES+2j/d2UbjYMg/tV19wJxz31+d88RYfmbVVLnjfA8hlfXZh7vdoRIRFO2fg6n5BCi42tug+UjL8wM8ccUfQ==
+      integrity: sha512-aocPGyReo73dHhxjPLme3k7AiuGP2Q+aWoeCvvwyhb1WAkG4ZAbilg/M88whgl5Y+CSwAThs+HfPYfn6kX/GAQ==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10444,7 +10480,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-G8w6DyPTyFjR+32e7Dz+Ylgddr1wq0+NIuPsfIyuDPz8GXlR5LNNck2akFSh1QjotTiM28a5VjH3ZXN3DQOlXQ==
+      integrity: sha512-MMWyt5rYLC4SourdFgG6OWHjbFMI+0v/KRWMuD40jQGTuqqoOuVzZpVz7jxYEIDhW+g/lhe1wbag9EUJrU8hQQ==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10460,13 +10496,13 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-cfr2WVXEm2leCtG7XO4ggZjjgHlX5oc7C/6PUAN+wJstgXMT/DZ/B60O9fWCwDThE2mla2b4q/Tqb1rliRbvwQ==
+      integrity: sha512-y+1RLyBjroH8j3f35x2N+ICGIJFlJOPoP3+VDoSZ4/Dx8ULcXq2DUMubWlYjNqpbqgQBoilCzl7yke54SHi/+w==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/fs-extra': 5.0.4
       '@types/jest': 23.3.11
       '@types/jju': 1.4.1
@@ -10480,7 +10516,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-aeWZMHzvBmTRva5VE7y3ToN13GS/ceEm0HMyYa/7asYBEdWtfXJjiafJTykahsEeOJicKBgdtla2CGhpW1ibZg==
+      integrity: sha512-Hb3tOmNLIbkwaDGRigp/PQ33JECDxaKjfCHVNBaulbDYN3qSrsqC6Il5Qqu2oszi5JbhNg4Y885qKemgJPvCkQ==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build-eslint-test.tgz':
@@ -10493,7 +10529,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-eslint-test'
     resolution:
-      integrity: sha512-+/LEjGGBHIuXvPCX3FHWOLEYr6yxdGTZJLqJD4I5MUGgiKfO8Ffobbk2+njA0gzuVGcy03Tz/rhp2U8EEShYAA==
+      integrity: sha512-AH98oMq8rcv8TX7FON6axg81rd0ayq9BKJsTSdrzeUT/NuN+6Qq1dcHJW17WmdMB6lwKd6gYEQKWn9yRgtVzHg==
       tarball: 'file:projects/node-library-build-eslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build-tslint-test.tgz':
@@ -10506,7 +10542,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-tslint-test'
     resolution:
-      integrity: sha512-iQuwbxsB4zC1wTjHsdwHEwShKv6JIjEnlbkWVW3zrpm/5nsrts+l67K+GZ3/JTn+Nc9Dt0wrfATe+2CVgjNjDQ==
+      integrity: sha512-hJWnem40B/1abH0OOhrOJb95AQf6rC3VsKbLR0mnS++3WpBE/Wh1Lk1+eQFj5aQMiSNeumE4Af5PZ/583TzZHg==
       tarball: 'file:projects/node-library-build-tslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10517,7 +10553,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-asP7Q4sRg4TAgXzANmKQRnSNZFTlsy7iPKwvuToGnkvdpWlJcwlK0qFHgIUkc65m/+28nWdLun135a1kBN15lQ==
+      integrity: sha512-fTgDCW/tD2mtVDQhziuBTmpTNdIQl7EV3LrxXPKuiGW7VRyROtcggD2464AbOV7El6K9D6jlqZgSH4Gi6IzzcQ==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10530,7 +10566,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-A+HEvhGb8ISToDHjEjKb3AtiNhu1AozlBfsRRmdq79rFyJOqZdFvRjJeBvJmIDa4I58gw/fYmRHGeyVI+tufmw==
+      integrity: sha512-cdoqYpHrveE3HmeXU2KdOpGDnzm67BYV9BhgZOC/4ImHwydefCDs91o5NjCs/f4c+/ZvUMJKqa1yLnfCF0EzSw==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/repo-toolbox.tgz':
@@ -10540,7 +10576,7 @@ packages:
     dev: false
     name: '@rush-temp/repo-toolbox'
     resolution:
-      integrity: sha512-FC8XhyGAM3JodNBpzcn413wEKoPYLGpm0m2PxIWel9N1AE5ucqoRdKA2UumnFiDJQ6esrFtGY5TD0WhUl6XzRQ==
+      integrity: sha512-D5SbVZYSnV29rR7ta1wDGUCYd9IC3wAgpLXx92KpAYKUX8u+dWIav0KY4qEECrII8YoKW23kSgvwrG6KylW8cw==
       tarball: 'file:projects/repo-toolbox.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10553,7 +10589,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-H6yvoklD2422eHlubGWWyCEhLe/JZcLVKU7fM8vU0Pgd8KjbcEqgOCf0afq+gYptUhwjLwIVtQ2o5S0q4tinuQ==
+      integrity: sha512-dbe1J/2AHC9SmHDX9GYsuVbJhWsaPRVOoZf/TYL4q+Q7LlalAum/+GbYm3meuTtCrTMm/Bai1ruif0o37+0g1Q==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -10564,7 +10600,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-CPFdD7aIsqbkEgAEN3wzWeb7T/kPh6VDNNxe7WEK7VB3de3Oca0v+xsGYLzIVJTPpk45RLG0O43ILOVTmUOiUw==
+      integrity: sha512-j/8UZ0/pwN685MYLqHr+thz+EXJDEUZuBbU40+Ghsd55S327aWInEqru8WswGu2WEh2xvgXM7Cq+KeL34zNZRQ==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10607,7 +10643,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-HfnY94Zab0KUmiilt2zHsHPv8uXjW4Waq3HqJFe5D0mHprCwHCpjJ0Ut0p9E9OawU+0pZ5bmj0PnMRLUQH167g==
+      integrity: sha512-EFmlhtr3/YuTYZPa6qrfL6AquVkjv9Ydpa0LTVIhpCX8q08WdUtoUhhP043Y4gJ/mmiC+4Cd7wdDAHF6f7XOSg==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -10617,13 +10653,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-J7kiQ2KlEPy3suAc2KKMQjzKuN3A2f+/aGMkMGlYNV6gldEGuD7vRCHscJochpfmu14/M097z+ngOS+MVKkWzA==
+      integrity: sha512-XJHpk4JNODHzoRs6/PEhMtVw433++6LxcYyeyrHcgQs5eqXi4gX3lncYswjDvESw2hDGbOuXZMKBzk75CsjZzQ==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10633,7 +10669,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-xF1MtEKz9UijbCXwfRoHFadzIr+3UcD5rXbKnyU7ESH6k3gvA3rVPYEHgE32DrM/9ZpllZnl7BicWizLjyL2Nw==
+      integrity: sha512-7AKVGT5R0PgSU1HjMazjpjYR6+sGZ9q2WKE3aGvhfmNSHYp8QUo5v/kDeT7u0PF5KxfdycF/jkJGeUTNH7PjBA==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -10643,13 +10679,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-ytr5EcAy7Ru2EWszYaKAXLMgvA0VGfRmvbugbzV1M8gjvwD++q4V1y31BOSNyw58P0QbMh329BNvaxz57g/SKA==
+      integrity: sha512-fEpt7shTXflJZ7Xa5ajJbMEVbsvrSmHPfd5UHf5ndybi10jJgUzkOC0D29qgsqjkCa7oTB0k5OxiwWSKWZmyrg==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10659,7 +10695,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-oPodgZQI6ZHuwEtJyI11hM7qPRD2JHGV2Rwjw9V+j0MM2OLlmwxVw69X72xWEncDSTWpjiQITwj62hcwNllP3w==
+      integrity: sha512-urRRFJZ5QVgeJ/q17wWeE0F2fvnOKqRx0iZrA6DkJuppAoF/Htg0vlOm2TqbAQ//et77HsMR45idQ4Ti5DV8HQ==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -10669,13 +10705,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-57ivQ0gyOrK8dmg0Xsm59GazUq4ABYQiya1XvOYsz9c48nhrQQpblq9iXrjtyTUX/c/sxhklTS2mQn6E7t5rzA==
+      integrity: sha512-JDVU9PdbTAO/yjm/J4wUbW2e/Serf2WI1D/RxuKbhrWKOQK6tXDb0kFfQTq1LQb8uCd0HOmYEWCDspWAY6cBZg==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10685,7 +10721,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-/ki4tH958pQizkDVpFi/WRs2bgnkqoyd2BNbkrdprx82jnxIIXEJ1olz7sobQg8XPDyRmy9Cu/1+DnRQMCRzkQ==
+      integrity: sha512-QxWOaLdeWZhcGyeNSLxw/Q1JyRbZhdz/E7nSLJb/XrzD6DH7bRwY+nYTKA9uLrVDx0r9JIPSSv4GLwsPXIuq6Q==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -10695,13 +10731,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-PEoyuHWvyJWv+tBnxI9cmyHPSSvuBLvE1eMxrBMXz2smbZ4aRevoLmZB0/Ho8wAXhpfKNimjWuvHqMwgXrj29Q==
+      integrity: sha512-GHWkbrITtXEdxAiWTz0a0iFJTegIEqwSwGhf+GwPp7DhmgWz8IFFRaT2AHaMyKJRyj5+CdeuXx6GNVwlUzJ6gg==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10711,7 +10747,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-HZ8vw0ontLhBGSbuUBRV/WjC/qXb2IigCPSkKWq0UkHjyEXPvLqzzKngzWG/wv7HbihSV8lJivrQqKsl7txHpQ==
+      integrity: sha512-MeIfj3FC3FqCDRsQ15gPejeesgQwcXFWbaLrHNsmuzHwG6PMZA9ewOEsIGc8vKv1d2bNcAoZQ6pmb/NZx22M5Q==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -10721,13 +10757,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-3KIE5asRnfUHsz8MwegNbXEt31lYukhSpCUnksVSpgvjZYcXjMhVQ/FxqB7s+5lTiyUAp4hEMvBh96fYGVUOUQ==
+      integrity: sha512-Fs+CPNi+MTRLzA/8paPaMwIH+yQ94+2gZrVBVFbAV1y3o0aUDoY1FAybQi1E3RJvQY/gC484lBm5rh+zJUG5nw==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10737,7 +10773,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-2xnd6mbwkwq5D/1bXSPfYQdG+N35hdE5Wjxvsm4NGJ2pb3PxRnlVwTjy5AMM92QqY0XQEDWlYByK2valnkMCGg==
+      integrity: sha512-IkpB+GxggHFzV9E/wBCES9QudOD6OEIX6KWgyQWrPnFNvAi1qcxlbITVHjszu0hR9QX6WUwTLmHYgoWrhN0eOw==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -10747,13 +10783,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-rezb/gjbkY/18hSzzG6EwG+yNC70mvWWcvpIzp4Una7bnZt7Bg7Q9c1Cug/uMzWC2LSG8GOTey+P9rLkhvYZdA==
+      integrity: sha512-vbMR6GHRnNSOn/kbRqOmUHXoQ2dvEDei2gfhgmgi+gPSEWpezERiGtlHLtAMTIDg0n6MzZFGMG3X89WArb392g==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10763,7 +10799,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-EN3rL55iMNLh4KmpclEqjT8BfoFHIXi9a0ZBf52Ib0OkCWuad0jI5s9o+ScMd0HbZRZ+FPIoAA4Nkk60DzCxzQ==
+      integrity: sha512-vCrzRTB7ggm4a8XS0u/tIBxl0GQgGioiAiAUOBzYUAYa7Ba51gMiMlygoMHaYUhzeXa2DtqVe4LO9b0Mapr+dQ==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -10773,13 +10809,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-qzM4v9BjtapAbcqYHyuzJSTIBEwh7Y1ggqbQWMJy8IRJOZf/2DQYCg2NGGmFB8qlG582iBf1Tx2aN/8EcgoNQg==
+      integrity: sha512-WfsluvrrPkPGNjomauAUbfhE+k/AJbywtclsK/aRDIuGRuQP4Rx2zMXn6pZYGlO1J8dhjxDDh+cRz8W8mGG+2g==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10789,7 +10825,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-lcqPK+zoT2zwlCEIu3fTZjstdcRnq/5arN4+BmVGhVKUgdpevIh6pfTyYbjrW9LpVitZLf+sa3wmUTLZYSEykA==
+      integrity: sha512-Q5OO94xGnOdpCHroDDua/5dQydssjKjbKT2vpmJieUD3sAfSYdxU8yO5n2vJxn7g7C1d3NWx8FlxbZkoYNJ5BQ==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -10799,13 +10835,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-M4M6JHR8Sr4jaJfITLGAr5g6NbmAxxWfZiARMGQkRJWCsDF6xdskptn5MQ5KBvF0cXifALzKCYN9ipryrAKHNQ==
+      integrity: sha512-DQiAay2cteSw7K4BBxxjnf0A1tDMtDj+J8i5dWrkJ905FKdo/jLKGeeQS6jKC4cbWA7v1w/ozFM+qK7RlC0G3g==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10815,7 +10851,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-YZl0KQa4IamuGgPPpIv70ZyugQSYba9ePoLSYgW5lS+/68KwVvbwCXU7lEnE2EHNOrxNjdYaul2b/4g9TWJbUw==
+      integrity: sha512-f2e/48ljpJlCYi6gkID8C7JuAHvhGvhK7LErwJef6DmCKRy2tw8U7HONt9uS7i/dBuWXmey08YVAS4FjGio9Kg==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -10825,13 +10861,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-s0Hasl2EOOJaee/8xrqUV4Z0WCgj/gfdRoGjoZLQHQ051hInfVDVwKT7bddLR4TK4wH12FN0wFOcfgv1OLVZ8Q==
+      integrity: sha512-0+Bf7E3wMwFKis+Q57gWMavzrjADcywxifb/XSZij9wc8No+xS4h/ER1wNn58B37D1HmbrvMbQ6lUgWhoS7pcQ==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10841,7 +10877,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-h4kVcGOgkXTDwV7vzouHWaeCmsFKbR9eSYRcnrOhrqVFemWNVVKwpZbC0As16aOT4PDvbCnKi/DYlu4IV/RrKw==
+      integrity: sha512-tr6sg7ZBom45MPy8XMhxDD4/W866SgTCBqstD7rNVcOt/igrVrDLUmX0P4wVb+t7b1UCAfa2icAFv9vPkryCcA==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -10851,13 +10887,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-fQAixzZNKpzJ+uVyqnLMuv5nclXqyWOZWLHENMc3YlgbqobI1ofOys+NSI4Q+5aZ+lbV+IQpjZcjn6yRW4yx2Q==
+      integrity: sha512-Fafg5XCS9Iz1wlevmY/RD3beYW6iA7oov6SCEHEZRk1aCF2/KRGrGHrbCe1LRPEfhDkjMakv6uGOqLQRCO3z4w==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/node': 8.10.54
       eslint: 6.5.1
       gulp: 4.0.2
@@ -10867,7 +10903,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-QQbeGdL3beGB7B/3yaN2h25HU2fBZKqzGHpYf5thDVDn3OwYcQIn5ZidzOzIUf1SeXzS7DvX1bV5GzRgcO0dwQ==
+      integrity: sha512-EW+4viyVsnyE0pyhzqZxOSnuAalGIYYwK8pYd7N9YepGEmjefvZM9N18UvYlKeg9srAfkKqpiNhY3oDQr2X1Ow==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -10881,7 +10917,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-/Z6snQrdVIqDZQtXWyEEGGiTSF+um4ehJBot02B+p4Q/kZVanQXrrcp7IUJJ175/st2uS7Tie2aBnGg3U054QA==
+      integrity: sha512-fZKBxb17ti+Qz/6oLACWjpCibpCjm5L6py/OGoHzzaXoE67Yak1N4hBnSIdpaddQ8WNZGVUnu3FzUc3wqB8LDg==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10892,7 +10928,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-FtA4LYeUzuJ6Zz88XLHsKrAT3QjRMzqwdON/7AHQvjG1OLLsYbLZQShL0q2noUDICnH5TLJzZ4ulzFEGmFyIDw==
+      integrity: sha512-sdbG1mBYHRsQmPqqaymekHPc55wTeBqLcIpqs88cxwoEPpVfAtyDRYN0SW9HkP/jsyPFxMM074wbfV5cxcGnCg==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10910,7 +10946,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-Vmal6wmwMlFx8DY3JxyL4QvqUroUCZ9j8RNIfusgpiKu1TnXn5DEdamYU/4uMd80hVAQIbNyewXItLDMcLbkug==
+      integrity: sha512-SwxyaQ+7r2mP7SHCjrSVvU2lNjDk/Abix5eE2QgTWPWNexagLNLX+ZSSLIPPn3azUTLTuBX3K2dgQHcl5orPPg==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10923,7 +10959,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-+ZGviR5nWF3mYg+T+/EH93pZAgwHtkOrPgv8N5dYIhQD3530zmED1YrOPnu0fsbZuck9yCf85lDvnZ1VRNaGyw==
+      integrity: sha512-M8wovqhoIWLOkjjlNjqzZ7wt+arSphX2geP2ys/B21JCZEKEpX/nGwymwrXWL44lGU2pOk//eabO7NkeesMziA==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10942,7 +10978,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-+F9pYpk0KSv74/GP0q6u7eJLGF1e4Xiv3nEeXiILuodfD7mJpHmyVUIE8QgrnzZZAAmx1DunrxIaJtinmLWV1Q==
+      integrity: sha512-wGxTBQCJdqaM1Fb4CyrolFxfI7IGBDCjh/LXlyqnIDQXB7+cXxp/h2A9EdYm2lYI5+yptwHFeKhwRV6rVIcOQQ==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10957,13 +10993,13 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-QQBXx8k3vEgrkCcyQcKdb/QYczTXrPVJBQwYYLbBe7wCpQ7aPwh/UvnrYay43aKS+LaOp7XVlixkmWgbrwCzYQ==
+      integrity: sha512-z2mQ8vlv4YS0br0dDAz/akxrkGE7QR+EzoULRD0tOeh7aYysbTuof+0dyw7y/h20Xu2l9+xyyfJrrEwLRi9gJg==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.1.2
-      '@microsoft/rush-stack-compiler-3.4': 0.1.15
+      '@microsoft/node-library-build': 6.3.0
+      '@microsoft/rush-stack-compiler-3.4': 0.3.0
       '@types/argparse': 1.0.33
       '@types/jest': 23.3.11
       '@types/node': 8.10.54
@@ -10973,7 +11009,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-apTj3TZ40WkoBd0hWRIjqYb8ODd2Tw6t+UGTm/uTbgpIwIgnEhvx0gB+OFRj/2Jzqx4ZfUmwn0oliFAA4uuSAg==
+      integrity: sha512-SS44oS1ReI1Urm1DSRjNP5NQcS+gpVbrwsN8vJD7YgIJN6d+D0ydQ0RgYRaEx1QHdnsI7IkQOlKB1R4WTXNP5Q==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -10984,7 +11020,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-8ADHI5wuQUiElyuO7QcGc9Y70KAHf9s63wjLbLVuNowM6FEcLW/vMaDFvAyudXSUsd6eGVJlNVnojcGZGXN8kA==
+      integrity: sha512-L42IfAB7XjKv892UIKYNZRdSmEsOWRUEyJIP5Lf7ldaY9x7uNb0eDx+VzrW7XA4SoHPlzL1mV9EGfkyO245d4g==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10996,12 +11032,12 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-OTH75TKr6g2JXYEMKJGkrhCSWLNBa2BrhVZC9wqOLTIdFM44m5kiP4pvY0UokFJ+ObwnPSF+tcwQbrotyMb9zw==
+      integrity: sha512-KczFk0tnmJbldOZsoZh85XEMmoYrkWIlgVBfluG+KxI1RzbjTOgizkJm/CeYno0dJVqTP8xvdRTrvvKiyDbCmA==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 specifiers:
-  '@microsoft/node-library-build': 6.1.2
-  '@microsoft/rush-stack-compiler-3.4': 0.1.15
+  '@microsoft/node-library-build': 6.3.0
+  '@microsoft/rush-stack-compiler-3.4': 0.3.0
   '@microsoft/teams-js': 1.3.0-beta.4
   '@microsoft/tsdoc': 0.12.14
   '@pnpm/link-bins': ~1.0.1

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -21,7 +21,7 @@
     "gulp-mocha": "~6.0.0"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@types/glob": "5.0.30",
     "@types/gulp": "4.0.6",
     "@types/gulp-istanbul": "0.9.30",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -23,9 +23,9 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.5.1",
-    "@microsoft/node-library-build": "6.1.2",
+    "@microsoft/node-library-build": "6.3.0",
     "@microsoft/rush-stack-compiler-3.1": "0.8.0",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@types/glob": "5.0.30",
     "@types/resolve": "0.0.8",
     "gulp": "~4.0.2",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -51,8 +51,8 @@
   "devDependencies": {
     "@types/mocha": "5.2.5",
     "@types/chai": "3.4.34",
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@types/z-schema": "3.16.31",
     "chai": "~3.5.0"
   }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -24,7 +24,7 @@
     "@types/jju": "1.4.1",
     "@types/z-schema": "3.16.31",
     "gulp": "~4.0.2",
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15"
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0"
   }
 }

--- a/libraries/node-core-library/src/LegacyAdapters.ts
+++ b/libraries/node-core-library/src/LegacyAdapters.ts
@@ -3,11 +3,13 @@
 
 /**
  * Callback used by {@link LegacyAdapters}.
+ * @public
  */
 export type LegacyCallback<TResult, TError> = (error: TError, result: TResult) => void;
 
 /**
  * Helper functions used when interacting with APIs that do not follow modern coding practices.
+ * @public
  */
 export class LegacyAdapters {
   /**

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "23.3.11",
     "@types/node": "8.10.54",
     "gulp": "~4.0.2",
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15"
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.15.1",
+  "rushVersion": "5.16.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/stack/rush-stack-compiler-2.4/package.json
+++ b/stack/rush-stack-compiler-2.4/package.json
@@ -29,8 +29,8 @@
     "typescript": "~2.4.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-2.7/package.json
+++ b/stack/rush-stack-compiler-2.7/package.json
@@ -29,8 +29,8 @@
     "typescript": "~2.7.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-2.8/package.json
+++ b/stack/rush-stack-compiler-2.8/package.json
@@ -29,8 +29,8 @@
     "typescript": "~2.8.4"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-2.9/package.json
+++ b/stack/rush-stack-compiler-2.9/package.json
@@ -29,8 +29,8 @@
     "typescript": "~2.9.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.0/package.json
+++ b/stack/rush-stack-compiler-3.0/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.0.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.1/package.json
+++ b/stack/rush-stack-compiler-3.1/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.1.6"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.2/package.json
+++ b/stack/rush-stack-compiler-3.2/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.2.4"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.3/package.json
+++ b/stack/rush-stack-compiler-3.3/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.3.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.4/package.json
+++ b/stack/rush-stack-compiler-3.4/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.4.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }

--- a/stack/rush-stack-compiler-3.5/package.json
+++ b/stack/rush-stack-compiler-3.5/package.json
@@ -29,8 +29,8 @@
     "typescript": "~3.5.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.1.2",
-    "@microsoft/rush-stack-compiler-3.4": "0.1.15",
+    "@microsoft/node-library-build": "6.3.0",
+    "@microsoft/rush-stack-compiler-3.4": "0.3.0",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~4.0.2"
   }


### PR DESCRIPTION
This PR updates everything to use the new `gulp-core-build-typescript` with ESLint support.