### PR TITLE
[load-themed-styles] removing text/css type from style element

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/notype_2020-01-07-01-47.json
+++ b/common/changes/@microsoft/load-themed-styles/notype_2020-01-07-01-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Removed type attribute from style tags to align with WHATWG HTML guidelines",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "karansin@microsoft.com"
+}

--- a/libraries/load-themed-styles/src/index.ts
+++ b/libraries/load-themed-styles/src/index.ts
@@ -395,7 +395,6 @@ function registerStyles(styleArray: ThemableArray): void {
   } = resolveThemableArray(styleArray);
 
   styleElement.setAttribute('data-load-themed-styles', 'true');
-  styleElement.type = 'text/css';
   if (_styleNonce) {
     styleElement.setAttribute('nonce', _styleNonce);
   }


### PR DESCRIPTION
This PR accompanies https://github.com/microsoft/rushstack/issues/1673 by removing the type=text/css attribute from generated style tags. This is to reduce HTML validation errors in client pages (details in issue) & align with the [WHATWG ](https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features:attr-style-type)/ [Mozilla ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)docs.