### PR TITLE
[eslint-config] Add eslint-plugin-tsdoc

### DIFF
--- a/common/changes/@microsoft/node-core-library/octogonz-tsdoc-eslint-plugin_2019-11-09-06-20.json
+++ b/common/changes/@microsoft/node-core-library/octogonz-tsdoc-eslint-plugin_2019-11-09-06-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-config/octogonz-tsdoc-eslint-plugin_2019-11-09-06-04.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-tsdoc-eslint-plugin_2019-11-09-06-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Add eslint-plugin-tsdoc; update plugin versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -259,6 +259,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "eslint-plugin-tsdoc",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "express",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -112,10 +112,10 @@ dependencies:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.6.1
-  '@typescript-eslint/experimental-utils': 2.6.1
-  '@typescript-eslint/parser': 2.6.1
-  '@typescript-eslint/typescript-estree': 2.6.1
+  '@typescript-eslint/eslint-plugin': 2.3.3
+  '@typescript-eslint/experimental-utils': 2.3.3
+  '@typescript-eslint/parser': 2.3.3
+  '@typescript-eslint/typescript-estree': 2.3.3
   '@yarnpkg/lockfile': 1.0.2
   argparse: 1.0.10
   autoprefixer: 9.1.5
@@ -867,6 +867,41 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
+  /@typescript-eslint/eslint-plugin/2.3.3:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.3.3
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
+  /@typescript-eslint/eslint-plugin/2.3.3_5b3b7d3a75edb27abc53579646941536:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
+      eslint: 6.5.1
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1_typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
   /@typescript-eslint/eslint-plugin/2.3.3_e4f20efab8ef9037bea9f2d5cf7da5d2:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
@@ -885,40 +920,18 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
-  /@typescript-eslint/eslint-plugin/2.6.1:
+  /@typescript-eslint/experimental-utils/2.3.3:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.6.1
-      eslint-utils: 1.4.3
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1
+      '@types/json-schema': 7.0.3
+      '@typescript-eslint/typescript-estree': 2.3.3
+      eslint-scope: 5.0.0
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
+      eslint: '*'
     resolution:
-      integrity: sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
-  /@typescript-eslint/eslint-plugin/2.6.1_7899e9f92895af58c211f5c1288d263e:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
-      '@typescript-eslint/parser': 2.6.1_eslint@6.5.1
-      eslint: 6.5.1
-      eslint-utils: 1.4.3
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.5.3
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+      integrity: sha512-MQ4jKPMTU1ty4TigJCRKFPye2qyQdH8jzIIkceaHgecKFmkNS1hXPqKiZ+mOehkz6+HcN5Nuvwm+frmWZR9tdg==
   /@typescript-eslint/experimental-utils/2.3.3_eslint@6.5.1:
     dependencies:
       '@types/json-schema': 7.0.3
@@ -932,31 +945,19 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-MQ4jKPMTU1ty4TigJCRKFPye2qyQdH8jzIIkceaHgecKFmkNS1hXPqKiZ+mOehkz6+HcN5Nuvwm+frmWZR9tdg==
-  /@typescript-eslint/experimental-utils/2.6.1:
+  /@typescript-eslint/parser/2.3.3:
     dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.6.1
-      eslint-scope: 5.0.0
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 2.3.3
+      '@typescript-eslint/typescript-estree': 2.3.3
+      eslint-visitor-keys: 1.1.0
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      eslint: '*'
+      eslint: ^5.0.0 || ^6.0.0
     resolution:
-      integrity: sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
-  /@typescript-eslint/experimental-utils/2.6.1_eslint@6.5.1:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.6.1
-      eslint: 6.5.1
-      eslint-scope: 5.0.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+      integrity: sha512-+cV53HuYFeeyrNW8x/rgPmbVrzzp/rpRmwbJnNtwn4K8mroL1BdjxwQh7X9cUHp9rm4BBiEWmD3cSBjKG7d5mw==
   /@typescript-eslint/parser/2.3.3_eslint@6.5.1:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
@@ -971,33 +972,6 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-+cV53HuYFeeyrNW8x/rgPmbVrzzp/rpRmwbJnNtwn4K8mroL1BdjxwQh7X9cUHp9rm4BBiEWmD3cSBjKG7d5mw==
-  /@typescript-eslint/parser/2.6.1:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.6.1
-      '@typescript-eslint/typescript-estree': 2.6.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
-  /@typescript-eslint/parser/2.6.1_eslint@6.5.1:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.6.1
-      eslint: 6.5.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
   /@typescript-eslint/typescript-estree/2.3.3:
     dependencies:
       glob: 7.1.6
@@ -1009,19 +983,6 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-GkACs12Xp8d/STunNv/iSMYJFQrkrax9vuPZySlgSzoJJtw1cp6tbEw4qsLskQv6vloLrkFJHcTJ0a/yCB5cIA==
-  /@typescript-eslint/typescript-estree/2.6.1:
-    dependencies:
-      debug: 4.1.1
-      glob: 7.1.6
-      is-glob: 4.0.1
-      lodash.unescape: 4.0.1
-      semver: 6.3.0
-      tsutils: 3.17.1
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
   /@yarnpkg/lockfile/1.0.2:
     dev: false
     resolution:
@@ -2971,7 +2932,7 @@ packages:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   /es-abstract/1.16.0:
     dependencies:
-      es-to-primitive: 1.2.0
+      es-to-primitive: 1.2.1
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.0
@@ -2986,7 +2947,7 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
-  /es-to-primitive/1.2.0:
+  /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.1.4
       is-date-object: 1.0.1
@@ -2995,7 +2956,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+      integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   /es5-ext/0.10.52:
     dependencies:
       es6-iterator: 2.0.3
@@ -10343,10 +10304,10 @@ packages:
     version: 0.0.0
   'file:projects/eslint-config.tgz':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.6.1_7899e9f92895af58c211f5c1288d263e
-      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
-      '@typescript-eslint/parser': 2.6.1_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.6.1
+      '@typescript-eslint/eslint-plugin': 2.3.3_5b3b7d3a75edb27abc53579646941536
+      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
+      '@typescript-eslint/typescript-estree': 2.3.3
       eslint: 6.5.1
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.16.0_eslint@6.5.1
@@ -10356,7 +10317,7 @@ packages:
     dev: false
     name: '@rush-temp/eslint-config'
     resolution:
-      integrity: sha512-VfV/vXQkvnj3tweb6zhypv3wjpvXDLBhDVFoy3q6Fy0AOIRoFGPoJFlgVUVf0+Tc4Ywmw1XMm9WbN0GKiaTYOw==
+      integrity: sha512-H7VVmFwzoVggQJf65IiFvGMSkni+4x4rQlDIivvI+ONXSmPSF7Mgf2EeIxOy1OLnphqv+/tXHksi4UMdatseTg==
       tarball: 'file:projects/eslint-config.tgz'
     version: 0.0.0
   'file:projects/generate-api-docs.tgz':
@@ -11235,10 +11196,10 @@ specifiers:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.6.1
-  '@typescript-eslint/experimental-utils': 2.6.1
-  '@typescript-eslint/parser': 2.6.1
-  '@typescript-eslint/typescript-estree': 2.6.1
+  '@typescript-eslint/eslint-plugin': 2.3.3
+  '@typescript-eslint/experimental-utils': 2.3.3
+  '@typescript-eslint/parser': 2.3.3
+  '@typescript-eslint/typescript-estree': 2.3.3
   '@yarnpkg/lockfile': ~1.0.2
   argparse: ~1.0.9
   autoprefixer: ~9.1.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -112,10 +112,10 @@ dependencies:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.3.3
