### PR TITLE
Make API Extractor newlines configurable; add support for OS-default newlines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,16 +6,20 @@
   // When enabled, will trim trailing whitespace when you save a file.
   "files.trimTrailingWhitespace": true,
   // Controls if the editor should automatically close brackets after opening them
-  "editor.autoClosingBrackets": false,
+  "editor.autoClosingBrackets": "never",
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,
-    "dist": true,
-    "lib": true,
-    "lib-amd": true,
-    "temp": true,
+    "**/dist": true,
+    "**/lib": true,
+    "**/lib-amd": true,
     "**/test/**/temp": false,
-    "coverage": true
+    "**/temp": true,
+    "**/coverage": true
+  },
+  "files.associations": {
+    "**/package.json": "json",
+    "**/*.json": "jsonc"
   }
 }

--- a/apps/api-documenter/src/documenters/DocumenterConfig.ts
+++ b/apps/api-documenter/src/documenters/DocumenterConfig.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { JsonSchema, JsonFile } from '@microsoft/node-core-library';
+import { JsonSchema, JsonFile, NewlineKind } from '@microsoft/node-core-library';
 import { IConfigFile } from './IConfigFile';
 
 /**
@@ -13,6 +13,12 @@ import { IConfigFile } from './IConfigFile';
 export class DocumenterConfig {
   public readonly configFilePath: string;
   public readonly configFile: IConfigFile;
+
+  /**
+   * Specifies what type of newlines API Documenter should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.
+   */
+  public readonly newlineKind: NewlineKind;
 
   /**
    * The JSON Schema for API Extractor config file (api-extractor.schema.json).
@@ -28,6 +34,18 @@ export class DocumenterConfig {
   private constructor(filePath: string, configFile: IConfigFile) {
     this.configFilePath = filePath;
     this.configFile = configFile;
+
+    switch (configFile.newlineKind) {
+      case 'lf':
+        this.newlineKind = NewlineKind.Lf;
+        break;
+      case 'os':
+        this.newlineKind = NewlineKind.OsDefault;
+        break;
+      default:
+        this.newlineKind = NewlineKind.CrLf;
+        break;
+    }
   }
 
   /**

--- a/apps/api-documenter/src/documenters/IConfigFile.ts
+++ b/apps/api-documenter/src/documenters/IConfigFile.ts
@@ -69,13 +69,23 @@ export interface IConfigPlugin {
 }
 
 /**
- * This interface represents the api-extractor.json file format.
+ * This interface represents the api-documenter.json file format.
  */
 export interface IConfigFile {
   /**
    * Specifies the output target.
    */
   outputTarget: 'docfx' | 'markdown';
+
+  /**
+   * Specifies what type of newlines API Documenter should use when writing output files.
+   *
+   * @remarks
+   * By default, the output files will be written with Windows-style newlines.
+   * To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   */
+  newlineKind?: 'crlf' | 'lf' | 'os';
 
   /** {@inheritDoc IConfigPlugin} */
   plugins?: IConfigPlugin[];

--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -285,7 +285,7 @@ export class MarkdownDocumenter {
     }
 
     FileSystem.writeFile(filename, pageContent, {
-      convertLineEndings: NewlineKind.CrLf
+      convertLineEndings: this._documenterConfig ? this._documenterConfig.newlineKind : NewlineKind.CrLf
     });
   }
 

--- a/apps/api-documenter/src/schemas/api-documenter-template.json
+++ b/apps/api-documenter/src/schemas/api-documenter-template.json
@@ -5,6 +5,31 @@
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-documenter.schema.json",
 
   /**
+   * Specifies the output target.
+   * Supported values are "docfx" or "markdown"
+   */
+  // "outputTarget": "markdown",
+
+  /**
+   * Specifies what type of newlines API Documenter should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   *
+   * DEFAULT VALUE: "crlf"
+   */
+  // "newlineKind": "crlf",
+
+  /**
+   * Describes plugin packages to be loaded, and which features to enable.
+   */
+  "plugins": [
+    // {
+    //  "packageName": "doc-plugin-example",
+    //  "enabledFeatureNames": [ "example-feature" ]
+    // }
+  ],
+
+  /**
    * Configures how the table of contents is generated.
    */
   "tableOfContents": {

--- a/apps/api-documenter/src/schemas/api-documenter.schema.json
+++ b/apps/api-documenter/src/schemas/api-documenter.schema.json
@@ -17,6 +17,13 @@
       ]
     },
 
