### PR TITLE
[load-theme-styles] Add es6 "module" entry in package.json

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/es6_2019-12-17-05-40.json
+++ b/common/changes/@microsoft/load-themed-styles/es6_2019-12-17-05-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "adds es6 library for load-theme-styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/es6_2019-12-17-05-40.json
+++ b/common/changes/@microsoft/load-themed-styles/es6_2019-12-17-05-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/load-themed-styles",
-      "comment": "adds es6 library for load-theme-styles",
+      "comment": "Add a \"module\" entry in package.json for the es6-style library.",
       "type": "patch"
     }
   ],

--- a/libraries/load-themed-styles/package.json
+++ b/libraries/load-themed-styles/package.json
@@ -10,6 +10,7 @@
     "build": "gulp --clean"
   },
   "main": "lib/index.js",
+  "module": "lib-es6/index.js",
   "typings": "lib/index.d.ts",
   "keywords": [],
   "devDependencies": {


### PR DESCRIPTION
Fixes #1292

Simply adds a package.json entry for load-theme-styles to make esm friendly bundlers happy