-  '@typescript-eslint/experimental-utils': 2.3.3
-  '@typescript-eslint/parser': 2.3.3
-  '@typescript-eslint/typescript-estree': 2.3.3
+  '@typescript-eslint/eslint-plugin': 2.6.1
+  '@typescript-eslint/experimental-utils': 2.6.1
+  '@typescript-eslint/parser': 2.6.1
+  '@typescript-eslint/typescript-estree': 2.6.1
   '@yarnpkg/lockfile': 1.0.2
   argparse: 1.0.10
   autoprefixer: 9.1.5
@@ -132,6 +132,7 @@ dependencies:
   eslint-plugin-promise: 4.2.1
   eslint-plugin-react: 7.16.0
   eslint-plugin-security: 1.4.0
+  eslint-plugin-tsdoc: 0.1.2
   express: 4.16.4
   fs-extra: 7.0.1
   git-repo-info: 2.1.1
@@ -344,12 +345,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q==
+  /@microsoft/tsdoc/0.12.15:
+    dev: false
+    resolution:
+      integrity: sha512-m5lmb/xFsWXyXZzWGps6HR+4itbmEBecr8ec/PO/N68mLgyAOo2TPgSKgz4DV6WHhrQxflWzReNpDA6DIupdxQ==
   /@pnpm/link-bins/1.0.3:
     dependencies:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.17.4
+      '@types/node': 10.17.5
       '@types/ramda': 0.25.51
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
@@ -373,7 +378,7 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.17.4
+      '@types/node': 10.17.5
       '@types/ramda': 0.25.51
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
@@ -393,7 +398,7 @@ packages:
       integrity: sha512-thVgwrQ5rMcPYI6a0IPOt2pnlF1n5zX7BN4CrFeBp0/JCGsZAht/VOPv9bD3cZ+j0vDemEwE23BfhOWxmxq2yQ==
   /@pnpm/logger/1.0.2:
     dependencies:
-      '@types/node': 10.17.4
+      '@types/node': 10.17.5
       bole: 3.0.2
       ndjson: 1.5.0
     dev: false
@@ -537,17 +542,17 @@ packages:
   /@types/http-proxy-middleware/0.19.3:
     dependencies:
       '@types/connect': 3.4.32
-      '@types/http-proxy': 1.17.0
+      '@types/http-proxy': 1.17.1
       '@types/node': 8.10.54
     dev: false
     resolution:
       integrity: sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
-  /@types/http-proxy/1.17.0:
+  /@types/http-proxy/1.17.1:
     dependencies:
       '@types/node': 8.10.54
     dev: false
     resolution:
-      integrity: sha512-l+s0IoxSHqhLFJPDHRfO235kgrCkvFD8JmdV/T9C4BKBYPIjrQopGFH4r7h2e3jQqgJRCthRCAZIxDoFnj1zwQ==
+      integrity: sha512-dm/rPkk/B35nP/653X2K+ecA3TSa39c7n/wpQ2BZRkmKndPe3HDFjsKWoiiZ4i49hC1BF8AFWz3OnjxBzsy5zw==
   /@types/inquirer/0.0.43:
     dependencies:
       '@types/rx': 4.1.1
@@ -600,7 +605,7 @@ packages:
       integrity: sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==
   /@types/mz/0.0.32:
     dependencies:
-      '@types/node': 10.17.4
+      '@types/node': 10.17.5
     dev: false
     resolution:
       integrity: sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==
@@ -626,10 +631,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-uNpVWhwVmbB5luE7b8vxcJwu5np75YkVTBJS0O3ar+hrxqLfyhOKXg9NYBwJ6mMQX/V6/8d6mMZTB7x2r5x9Bw==
-  /@types/node/10.17.4:
+  /@types/node/10.17.5:
     dev: false
     resolution:
-      integrity: sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==
+      integrity: sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==
   /@types/node/8.10.54:
     dev: false
     resolution:
@@ -862,41 +867,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
-  /@typescript-eslint/eslint-plugin/2.3.3:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.3.3
-      eslint-utils: 1.4.3
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
-  /@typescript-eslint/eslint-plugin/2.3.3_5b3b7d3a75edb27abc53579646941536:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
-      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
-      eslint: 6.5.1
-      eslint-utils: 1.4.3
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.5.3
-      typescript: 3.5.3
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
   /@typescript-eslint/eslint-plugin/2.3.3_e4f20efab8ef9037bea9f2d5cf7da5d2:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
@@ -915,18 +885,40 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
-  /@typescript-eslint/experimental-utils/2.3.3:
+  /@typescript-eslint/eslint-plugin/2.6.1:
     dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.3.3
-      eslint-scope: 5.0.0
+      '@typescript-eslint/experimental-utils': 2.6.1
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      eslint: '*'
+      '@typescript-eslint/parser': ^2.0.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
     resolution:
-      integrity: sha512-MQ4jKPMTU1ty4TigJCRKFPye2qyQdH8jzIIkceaHgecKFmkNS1hXPqKiZ+mOehkz6+HcN5Nuvwm+frmWZR9tdg==
+      integrity: sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+  /@typescript-eslint/eslint-plugin/2.6.1_7899e9f92895af58c211f5c1288d263e:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
+      '@typescript-eslint/parser': 2.6.1_eslint@6.5.1
+      eslint: 6.5.1
+      eslint-utils: 1.4.3
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1_typescript@3.5.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
   /@typescript-eslint/experimental-utils/2.3.3_eslint@6.5.1:
     dependencies:
       '@types/json-schema': 7.0.3
@@ -940,19 +932,31 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-MQ4jKPMTU1ty4TigJCRKFPye2qyQdH8jzIIkceaHgecKFmkNS1hXPqKiZ+mOehkz6+HcN5Nuvwm+frmWZR9tdg==
-  /@typescript-eslint/parser/2.3.3:
+  /@typescript-eslint/experimental-utils/2.6.1:
     dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.3.3
-      '@typescript-eslint/typescript-estree': 2.3.3
-      eslint-visitor-keys: 1.1.0
+      '@types/json-schema': 7.0.3
+      '@typescript-eslint/typescript-estree': 2.6.1
+      eslint-scope: 5.0.0
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
+      eslint: '*'
     resolution:
-      integrity: sha512-+cV53HuYFeeyrNW8x/rgPmbVrzzp/rpRmwbJnNtwn4K8mroL1BdjxwQh7X9cUHp9rm4BBiEWmD3cSBjKG7d5mw==
+      integrity: sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+  /@typescript-eslint/experimental-utils/2.6.1_eslint@6.5.1:
+    dependencies:
+      '@types/json-schema': 7.0.3
+      '@typescript-eslint/typescript-estree': 2.6.1
+      eslint: 6.5.1
+      eslint-scope: 5.0.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: '*'
+    resolution:
+      integrity: sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
   /@typescript-eslint/parser/2.3.3_eslint@6.5.1:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
@@ -967,9 +971,36 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-+cV53HuYFeeyrNW8x/rgPmbVrzzp/rpRmwbJnNtwn4K8mroL1BdjxwQh7X9cUHp9rm4BBiEWmD3cSBjKG7d5mw==
+  /@typescript-eslint/parser/2.6.1:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 2.6.1
+      '@typescript-eslint/typescript-estree': 2.6.1
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
+  /@typescript-eslint/parser/2.6.1_eslint@6.5.1:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
+      '@typescript-eslint/typescript-estree': 2.6.1
+      eslint: 6.5.1
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
   /@typescript-eslint/typescript-estree/2.3.3:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
       is-glob: 4.0.1
       lodash.unescape: 4.0.1
       semver: 6.3.0
