### PR TITLE
[api-extractor] Clarified the error message

### DIFF
--- a/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -154,7 +154,8 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
 
     public addMember(member: ApiItem): void {
       if (this[_membersByContainerKey].has(member.containerKey)) {
-        throw new Error(`Another member has already been added with the same name (${member.name}) and containerKey (${member.containterKey})`);
+        throw new Error(`Another member has already been added with the same name (${member.displayName})` +
+          ` and containerKey (${member.containerKey})`);
       }
 
       const existingParent: ApiItem | undefined = member.parent;

--- a/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -154,7 +154,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
 
     public addMember(member: ApiItem): void {
       if (this[_membersByContainerKey].has(member.containerKey)) {
-        throw new Error('Another member has already been added with the same name and containerKey');
+        throw new Error(`Another member has already been added with the same name (${member.name}) and containerKey (${member.containterKey})`);
       }
 
       const existingParent: ApiItem | undefined = member.parent;

--- a/common/changes/@microsoft/api-extractor-model/patch-1_2019-10-21-09-12.json
+++ b/common/changes/@microsoft/api-extractor-model/patch-1_2019-10-21-09-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Clarified an error message",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "robin.stevens@scz.be"
+}


### PR DESCRIPTION
Clarified the error message by specifying which name and containerKey are already in use.