### PR TITLE
[rush] Fix applying git tags when using --pack --apply-git-tags-on-pack and using publish --include-all

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -324,13 +324,15 @@ export class PublishAction extends BaseRushAction {
             return;
           }
 
+          const packageVersion: string = packageConfig.packageJson.version;
+
           // Do not create a new tag if one already exists, this will result in a fatal error
           if (git.hasTag(packageConfig)) {
-            console.log(`Not tagging ${packageName}@${packageConfig.packageJson.version}. A tag already exists for this version.`);
+            console.log(`Not tagging ${packageName}@${packageVersion}. A tag already exists for this version.`);
             return;
           }
 
-          git.addTag(!!this._publish.value, packageName, packageConfig.packageJson.version);
+          git.addTag(!!this._publish.value, packageName, packageVersion);
           updated = true;
         };
 

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -339,7 +339,6 @@ export class PublishAction extends BaseRushAction {
         if (this._pack.value) {
           // packs to tarball instead of publishing to NPM repository
           this._npmPack(packageName, packageConfig);
-          // Do not tag packages that already exist. This will fail with a fatal error.
           applyTag(this._applyGitTagsOnPack.value);
         } else if (this._force.value || !this._packageExists(packageConfig)) {
           // Publish to npm repository

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -324,18 +324,20 @@ export class PublishAction extends BaseRushAction {
             return;
           }
 
-          // Do not tag packages that already exist. This will fail with a fatal error.
-          if (this._packageExists(packageConfig)) {
+          // Do not create a new tag if one already exists, this will result in a fatal error
+          if (git.hasTag(packageConfig)) {
+            console.log(`Not tagging ${packageName}@${packageConfig.packageJson.version}. A tag already exists for this version.`);
             return;
           }
 
-          git.addTag(!!this._publish.value && !this._registryUrl.value, packageName, packageConfig.packageJson.version);
+          git.addTag(!!this._publish.value, packageName, packageConfig.packageJson.version);
           updated = true;
         };
 
         if (this._pack.value) {
           // packs to tarball instead of publishing to NPM repository
           this._npmPack(packageName, packageConfig);
+          // Do not tag packages that already exist. This will fail with a fatal error.
           applyTag(this._applyGitTagsOnPack.value);
         } else if (this._force.value || !this._packageExists(packageConfig)) {
           // Publish to npm repository

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import { PublishUtilities } from './PublishUtilities';
+import { Utilities } from '../utilities/Utilities';
+import { RushConfigurationProject } from '../api/RushConfigurationProject';
 
 export class PublishGit {
   private _targetBranch: string | undefined;
@@ -49,6 +51,19 @@ export class PublishGit {
       !!this._targetBranch && shouldExecute,
       'git',
       ['tag', '-a', tagName, '-m', `${packageName} v${packageVersion}`]);
+  }
+
+  public hasTag(packageConfig: RushConfigurationProject): boolean {
+    const tagName: string = PublishUtilities.createTagname(packageConfig.packageName, packageConfig.packageJson.version);
+    const tagOutput: string = Utilities.executeCommandAndCaptureOutput(
+      'git',
+      ['tag', '-l', tagName],
+      packageConfig.projectFolder,
+      PublishUtilities.getEnvArgs(),
+      true
+    ).replace(/(\r\n|\n|\r)/gm, '');
+
+    return tagOutput === tagName;
   }
 
   public commit(commitMessage: string): void {

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -54,7 +54,10 @@ export class PublishGit {
   }
 
   public hasTag(packageConfig: RushConfigurationProject): boolean {
-    const tagName: string = PublishUtilities.createTagname(packageConfig.packageName, packageConfig.packageJson.version);
+    const tagName: string = PublishUtilities.createTagname(
+      packageConfig.packageName,
+      packageConfig.packageJson.version
+    );
     const tagOutput: string = Utilities.executeCommandAndCaptureOutput(
       'git',
       ['tag', '-l', tagName],

--- a/common/changes/@microsoft/rush/master_2019-11-22-21-16.json
+++ b/common/changes/@microsoft/rush/master_2019-11-22-21-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Resolve an issue where git tags were not being applied when using pack or publish with --include-all",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chaseholland@users.noreply.github.com"
+}


### PR DESCRIPTION
Resolving an issue where git tags would not be applied when using `--pack --apply-git-tags-on-pack` and using `publish --include-all`.

The issue was, publish was checking if a package was already published before adding a tag. In the `publish --include-all` flow, rush publishes and then goes to add the tag, so the package reads as published and the tag is not applied. 

This check has been moved to checking whether not a tag already exists locally via a new utility method in `PublishGit.ts`.