@@ -978,6 +1009,19 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-GkACs12Xp8d/STunNv/iSMYJFQrkrax9vuPZySlgSzoJJtw1cp6tbEw4qsLskQv6vloLrkFJHcTJ0a/yCB5cIA==
+  /@typescript-eslint/typescript-estree/2.6.1:
+    dependencies:
+      debug: 4.1.1
+      glob: 7.1.6
+      is-glob: 4.0.1
+      lodash.unescape: 4.0.1
+      semver: 6.3.0
+      tsutils: 3.17.1
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
   /@yarnpkg/lockfile/1.0.2:
     dev: false
     resolution:
@@ -1507,7 +1551,7 @@ packages:
       babel-traverse: 6.26.0
       babel-types: 6.26.0
       babylon: 6.18.0
-      convert-source-map: 1.6.0
+      convert-source-map: 1.7.0
       debug: 2.6.9
       json5: 0.5.1
       lodash: 4.17.15
@@ -1906,7 +1950,7 @@ packages:
   /browserslist/4.7.2:
     dependencies:
       caniuse-lite: 1.0.30001008
-      electron-to-chromium: 1.3.304
+      electron-to-chromium: 1.3.306
       node-releases: 1.1.39
     dev: false
     hasBin: true
@@ -1932,14 +1976,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
-  /buffer/4.9.1:
+  /buffer/4.9.2:
     dependencies:
       base64-js: 1.3.1
       ieee754: 1.1.13
       isarray: 1.0.0
     dev: false
     resolution:
-      integrity: sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+      integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   /builtin-modules/1.1.1:
     dev: false
     engines:
@@ -2370,12 +2414,12 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-  /convert-source-map/1.6.0:
+  /convert-source-map/1.7.0:
     dependencies:
       safe-buffer: 5.1.2
     dev: false
     resolution:
-      integrity: sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+      integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   /cookie-signature/1.0.6:
     dev: false
     resolution:
@@ -2857,10 +2901,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.304:
+  /electron-to-chromium/1.3.306:
     dev: false
     resolution:
-      integrity: sha512-a5mqa13jCdBc+Crgk3Gyr7vpXCiFWfFq23YDCEmrPYeiDOQKZDVE6EX/Q4Xdv97n3XkcjiSBDOY0IS19yP2yeA==
+      integrity: sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==
   /elliptic/6.5.1:
     dependencies:
       bn.js: 4.11.8
@@ -3009,7 +3053,7 @@ packages:
   /es6-symbol/3.1.3:
     dependencies:
       d: 1.0.1
-      ext: 1.1.2
+      ext: 1.2.0
     dev: false
     resolution:
       integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
@@ -3037,7 +3081,7 @@ packages:
       esprima: 3.1.3
       estraverse: 4.3.0
       esutils: 2.0.3
-      optionator: 0.8.2
+      optionator: 0.8.3
     dev: false
     engines:
       node: '>=4.0'
@@ -3065,7 +3109,7 @@ packages:
       esprima: 2.7.3
       estraverse: 1.9.3
       esutils: 2.0.3
-      optionator: 0.8.2
+      optionator: 0.8.3
     dev: false
     engines:
       node: '>=0.12.0'
@@ -3134,6 +3178,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==
+  /eslint-plugin-tsdoc/0.1.2:
+    dependencies:
+      '@microsoft/tsdoc': 0.12.15
+    dev: false
+    resolution:
+      integrity: sha512-Idsdc5k42RS+/5VxmaCChNN0zrJTeRrcfpJrpu/uZpRheIUfYTkMlEckPI5jfiG/GQzmjCfy7wSZDIEqw4uWwQ==
   /eslint-scope/5.0.0:
     dependencies:
       esrecurse: 4.2.1
@@ -3187,7 +3237,7 @@ packages:
       minimatch: 3.0.4
       mkdirp: 0.5.1
       natural-compare: 1.4.0
-      optionator: 0.8.2
+      optionator: 0.8.3
       progress: 2.0.3
       regexpp: 2.0.1
       semver: 6.3.0
@@ -3476,12 +3526,12 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
-  /ext/1.1.2:
+  /ext/1.2.0:
     dependencies:
       type: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==
+      integrity: sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==
   /extend-shallow/2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -3879,6 +3929,7 @@ packages:
       - node-pre-gyp
     dependencies:
       nan: 2.14.0
+    deprecated: 'One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size'
     dev: false
     engines:
       node: '>=4.0'
@@ -4013,7 +4064,7 @@ packages:
   /glob-stream/6.1.0:
     dependencies:
       extend: 3.0.2
-      glob: 7.1.5
+      glob: 7.1.6
       glob-parent: 3.1.0
       is-negated-glob: 1.0.0
       ordered-read-streams: 1.0.1
@@ -4072,7 +4123,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
-  /glob/7.1.5:
+  /glob/7.1.6:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -4082,7 +4133,7 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
+      integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   /glob2base/0.0.12:
     dependencies:
       find-index: 0.1.1
@@ -4140,7 +4191,7 @@ packages:
       integrity: sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=
   /globule/1.2.1:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
       lodash: 4.17.15
       minimatch: 3.0.4
     dev: false
@@ -4338,7 +4389,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.6.7
+      uglify-js: 3.6.8
     resolution:
       integrity: sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==
   /har-schema/2.0.0:
@@ -5246,7 +5297,7 @@ packages:
       ansi-escapes: 3.2.0
       chalk: 2.4.2
       exit: 0.1.2
-      glob: 7.1.5
+      glob: 7.1.6
       graceful-fs: 4.2.3
       import-local: 1.0.0
       is-ci: 1.2.1
@@ -5288,7 +5339,7 @@ packages:
       ansi-escapes: 3.2.0
       chalk: 2.4.2
       exit: 0.1.2
-      glob: 7.1.5
+      glob: 7.1.6
       graceful-fs: 4.2.3
       import-local: 1.0.0
       is-ci: 1.2.1
@@ -5330,7 +5381,7 @@ packages:
   /jest-config/22.4.4:
     dependencies:
       chalk: 2.4.2
-      glob: 7.1.5
+      glob: 7.1.6
       jest-environment-jsdom: 22.4.3
       jest-environment-node: 22.4.3
       jest-get-type: 22.4.3
@@ -5348,7 +5399,7 @@ packages:
       babel-core: 6.26.3
       babel-jest: 23.6.0_babel-core@6.26.3
       chalk: 2.4.2
-      glob: 7.1.5
+      glob: 7.1.6
       jest-environment-jsdom: 23.4.0
       jest-environment-node: 23.4.0
       jest-get-type: 22.4.3
@@ -5623,7 +5674,7 @@ packages:
       babel-jest: 22.4.4_babel-core@6.26.3
       babel-plugin-istanbul: 4.1.6
       chalk: 2.4.2
-      convert-source-map: 1.6.0
+      convert-source-map: 1.7.0
       exit: 0.1.2
       graceful-fs: 4.2.3
       jest-config: 22.4.4
@@ -5648,7 +5699,7 @@ packages:
       babel-core: 6.26.3
       babel-plugin-istanbul: 4.1.6
       chalk: 2.4.2
-      convert-source-map: 1.6.0
+      convert-source-map: 1.7.0
       exit: 0.1.2
       fast-json-stable-stringify: 2.0.0
       graceful-fs: 4.2.3
@@ -6722,7 +6773,7 @@ packages:
     dependencies:
       assert: 1.5.0
       browserify-zlib: 0.2.0