+    "newlineKind": {
+      "description": "Specifies what type of newlines API Documenter should use when writing output files.  By default, the output files will be written with Windows-style newlines.  To use POSIX-style newlines, specify \"lf\" instead. To use the OS's default newline kind, specify \"os\".",
+      "type": "string",
+      "enum": ["crlf", "lf", "os"],
+      "default": "crlf"
+    },
+
     "plugins": {
       "description": "Specifies plugin packages to be loaded",
       "type": "array"

--- a/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
@@ -132,7 +132,7 @@ export class PackageMetadataManager {
   /**
    * Writes the TSDoc metadata file to the specified output file.
    */
-  public static writeTsdocMetadataFile(tsdocMetadataPath: string, newlineKind: NewlineKind = NewlineKind.CrLf): void {
+  public static writeTsdocMetadataFile(tsdocMetadataPath: string, newlineKind: NewlineKind): void {
     const fileObject: JsonObject = {
       tsdocVersion: '0.12',
       toolPackages: [

--- a/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
@@ -132,7 +132,7 @@ export class PackageMetadataManager {
   /**
    * Writes the TSDoc metadata file to the specified output file.
    */
-  public static writeTsdocMetadataFile(tsdocMetadataPath: string): void {
+  public static writeTsdocMetadataFile(tsdocMetadataPath: string, newlineKind: NewlineKind = NewlineKind.CrLf): void {
     const fileObject: JsonObject = {
       tsdocVersion: '0.12',
       toolPackages: [
@@ -149,7 +149,7 @@ export class PackageMetadataManager {
       JsonFile.stringify(fileObject);
 
     FileSystem.writeFile(tsdocMetadataPath, fileContent, {
-      convertLineEndings: NewlineKind.CrLf,
+      convertLineEndings: newlineKind,
       ensureFolderExists: true
     });
   }

--- a/apps/api-extractor/src/analyzer/Span.ts
+++ b/apps/api-extractor/src/analyzer/Span.ts
@@ -489,7 +489,7 @@ export class Span {
   }
 
   private _getTrimmed(text: string): string {
-    const trimmed: string = text.replace(/[\r\n]/g, '\\n');
+    const trimmed: string = text.replace(/\r?\n/g, '\\n');
 
     if (trimmed.length > 100) {
       return trimmed.substr(0, 97) + '...';

--- a/apps/api-extractor/src/analyzer/test/PackageMetadataManager.test.ts
+++ b/apps/api-extractor/src/analyzer/test/PackageMetadataManager.test.ts
@@ -1,7 +1,7 @@
 
 import * as path from 'path';
 import { PackageMetadataManager } from '../PackageMetadataManager';
-import { FileSystem, PackageJsonLookup, INodePackageJson } from '@microsoft/node-core-library';
+import { FileSystem, PackageJsonLookup, INodePackageJson, NewlineKind } from '@microsoft/node-core-library';
 
 const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
 
@@ -40,7 +40,7 @@ describe('PackageMetadataManager', () => {
     });
 
     it('writes the tsdoc metadata file at the provided path', () => {
-      PackageMetadataManager.writeTsdocMetadataFile('/foo/bar');
+      PackageMetadataManager.writeTsdocMetadataFile('/foo/bar', NewlineKind.CrLf);
       expect(firstArgument(mockWriteFile)).toBe('/foo/bar');
     });
   });

--- a/apps/api-extractor/src/api/Extractor.ts
+++ b/apps/api-extractor/src/api/Extractor.ts
@@ -332,7 +332,8 @@ export class Extractor {
 
     if (extractorConfig.tsdocMetadataEnabled) {
       // Write the tsdoc-metadata.json file for this project
-      PackageMetadataManager.writeTsdocMetadataFile(extractorConfig.tsdocMetadataFilePath);
+      PackageMetadataManager.writeTsdocMetadataFile(
+        extractorConfig.tsdocMetadataFilePath, extractorConfig.newlineKind);
     }
 
     // Show all the messages that we collected during analysis

--- a/apps/api-extractor/src/api/Extractor.ts
+++ b/apps/api-extractor/src/api/Extractor.ts
@@ -234,7 +234,7 @@ export class Extractor {
         toolPackage: Extractor.packageName,
         toolVersion: Extractor.version,
 
-        newlineConversion: NewlineKind.CrLf,
+        newlineConversion: extractorConfig.newlineKind,
         ensureFolderExists: true,
         testMode: extractorConfig.testMode
       });
@@ -254,7 +254,7 @@ export class Extractor {
       // Write the actual file
       FileSystem.writeFile(actualApiReportPath, actualApiReportContent, {
         ensureFolderExists: true,
-        convertLineEndings: NewlineKind.CrLf
+        convertLineEndings: extractorConfig.newlineKind
       });
 
       // Compare it against the expected file
@@ -279,7 +279,7 @@ export class Extractor {
 
             FileSystem.writeFile(expectedApiReportPath, actualApiReportContent, {
               ensureFolderExists: true,
-              convertLineEndings: NewlineKind.CrLf
+              convertLineEndings: extractorConfig.newlineKind
             });
           }
        } else {
@@ -310,7 +310,7 @@ export class Extractor {
             );
           } else {
             FileSystem.writeFile(expectedApiReportPath, actualApiReportContent, {
-              convertLineEndings: NewlineKind.CrLf
+              convertLineEndings: extractorConfig.newlineKind
             });
             messageRouter.logWarning(ConsoleMessageId.ApiReportCreated,
               'The API report file was missing, so a new file was created. Please add this file to Git:\n'
@@ -322,9 +322,12 @@ export class Extractor {
     }
 
     if (extractorConfig.rollupEnabled) {
-      Extractor._generateRollupDtsFile(collector, extractorConfig.publicTrimmedFilePath, DtsRollupKind.PublicRelease);
-      Extractor._generateRollupDtsFile(collector, extractorConfig.betaTrimmedFilePath, DtsRollupKind.BetaRelease);
-      Extractor._generateRollupDtsFile(collector, extractorConfig.untrimmedFilePath, DtsRollupKind.InternalRelease);
+      Extractor._generateRollupDtsFile(
+        collector, extractorConfig.publicTrimmedFilePath, DtsRollupKind.PublicRelease, extractorConfig.newlineKind);
+      Extractor._generateRollupDtsFile(
+        collector, extractorConfig.betaTrimmedFilePath, DtsRollupKind.BetaRelease, extractorConfig.newlineKind);
+      Extractor._generateRollupDtsFile(
+        collector, extractorConfig.untrimmedFilePath, DtsRollupKind.InternalRelease, extractorConfig.newlineKind);
     }
 
     if (extractorConfig.tsdocMetadataEnabled) {
@@ -355,10 +358,12 @@ export class Extractor {
     });
   }
 
-  private static _generateRollupDtsFile(collector: Collector, outputPath: string, dtsKind: DtsRollupKind): void {
+  private static _generateRollupDtsFile(
+    collector: Collector, outputPath: string, dtsKind: DtsRollupKind, newlineKind: NewlineKind
+  ): void {
     if (outputPath !== '') {
       collector.messageRouter.logVerbose(ConsoleMessageId.WritingDtsRollup, `Writing package typings: ${outputPath}`);
-      DtsRollupGenerator.writeTypingsFile(collector, outputPath, dtsKind);
+      DtsRollupGenerator.writeTypingsFile(collector, outputPath, dtsKind, newlineKind);
     }
   }
 }

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -197,7 +197,10 @@ export class ExtractorConfig {
   /** {@inheritDoc IConfigTsdocMetadata.tsdocMetadataFilePath} */
   public readonly tsdocMetadataFilePath: string;
 
-  /** {@inheritDoc IConfigFile.newlineKind} */
+  /**
+   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.
+   */
   public readonly newlineKind: NewlineKind;
 
   /** {@inheritDoc IConfigFile.messages} */
@@ -661,10 +664,10 @@ export class ExtractorConfig {
 
       let newlineKind: NewlineKind;
       switch (configObject.newlineKind) {
-        case 'Lf':
+        case 'lf':
           newlineKind = NewlineKind.Lf;
           break;
-        case 'OsDefault':
+        case 'os':
           newlineKind = NewlineKind.OsDefault;
           break;
         default:

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -14,7 +14,8 @@ import {
   PackageName,
   Text,
   InternalError,
-  Path
+  Path,
+  NewlineKind
 } from '@microsoft/node-core-library';
 import {
   IConfigFile,
@@ -111,6 +112,7 @@ interface IExtractorConfigParameters {
   omitTrimmingComments: boolean;
   tsdocMetadataEnabled: boolean;
   tsdocMetadataFilePath: string;
+  newlineKind: string;
   messages: IExtractorMessagesConfig;
   testMode: boolean;
 }
@@ -194,6 +196,9 @@ export class ExtractorConfig {
   public readonly tsdocMetadataEnabled: boolean;
   /** {@inheritDoc IConfigTsdocMetadata.tsdocMetadataFilePath} */
   public readonly tsdocMetadataFilePath: string;
+
+  /** {@inheritDoc IConfigFile.newlineKind} */
+  public readonly newlineKind: NewlineKind;
 
   /** {@inheritDoc IConfigFile.messages} */
   public readonly messages: IExtractorMessagesConfig;
@@ -654,6 +659,19 @@ export class ExtractorConfig {
         omitTrimmingComments = !!configObject.dtsRollup.omitTrimmingComments;
       }
 
+      let newlineKind: NewlineKind;
+      switch (configObject.newlineKind) {
+        case 'Lf':
+          newlineKind = NewlineKind.Lf;
+          break;
+        case 'OsDefault':
+          newlineKind = NewlineKind.OsDefault;
+          break;
+        default:
+          newlineKind = NewlineKind.CrLf;
+          break;
+      }
+
       return new ExtractorConfig({
         projectFolder: projectFolder,
         packageJson,
@@ -675,6 +693,7 @@ export class ExtractorConfig {
         omitTrimmingComments,
         tsdocMetadataEnabled,
         tsdocMetadataFilePath,
+        newlineKind,
         messages: configObject.messages || { },
         testMode: !!configObject.testMode
       });

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -368,9 +368,12 @@ export interface IConfigFile {
   tsdocMetadata?: IConfigTsdocMetadata;
 
   /**
-   * Specifies the type of newline to use in all generated files.
+   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   * @defaultValue 'crlf'
    */
-  newlineKind?: 'CrLf' | 'Lf' | 'OsDefault';
+  newlineKind?: 'crlf' | 'lf' | 'os';
 
   /**
    * {@inheritDoc IExtractorMessagesConfig}

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -368,10 +368,12 @@ export interface IConfigFile {
   tsdocMetadata?: IConfigTsdocMetadata;
 
   /**
-   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
-   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * Specifies what type of newlines API Extractor should use when writing output files.
+   *
+   * @remarks
+   * By default, the output files will be written with Windows-style newlines.
+   * To use POSIX-style newlines, specify "lf" instead.
    * To use the OS's default newline kind, specify "os".
-   * @defaultValue 'crlf'
    */
   newlineKind?: 'crlf' | 'lf' | 'os';
 

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -368,6 +368,11 @@ export interface IConfigFile {
   tsdocMetadata?: IConfigTsdocMetadata;
 
   /**
+   * Specifies the type of newline to use in all generated files.
+   */
+  newlineKind?: 'CrLf' | 'Lf' | 'OsDefault';
+
+  /**
    * {@inheritDoc IExtractorMessagesConfig}
    */
   messages?: IExtractorMessagesConfig;

--- a/apps/api-extractor/src/generators/ApiReportGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiReportGenerator.ts
@@ -18,6 +18,8 @@ import { StringWriter } from './StringWriter';
 import { DtsEmitHelpers } from './DtsEmitHelpers';
 
 export class ApiReportGenerator {
+  private static _TrimSpacesRegExp: RegExp = / +$/gm;
+
   /**
    * Compares the contents of two API files that were created using ApiFileGenerator,
    * and returns true if they are equivalent.  Note that these files are not normally edited
@@ -155,7 +157,7 @@ export class ApiReportGenerator {
     stringWriter.writeLine('\n```');
 
     // Remove any trailing spaces
-    return stringWriter.toString().replace(/ +$/gm, '');
+    return stringWriter.toString().replace(ApiReportGenerator._TrimSpacesRegExp, '');
   }
 
   /**

--- a/apps/api-extractor/src/generators/ApiReportGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiReportGenerator.ts
@@ -154,7 +154,8 @@ export class ApiReportGenerator {
     // Write the closing delimiter for the Markdown code fence
     stringWriter.writeLine('\n```');
 
-    return stringWriter.toString();
+    // Remove any trailing spaces
+    return stringWriter.toString().replace(/ +$/gm, '');
   }
 
   /**

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -50,13 +50,15 @@ export class DtsRollupGenerator {
    *
    * @param dtsFilename    - The *.d.ts output filename
    */
-  public static writeTypingsFile(collector: Collector, dtsFilename: string, dtsKind: DtsRollupKind): void {
+  public static writeTypingsFile(
+    collector: Collector, dtsFilename: string, dtsKind: DtsRollupKind, newlineKind: NewlineKind = NewlineKind.CrLf
+  ): void {
     const stringWriter: StringWriter = new StringWriter();
 
     DtsRollupGenerator._generateTypingsFileContent(collector, stringWriter, dtsKind);
 
     FileSystem.writeFile(dtsFilename, stringWriter.toString(), {
-      convertLineEndings: NewlineKind.CrLf,
+      convertLineEndings: newlineKind,
       ensureFolderExists: true
     });
   }
@@ -238,7 +240,7 @@ export class DtsRollupGenerator {
             // (which may possibly contain multiple variable declarations), so it's not part of the Span.
             // Instead we need to manually inject it.
             let originalComment: string = declarationMetadata.tsdocParserContext.sourceRange.toString();
-            if (!/[\r\n]\s*$/.test(originalComment)) {
+            if (!/\r?\n\s*$/.test(originalComment)) {
               originalComment += '\n';
             }
             span.modification.prefix = originalComment + span.modification.prefix;

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -51,7 +51,7 @@ export class DtsRollupGenerator {
    * @param dtsFilename    - The *.d.ts output filename
    */
   public static writeTypingsFile(
-    collector: Collector, dtsFilename: string, dtsKind: DtsRollupKind, newlineKind: NewlineKind = NewlineKind.CrLf
+    collector: Collector, dtsFilename: string, dtsKind: DtsRollupKind, newlineKind: NewlineKind
   ): void {
     const stringWriter: StringWriter = new StringWriter();
 

--- a/apps/api-extractor/src/schemas/api-extractor-defaults.json
+++ b/apps/api-extractor/src/schemas/api-extractor-defaults.json
@@ -5,6 +5,8 @@
 
   "bundledPackages": [ ],
 
+  "newlineKind": "crlf",
+
   "compiler": {
     "tsconfigFilePath": "<projectFolder>/tsconfig.json",
     "skipLibCheck": false

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -264,6 +264,15 @@
   },
 
   /**
+   * Specifies the type of newline to use in all generated files.
+   *
+   * Supported values are "CrLf", "Lf", or "OsDefault".
+   *
+   * DEFAULT VALUE: "CrLf"
+   */
+  // "newlineKind": "CrLf",
+
+  /**
    * Configures how API Extractor reports error and warning messages produced during analysis.
    *
    * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -264,13 +264,13 @@
   },
 
   /**
-   * Specifies the type of newline to use in all generated files.
+   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
    *
-   * Supported values are "CrLf", "Lf", or "OsDefault".
-   *
-   * DEFAULT VALUE: "CrLf"
+   * DEFAULT VALUE: "crlf"
    */
-  // "newlineKind": "CrLf",
+  // "newlineKind": "crlf",
 
   /**
    * Configures how API Extractor reports error and warning messages produced during analysis.

--- a/apps/api-extractor/src/schemas/api-extractor.schema.json
+++ b/apps/api-extractor/src/schemas/api-extractor.schema.json
@@ -143,10 +143,10 @@
     },
 
     "newlineKind": {
-      "description": "Specifies the type of newline to use in all generated files.",
+      "description": "Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files will be written with Windows-style newlines.  To use POSIX-style newlines, specify \"lf\" instead. To use the OS's default newline kind, specify \"os\".",
       "type": "string",
-      "enum": ["CrLf", "Lf", "OsDefault"],
-      "default": "CrLf"
+      "enum": ["crlf", "lf", "os"],
+      "default": "crlf"
     },
 
     "messages": {

--- a/apps/api-extractor/src/schemas/api-extractor.schema.json
+++ b/apps/api-extractor/src/schemas/api-extractor.schema.json
@@ -142,6 +142,13 @@
       "additionalProperties": false
     },
 
+    "newlineKind": {
+      "description": "Specifies the type of newline to use in all generated files.",
+      "type": "string",
+      "enum": ["CrLf", "Lf", "OsDefault"],
+      "default": "CrLf"
+    },
+
     "messages": {
       "description": "Configures how API Extractor reports error and warning messages produced during analysis.",
       "type": "object",

--- a/build-tests/api-documenter-test/config/api-documenter.json
+++ b/build-tests/api-documenter-test/config/api-documenter.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-documenter.schema.json",
 
+  "newlineKind": "crlf",
+
   "tableOfContents": {
     "tocConfig": {
       "items": [

--- a/build-tests/api-documenter-test/config/api-extractor.json
+++ b/build-tests/api-documenter-test/config/api-extractor.json
@@ -3,6 +3,8 @@
 
   "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
+  "newlineKind": "crlf",
+
   "apiReport": {
     "enabled": true,
   },

--- a/common/changes/@microsoft/api-documenter/os-default-eol_2019-11-12-23-24.json
+++ b/common/changes/@microsoft/api-documenter/os-default-eol_2019-11-12-23-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Make newline type for generated files configurable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/os-default-eol_2019-11-12-22-09.json
+++ b/common/changes/@microsoft/api-extractor/os-default-eol_2019-11-12-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Make newline type for generated files configurable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/os-default-eol_2019-11-12-22-09.json
+++ b/common/changes/@microsoft/node-core-library/os-default-eol_2019-11-12-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add NewlineKind.OsDefault and fix some comments",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -6,6 +6,7 @@
 
 import { INodePackageJson } from '@microsoft/node-core-library';
 import { JsonSchema } from '@microsoft/node-core-library';
+import { NewlineKind } from '@microsoft/node-core-library';
 import * as tsdoc from '@microsoft/tsdoc';
 
 // @public
@@ -52,6 +53,7 @@ export class ExtractorConfig {
     static loadFileAndPrepare(configJsonFilePath: string): ExtractorConfig;
     readonly mainEntryPointFilePath: string;
     readonly messages: IExtractorMessagesConfig;
+    readonly newlineKind: NewlineKind;
     readonly omitTrimmingComments: boolean;
     readonly overrideTsconfig: {} | undefined;
     readonly packageFolder: string | undefined;
@@ -184,6 +186,7 @@ export interface IConfigFile {
     extends?: string;
     mainEntryPointFilePath: string;
     messages?: IExtractorMessagesConfig;
+    newlineKind?: 'CrLf' | 'Lf' | 'OsDefault';
     projectFolder?: string;
     testMode?: boolean;
     // @beta

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -186,7 +186,7 @@ export interface IConfigFile {
     extends?: string;
     mainEntryPointFilePath: string;
     messages?: IExtractorMessagesConfig;
-    newlineKind?: 'CrLf' | 'Lf' | 'OsDefault';
+    newlineKind?: 'crlf' | 'lf' | 'os';
     projectFolder?: string;
     testMode?: boolean;
     // @beta

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -414,7 +414,8 @@ export class MapExtensions {
 // @public
 export const enum NewlineKind {
     CrLf = "\r\n",
-    Lf = "\n"
+    Lf = "\n",
+    OsDefault = "os"
 }
 
 // @public
@@ -538,6 +539,7 @@ export enum TerminalProviderSeverity {
 export class Text {
     static convertToCrLf(input: string): string;
     static convertToLf(input: string): string;
+    static convertToOsDefault(input: string): string;
     static ensureTrailingNewline(s: string, newlineKind?: NewlineKind): string;
     static padEnd(s: string, minimumLength: number, paddingCharacter?: string): string;
     static padStart(s: string, minimumLength: number, paddingCharacter?: string): string;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -537,9 +537,9 @@ export enum TerminalProviderSeverity {
 
 // @public
 export class Text {
+    static convertTo(input: string, newlineKind: NewlineKind): string;
     static convertToCrLf(input: string): string;
     static convertToLf(input: string): string;
-    static convertToOsDefault(input: string): string;
     static ensureTrailingNewline(s: string, newlineKind?: NewlineKind): string;
     static padEnd(s: string, minimumLength: number, paddingCharacter?: string): string;
     static padStart(s: string, minimumLength: number, paddingCharacter?: string): string;

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -18,7 +18,7 @@ import { PosixModeBits } from './PosixModeBits';
 export interface IFileSystemReadFolderOptions {
   /**
    * If true, returns the absolute paths of the files in the folder.
-   * Defaults to `false`.
+   * @defaultValue false
    */
   absolutePaths?: boolean;
 }
@@ -36,13 +36,13 @@ export interface IFileSystemWriteFileOptions {
 
   /**
    * If specified, will normalize line endings to the specified style of newline.
-   * @defaultValue undefined
+   * @defaultValue `undefined` which means no conversion will be performed
    */
   convertLineEndings?: NewlineKind;
 
   /**
    * If specified, will change the encoding of the file that will be written.
-   * Defaults to `"utf8"`.
+   * @defaultValue "utf8"
    */
   encoding?: Encoding;
 }
@@ -60,7 +60,7 @@ export interface IFileSystemReadFileOptions {
 
   /**
    * If specified, will normalize line endings to the specified style of newline.
-   * @defaultValue undefined
+   * @defaultValue `undefined` which means no conversion will be performed
    */
   convertLineEndings?: NewlineKind;
 }
@@ -370,7 +370,9 @@ export class FileSystem {
       FileSystem.ensureFolder(folderPath);
     }
 
-    contents = FileSystem._convertLineEndings(contents.toString(), options.convertLineEndings);
+    if (options.convertLineEndings) {
+      contents = Text.convertTo(contents.toString(), options.convertLineEndings);
+    }
 
     fsx.writeFileSync(filePath, contents, { encoding: options.encoding });
   }
@@ -397,7 +399,9 @@ export class FileSystem {
       FileSystem.ensureFolder(folderPath);
     }
 
-    contents = FileSystem._convertLineEndings(contents.toString(), options.convertLineEndings);
+    if (options.convertLineEndings) {
+      contents = Text.convertTo(contents.toString(), options.convertLineEndings);
+    }
 
     fsx.appendFileSync(filePath, contents, { encoding: options.encoding });
   }
@@ -415,8 +419,11 @@ export class FileSystem {
       ...options
     };
 
-    const contents: string = FileSystem.readFileToBuffer(filePath).toString(options.encoding);
-    return FileSystem._convertLineEndings(contents, options.convertLineEndings);
+    let contents: string = FileSystem.readFileToBuffer(filePath).toString(options.encoding);
+    if (options.convertLineEndings) {
+      contents = Text.convertTo(contents, options.convertLineEndings);
+    }
+    return contents;
   }
 
   /**
@@ -513,23 +520,5 @@ export class FileSystem {
    */
   public static getRealPath(linkPath: string): string {
     return fsx.realpathSync(linkPath);
-  }
-
-  /**
-   * A helper function that converts line endings on a string.
-   * @param text - The text to be normalized.
-   * @param lineEndings - The style of line endings to use.
-   */
-  private static _convertLineEndings(text: string, lineEndings: NewlineKind | undefined): string {
-    switch (lineEndings) {
-      case NewlineKind.CrLf:
-        return Text.convertToCrLf(text);
-      case NewlineKind.Lf:
-        return Text.convertToLf(text);
-      case NewlineKind.OsDefault:
-        return Text.convertToOsDefault(text);
-      default:
-        return text;
-    }
   }
 }

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -30,13 +30,13 @@ export interface IFileSystemReadFolderOptions {
 export interface IFileSystemWriteFileOptions {
   /**
    * If true, will ensure the folder is created before writing the file.
-   * Defaults to `false`.
+   * @defaultValue false
    */
   ensureFolderExists?: boolean;
 
   /**
    * If specified, will normalize line endings to the specified style of newline.
-   * Defaults to `NewlineKind.None`.
+   * @defaultValue undefined
    */
   convertLineEndings?: NewlineKind;
 
@@ -54,13 +54,13 @@ export interface IFileSystemWriteFileOptions {
 export interface IFileSystemReadFileOptions {
   /**
    * If specified, will change the encoding of the file that will be written.
-   * Defaults to `"utf8"`.
+   * @defaultValue Encoding.Utf8
    */
   encoding?: Encoding;
 
   /**
    * If specified, will normalize line endings to the specified style of newline.
-   * Defaults to `NewlineKind.None`.
+   * @defaultValue undefined
    */
   convertLineEndings?: NewlineKind;
 }
@@ -83,13 +83,14 @@ export interface IFileSystemMoveOptions {
   destinationPath: string;
 
   /**
-   * If true, will overwrite the file if it already exists. Defaults to true.
+   * If true, will overwrite the file if it already exists.
+   * @defaultValue true
    */
   overwrite?: boolean;
 
   /**
    * If true, will ensure the folder is created before writing the file.
-   * Defaults to `false`.
+   * @defaultValue false
    */
   ensureFolderExists?: boolean;
 }
@@ -119,7 +120,7 @@ export interface IFileSystemCopyFileOptions {
 export interface IFileSystemDeleteFileOptions {
   /**
    * If true, will throw an exception if the file did not exist before `deleteFile()` was called.
-   * Defaults to `false`.
+   * @defaultValue false
    */
   throwIfNotExists?: boolean;
 }
@@ -525,6 +526,8 @@ export class FileSystem {
         return Text.convertToCrLf(text);
       case NewlineKind.Lf:
         return Text.convertToLf(text);
+      case NewlineKind.OsDefault:
+        return Text.convertToOsDefault(text);
       default:
         return text;
     }

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -157,14 +157,7 @@ export class JsonFile {
     stringified = Text.ensureTrailingNewline(stringified);
 
     if (options && options.newlineConversion) {
-      switch (options.newlineConversion) {
-        case NewlineKind.CrLf:
-          return Text.convertToCrLf(stringified);
-        case NewlineKind.Lf:
-          return Text.convertToLf(stringified);
-        case NewlineKind.OsDefault:
-          return Text.convertToOsDefault(stringified);
-      }
+      stringified = Text.convertTo(stringified, options.newlineConversion);
     }
 
     return stringified;

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -27,7 +27,7 @@ export type JsonObject = any;
  */
 export interface IJsonFileStringifyOptions {
   /**
-   * If true, then `\n` will be used for newlines instead of the default `\r\n`.
+   * If provided, the specified newline type will be used instead of the default `\r\n`.
    */
   newlineConversion?: NewlineKind;
 
@@ -162,6 +162,8 @@ export class JsonFile {
           return Text.convertToCrLf(stringified);
         case NewlineKind.Lf:
           return Text.convertToLf(stringified);
+        case NewlineKind.OsDefault:
+          return Text.convertToOsDefault(stringified);
       }
     }
 

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -76,10 +76,11 @@ export class Text {
   }
 
   /**
-   * Converts all newlines in the provided string to use the default newline type for this operating system.
+   * Converts all newlines in the provided string to use the specified newline type.
    */
-  public static convertToOsDefault(input: string): string {
-    return input.replace(Text._newLineRegEx, os.EOL);
+  public static convertTo(input: string, newlineKind: NewlineKind): string {
+    const newline: string = newlineKind === NewlineKind.OsDefault ? os.EOL : newlineKind as string;
+    return input.replace(Text._newLineRegEx, newline);
   }
 
   /**

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as os from 'os';
+
 /**
  * The allowed types of encodings, as supported by Node.js
  * @public
@@ -25,7 +27,12 @@ export const enum NewlineKind {
    * @remarks
    * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
    */
-  Lf = '\n'
+  Lf = '\n',
+
+  /**
+   * Default newline type for this operating system (`os.EOL`).
+   */
+  OsDefault = 'os'
 }
 
 /**
@@ -66,6 +73,13 @@ export class Text {
    */
   public static convertToLf(input: string): string {
     return input.replace(Text._newLineRegEx, '\n');
+  }
+
+  /**
+   * Converts all newlines in the provided string to use the default newline type for this operating system.
+   */
+  public static convertToOsDefault(input: string): string {
+    return input.replace(Text._newLineRegEx, os.EOL);
   }
 
   /**


### PR DESCRIPTION
### API Extractor

- Add a `newlineKind` option, which determines the type of newline used in all generated files. Options are `crlf` (default), `lf`, and (new) `os`. Fixes #1366.
- Trim trailing spaces from API rollup files, to prevent spurious diffs if the file is ever edited manually and the user has their editor configured to trim trailing spaces.
- Change some regexes which were checking for `[\r\n]` to check for `\r?\n` instead, so that any replacement is only applied once per actual newline.

### API Documenter

Same as API Extractor.

### node-core-library

- Add `NewlineKind.OsDefault` (and related conversion methods) to use the default newline kind for the operating system, as determined by `os.EOL`. This is always opt-in.
- Fix some doc comments

### Dev experience

Fix the VS Code settings to exclude generated files in all subfolders and use commented JSON syntax for all JSON files (except package.json) by default.