### PR TITLE
[api-extractor]: Add support for `@throws`

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -234,6 +234,7 @@ export class MarkdownDocumenter {
       case ApiItemKind.MethodSignature:
       case ApiItemKind.Function:
         this._writeParameterTables(output, apiItem as ApiParameterListMixin);
+        this._writeThrowsSection(output, apiItem);
         break;
       case ApiItemKind.Namespace:
         this._writePackageOrNamespaceTables(output, apiItem as ApiNamespace);
@@ -313,6 +314,27 @@ export class MarkdownDocumenter {
           this._appendSection(output, exampleBlock.content);
 
           ++exampleNumber;
+        }
+      }
+    }
+  }
+
+  private _writeThrowsSection(output: DocSection, apiItem: ApiItem): void {
+    if (apiItem instanceof ApiDocumentedItem) {
+      const tsdocComment: DocComment | undefined = apiItem.tsdocComment;
+
+      if (tsdocComment) {
+        // Write the @throws blocks
+        const throwsBlocks: DocBlock[] = tsdocComment.customBlocks.filter(x => x.blockTag.tagNameWithUpperCase
+          === StandardTags.throws.tagNameWithUpperCase);
+
+        if (throwsBlocks.length > 0) {
+          const heading: string = 'Exceptions';
+          output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: heading }));
+
+          for (const throwsBlock of throwsBlocks) {
+            this._appendSection(output, throwsBlock.content);
+          }
         }
       }
     }

--- a/apps/api-extractor-model/src/aedoc/AedocDefinitions.ts
+++ b/apps/api-extractor-model/src/aedoc/AedocDefinitions.ts
@@ -56,6 +56,7 @@ export class AedocDefinitions {
           StandardTags.remarks,
           StandardTags.returns,
           StandardTags.sealed,
+          StandardTags.throws,
           StandardTags.virtual
         ],
         true

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -171,7 +171,7 @@
             {
               "kind": "Method",
               "canonicalReference": "api-documenter-test!DocClass1#exampleFunction:member(1)",
-              "docComment": "/**\n * This is an overloaded function.\n *\n * @param a - the first string\n *\n * @param b - the second string\n */\n",
+              "docComment": "/**\n * This is an overloaded function.\n *\n * @param a - the first string\n *\n * @param b - the second string\n *\n * @throws\n *\n * `Error` The first throws line\n *\n * @throws\n *\n * The second throws line\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction.md
@@ -23,3 +23,9 @@ exampleFunction(a: string, b: string): string;
 
 `string`
 
+## Exceptions
+
+`Error` The first throws line
+
+The second throws line
+

--- a/build-tests/api-documenter-test/src/DocClass1.ts
+++ b/build-tests/api-documenter-test/src/DocClass1.ts
@@ -158,6 +158,11 @@ export class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInter
    * This is an overloaded function.
    * @param a - the first string
    * @param b - the second string
+   *
+   * @throws `Error`
+   *  The first throws line
+   *
+   * @throws The second throws line
    */
   exampleFunction(a: string, b: string): string;
 

--- a/common/changes/@microsoft/api-documenter/throws_2019-11-19-15-40.json
+++ b/common/changes/@microsoft/api-documenter/throws_2019-11-19-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Added support for `@throws`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "vidartf@gmail.com"
+}

--- a/common/changes/@microsoft/api-extractor-model/throws_2019-11-19-15-40.json
+++ b/common/changes/@microsoft/api-extractor-model/throws_2019-11-19-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Added support for `@throws`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "vidartf@gmail.com"
+}


### PR DESCRIPTION
Fixes #1631.

Note: I originally added a `@throws` line to one of the interfaces callables, and spent quite some time debugging why this didn't cause any change. I then realized that interface callables are not documented?