-      buffer: 4.9.1
+      buffer: 4.9.2
       console-browserify: 1.2.0
       constants-browserify: 1.0.0
       crypto-browserify: 3.12.0
@@ -7080,19 +7131,19 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=
-  /optionator/0.8.2:
+  /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
       fast-levenshtein: 2.0.6
       levn: 0.3.0
       prelude-ls: 1.1.2
       type-check: 0.3.2
-      wordwrap: 1.0.0
+      word-wrap: 1.2.3
     dev: false
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+      integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
   /orchestrator/0.3.8:
     dependencies:
       end-of-stream: 0.1.5
@@ -7757,7 +7808,7 @@ packages:
       integrity: sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
   /read-package-json/2.1.0:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
       json-parse-better-errors: 1.0.2
       normalize-package-data: 2.5.0
       slash: 1.0.0
@@ -8153,14 +8204,14 @@ packages:
       integrity: sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
   /rimraf/2.6.3:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   /rimraf/2.7.1:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
     dev: false
     hasBin: true
     resolution:
@@ -9171,7 +9222,7 @@ packages:
       integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
   /true-case-path/1.0.3:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
     dev: false
     resolution:
       integrity: sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
@@ -9248,7 +9299,7 @@ packages:
       chalk: 2.4.2
       commander: 2.20.3
       diff: 3.5.0
-      glob: 7.1.5
+      glob: 7.1.6
       js-yaml: 3.13.1
       minimatch: 3.0.4
       resolve: 1.8.1
@@ -9462,7 +9513,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==
-  /uglify-js/3.6.7:
+  /uglify-js/3.6.8:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -9472,7 +9523,7 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==
+      integrity: sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==
   /uglify-to-browserify/1.0.2:
     dev: false
     optional: true
@@ -9711,7 +9762,7 @@ packages:
   /vinyl-sourcemap/1.1.0:
     dependencies:
       append-buffer: 1.0.2
-      convert-source-map: 1.6.0
+      convert-source-map: 1.7.0
       graceful-fs: 4.2.3
       normalize-path: 2.1.1
       now-and-later: 2.0.1
@@ -9896,6 +9947,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
+  /word-wrap/1.2.3:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
   /wordwrap/0.0.2:
     dev: false
     engines:
@@ -10117,7 +10174,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-lGp4zTrPmXL0tz/TWQPMF7EL/vGqlxikRPyVl+5YxD8E7r+MWar5o3cpJ+nDTKMKJdBhCTeBbeVUguXQ6PwP/w==
+      integrity: sha512-/q6DUtvjLrpXcO7Qyaw86fkPezfSkgzwj59NfoWGM95C5TLm9oHs7VOfc37yFU+F2BEKhflIygWKq1Iy4HeDMg==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -10135,7 +10192,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-xu03DITcj17GR5z7EG2PyFSWwSIfgFka4Od6myMyxyOLjeM+V8zi+pn6rR7KmVaI4cMZ7MrsSBploGd1Hlz3Jw==
+      integrity: sha512-5Al/lmm3zcsOUu1shql9yBJmU5bCH7cCbrY+cJr3tU1+E7A+iVeIfwbvnTZx0S+vFkZU9IA/rEPpjfnIU7XJqg==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -10147,7 +10204,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-arRZNKzRjygqGBY7VMKW0VrfOjw14BqYWgXt1AuXCvCjb+uDOOLAjdVDB5b0dzSW+FESg+PfXjEbzq/NWcWF5g==
+      integrity: sha512-Y9I/cAdHpwgvSQ7vIussDXEeAyQQ0Rk8ZuDjSoDQesHC2AjzN9ZrrV07MHlnC/oFlbNeCFz0KAL6RPXJ0S+uGA==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -10159,7 +10216,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-LfPAfd40Jo9kjek4I0Tlpll/Qe3/9WYMGISPKJASpfbU9x9pNGuXgGUfNCqVWZdmYifmzlfyPWAmNv9kmwCPUw==
+      integrity: sha512-Puf+1++6izvxyKEPmGT/Eoxo8yLc6/t+pCqWtLb5oXoACWLqQFxuobMUTjkY3yVXxbrG1jsdcu5nQqMQe86dww==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -10171,7 +10228,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-hfSXABYO1srcFFVntPh+UbF/MDq/y4clcrwTj+XbY7Wji0mKVyymS3piO/ZEpXuWsPKaERzSF2D779Q6miEJQw==
+      integrity: sha512-uVYfk4YUkXdWyVQqM1f1kkZ5cK/9NckTxyIurNvbXCUY0tQx2KbFQzBJLqzB8Xy2ZpBiHBnq+kuTlMd2LVXolg==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -10182,11 +10239,10 @@ packages:
       '@types/jest': 23.3.11
       '@types/node': 8.10.54
       gulp: 4.0.2
-      tslint-microsoft-contrib: 5.2.1
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-q6D1qjGkqpUlkVqJTv00P2rJzHlXOrQ4kFbemV9X/qUK4yjDNbTHHo/gItuPOaCkYdaMW5vU1E04qUQ4XvftOQ==
+      integrity: sha512-LK59eyWwJbjBzc5kJJmo8hyGgyFdTIfA6hwqU1TXefgiVI01afswITFktOTTwXgnx9/UpLMczGYOPMj3kDO+nw==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -10200,7 +10256,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-D/8oDWWDeduETUbeXBU8lB73I0d/oVgAL1k+YcyWJXAhx35K86JTBxS5SspIRKTlravDCz846DYGN1h0mJAa+w==
+      integrity: sha512-NknPatmA2Z1hWT0O7G3ZOo1cygjiNaQL4XFgrNyjZ4MdyT2AkVgwDrLHyQDx9lavi/UL9/lpaDX5I+Njf6YSdg==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -10214,7 +10270,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-49HseWgpjfyCQzj3Oy/gbmD3s3tyXbn33SIMyciUXSC12T2wZ2lF4gtDARhBmhKBcwCOvL19PAm+nox9nfnSUw==
+      integrity: sha512-pX3MSxmn71D2LS+TE7KmiIUJn1P1xVXXwXd6fEdaJG8Gc1U3R0b/clw2oAsvKqe9PbWNAE8T9W08Av8RweVBGA==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -10227,7 +10283,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-EFQPtc/1dNPg9DBmzDthxvw0RqMmOoCVO8xPQSnVduNCj7+UBhOEjAYbArsDLhlJtCd6i/BnCiuxNhQAqICRxg==
+      integrity: sha512-3LANEay7i578s/i2hLygmyf3Q/gw6yCLVebw4ZlI2gVMDguTCaCKNWVZI2PXa77vXD+lJwxIj8gaTX7CVmRVzw==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -10249,7 +10305,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-LDNBXmoqnVwJ4Mrg32fkaiojeMfuDxmuI4lC5LR0lwD35ZRwDCY1YX/sml6FGCFWEJPMq5yzEfWmwwPH625Fog==
+      integrity: sha512-YB6LgY9J75/wTOQA2Cgslnhpq4xiT+kHKISIRhJ1EKzkoeJHGpPg/5Y2xAhVpkK5+MKaonrO0E1TaYba/5C+4w==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -10282,35 +10338,37 @@ packages:
     dev: false
     name: '@rush-temp/doc-plugin-rush-stack'
     resolution:
-      integrity: sha512-CnYeMPgVjrGHjPbSV2/QcfeVgVNOYwpwgjyTcbVRpae0gnU0BllXPSp3SzRfmvgHxFobQvkKZc2Z2JK6vHzpJw==
+      integrity: sha512-y4gVcBJ1w84vW9XYhtlYzsothjkRsD3EU9npdlls/cCnu8H12x43TARJ0Hli5nfCGGZhOt5VpUczdQn6OESo/Q==
       tarball: 'file:projects/doc-plugin-rush-stack.tgz'
     version: 0.0.0
   'file:projects/eslint-config.tgz':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.3.3_5b3b7d3a75edb27abc53579646941536
-      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
-      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.3.3
+      '@typescript-eslint/eslint-plugin': 2.6.1_7899e9f92895af58c211f5c1288d263e
+      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.5.1
+      '@typescript-eslint/parser': 2.6.1_eslint@6.5.1
+      '@typescript-eslint/typescript-estree': 2.6.1
       eslint: 6.5.1
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.16.0_eslint@6.5.1
       eslint-plugin-security: 1.4.0
+      eslint-plugin-tsdoc: 0.1.2
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/eslint-config'
     resolution:
-      integrity: sha512-LhD8XXJ+Ia0W0dL6azLYM3Yx/P/3ynLB1IYo/rYbLkSE77h9g6D0MXnLOu934fYC2c1fXQP8WcJ0frgZMSEq8Q==
+      integrity: sha512-VfV/vXQkvnj3tweb6zhypv3wjpvXDLBhDVFoy3q6Fy0AOIRoFGPoJFlgVUVf0+Tc4Ywmw1XMm9WbN0GKiaTYOw==
       tarball: 'file:projects/eslint-config.tgz'
     version: 0.0.0
   'file:projects/generate-api-docs.tgz':
     dev: false
     name: '@rush-temp/generate-api-docs'
     resolution:
-      integrity: sha512-01TTdeE5+/816Z7g6WL34W4FHD0ztgzsZRXJMVPRKw411SuZaHK0VMUPXndfFNx9IPLOH++vbyBTH4o0GWCq2A==
+      integrity: sha512-uN0aud48wD/6vopgBLLRD/LMuyRMUojj5mI/65iRPTA3E48rhtsDKnfa0naPMLfroLCyom0nh1n6d9sDagNfKg==
       tarball: 'file:projects/generate-api-docs.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
     dependencies:
+      '@microsoft/node-library-build': 6.3.2
       '@microsoft/rush-stack-compiler-3.4': 0.3.2
       '@types/glob': 5.0.30
       '@types/gulp': 4.0.6
@@ -10326,7 +10384,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-t6QaEVt/dPpF0VYse15uyCanymX2UpTyaHGzzowl3UeZEqZPY1N6ORURi9QW1XHCERlPPyPS5xw2z01asRi9cg==
+      integrity: sha512-m0RXvd/SsBaiT2ukG32qTKkVdsqdfeXMm/oI1vJMTecYSI1N+tlN1K6/77PqE/s8sM9bTI9B5VVkzmRt34YY2w==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -10348,7 +10406,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-4OtMV82ikqd2g24ltv+SfrM6Nu48D+PKaEuQKpW0pkY6CB2Uyp/5VF6C8SnsvOWoemOj1p20OhsVJYttQMUwBQ==
+      integrity: sha512-VoNzj/kDz6yXgdaFwnh40PH0KvZc4m0Kv6EJSyAk2TCg6jre6lnTgrhwMiGCY2Udh7igF0f4/iT85k35ArQdjA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10374,7 +10432,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-ftLVv3e90hWtAKlCBfCChdk1uhdArvEqjCjGO6cwJsBqf83ekRRSkRQrwmVE2Xh4LW2JVI6cnxKj9tX2JzWpHg==
+      integrity: sha512-lB4RB6cZvRDVTdgP8qg6U0KmFKxVWM2OE6+ljvX/bmh2yuw857+nyfPYX3rTO+fbNvIhkOo8dx1pOQmEVPmT0g==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -10389,12 +10447,11 @@ packages:
       glob-escape: 0.0.2
       gulp: 4.0.2
       resolve: 1.8.1
-      tslint-microsoft-contrib: 5.2.1
       typescript: 3.2.4
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-8ovRWSDa8eN09yYDqJHmtrt8zzOo3tR6k+gxu0/K2jCIg7DAb2zCRR25o4Rh9IWkAkuLWeeQtaB8g4JnzMsavg==
+      integrity: sha512-EJJmIEK4QErO8AxF7UJ2nrjyEPUxi+PZtFRAca1/rjMuQrzqekw3Q6hebBQMn/PBmFXQuMlBPhzy+RehSaT7RA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10412,7 +10469,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-zXxWCI0k2f2DSvY5HJgsNRqDFC5XmAdReUF5xO9fXZMgo7yIby4ftAp3dUkloidJ1Sqfg26I/7RII70BHePDrQ==
+      integrity: sha512-uy3wxQsNzOHFjFUn+atGUasC3qWMeA93YTg+S8zd7pg8xDtT3g9mcySgMKu8C7ns2kQoRcDBAFM3cz+ePeEmNw==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10435,6 +10492,7 @@ packages:
       colors: 1.2.5
       del: 2.2.2
       end-of-stream: 1.1.0
+      glob: 7.0.6
       glob-escape: 0.0.2
       globby: 5.0.0
       gulp: 4.0.2
@@ -10459,7 +10517,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-8wtdZXq6ni8be9dJtGGZDzfV/xwvv5n9bYPmuuyPt/5s2KfFprKRoblY9mMyq4sbRV2cfjt+9Xwzldj8Wo83tw==
+      integrity: sha512-pOqZn6vivptdECFpiGnYbMnsyxh9tGMP6ygmXFceDVVUMRa8aGS6mlD9E2ihBTYGaTSfRZkOpg20lKkbhPKvYw==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10472,7 +10530,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-8D2G1OosscqaQYrgQMBGipZ4gJNMYnHU2txt6/t5aZ8VrB6mIViGf2u8tCwzjam//mbMPTB4XLl9WZRtK4spuQ==
+      integrity: sha512-Yb5I3fvSjB8Qo5LytXONgQMxSMDO+Lf7zLqeTrDq1eCXS9ZZEPLM6vhVbXiCEzAMketVs3ZMR56S2ZDeMGiq1Q==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10487,7 +10545,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-p+25D/ZutXSPFlRwFk45Vwy6W0jU9zZfUBMNv6C5apJj32Hw/UWMWYeCa3Vrs5t2f6HTdT3eOtiv9QU941+jXA==
+      integrity: sha512-3ISSrXJg6dqMIh4LtDlP7UW2a+hjbO/NYe8lnUTyPUBdyO54YGPBRMvuyUMPRni/HaH3ezrnjhMhfXe++J0+RQ==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10501,7 +10559,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-XE8D7KJkezo+XAGdRZxZjI5EJu+9mMEzJcGyhqGepZUFAGr7S1qzzrNqSw84BlKo4A2qUnhqfJ/e6el3pqNQcQ==
+      integrity: sha512-6j3DAzjCIPaNFaCfGzcouAmzF8QxgcT7zGKIacacawL2zAcq61T4o9AqUpJTASlFjKUC0Ns/wPm9rIUKeQoPCw==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10517,7 +10575,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-gjFD0WGo62BAy527zu1y2+tLsKu4f9zU174GmFXi3jImPRbZJR8SYWyyCyk5mmrNymgZJNGewvkveaopOauCKw==
+      integrity: sha512-D1lIWWz2VTB7hn/pQSDOYDs3v6mDDdURq5ZqkD2GLzyejhPnyYqRtKFn4hZntaye7I0SGeZL6Xv0ZNlkyTjk0A==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10554,7 +10612,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-eslint-test'
     resolution:
