### PR TITLE
API Extractor: Add support for custom TSDoc tags

### DIFF
--- a/apps/api-extractor-model/src/aedoc/AedocDefinitions.ts
+++ b/apps/api-extractor-model/src/aedoc/AedocDefinitions.ts
@@ -27,44 +27,56 @@ export class AedocDefinitions {
     syntaxKind: TSDocTagSyntaxKind.ModifierTag
   });
 
+  /**
+   * @deprecated Use `AedocDefinitions.getTsdocConfiguration()` instead, to allow customization of supported tags
+   * without polluting a global object.
+   */
   public static get tsdocConfiguration(): TSDocConfiguration {
     if (!AedocDefinitions._tsdocConfiguration) {
-      const configuration: TSDocConfiguration = new TSDocConfiguration();
-      configuration.addTagDefinitions([
-        AedocDefinitions.betaDocumentation,
-        AedocDefinitions.internalRemarks,
-        AedocDefinitions.preapprovedTag
-      ], true);
-
-      configuration.setSupportForTags(
-        [
-          StandardTags.alpha,
-          StandardTags.beta,
-          StandardTags.defaultValue,
-          StandardTags.deprecated,
-          StandardTags.eventProperty,
-          StandardTags.example,
-          StandardTags.inheritDoc,
-          StandardTags.internal,
-          StandardTags.link,
-          StandardTags.override,
-          StandardTags.packageDocumentation,
-          StandardTags.param,
-          StandardTags.privateRemarks,
-          StandardTags.public,
-          StandardTags.readonly,
-          StandardTags.remarks,
-          StandardTags.returns,
-          StandardTags.sealed,
-          StandardTags.virtual
-        ],
-        true
-      );
-
-      AedocDefinitions._tsdocConfiguration = configuration;
+      AedocDefinitions._tsdocConfiguration = AedocDefinitions.getTsdocConfiguration([]);
     }
     return AedocDefinitions._tsdocConfiguration;
   }
 
   private static _tsdocConfiguration: TSDocConfiguration | undefined;
+
+  /**
+   * Gets a TSDoc configuration, optionally with additional supported tags.
+   */
+  public static getTsdocConfiguration(additionalTags: ReadonlyArray<TSDocTagDefinition> = []): TSDocConfiguration {
+    const configuration: TSDocConfiguration = new TSDocConfiguration();
+    configuration.addTagDefinitions([
+      AedocDefinitions.betaDocumentation,
+      AedocDefinitions.internalRemarks,
+      AedocDefinitions.preapprovedTag,
+      ...additionalTags
+    ], true);
+
+    configuration.setSupportForTags(
+      [
+        StandardTags.alpha,
+        StandardTags.beta,
+        StandardTags.defaultValue,
+        StandardTags.deprecated,
+        StandardTags.eventProperty,
+        StandardTags.example,
+        StandardTags.inheritDoc,
+        StandardTags.internal,
+        StandardTags.link,
+        StandardTags.override,
+        StandardTags.packageDocumentation,
+        StandardTags.param,
+        StandardTags.privateRemarks,
+        StandardTags.public,
+        StandardTags.readonly,
+        StandardTags.remarks,
+        StandardTags.returns,
+        StandardTags.sealed,
+        StandardTags.virtual
+      ],
+      true
+    );
+
+    return configuration;
+  }
 }

--- a/apps/api-extractor-model/src/items/ApiDocumentedItem.ts
+++ b/apps/api-extractor-model/src/items/ApiDocumentedItem.ts
@@ -3,7 +3,6 @@
 
 import * as tsdoc from '@microsoft/tsdoc';
 import { ApiItem, IApiItemOptions, IApiItemJson } from './ApiItem';
-import { AedocDefinitions } from '../aedoc/AedocDefinitions';
 import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
