### PR TITLE
[api-extractor] Implement support for @link to reference function overloads

### DIFF
--- a/apps/api-extractor/src/analyzer/AstReferenceResolver.ts
+++ b/apps/api-extractor/src/analyzer/AstReferenceResolver.ts
@@ -133,7 +133,9 @@ export class AstReferenceResolver {
   private _selectDeclaration(astDeclarations: ReadonlyArray<AstDeclaration>,
     memberReference: tsdoc.DocMemberReference, astSymbolName: string): AstDeclaration | ResolverFailure {
 
-    if (memberReference.selector === undefined) {
+    const memberSelector: tsdoc.DocMemberSelector | undefined = memberReference.selector;
+
+    if (memberSelector === undefined) {
       if (astDeclarations.length === 1) {
         return astDeclarations[0];
       } else {
@@ -149,11 +151,20 @@ export class AstReferenceResolver {
       }
     }
 
-    const selectorName: string = memberReference.selector.selector;
-
-    if (memberReference.selector.selectorKind !== tsdoc.SelectorKind.System) {
-      return new ResolverFailure(`The selector "${selectorName}" is not a supported selector type`);
+    switch (memberSelector.selectorKind) {
+      case tsdoc.SelectorKind.System:
+        return this._selectUsingSystemSelector(astDeclarations, memberSelector, astSymbolName);
+      case tsdoc.SelectorKind.Index:
+        return this._selectUsingIndexSelector(astDeclarations, memberSelector, astSymbolName);
     }
+
+    return new ResolverFailure(`The selector "${memberSelector.selector}" is not a supported selector type`);
+  }
+
+  private _selectUsingSystemSelector(astDeclarations: ReadonlyArray<AstDeclaration>,
+    memberSelector: tsdoc.DocMemberSelector, astSymbolName: string): AstDeclaration | ResolverFailure {
+
+    const selectorName: string = memberSelector.selector;
 
     let selectorSyntaxKind: ts.SyntaxKind;
 
@@ -198,6 +209,37 @@ export class AstReferenceResolver {
 
       return new ResolverFailure(`More than one declaration "${astSymbolName}" matches the`
         + ` TSDoc selector "${selectorName}"`);
+    }
+    return matches[0];
+  }
+
+  private _selectUsingIndexSelector(astDeclarations: ReadonlyArray<AstDeclaration>,
+    memberSelector: tsdoc.DocMemberSelector, astSymbolName: string): AstDeclaration | ResolverFailure {
+
+    const selectorOverloadIndex: number = parseInt(memberSelector.selector);
+
+    const matches: AstDeclaration[] = [];
+    for (const astDeclaration of astDeclarations) {
+      const overloadIndex: number = this._collector.getOverloadIndex(astDeclaration);
+      if (overloadIndex === selectorOverloadIndex) {
+        matches.push(astDeclaration);
+      }
+    }
+
+    if (matches.length === 0) {
+      return new ResolverFailure(`An overload for "${astSymbolName}" was not found that matches the`
+        + ` TSDoc selector ":${selectorOverloadIndex}"`);
+    }
+    if (matches.length > 1) {
+      // If we found multiple matches, but the extra ones are all ancillary declarations,
+      // then return the main declaration.
+      const nonAncillaryMatch: AstDeclaration | undefined = this._tryDisambiguateAncillaryMatches(matches);
+      if (nonAncillaryMatch) {
+        return nonAncillaryMatch;
+      }
+
+      return new ResolverFailure(`More than one declaration for "${astSymbolName}" matches the`
+      + ` TSDoc selector ":${selectorOverloadIndex}"`);
     }
     return matches[0];
   }

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -339,7 +339,7 @@ export class Collector {
 
     if (overloadIndex === undefined) {
       // This should never happen
-      throw new Error('Error calculating overload index for declaration');
+      throw new InternalError('Error calculating overload index for declaration');
     }
 
     return overloadIndex;

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -82,6 +82,9 @@ export class Collector {
   private readonly _dtsTypeReferenceDirectives: Set<string> = new Set<string>();
   private readonly _dtsLibReferenceDirectives: Set<string> = new Set<string>();
 
+  // Used by getOverloadIndex()
+  private readonly _cachedOverloadIndexesByDeclaration: Map<AstDeclaration, number>;
+
   public constructor(options: ICollectorOptions) {
     this.packageJsonLookup = new PackageJsonLookup();
 
@@ -119,6 +122,8 @@ export class Collector {
     this.astSymbolTable = new AstSymbolTable(this.program, this.typeChecker, this.packageJsonLookup,
       bundledPackageNames, this.messageRouter);
     this.astReferenceResolver = new AstReferenceResolver(this);
+
+    this._cachedOverloadIndexesByDeclaration = new Map<AstDeclaration, number>();
   }
 
   /**
@@ -304,6 +309,40 @@ export class Collector {
     }
 
     return parts.join('');
+  }
+
+  /**
+   * For function-like signatures, this returns the TSDoc "overload index" which can be used to identify
+   * a specific overload.
+   */
+  public getOverloadIndex(astDeclaration: AstDeclaration): number {
+    const allDeclarations: ReadonlyArray<AstDeclaration> = astDeclaration.astSymbol.astDeclarations;
+    if (allDeclarations.length === 1) {
+      return 1; // trivial case
+    }
+
+    let overloadIndex: number | undefined = this._cachedOverloadIndexesByDeclaration.get(astDeclaration);
+
+    if (overloadIndex === undefined) {
+      // TSDoc index selectors are positive integers counting from 1
+      let nextIndex: number = 1;
+      for (const other of allDeclarations) {
+        // Filter out other declarations that are not overloads.  For example, an overloaded function can also
+        // be a namespace.
+        if (other.declaration.kind === astDeclaration.declaration.kind) {
+          this._cachedOverloadIndexesByDeclaration.set(other, nextIndex);
+          ++nextIndex;
+        }
+      }
+      overloadIndex = this._cachedOverloadIndexesByDeclaration.get(astDeclaration);
+    }
+
+    if (overloadIndex === undefined) {
+      // This should never happen
+      throw new Error('Error calculating overload index for declaration');
+    }
+
+    return overloadIndex;
   }
 
   private _createCollectorEntity(astEntity: AstEntity, exportedName: string | undefined): void {

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -99,7 +99,7 @@
         {
           "kind": "Class",
           "canonicalReference": "api-documenter-test!DocClass1:class",
-          "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * These are some remarks.\n *\n * The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.\n *\n * @defaultValue\n *\n * a default value for this function\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
+          "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * {@link DocClass1.(exampleFunction:1) | Link to overload 1}\n *\n * {@link DocClass1.(exampleFunction:2) | Link to overload 2}\n *\n * {@docCategory DocClass1}\n *\n * The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
@@ -14,7 +14,10 @@ export declare class DocClass1 extends DocBaseClass implements IDocInterface1, I
 
 ## Remarks
 
-These are some remarks.
+[Link to overload 1](./api-documenter-test.docclass1.examplefunction.md)
+
+[Link to overload 2](./api-documenter-test.docclass1.examplefunction_1.md)
+
 
 The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.
 

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docclass1.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docclass1.yml
@@ -3,7 +3,11 @@ items:
   - uid: 'api-documenter-test!DocClass1:class'
     summary: This is an example class.
     remarks: >-
-      These are some remarks.
+      [Link to overload 1](xref:api-documenter-test!DocClass1#exampleFunction:member(1))
+
+
+      [Link to overload 2](xref:api-documenter-test!DocClass1#exampleFunction:member(2))
+
 
 
       The constructor for this class is marked as internal. Third-party code should not call the constructor directly or

--- a/build-tests/api-documenter-test/src/DocClass1.ts
+++ b/build-tests/api-documenter-test/src/DocClass1.ts
@@ -140,8 +140,10 @@ export interface IDocInterface4 {
  * This is an example class.
  *
  * @remarks
- * These are some remarks.
- * @defaultValue a default value for this function
+ * {@link DocClass1.(exampleFunction:1)|Link to overload 1}
+ *
+ * {@link DocClass1.(exampleFunction:2)|Link to overload 2}
+ *
  * @public
  * {@docCategory DocClass1}
  */

--- a/common/changes/@microsoft/api-extractor-model/octogonz-ae-function-selectors_2019-12-03-02-10.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-ae-function-selectors_2019-12-03-02-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Improve declaration reference syntax to allow linking to overloaded functions/methods",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-function-selectors_2019-12-03-02-10.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-function-selectors_2019-12-03-02-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improve declaration reference syntax to allow linking to overloaded functions/methods",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/1240

Suppose you have an overloaded method like this:
```ts
export class MyClass {
  /** Overload 1 */
  exampleFunction(a: string, b: string): string;

  /** Overload 2 */
  exampleFunction(x: number): number;

  // Implementation
  public exampleFunction(x: number | string, y?: string): string | number {
    return x;
  }
}
```

This PR enable the `@link` tag to reference this function, by specifying the overload index.  For example:
```ts
/** See {@link (MyClass.exampleFunction:2)} for details */
export class Y {
}
```


NOTE: In the future, we are planning to change the syntax for declaration references with `@link` .  See https://github.com/microsoft/rushstack/issues/1240#issuecomment-554845029 for details.