-      integrity: sha512-VuOId/iQkZrAWJiYhHtF9JMNv/IEsYlGKvFFkmtwHoXkh0oDwuXHLtHe7nPbbe8RmoGEH1F7ghsc4KqtFhBqmA==
+      integrity: sha512-4dr5SlMtxzAbkZ02m7B8jbU30Q+i5l264EgX8a7Vpi6/5kiFXF2P9u+385G472JDq6/i+P0CfpKDDNYWduOUhA==
       tarball: 'file:projects/node-library-build-eslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build-tslint-test.tgz':
@@ -10567,7 +10625,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-tslint-test'
     resolution:
-      integrity: sha512-OMSmmeK/kGFxNUYBMGqlLu1BC5C7kOzmv/dnTGG/sUHZr0/yiN8friaASQODF42FwQcC5PyN6Sy5193k91tQeA==
+      integrity: sha512-Y3OFdAmCICERaUggCTQ3GTj6e+I9phv0f1XjTt3Xk14QYkk5LkfaV/xL1T+ZkJWko3q5R47CfMGt6P5tD7eQzg==
       tarball: 'file:projects/node-library-build-tslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10578,7 +10636,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-9ZLDnwgGoghiPNZyuzjFkMKxJGXUSlsDTEaoJJMA1j7QcyASO0oG/s23evg+9prRkIOHQifOE2gAO0a/CQ+w/A==
+      integrity: sha512-odWtrja8Qpe7pQ9YLoZ9H0lhiCDTBzSXIKHKiNapDLiFnZhTq2kk8Mnk8XbZ2WD8b9OgG7AeflAnXQLJ6E41sg==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10591,7 +10649,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-iu3CzlNgKYjajPnElq5TOaBurlVkL8XxlFoUl1RUDjZEgolr+0+ujKZllABKS9VW92O1XRbMVo2z4HXAHchKOQ==
+      integrity: sha512-sNofDDuHoxRC1+L9v5m1He1DQXNBKaQR/9MoXg8kmQkGO5lQkPo7uo/XWzJnq9sTpWwmIZF63s0uVHLhK1c3+w==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/repo-toolbox.tgz':
@@ -10601,12 +10659,13 @@ packages:
     dev: false
     name: '@rush-temp/repo-toolbox'
     resolution:
-      integrity: sha512-5c9zqh90UX2ZB7p9Vx1KiTF4DTqmTKQR5jnNmTTFiUy1+ctzYoZPzl74ZYL+EYT+F/oFk+B8q2b4IBrZsWCOGw==
+      integrity: sha512-hps/P0ni2Dy0lE7X3OWa1eVGy6Xqd0XjE2DwmOjGf88jNzvJKaNIzeK70uy1nPdfvQFwz/1EG2yVlbLaiK2Tzw==
       tarball: 'file:projects/repo-toolbox.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
     dependencies:
       '@types/mocha': 5.2.5
+      '@types/node': 8.10.54
       '@types/webpack': 4.39.8
       chai: 3.5.0
       gulp: 4.0.2
@@ -10614,7 +10673,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-HA+5ftVhSUkQSHvpNz01D3adXNq9P4DtAl119B2wnAn80LiEWA2cnYiboReN/B1e5jsYHXYkLwqbfCG4R4VMxg==
+      integrity: sha512-a5ubMTngkG8RZnV8albUI1qHNnhnETG4npM3uFVTEwrsRZj1iruWFDfgENem6rtJCh47J22YaCcVFcqkWTrDTQ==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -10625,7 +10684,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-Q8b6tPN9+lu3E53rMQgAlBrNHXJiYiFf+GJnkZ+KSjwTaNi1dXUF9ge5KUYJ7nUl6XGEaSUJASjiGU1JO+MHOw==
+      integrity: sha512-ufPfcLalFw5zQVFHQ+J1qnvVoNIqwRPqDNH/ymD40s+COVDaoceOKoz10amLEqWy4YpDdJkvVj8xgNSg1apH4g==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10653,6 +10712,7 @@ packages:
       gulp: 4.0.2
       https-proxy-agent: 2.2.4
       inquirer: 6.2.2
+      jest: 23.6.0
       js-yaml: 3.13.1
       lodash: 4.17.15
       minimatch: 3.0.4
