### PR TITLE
Fix some old URLs that referenced web-build-tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -73,6 +73,6 @@ yarn.lock                    merge=binary
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.
 #
-# For more information, see this issue: https://github.com/Microsoft/rushstack/issues/1088
+# For more information, see this issue: https://github.com/microsoft/rushstack/issues/1088
 #
 *.json            linguist-language=JSON-with-Comments

--- a/.gitattributes
+++ b/.gitattributes
@@ -73,6 +73,6 @@ yarn.lock                    merge=binary
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.
 #
-# For more information, see this issue: https://github.com/Microsoft/web-build-tools/issues/1088
+# For more information, see this issue: https://github.com/Microsoft/rushstack/issues/1088
 #
 *.json            linguist-language=JSON-with-Comments

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><a href="https://rushstack.io/">https://rushstack.io/</a></p>
 </td></tr></table>
 
-[![Join the chat at https://gitter.im/web-build-tools](https://badges.gitter.im/web-build-tools.svg)](https://gitter.im/web-build-tools?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) &nbsp; [![Build Status](https://dev.azure.com/RushStack/GitHubProjects/_apis/build/status/rushstack/rushstack%20CI%20Build?branchName=master)](https://dev.azure.com/RushStack/GitHubProjects/_build/latest?definitionId=3&branchName=master)
+[![Join the chat at https://gitter.im/rushstack](https://badges.gitter.im/rushstack.svg)](https://gitter.im/rushstack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) &nbsp; [![Build Status](https://dev.azure.com/RushStack/GitHubProjects/_apis/build/status/rushstack/rushstack%20CI%20Build?branchName=master)](https://dev.azure.com/RushStack/GitHubProjects/_build/latest?definitionId=3&branchName=master)
 
 The home for various projects maintained by the Rush Stack community, whose mission is to develop reusable tooling
 for large scale TypeScript monorepos.
@@ -13,7 +13,7 @@ for large scale TypeScript monorepos.
 
 - [What is Rush Stack?](https://rushstack.io/) - learn about the mission behind these projects
 - [API reference](https://rushstack.io/pages/api/) - browse API documentation for NPM packages
-- [Gitter chat room](https://gitter.im/web-build-tools/web-build-tools) - chat with the Rush Stack developers
+- [Gitter chat room](https://gitter.im/rushstack/rushstack) - chat with the Rush Stack developers
 - [Rush](https://rushjs.io/) - a build orchestrator for large scale TypeScript monorepos
 - [API Extractor](https://api-extractor.com/) - create .d.ts rollups and track your TypeScript API signatures
 - [API Documenter](https://api-extractor.com/pages/setup/generating_docs/) - use TSDoc comments to publish an API documentation website

--- a/apps/rush-lib/assets/rush-init/[dot]gitattributes
+++ b/apps/rush-lib/assets/rush-init/[dot]gitattributes
@@ -9,6 +9,6 @@ yarn.lock                    merge=binary
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.
 #
-# For more information, see this issue: https://github.com/Microsoft/web-build-tools/issues/1088
+# For more information, see this issue: https://github.com/Microsoft/rushstack/issues/1088
 #
 *.json                       linguist-language=JSON-with-Comments

--- a/apps/rush-lib/assets/rush-init/[dot]gitattributes
+++ b/apps/rush-lib/assets/rush-init/[dot]gitattributes
@@ -9,6 +9,6 @@ yarn.lock                    merge=binary
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.
 #
-# For more information, see this issue: https://github.com/Microsoft/rushstack/issues/1088
+# For more information, see this issue: https://github.com/microsoft/rushstack/issues/1088
 #
 *.json                       linguist-language=JSON-with-Comments

--- a/common/changes/@microsoft/rush-stack/octogonz-update-urls_2019-12-05-20-58.json
+++ b/common/changes/@microsoft/rush-stack/octogonz-update-urls_2019-12-05-20-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/octogonz-update-urls_2019-12-05-20-58.json
+++ b/common/changes/@microsoft/rush/octogonz-update-urls_2019-12-05-20-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update GitHub project URL in some resource files",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/rush-stack/README.md
+++ b/stack/rush-stack/README.md
@@ -31,4 +31,4 @@ with the following common goals:
 
 ## Project Status
 
-**Rush Stack** is still in its early phases.  If you'd like to participate, please [open an issue](https://github.com/microsoft/rushstack/issues) or join the [web-build-tools Gitter community](https://gitter.im/web-build-tools/web-build-tools).
+**Rush Stack** is still in its early phases.  If you'd like to participate, please [open an issue](https://github.com/microsoft/rushstack/issues) or join the [rushstack Gitter community](https://gitter.im/rushstack/rushstack).


### PR DESCRIPTION
When we recently renamed `web-build-tools` --> `rushstack`, we missed some files.

Fixes https://github.com/microsoft/rushstack/issues/1654