### PR TITLE
Removing check for --registry when using --pack

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -230,9 +230,6 @@ export class PublishAction extends BaseRushAction {
     if (this._releaseFolder.value && !this._pack.value) {
       throw new Error(`--release-folder can only be used with --pack`);
     }
-    if (this._registryUrl.value && this._pack.value) {
-      throw new Error(`--registry cannot be used with --pack`);
-    }
     if (this._applyGitTagsOnPack.value && !this._pack.value) {
       throw new Error(`${this._applyGitTagsOnPack.longName} must be used `
       + `with ${this._pack.longName}`);

--- a/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
+++ b/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Removing registry check from --pack, since --pack might need to run view against a registry to check if a package exists",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chaseholland@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
+++ b/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Removing registry check from --pack, since --pack might need to run view against a registry to check if a package exists",
+      "comment": "Remove an error thrown when the --registry and --pack arguments are used on rush publish, because --registry might be required to check if a package has already been published against a custom registry.",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
+++ b/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Remove an error thrown when the --registry and --pack arguments are used on rush publish, because --registry might be required to check if a package has already been published against a custom registry.",
-      "type": "patch"
+      "type": ""
     }
   ],
   "packageName": "@microsoft/rush",

--- a/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
+++ b/common/changes/@microsoft/rush/master_2019-11-20-02-32.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Removing registry check from --pack, since --pack might need to run view against a registry to check if a package exists",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/rush",


### PR DESCRIPTION
Removing the `--registry` check when using `--pack`, since some pack flows will run `npm run view`, which requires the registry component.