@@ -10668,7 +10728,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-Nte72YXb3Rg1fnPIIsVnFHdte1CjhXunrllkkecuU9cHt25Cj7MuFdOcivQWvYbAndKQZA73DYzZTyf33tt1FQ==
+      integrity: sha512-CSHl5Gq58AdUbnETJ7JJBbcJSrfEzg9d080mgKFtsOzxoDy+6BPu5LBURQdCvdtN53YQitd9bqKVNnsr1detZw==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -10678,7 +10738,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-kPfTZDnoBQZQjkxtLnw8Qz8aBDKrU4zZULx24KPunQXuXecnxrlePPK07bhJJf+Gzs7pmO4QfdNEHahWuQ18zA==
+      integrity: sha512-pwi4wiB2rznUmvkgOmic1lFz5OqffDrwfRlr7RvPcibZQOes42ym6ngbPvCwHz5gKg8KaBrGkSc6AQHFr4+tfA==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
@@ -10694,7 +10754,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-BX95VbfRLAGpZX2PB2bE8mUuk5qMyjSwy7cQN7eq2gnbsq4O2tM9iO2iarymOc/uTw+M6fpVjfQvNYmrnzHr+Q==
+      integrity: sha512-MKxyfEfJCaOqthAzVk41/OD9wE/P2iKESAyOOIpqp9G/oIW4rUVnZhTj5b5UfKmnSN4wg/fkg1VYOn+stcBEEg==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -10704,7 +10764,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-MyUhcWLGA1h8vheJoxbnE4xmXfVzS/iCI4nR/VIpGihKuhQ3SeSwk0Wzd49jJm8LWZ1eiLqWrUcZxgujLEAvog==
+      integrity: sha512-6SWT6MqTF3SOUs+7LRoPenU4fxSG8wMzgwJIPcU7djoZQYace7Y9Da6atVULReCAIiGqsdTmaBRavTUoZbRHgA==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
@@ -10720,7 +10780,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-YStvOJUQtTT8hfS1jwPFISxotKxnLUG3/R0WiriWshHYvkM/8Nq661DUDIf79LZ1tbdauEeNZmrzVFPQpPp7aw==
+      integrity: sha512-SK5cHLpcGlkUEBz3KWl9aB1Lu9UZmmzD4tm4humPSeKa8y810ZTV/3AVlh43fnaTWSirYyt1LG8CcOhZ5AB4DQ==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -10730,7 +10790,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-XDEHlkPLZ1+P8xG9QFicxb/Bsbq/RiOawiosKfb1EyruUZ9HdPyiTc2D9bTXIAbAm1LEYBHumpJjObrf75EDaA==
+      integrity: sha512-qYxsQRGH12jHy3r7cJwUG5vzv639+oMQzXhomoiBGFKvwthriouH35+v1UDPv5CH0/YtLXs+bqxm9oL03Hn/Qg==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
@@ -10746,7 +10806,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-opNaW/KXHTeXYHSsNVGcr3jUZ5JRe/2Nim5gU3VP0WFJEs9Bn6JlH2LPL+qMUnFRWOo/YLeAN/uMrwwxsJ6DnA==
+      integrity: sha512-V/rmeFYFN09X7QvLTO/MmKyj27iyTcI5/VnoOMye0AhhRa26Wdy2D2VbrnABhzK2zYYo+tQGKtZI29ozGJ4swA==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -10756,7 +10816,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-AGwxRINpeaPoyMSZ2bcTZyqqH+b0f0v7BTZFPNyeAcmYNfedusAdw24xc/BnvQQqoYTf81xyznIgdIf4Nw3e+Q==
+      integrity: sha512-EoEKGXfwnpdS//aOWznXq2tvrVrQ9S8VdPns8AKMEwl6RTorOF5MeVVBf9npKEv1Qgc29+dGDmpu+aaTtSciGg==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
@@ -10772,7 +10832,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-Ivl7kQZ9iwbnCUVQBv+4fYXw/tcOwJzZVDWm/JORaltgO9yHjOIeRTK39VtBh9CF1jBsUIVS+c/uEpEYWRD3/Q==
+      integrity: sha512-ZhxYMu4XpMkXt4Eni/cpiPlFBeavXwsUSw7w2HyCi7I0AZIebS8oVSg+N4x59xxJICqa98HMtooSmC1HnETEZw==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -10782,7 +10842,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-b/oafndJCqG9rINNHyVmgWv1JYWHPLMjAyYZwF+ryjdI0VcN6PX/zv/6u/+lv7lRsNm0pkrebcC3El4t5t4sRA==
+      integrity: sha512-AvCuMZQSBKi2ogHNiOeG9Ayl9QQnb58Ti7R0FlIiF00EbpQjfoOa4niHpixKPiXBs7yLucr0lNeXUjx6MV82jQ==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
@@ -10798,7 +10858,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-OUSOq4tQez0Tf6+3XDK/xBCO4OWDE4j2D/jvaZhqWoGuwG762q3TvpKDUzSjBZ50PD7OxMvc88hJe93pwIGUHQ==
+      integrity: sha512-O+4S7WlriLKRW2AvqaAzmFwE4fw2+4qcFMRSojz5NkSjIShwGZXsmA+AMFGJVSsm56Z64dIT2THQUymmCYokQw==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -10808,7 +10868,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-8vP4icW6zsxMyynP8PQar7dMCXt9TVHK8G2t/EwpjKL3c0QLiepWi3e43iPo+O6knEi9DRFIpvBix/kQvaKBqQ==
+      integrity: sha512-ONAgqL8UdIzpGuwyuYmJwbbo0tiMuSHElk0e37wx5OEvBlCLsgLydGbGi4IZ5lXzpWefy7YEeI7bPRVcZYx7Nw==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
@@ -10824,7 +10884,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-BTizdXjFiWq7zo5Ej3kf+i/DditnknNlszmTa8ml8nN5/ziBd5tzErlb0eyTgbjDg6tA6x75mbOXB7fIRI1ikg==
+      integrity: sha512-E0GrmKVJnNNGd7q+voseJ0DId7+8dDXEX0+X4ufdKW2yE7cY2r466pKRRvHl0RYU4CiJ2ElHXE3AX/ogtkWkow==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -10834,7 +10894,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-gUjN90rqy7QnAdpgSVQzRdxDsEZ7g3IQayV6Wy+TxaJysHIL6DxrXnWHOLZ9zeqYTW1uvK7hwuHWFnJ0UCFUyA==
+      integrity: sha512-li2lt6+z0BG8WQZMNBAEBVLkT6Fs+uJM62owhvDAetYeTfDpDeNQ2u6BJCHHRz+VITEg8YLzyfco6sYKLgulJQ==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
@@ -10850,7 +10910,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-lZ71LPQml5sj31jd+szDqyQtEB21TC9M8EKjc+Yxp6NqDnFpFNWMTVp1G+t74qV9jJvPloUjcZdfIl4X1Jp9Ag==
+      integrity: sha512-KRX+c6Qlr/ciZOGw5NdS1efeWMNQqb7+nfu7V+kEG7/hGByCBHJ0+d/TgOSttEbGiYXiNPfGYts2ceDGYV3wLQ==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -10860,7 +10920,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-zo0XFk2GUiSLnLUOCvdaoS/Pq+IFhO6OMvxDDBl2WwkgTmiKyyGHipAsPLdkSvHpNpTFqvqQFUFAkGxHedpnpQ==
+      integrity: sha512-gbGP6O0VEckRBjTzMRgeI7WhsJ6B8vANj8gtRBdpW/ECJ6797PLCqlzdB4W/q1kp5jGLCS1IIN3DKddFpQzrwg==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
@@ -10876,7 +10936,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-z8y8+MANNw8N31sBX0lUe917njqSP7ED6eZf47qmlWd24j5F75VCJ1/FoWlLU58frm7Z9PuzNxw5ywMHtOOsew==
+      integrity: sha512-5G6sVQ9mo4mr2rQAvYi5qcF9ZRJXjLSGQpWcRfEWx0EHIOfPMWBGNBPVvWXahn20CM+qPvfr8Df7SnJLCLG/Cw==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -10886,7 +10946,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-Jr0Waj7PkEDest9sqwp6i6pN7TTiswh3AulXanCJHVc0pesdpBBCITAA/w+p0lI5+JA7RLqmHi705KUqFg7toA==
+      integrity: sha512-NIV9wQ1t9V/6NkIikmq/Z4dDBzYXdzcHfUehTOTEFyx3rrUHK/FoHO+ry7o5TDLgpCd+EkMD/WaR89TghjTyLA==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
@@ -10902,7 +10962,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-xdflICSNzGrj8o5No45PpnNLw5J9qVym567abfVFUl7SjqS3bAkJp7FbBCo0Q32ZbgDVdnBrKyT6N/txggkmbw==
+      integrity: sha512-q7NQVvvD/cem1u6iqpJGgXQUCttsvoej2aHbgmLFOp4MWq2NeJxUDwX9aX1HQlepUxW9aIeSkYyc1TmrqThYyA==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -10912,7 +10972,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-mCr5/dlIsV0ulrAHjaZUr0MHRHn3Si2Haa7enVdLWRJZQ0KDLOeWDrujTJJz2rm2NptishkU2CVHsxoA8GzyZQ==
+      integrity: sha512-1hsI5cskje6jyEVVfshHErW5/9WU1eoSQryAdMgIh0v3EDAbhw/dCO9GIhO3UaRAEwTtodnPWxrvpxTu7jbayA==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -10928,7 +10988,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-hkMvdnF43xHrf6CVwevKJO4Z21CsVoAq11A7KiLFkp7rcRSmKhrpLMuBHIg/8YqWZ0di0cOer6FYyC3Z8gyFoQ==
+      integrity: sha512-nkosV/X+kUuKtpur+ifBhZ+P0FtK9l53IPkb5/HZ6QyHuAUDfQd/qlUzfeG/YUqfsIZZtljWXMpYibpv7GnSLA==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -10942,7 +11002,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-cbHzIHubAHmA/1eu8ubc1EOxhocZspBnrIVB8a+UN1/cxH4ZlYz8UmIyxxSayynVmO8j4XNY5mMD79lVa8E3bw==
+      integrity: sha512-+UBdUub3yLvxelPW6/eXOXWaOwditPEi+DFNTnU3da1OgFhgg22+jzZ2dtSMnsHrC5TN0EuFstQnjGetewZR7Q==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10953,7 +11013,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-yNM/qZDWp8rh6N1bICFpDY9edDXrTzB6/b4GCKtZE9+/fOpLg+wO10hBkWFy6gA6VDdbCSrnOp3XMDt1LavQUg==
+      integrity: sha512-ttC54YyPxRqbyg+GlaJSN7bH4XCjce4n2Vi8kNLillEKarFDKEjZxpUzLPtRm39QjZPwaaGjHlQQsEHXtmd9CA==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10971,7 +11031,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-70U+8HiUlLL/CYxFh0rjpYbLyAN9Id5M13Yb4S5B9YZewhe1oDLffrO1MlXufR5uUvTfHGIkyy2UTdpbzRvkoQ==
+      integrity: sha512-bOmwAWnR/OAIqvmOP7dLmwjD9tTSTjUbn6zxP1HxN/xZf+hrpxYL71fR03BTkqSST2Sp9PQws4eUjWMCPGw4mg==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10984,7 +11044,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-YHrwCcRMyDwMv5ohetmY1U0BC3vXKv/ovLhpUsU4UdgsvyjSV/92YvsvPcKHGeWqpVf0Ez/J1EcqCk2Pe6GhGw==
+      integrity: sha512-jJXeAy5bH0qrLh50E2oRwRPCUMYMWi/kbLq5FOv8sn2ZsRoM6QOUpDJJBobWqK4ZWm7wkGBkQ0oGtE5qwZPcxQ==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -11003,7 +11063,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-7J4OSAJEQQYlVgb8PelFKyqOurxWuREePTO1Kc14aFvUnITBafTFBEDBsCb5LdIDqTuoLbFPZlBS2vj5PWfRpg==
+      integrity: sha512-+7saB2H8EaTNet8wRL3DCu9GsnR9+LeYLSGrxnVEFw/63P4Ap1q/tw8SU8rkt0z3NAmZLNR8r7Er1faVwt7Lvw==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -11018,7 +11078,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-wR7Mftz5qoZAv6l6yBuiSW7naL10Amb+wti3xZWQ0yncHqLXq2+QJbBM7rSmRMUVsx4DOzheDy2A/q8tdfjFIw==
+      integrity: sha512-pJ1vuuyxWDTNkB88wGpqZebvm+QRchZdEPyi3+fosC9wH3TAY5F9ebL73MQSZpcXz0zoPuiS1/6CplmUy1R9LQ==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -11041,11 +11101,12 @@ packages:
     dependencies:
       '@types/jest': 23.3.11
       gulp: 4.0.2
