### PR TITLE
Don't use the build verb when printing task failures

### DIFF
--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -105,7 +105,7 @@ export class TaskRunner {
       this._printTaskStatus();
 
       if (this._hasAnyFailures) {
-        return Promise.reject(new Error('Project(s) failed to build'));
+        return Promise.reject(new Error('Project(s) failed'));
       } else if (this._hasAnyWarnings && !this._allowWarningsInSuccessfulBuild) {
         this._terminal.writeWarningLine('Project(s) succeeded with warnings');
         return Promise.reject(new AlreadyReportedError());
@@ -195,7 +195,7 @@ export class TaskRunner {
    * Marks a task as having failed and marks each of its dependents as blocked
    */
   private _markTaskAsFailed(task: ITask): void {
-    this._terminal.writeErrorLine(`${os.EOL}${this._getCurrentCompletedTaskString()}[${task.name}] failed to build!`);
+    this._terminal.writeErrorLine(`${os.EOL}${this._getCurrentCompletedTaskString()}[${task.name}] failed!`);
     task.status = TaskStatus.Failure;
     task.dependents.forEach((dependent: ITask) => {
       this._markTaskAsBlocked(dependent, task);

--- a/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskRunner.test.ts.snap
+++ b/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskRunner.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TaskRunner Constructor throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number or 'max'"`;
 
-exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 1`] = `"Project(s) failed to build"`;
+exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 1`] = `"Project(s) failed"`;
 
 exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stderr with leading and trailing blanks] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stderr with leading and trailing blanks (0.10 seconds)[x][39m[n]List of errors:[-n-] - error #1;[-n-] - error #2;[-n-] - error #3;[-n-] - error #4;[-n-] - error #5;[-n-] - error #6;[-n-] - error #7;[-n-] - error #8;[-n-] - error #9;[-n-][...21 lines omitted...][-n-] - error #31;[-n-] - error #32;[-n-] - error #33;[-n-] - error #34;[-n-] - error #35;[-n-] - error #36;[-n-] - error #37;[-n-] - error #38;[-n-] - error #39;[-n-] - error #40;[-n-] - error #41;[-n-] - error #42;[-n-] - error #43;[-n-] - error #44;[-n-] - error #45;[-n-] - error #46;[-n-] - error #47;[-n-] - error #48;[-n-] - error #49;[-n-] - error #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
 
@@ -10,9 +10,9 @@ exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks
 
 exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 4`] = `""`;
 
-exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 5`] = `"[x][31m[-n-]1 of 1: [large stderr with leading and trailing blanks] failed to build![x][39m[n]"`;
+exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 5`] = `"[x][31m[-n-]1 of 1: [large stderr with leading and trailing blanks] failed![x][39m[n]"`;
 
-exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed to build"`;
+exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed"`;
 
 exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stdout only (0.10 seconds)[x][39m[n]Building units...[-n-] - unit #1;[-n-] - unit #2;[-n-] - unit #3;[-n-] - unit #4;[-n-] - unit #5;[-n-] - unit #6;[-n-] - unit #7;[-n-] - unit #8;[-n-] - unit #9;[-n-][...21 lines omitted...][-n-] - unit #31;[-n-] - unit #32;[-n-] - unit #33;[-n-] - unit #34;[-n-] - unit #35;[-n-] - unit #36;[-n-] - unit #37;[-n-] - unit #38;[-n-] - unit #39;[-n-] - unit #40;[-n-] - unit #41;[-n-] - unit #42;[-n-] - unit #43;[-n-] - unit #44;[-n-] - unit #45;[-n-] - unit #46;[-n-] - unit #47;[-n-] - unit #48;[-n-] - unit #49;[-n-] - unit #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
 
@@ -20,9 +20,9 @@ exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr
 
 exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 4`] = `""`;
 
-exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 5`] = `"[x][31m[-n-]1 of 1: [large stdout only] failed to build![x][39m[n]"`;
+exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 5`] = `"[x][31m[-n-]1 of 1: [large stdout only] failed![x][39m[n]"`;
 
-exports[`TaskRunner Error logging printedStderrAfterError 1`] = `"Project(s) failed to build"`;
+exports[`TaskRunner Error logging printedStderrAfterError 1`] = `"Project(s) failed"`;
 
 exports[`TaskRunner Error logging printedStderrAfterError 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout+stderr] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout+stderr (0.10 seconds)[x][39m[n]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
 
@@ -30,9 +30,9 @@ exports[`TaskRunner Error logging printedStderrAfterError 3`] = `""`;
 
 exports[`TaskRunner Error logging printedStderrAfterError 4`] = `""`;
 
-exports[`TaskRunner Error logging printedStderrAfterError 5`] = `"[x][31m[-n-]1 of 1: [stdout+stderr] failed to build![x][39m[n]"`;
+exports[`TaskRunner Error logging printedStderrAfterError 5`] = `"[x][31m[-n-]1 of 1: [stdout+stderr] failed![x][39m[n]"`;
 
-exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed to build"`;
+exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed"`;
 
 exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout only (0.10 seconds)[x][39m[n]Build step 1[-n-]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
 
@@ -40,7 +40,7 @@ exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 3`] = `
 
 exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 4`] = `""`;
 
-exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 5`] = `"[x][31m[-n-]1 of 1: [stdout only] failed to build![x][39m[n]"`;
+exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 5`] = `"[x][31m[-n-]1 of 1: [stdout only] failed![x][39m[n]"`;
 
 exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 1`] = `"An error occurred."`;
 

--- a/common/changes/@microsoft/rush/bbenoist-print-task-run_2019-12-19-14-21.json
+++ b/common/changes/@microsoft/rush/bbenoist-print-task-run_2019-12-19-14-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Don't use the `build` verb when printing task failures",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "bbenoist@users.noreply.github.com"
+}


### PR DESCRIPTION
As my test command does not build anything nor requires any sort of build to be called, the following output "is very offensive to me" ™️ ( 🤡):

```
$ rush test
. . .
[my-project] failed to build!
. . .
Error: Project(s) failed to build
```

I've made the changes so that the output now is:

```text
$ rush build
. . .
[my-project] failed!
. . .
Error: Project(s) failed
```