@@ -45,7 +44,7 @@ export class ApiDocumentedItem extends ApiItem {
     const documentedJson: IApiDocumentedItemJson = jsonObject as IApiDocumentedItemJson;
 
     if (documentedJson.docComment) {
-      const tsdocParser: tsdoc.TSDocParser = new tsdoc.TSDocParser(AedocDefinitions.tsdocConfiguration);
+      const tsdocParser: tsdoc.TSDocParser = new tsdoc.TSDocParser(context.tsdocConfig);
 
       // NOTE: For now, we ignore TSDoc errors found in a serialized .api.json file.
       // Normally these errors would have already been reported by API Extractor during analysis.

--- a/apps/api-extractor-model/src/model/ApiPackage.ts
+++ b/apps/api-extractor-model/src/model/ApiPackage.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { DeclarationReference } from '@microsoft/tsdoc/lib/beta/DeclarationReference';
+import * as tsdoc from '@microsoft/tsdoc';
 import { ApiItem, ApiItemKind, IApiItemJson } from '../items/ApiItem';
 import { ApiItemContainerMixin, IApiItemContainerMixinOptions } from '../mixins/ApiItemContainerMixin';
 import { JsonFile, IJsonFileSaveOptions, PackageJsonLookup, IPackageJson } from '@microsoft/node-core-library';
@@ -106,7 +107,7 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
     super(options);
   }
 
-  public static loadFromJsonFile(apiJsonFilename: string): ApiPackage {
+  public static loadFromJsonFile(apiJsonFilename: string, tsdocConfig?: tsdoc.TSDocConfiguration): ApiPackage {
     const jsonObject: IApiPackageJson = JsonFile.load(apiJsonFilename);
 
     if (!jsonObject
@@ -152,7 +153,8 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
       apiJsonFilename,
       toolPackage: jsonObject.metadata.toolPackage,
       toolVersion: jsonObject.metadata.toolVersion,
-      versionToDeserialize: versionToDeserialize
+      versionToDeserialize: versionToDeserialize,
+      tsdocConfig
     });
 
     return ApiItem.deserialize(jsonObject, context) as ApiPackage;

--- a/apps/api-extractor-model/src/model/DeserializerContext.ts
+++ b/apps/api-extractor-model/src/model/DeserializerContext.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as tsdoc from '@microsoft/tsdoc';
+
 export enum ApiJsonSchemaVersion {
   /**
    * The initial release.
@@ -72,10 +74,16 @@ export class DeserializerContext {
    */
   public readonly versionToDeserialize: ApiJsonSchemaVersion;
 
+  /**
+   * TSDoc configuration to use when deserializing documentation comments.
+   */
+  public readonly tsdocConfig?: tsdoc.TSDocConfiguration;
+
   public constructor(options: DeserializerContext) {
     this.apiJsonFilename = options.apiJsonFilename;
     this.toolPackage = options.toolPackage;
     this.toolVersion = options.toolVersion;
     this.versionToDeserialize = options.versionToDeserialize;
+    this.tsdocConfig = options.tsdocConfig;
   }
 }

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -209,6 +209,53 @@ export interface IConfigTsdocMetadata {
 }
 
 /**
+ * Additional tags to support when parsing documentation comments with TSDoc.
+ *
+ * @remarks
+ * This is part of the {@link IConfigFile} structure.
+
+ * @public
+ */
+export interface IConfigTsdocTagDefinition {
+  /**
+   * Name of the custom tag. TSDoc tag names start with an at-sign (`@`) followed
+   * by ASCII letters using "camelCase" capitalization.
+   */
+  tagName: string;
+
+  /**
+   * Syntax kind of the custom tag.
+   *
+   * @remarks
+   * `"inline"` means that this tag can appear inside other documentation sections (example: `{@link}`).
+   * `"block"` means that this tag starts a new documentation section (example: `@remarks`).
+   * `"modifier"` means that this tag's presence indicates an aspect of the associated API item (example: `@internal`).
+   */
+  syntaxKind: 'inline' | 'block' | 'modifier';
+
+  /**
+   * If true, then this tag may appear multiple times in a doc comment.
+   * By default, a tag may only appear once.
+   */
+  allowMultiple?: boolean;
+}
+
+/**
+ * Custom configuration for TSDoc, including custom supported tags.
+ *
+ * @remarks
+ * This is part of the {@link IConfigFile} structure.
+
+ * @public
+ */
+export interface IConfigTsdoc {
+  /**
+   * {@inheritDoc IConfigTsdocTagDefinition}
+   */
+  tagDefinitions?: ReadonlyArray<IConfigTsdocTagDefinition>;
+}
+
+/**
  * Configures reporting for a given message identifier.
  *
  * @remarks
@@ -366,6 +413,11 @@ export interface IConfigFile {
    * @beta
    */
   tsdocMetadata?: IConfigTsdocMetadata;
+
+  /**
+   * {@inheritDoc IConfigTsdoc}
+   */
+  tsdoc?: IConfigTsdoc;
 
   /**
    * {@inheritDoc IExtractorMessagesConfig}

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -112,7 +112,7 @@ export class Collector {
     this.program = options.program;
     this.typeChecker = options.program.getTypeChecker();
 
-    this._tsdocParser = new tsdoc.TSDocParser(AedocDefinitions.tsdocConfiguration);
+    this._tsdocParser = new tsdoc.TSDocParser(this.extractorConfig.tsdocConfig);
 
     const bundledPackageNames: Set<string> = new Set<string>(this.extractorConfig.bundledPackages);
 

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -264,6 +264,40 @@
   },
 
   /**
+   * Custom configuration for TSDoc, including custom supported tags.
+   */
+  "tsdoc": {
+    /**
+     * Additional tags to support when parsing documentation comments with TSDoc.
+     */
+    "tagDefinitions": [
+      // {
+        /**
+         * Name of the custom tag (required). TSDoc tag names start with an at-sign (`@`) followed
+         * by ASCII letters using "camelCase" capitalization.
+         */
+        // "tagName": "@default",
+
+        /**
+         * Syntax kind of the custom tag (required).
+         *
+         * Possible values:
+         * - "inline" means that this tag can appear inside other documentation sections (example: `{@link}`).
+         * - "block" means that this tag starts a new documentation section (example: `@remarks`).
+         * - "modifier" means that this tag's presence indicates an aspect of the associated API item (example: `@internal`).
+         */
+        // "syntaxKind": "block",
+
+        /**
+         * If true, then this tag may appear multiple times in a doc comment.
+         * By default, a tag may only appear once.
+         */
+        // "allowMultiple": false
+      // }
+    ]
+  },
+
+  /**
    * Configures how API Extractor reports error and warning messages produced during analysis.
    *
    * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.

--- a/apps/api-extractor/src/schemas/api-extractor.schema.json
+++ b/apps/api-extractor/src/schemas/api-extractor.schema.json
@@ -142,6 +142,21 @@
       "additionalProperties": false
     },
 
+    "tsdoc": {
+      "description": "Custom configuration for TSDoc.",
+      "type": "object",
+      "properties": {
+        "tagDefinitions": {
+          "description": "Additional tags to support when parsing documentation comments with TSDoc.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tsdocTagDefinition"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "messages": {
       "description": "Configures how API Extractor reports error and warning messages produced during analysis.",
       "type": "object",
@@ -171,6 +186,28 @@
   "additionalProperties": false,
 
   "definitions": {
+    "tsdocTagDefinition": {
+      "description": "Configuration for a custom supported TSDoc tag.",
+      "type": "object",
+      "properties": {
+        "tagName": {
+          "description": "Name of the custom tag. TSDoc tag names start with an at-sign (@) followed by ASCII letters using camelCase capitalization.",
+          "type": "string"
+        },
+        "syntaxKind": {
+          "description": "Syntax kind of the custom tag. \"inline\" means that this tag can appear inside other documentation sections (example: {@link}). \"block\" means that this tag starts a new documentation section (example: @remarks). \"modifier\" means that this tag's presence indicates an aspect of the associated API item (example: @internal).",
+          "type": "string",
+          "enum": ["inline", "block", "modifier"]
+        },
+        "allowMultiple": {
+          "description": "If true, then this tag may appear multiple times in a doc comment. By default, a tag may only appear once.",
+          "type": "boolean"
+        }
+      },
+      "required": ["tagName", "syntaxKind"],
+      "additionalProperties": false
+    },
+
     "extractorMessageReportingTable": {
       "type":"object",
       "description": "Specifies a table of reporting rules for different message identifiers, and also the default rule used for identifiers that do not appear in the table. The key is a message identifier for the associated type of message, or \"default\" to specify the default policy. For example, the key might be \"TS2551\" (a compiler message), \"tsdoc-link-tag-unescaped-text\" (a TSDOc message), or \"ae-extra-release-tag\" (a message related to the API Extractor analysis).",

--- a/common/changes/@microsoft/api-extractor-model/custom-tags_2019-11-13-02-57.json
+++ b/common/changes/@microsoft/api-extractor-model/custom-tags_2019-11-13-02-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Add support for custom TSDoc tags",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/custom-tags_2019-11-13-02-57.json
+++ b/common/changes/@microsoft/api-extractor/custom-tags_2019-11-13-02-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add support for custom TSDoc tags",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { DeclarationReference } from '@microsoft/tsdoc/lib/beta/DeclarationReference';
-import { DocDeclarationReference } from '@microsoft/tsdoc';
 import { IJsonFileSaveOptions } from '@microsoft/node-core-library';
 import * as tsdoc from '@microsoft/tsdoc';
 import { TSDocConfiguration } from '@microsoft/tsdoc';
@@ -17,11 +16,12 @@ import { TSDocTagDefinition } from '@microsoft/tsdoc';
 export class AedocDefinitions {
     // (undocumented)
     static readonly betaDocumentation: TSDocTagDefinition;
+    static getTsdocConfiguration(additionalTags?: ReadonlyArray<TSDocTagDefinition>): TSDocConfiguration;
     // (undocumented)
     static readonly internalRemarks: TSDocTagDefinition;
     // (undocumented)
     static readonly preapprovedTag: TSDocTagDefinition;
-    // (undocumented)
+    // @deprecated (undocumented)
     static readonly tsdocConfiguration: TSDocConfiguration;
     }
 
@@ -362,7 +362,8 @@ export class ApiMethodSignature extends ApiMethodSignature_base {
 // 
 // @public
 export class ApiModel extends ApiModel_base {
-    constructor();
+    // Warning: (ae-forgotten-export) The symbol "IApiModelOptions" needs to be exported by the entry point index.d.ts
+    constructor(options?: IApiModelOptions);
     // @override (undocumented)
     addMember(member: ApiPackage): void;
     // @beta @override (undocumented)
@@ -376,9 +377,9 @@ export class ApiModel extends ApiModel_base {
     // (undocumented)
     readonly packages: ReadonlyArray<ApiPackage>;
     // (undocumented)
-    resolveDeclarationReference(declarationReference: DocDeclarationReference, contextApiItem: ApiItem | undefined): IResolveDeclarationReferenceResult;
+    resolveDeclarationReference(declarationReference: tsdoc.DocDeclarationReference, contextApiItem: ApiItem | undefined): IResolveDeclarationReferenceResult;
     tryGetPackageByName(packageName: string): ApiPackage | undefined;
-}
+    }
 
 // @public
 export function ApiNameMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiNameMixin);
@@ -428,7 +429,7 @@ export class ApiPackage extends ApiPackage_base {
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // (undocumented)
-    static loadFromJsonFile(apiJsonFilename: string): ApiPackage;
+    static loadFromJsonFile(apiJsonFilename: string, tsdocConfig?: tsdoc.TSDocConfiguration): ApiPackage;
     // (undocumented)
     saveToJsonFile(apiJsonFilename: string, options?: IApiPackageSaveOptions): void;
 }

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -65,6 +65,7 @@ export class ExtractorConfig {
     readonly skipLibCheck: boolean;
     readonly testMode: boolean;
     readonly tsconfigFilePath: string;
+    readonly tsdocConfig: tsdoc.TSDocConfiguration;
     readonly tsdocMetadataEnabled: boolean;
     readonly tsdocMetadataFilePath: string;
     readonly untrimmedFilePath: string;
@@ -186,6 +187,11 @@ export interface IConfigFile {
     messages?: IExtractorMessagesConfig;
     projectFolder?: string;
     testMode?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "IConfigTsdoc" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@microsoft/api-extractor" does not have an export "IConfigTsdoc"
+    // 
+    // (undocumented)
+    tsdoc?: IConfigTsdoc;
     // @beta
     tsdocMetadata?: IConfigTsdocMetadata;
 }


### PR DESCRIPTION
Add support for custom TSDoc tags in the API Extractor config file and when deserializing via `ApiModel`. Fixes #519.

Implementing this involved a couple significant design decisions which I've called out below. I'm open to suggestions on whether these (and really any element of the change) should be handled differently.

### Configuration placement and naming

Right now, the new section in the JSON is at the top level and would look like this:
```json
{
  "tsdoc": {
    "tagDefinitions": [
      {
        "tagName": "@foo",
        "syntaxKind": "block",
        "allowMultiple": true
      },
      {
        "tagName": "@bar",
        "syntaxKind": "inline"
      }
    ]
  }
}
```
The placement (top-level or not) and naming are negotiable. The idea of putting `tagDefinitions` under a parent `tsdoc` tag was to facilitate possibly adding more TSDoc-related options later. The tag definition items are based on [`ITSDocTagDefinitionParameters`](https://github.com/microsoft/tsdoc/blob/c1726fae9b4ac8dd309a39897cca30952ae73a90/tsdoc/src/configuration/TSDocTagDefinition.ts#L29).

### How to update and share the TSDoc configuration

Another significant design decision is whether the new tags should be added to the global `AedocDefinitions.tsdocConfiguration`, or whether a new TSDoc configuration should be generated when adding tags. The advantage of updating the global using `AedocDefinitions.tsdocConfiguration.addTagDefinitions(...)` is simplicity. The disadvantage is that it's polluting a global object, which makes behavior harder to trace and could cause problems if anyone wants to use different configurations within the same program. 

To avoid polluting a global, I went with creating a new TSDoc configuration which incorporates existing defaults, and passing it as a parameter to the various places that need it. Currently the configuration for API Extractor is created in `ExtractorConfig`, and the one for deserialization is created in `ApiModel` (though I wonder if that ought to be done in `ApiPackage` instead).