-      ts-jest: 22.4.6
+      jest: 23.6.0
+      ts-jest: 22.4.6_jest@23.6.0
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-dqTIA/toJB110rGPSKp0Tn7aLT6BzC3u9ICPC1ueMhKHfWyraE6BHEj7+PI6UDRmJ/Yks7hCpk3wHUJOyE4yWg==
+      integrity: sha512-Sd36Idkltf0oQ5OZDPq/6MvCw1ZBs1tgCe5GUbbCguDyWi664+n+T4SM6xT68zOmnL3Hb41xme+1TABAn8W9Ig==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -11057,7 +11118,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-P2YNiYoJz856DA4xKbq+Wzm/x1xieuTgXEV4jPuC+QGmQrvg2Lbo88KlXQStd3Cxx8EdUH4p+NRtaBiejaXERQ==
+      integrity: sha512-7tuaGDh4f4QBERbId3b09utAA0LEfrfPnMfJS+UYBgezw0KxANBQx6l19iI+ucdXiTUgGTsjRUCg6XE2FlRehQ==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 specifiers:
@@ -11174,10 +11235,10 @@ specifiers:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.3.3
-  '@typescript-eslint/experimental-utils': 2.3.3
-  '@typescript-eslint/parser': 2.3.3
-  '@typescript-eslint/typescript-estree': 2.3.3
+  '@typescript-eslint/eslint-plugin': 2.6.1
+  '@typescript-eslint/experimental-utils': 2.6.1
+  '@typescript-eslint/parser': 2.6.1
+  '@typescript-eslint/typescript-estree': 2.6.1
   '@yarnpkg/lockfile': ~1.0.2
   argparse: ~1.0.9
   autoprefixer: ~9.1.3
@@ -11194,6 +11255,7 @@ specifiers:
   eslint-plugin-promise: ~4.2.1
   eslint-plugin-react: ~7.16.0
   eslint-plugin-security: ~1.4.0
+  eslint-plugin-tsdoc: ~0.1.2
   express: ~4.16.2
   fs-extra: ~7.0.1
   git-repo-info: ~2.1.0

--- a/libraries/node-core-library/.eslintrc.js
+++ b/libraries/node-core-library/.eslintrc.js
@@ -4,4 +4,7 @@ require("@rushstack/eslint-config/patch-eslint6");
 module.exports = {
   extends: [ "@rushstack/eslint-config" ],
   parserOptions: { tsconfigRootDir: __dirname },
+
+  // TODO: Remove this once "tsdoc/syntax" is enabled by default
+  rules: { "tsdoc/syntax": "error" }
 };

--- a/libraries/node-core-library/src/LockFile.ts
+++ b/libraries/node-core-library/src/LockFile.ts
@@ -19,7 +19,7 @@ const procStatStartTimePos: number = 22;
 
 /**
  * Parses the process start time from the contents of a linux /proc/[pid]/stat file.
- * @param stat The contents of a linux /proc/[pid]/stat file.
+ * @param stat - The contents of a linux /proc/[pid]/stat file.
  * @returns The process start time in jiffies, or undefined if stat has an unexpected format.
  */
 export function getProcessStartTimeFromProcStat (stat: string): string | undefined {

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -473,6 +473,9 @@ module.exports = {
         // "Use strict" is redundant when using the TypeScript compiler.
         "strict": ["error", "never"],
 
+        // We're still experimenting with this plugin, so for now it is off by default.
+        "tsdoc/syntax": "off",
+
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "use-isnan": "error",
 

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -8,7 +8,8 @@ module.exports = {
   plugins: [
     "@typescript-eslint/eslint-plugin",
     "eslint-plugin-promise",
-    "eslint-plugin-security"
+    "eslint-plugin-security",
+    "eslint-plugin-tsdoc"
   ],
 
   overrides: [

--- a/stack/eslint-config/package.json
+++ b/stack/eslint-config/package.json
@@ -24,13 +24,14 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.3.3",
-    "@typescript-eslint/experimental-utils": "2.3.3",
-    "@typescript-eslint/parser": "2.3.3",
-    "@typescript-eslint/typescript-estree": "2.3.3",
+    "@typescript-eslint/eslint-plugin": "2.6.1",
+    "@typescript-eslint/experimental-utils": "2.6.1",
+    "@typescript-eslint/parser": "2.6.1",
+    "@typescript-eslint/typescript-estree": "2.6.1",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.16.0",
-    "eslint-plugin-security": "~1.4.0"
+    "eslint-plugin-security": "~1.4.0",
+    "eslint-plugin-tsdoc": "~0.1.2"
   },
   "devDependencies": {
     "eslint": "~6.5.1",

--- a/stack/eslint-config/package.json
+++ b/stack/eslint-config/package.json
@@ -24,10 +24,10 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.6.1",
-    "@typescript-eslint/experimental-utils": "2.6.1",
-    "@typescript-eslint/parser": "2.6.1",
-    "@typescript-eslint/typescript-estree": "2.6.1",
+    "@typescript-eslint/eslint-plugin": "2.3.3",
+    "@typescript-eslint/experimental-utils": "2.3.3",
+    "@typescript-eslint/parser": "2.3.3",
+    "@typescript-eslint/typescript-estree": "2.3.3",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.16.0",
     "eslint-plugin-security": "~1.4.0",


### PR DESCRIPTION
Update `@rushstack/eslint-config` to include @bafolts's new [eslint-plugin-tsdoc](https://www.npmjs.com/package/eslint-plugin-tsdoc) for validating TSDoc comments.

The configuration will initially be "opt-in" until we've tested it more exhaustively.