### PR TITLE
[eslint-plugin] Add a new ESLint rule "@rushstack/no-untyped-underscore"

### DIFF
--- a/build-tests/node-library-build-eslint-test/.vscode/launch.json
+++ b/build-tests/node-library-build-eslint-test/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "ESLint",
+            "program": "${workspaceFolder}/node_modules/@microsoft/rush-stack-compiler-3.5/bin/rush-eslint",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--debug", "-f", "unix", "src/**/*.{ts,tsx}"
+            ]
+        }
+    ]
+}

--- a/build-tests/node-library-build-eslint-test/package.json
+++ b/build-tests/node-library-build-eslint-test/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gulp test --clean",
-    "lint": "node ../../common/temp/node_modules/eslint/bin/eslint -f unix \"src/**/*.{ts,tsx}\""
+    "lint": "node node_modules/@microsoft/rush-stack-compiler-3.5/bin/rush-eslint -f unix \"src/**/*.{ts,tsx}\""
   },
   "devDependencies": {
     "@microsoft/node-library-build": "6.3.12",

--- a/build-tests/node-library-build-eslint-test/tsconfig.json
+++ b/build-tests/node-library-build-eslint-test/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "./node_modules/@microsoft/rush-stack-compiler-3.5/includes/tsconfig-node.json"
+  "extends": "./node_modules/@microsoft/rush-stack-compiler-3.5/includes/tsconfig-node.json",
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  }
 }

--- a/common/changes/@rushstack/eslint-plugin/octogonz-no-untyped-underscore_2020-01-08-03-37.json
+++ b/common/changes/@rushstack/eslint-plugin/octogonz-no-untyped-underscore_2020-01-08-03-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Add new rule `@rushstack/no-untyped-underscore`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -29,7 +29,7 @@
     // From the allowedAlternativeVersions list below, this should be the TypeScript version that's used to
     // build most of the projects in the repo.  Preferring it avoids errors for indirect dependencies
     // that request it as a peer dependency.
-    "typescript": "~3.4.3",
+    "typescript": "~3.5.3",
 
     // Workaround for https://github.com/microsoft/rushstack/issues/1466
     "eslint": "~6.5.1",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -195,7 +195,7 @@ dependencies:
   ts-jest: 22.4.6
   tslint: 5.12.1
   tslint-microsoft-contrib: 5.2.1
-  typescript: 3.4.5
+  typescript: 3.5.3
   uglify-js: 3.0.28
   vinyl: 2.2.0
   webpack: 4.31.0
@@ -10428,7 +10428,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-qEliL8yiNvxsYMg9MkHMdLdCru2I61AhmTBNSuO1Qt1rpI1LxfKk1CI8JqPT2byEvy4hF87xTcD0NVHDVct0yA==
+      integrity: sha512-7SVr+41W1CT33cxSdeZu+L/Jtn9oWq8mw9HzhUINhatCiuSU5hYdVsTvE5RbaEb2UYNv99Izes4SQYEnDvmyhA==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -10446,7 +10446,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-BZTZ8SRj3u5iGK52aBypWBrAqrc/8YcytCh0EqHCmbKjWcL+yC7t6+/6+iqXTXNtptbLGUzVZpomHf/eNakMkg==
+      integrity: sha512-ae2kpOLbTDu2jKtfjfsLAJrtvdLepyFGsLU+dFCqONRPGKB3Iwumshd2sizsOl7NoIMi/6tSwP7AOW66NhyUfA==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -10458,7 +10458,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-cVaE2OA0u42dOgLcZkJaaYJuHtzEwHyKW/xxkuOcW3XvkynPfn//VKNA0FhUtgT4oLYV7Gi4SquhL0ZoNeCwtw==
+      integrity: sha512-gVRmQcJzzQI2KfHW9lGbO1DZ0Iyt+rdqYBacCk2rEXicKqqRWZGApw2rBjFpq4ZwqEpydiTAILwnHwxc85kYHw==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -10470,7 +10470,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-ormTxqH52i7ruyI1Ec/rB04kfMwpUoBK0txgHpksJGAX8pc3Mf4X/mpvtvzZtNaGgmGF4K2B5Dyy3V87JJ8OVA==
+      integrity: sha512-HN7xTpTFcA5blLceavCS5nkiq6PXebRrLvJCvhtQT/RuizwrriWgCzUjcKXr8e1V+D/hF8bTvIv3mps3Hug5WQ==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -10482,7 +10482,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-6oTD16AUjfjLi2C+b8TjMxPf+E3ABhuReFLauKl1ME1xo2PpDCpkUJYGPnTfw5XmxcBXYpa2wgMPPOiFMmUKUA==
+      integrity: sha512-ejAxmbpJHuqlWzr7ha71M38HdbG7OfDtKNOKAeVc7U5NkUjByJd74kC0Fb5dLI1mWzXRWPyZpI2w4K3r87ICwQ==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -10496,7 +10496,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-/4OyS/2LOKaIpqdXPe+YXUCO9WIjDPvtY6NsVNzbm8yg+edtgTE3vmRWccYQgksBSrIdDcxQjv9voilIBJzCPQ==
+      integrity: sha512-1hlXYGcI7Dh90WCJT4z6oJhRT4fIxDqkFqUoyEcwXCti9LKj+8tt24wmIPJazeZudrekt2gcZ9Qijg2wDEYEpw==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -10510,7 +10510,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-akJvjdsVK4SuDugXYbueiF7dd+TzCYQVVFmYcEu17y4Kqft3xswDL4F/Zex/xdjsRDdTZbWZX2pXIiFaYQldVA==
+      integrity: sha512-tVqbchFeY79UbyMMyzsJnkzr4pXZeXZCuup0Hkh2eRphvLZRSaFnEwsF/ReCLHVM4Ui6+cgrf2WBiCkilIQyHw==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -10524,7 +10524,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-Et0UhhZ5M0crnrI3LYl6oWx8HZNTamme4Gy7wVZlk3xlWLlZhuL7zIVk1U28OMLfSwYHaNLuKGs66X4pKfSX6Q==
+      integrity: sha512-JMPcciu+KL+rFjOhzBmulUxs9xoJiTiedwtlCTPlvn+whpD3kiaWyS9Ft5DEJ4Z92UTJajpxan1o5iPYVo/ZJA==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -10537,7 +10537,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-mkrZzqUElEf4n40RR2dUFw0LV4x9Sbeujh7FrLOZwOF3D3etywwq2DmlBfWwp21DhjOWwGC239HUrkk80aAOyQ==
+      integrity: sha512-vYizHl+RRi4bTbzByuAKswDLfVdyGQUxKrbSr/xAn5EzoV/DDVBZZnIWB32HgqUlCP64uillqAngP7QeI6UpiA==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -10559,7 +10559,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-Mnu+JulbjoC52WRyZHVwP0YFCENiaikdIjtGYTa9Icsd5X0P/o1GL8qEryjAII6hCOwquJweZ5GYwKmC5ZaCfw==
+      integrity: sha512-GlEJk1+QvsYJtE3iO1CzHEjpWamUp2mr0L8Sd+Li0Dh8Wt0LUGmnN3pl2bNQYDuKxvqnMn202QLpjayx8jtrWA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -10579,7 +10579,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-Dp0YP0ohJZjnzwhNeLiN0gtk7FU0L8ElkdsOloeYAqVAcPd4b7o2e4qzw94IbsmN96g9TCxl3QzhJaxhtVEFbg==
+      integrity: sha512-Gm3uzOqAUGo1fP/75oe1VkSiiOrP+D0iLB7IbVfhVD4+QwpAVLfKyoeyTCVXlsl7eTrEwx/CAoaafPm4uudCyw==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/doc-plugin-rush-stack.tgz':
@@ -10592,7 +10592,7 @@ packages:
     dev: false
     name: '@rush-temp/doc-plugin-rush-stack'
     resolution:
-      integrity: sha512-Mt13B93izhGkKw5VeMJ/af7p7LfQEniYyX9JunCNgDcL17rXp0msA4wKT67Q3tXjnZ4Jg+gsmJ7SxOK5TQnACQ==
+      integrity: sha512-0szX6w5OV+70HPmnI5Ky3GwFrX61ohhsyu15W8LfM+CvNduT+QAeIHM4N9w46GVgZohIJEBEgi+OQObs8Z09wA==
       tarball: 'file:projects/doc-plugin-rush-stack.tgz'
     version: 0.0.0
   'file:projects/eslint-config.tgz':
@@ -10610,7 +10610,7 @@ packages:
     dev: false
     name: '@rush-temp/eslint-config'
     resolution:
-      integrity: sha512-1fqzuQbpWqQKS9vJGQA1HQHmVuPRAHpZB7H2uVE12rAkXCDfvfJurUrMB2bq78MG6aFE7vvOo245ioCFrmYgMQ==
+      integrity: sha512-EE4vyuQYbPi2bPDA3drgr3dUZmxMgh0xmbmkc/twnPRKNgC1YDn0Qu/vL0H3hDT0u+VuA2QMi9RvqUdtKPhKjQ==
       tarball: 'file:projects/eslint-config.tgz'
     version: 0.0.0
   'file:projects/eslint-plugin.tgz':
@@ -10636,7 +10636,7 @@ packages:
     dev: false
     name: '@rush-temp/generate-api-docs'
     resolution:
-      integrity: sha512-pJ2OEdK09uyXvjCuNLgW3y96U//Ei0GxLwwSbCdAmYT0maSfCA1mCCd0t3iZ/SI/WsgAVrLtdz/7QzZmPdxmUA==
+      integrity: sha512-8qH4I5yTylcURDFOVJZS38YOH+RPwccz/nwJjzdyA1vRoDjOsUWx4fLGqWVMVYMPgVhhTxuH7hidcsVVxFtrjw==
       tarball: 'file:projects/generate-api-docs.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -10657,7 +10657,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-bRw6xcGF6MG13OVl7N38/fplR1DEoUiy9dGngBUixO/nzynSQkZwIWgef54/s5GHIFS6vifYC1pj3Z+lQfcp6A==
+      integrity: sha512-ChjtlOtBDyADKrtZHL8lLbbTB4ZiFuufgkqUxGbeXaemDIC2vek64lTjTtkvYfwdiFFSYlS4Vre9Lb0tkZvhWg==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -10679,7 +10679,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-YTBG5DeaoIR9h0hWcsrGuD8A38loOXB6n+7+GR3gNK/zvABSTGYrpuGCB4ID9LyNbhDQJ1NFHy+q3h/Wjpmu8w==
+      integrity: sha512-nkG/rS7ZKQ/M0jsPCZFFIWqfb/IHZXNaNkoJov7kh82fbPZTNn52XkAP/7BNRorLUVgXkZvPbAHmssuQTZy3WA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10705,7 +10705,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-bi+XvEes/3EmCZ3EzLLm88l6JcbOWQ3ZF+7xbTPUrGXe9lpux3ZWsJ5ciQqtxbp8q7sDKArGZsY0BPdO9dzVpw==
+      integrity: sha512-82PWSfr/NeSKjbHc25gQNzgEliViAzS1prQuCSBhyO2puEqwfshYKC487TJ+PlJdPZKjWpGC/FtQpw3dyTmyqA==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -10724,7 +10724,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-NHFtWGudbyNBvvu/WVzBgBIMoqHKeixK4KoFA/sdoSClyUQg79UgdJI651q9id7/ed+nc8jeHSp+BxsDQo9mYw==
+      integrity: sha512-XdkuqF0vP+gPXYeKP0xSEozoTYHzql8Qkityhgd6ajul3o7FsSwfMVyxrFb0CBJl5yrroN5kp5LmVbRORz+48A==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10742,7 +10742,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-kI1hVd8/mLEcGULWN93uoVs0iXc49Kr5Bqu8STpUT+NKXQDiaBclKZezbnJ9qZBz0aOmeTxpxslbVYt8XeLtrQ==
+      integrity: sha512-4snFN5hMBMa7pwu7epl9YN1BHpIJQAXngCQShNC6J+hj8jyGjn6Nz2FdoLe6h/7TdYNJ70gKQMb66KC27TNMww==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10793,7 +10793,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-8zSl0R2yJpakrbehacfuZ/KoxwJmXrnNCF2pDC8cot3Mz6Rlms1T+fRUPSs9M7WKy9cuOWNy1o6+XO33+7fiTg==
+      integrity: sha512-2rjo6igpDRccFCoT4BVWjgSCxnLlw+vPbnaEggTeDATELOHruzeISTfCxnsXSTjfTYCNSD685hLgkXweXw697w==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10806,7 +10806,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-lZPlr0FZs7XQdiAuHZAS7jYfTfCFTWD4Q0KLCw4lEAbbfIJmaIvgF34urJAThNKk3WDHTfQ9B3mCal4etdzA6w==
+      integrity: sha512-dzIDVIVr9ruHoMYjL1o/uWsYRYcs9lJd30OIzR7OO2bpEt7ij5Cg2Kbb+rr11Jo0u0p0JvUeZnt+HdKvuoyRgQ==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10821,7 +10821,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-PqwZXBIPNSH0AWaWOfnghyOLW7y4/o/qNcvgl8UX4RgX7geVk9hlE1IAQv7kDlsHTlQQJp3a5DMbstuSCHXQZQ==
+      integrity: sha512-qOSfd9J3ffyryvIiQWexWQYTqjVc3zIejX/Mi9QL93vBRXGbiiVwIkCk5+HtV+xa76assvJbQAKj8ivOBgaHVw==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10835,7 +10835,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-pV+5e7p7+f+QFgQL07nP7vtL4fcffYc5iSK5WLakrCBrNwRN27+8MCIlxqh7y1YZEsC3ndCWIwWRb8O4RikkTQ==
+      integrity: sha512-Ubw2DPCmr06tgHamCzf2skhW4uaBXu7EOk3FauSkBISIifVA9vo+h0s7U/dxmO4hqIZYkPd/L8vmwuZ4OA3cKg==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10851,7 +10851,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-m27FjIUfR0RkH/PzZG3xeK2BiwM/w8Xf0A9GV2OvW2WIDTRCLoOI1rMVU7jR0saYOkjXBBJ9i3K8GfVjqYEcLQ==
+      integrity: sha512-fHB741EmNOWHMp1BRUHaQ6hrfdwul5CmIqwV8/e2GgWFJO51M+5qfPjEUeo6IaB6hnLr8KV2R1gxzknXXGnKtg==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10875,7 +10875,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-ppP48YLFFSSy3Rm++qzyMEN6XjBy8GIoAl/BeCc6qAX8Hp4FDJDNhuyotputhszpKUpDUHbYB4l+6dsc0Q4dbw==
+      integrity: sha512-r1iLS1L3XrqY4GzoaPvNkdyqy0K40GSxI7LNa0h3d+VM4+MFQwt1c0+/nYW4R4GfzlykOy8oUL/xmnoUDz0jjA==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build-eslint-test.tgz':
@@ -10888,7 +10888,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-eslint-test'
     resolution:
-      integrity: sha512-aYEalf3vl6VW5ssvY7dBZv/DuBLd7k5iw20NA0A0XDgQnNmDyqlhHtnuE7HFqhhXjsbvU40mC2hGlBJDRYtEwQ==
+      integrity: sha512-Safbqocv/akWLplQxGHTShDfd5++r8uG/n/RVEOPPRMWGAaFw9NuSSyIeAU58o3s08lyh4mdXQXGycaF0DUMrA==
       tarball: 'file:projects/node-library-build-eslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build-tslint-test.tgz':
@@ -10901,7 +10901,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-tslint-test'
     resolution:
-      integrity: sha512-s+Q680AEMhtsl932V7cz5a/HUY91GEF/ePhhFWwUd7X91x85IAiZRFpij0JBU+oS5flLjD7StvhFVU39T1ouEg==
+      integrity: sha512-EnEkme56qT5j/fKCb9d3IaqmuGWuy6fJ2YkRQ92i1KrIM6Q4pHKq5dbSsY876AyJ9I4qE6/T7yQDXXmAG3YoDQ==
       tarball: 'file:projects/node-library-build-tslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10912,7 +10912,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-gdNuS+7ibG4QV9XI3jRkvIXBQoyvxdoy6q9u7azHmN9j5zXawmw6mBLuuTop1cek5rBMrCfnOce2hncgR+Pd1w==
+      integrity: sha512-/dg4rhWTmVqNO5i3KN2xokSKAaL6uw3FXBMWvGa8VdKpA8ljH/my1OOvfilBtt23pVNfJlFQMJhjevxOlFGNyA==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10925,7 +10925,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-ouxLUwJ18s565A1hPi6NysNwfzoU8cHGrCupFB19MbGCEeXTyhevSV/ioBxg6sWYzw7zbnvI08aHqHXWheLsLA==
+      integrity: sha512-MuiJVeL5/XkOBZD1Pvg7BlL5ghjEcqr0yhm9qmhkpNTrqVanT7iGJf92bbvXCdW/Wfpgvj0zarYiUuc1emeubA==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/repo-toolbox.tgz':
@@ -10935,7 +10935,7 @@ packages:
     dev: false
     name: '@rush-temp/repo-toolbox'
     resolution:
-      integrity: sha512-A1YQpJdE7gaopM0E/AdPfDOqulP2ZEIMDS/FHYqkbanjqBFlXBmTX73DdwxAf3VJJCawekl0yU5AKlPy1+Aysw==
+      integrity: sha512-ikknXLF7VJcD0T+PfNZATDJPexmjuSm98TlPteeJSbFIZdRuxicQHNpJ4DYEBZ0Rn4KqE9ylnnamTkUSsrAr9w==
       tarball: 'file:projects/repo-toolbox.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10949,7 +10949,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-xfhxHJJwCjLuGBr2iJ++7dKqkIWpUZziXyrhuAkwdk9jZkJzD3XtYVS3hj7jDBbMDLckstYxRcFOC0zGvMw2DQ==
+      integrity: sha512-1lKwGO9quUfemNkVkE+CWiMY9HTRYJ4jUUiy+UYYmu7k2aQOIn0FPiUgplSGxrUrXh97DL4YhOsvC2lWOiP1Cg==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -10960,7 +10960,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-ptfkCDSBS2eiFKmS+02gulb1RyjeFLzuNkn88kqk3zo8ziFeuSouSU64G2xMRfLzqwr7r/SkAXterlP4AJ5lVg==
+      integrity: sha512-meNlXlomHAk50p9DSBr4iAIaXUTm7poCNR6Ani+xCPLG52nXdR+Mr9TOw5zvTglm3QpR//maIzfzCBVUaiUXYQ==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -11004,7 +11004,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-8Qiq9aTT3lOZTTHzh/ee2bZ+xV3iM/tRdl9C1NschU6oDohQ3C9Wda0R9rfClgvFsv6ZhMOULA2QuVQfMq/RPQ==
+      integrity: sha512-rm2KlA6ZL6VxEiSsRoxhchTgEb1XlrCO/Dvw5gO2ufDkV6WRNgWqiEz2Ap8nW1hl7PveoQGQERKUYAicpjn/OA==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -11014,7 +11014,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-qNHU5B7OL8vUYOZeHPcMhoh6uXq91BL8DbgBCmCvXyGvOzQQDPLL62PKY3VNDghd0USLq3ye96w7LzcdM3xQeQ==
+      integrity: sha512-5xS2l5HB4nxqC5QoKgMzzuJu6O6S135HtRf4ZMf1ZYL7KBOnq0IjdXEvCmUqrKKsEJpV4CqQEVc8IkzW3ACSpQ==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
@@ -11030,7 +11030,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-qnwmqvNsV6wlXZXFQg8PPDpox1KS27hGXEMTwVKG1BZf55slvrLRK+Cq6UASRKvCc4aDMmiQCXbRTH6z9UBgAA==
+      integrity: sha512-bvND2zVmCUJZGpDWgMI125jodCp5Zw8DNGTo5p9ARJ1rG/N3wvV1PmGuuJxsUmDsJhjEKNOxsEL//1Iu4GY+xw==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -11040,7 +11040,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-98svcqTyyfkUEwqyEd04U+yVHi063vg0pVCo1ZLBTvgEihIhixoatecAcAuNaBde6lV5ADMAL9R/YwsDELoIPA==
+      integrity: sha512-J+RSvaiDW68RCPCaVrcdGveZ60R+eMyIK+i6RX8zSkJGu3N0gc4+X5id0kUuKUGPhAkZVU5hzqcIk2kcdyUVMA==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
@@ -11056,7 +11056,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-DeJkOCwF9DDr0ac0PBCc7M2/YOLXhQq0hLdUGLmh6zJamL+7ncT3KTvuW7YdoHX2Q9hKHp8ZfEmgt4ckHAdQXQ==
+      integrity: sha512-z2GJbB50LVulFpRg+ba2kV7I46JzhhfF/RsehsQheDP6AjeUdZ/GBu507Z+vYIEmRt41ftXvMEFRFO/+WsxN+g==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -11066,7 +11066,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-8qSsG0fUJyDRdBNEjoUNdHFbfFKQKKcN+uRFIDZqPrGgstkSDq8ZV7fnvyjsDR+9FJ/iJz3087KkZmIInhpQcQ==
+      integrity: sha512-n2RtCkQ+OCCK6Kvkr/Ih9rk47DKJvY5KmF9bgmSfuKJipVAWtEtdpqUPy1tr26DCABA7nxIc2yqs+B7lqTS9zA==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
@@ -11082,7 +11082,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-qJkTz+l/N19xMItORoB4e/2AchAK7KcWYAbzdyQRr+9Lnp5eFqse+sfNeTFK9MDLtrNdfortEuMH1e6cq9NISw==
+      integrity: sha512-ZYwPz2lKjMB5IL7cjTOlcAQ7kFD6JLizNTrZDawGTvrnmDAsdkWR6BV/0UxQrSoSME25QJwwTZW/ARH7s953BA==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -11092,7 +11092,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-3BoMlCdCVL46FGuIUg42/IBG7hbKClp8PJPy1wBznojMsyNrLAf+Q16443oAfWuHhS+vLb+kpOuIvlSlcoBiAA==
+      integrity: sha512-f9Gfwk05NN95FG0YVd5WD1T+B94yfbnUX2623tNmSE8tTWC5Z7lIKleD8DdvUGMW467HmUbWCQvRTwD6QQpB9A==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
@@ -11108,7 +11108,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-3TW7yLFmL0tFxD1wGeJ6gzPkAnbjzJFTALfRnQ/NnRJo441uRc0WaySXG2RGiQprFWx8ohBdNaa2HEjzdgw0YA==
+      integrity: sha512-QlTQTq48YJ1nkSEZrlNBBkKzyGIn0yxNggcS5MRyNigIbeTXKMGW2PG0XL9mcxQoaLIcLaLTHokW2MW+3i407Q==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -11118,7 +11118,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-Ge7jTtAiZgGOIVvM4PRPRDy/MaUpTQJe2JdqeEw/EiyNPYRm69vtW5ZHc/umxNja53vzdiffMvBs7XtMrktKhg==
+      integrity: sha512-CasmRgA3zZMQSCskobm4Hsg7HKa1V+Y8sX3HZLvo+NWsLD9kLwKydo1oA4AquAQ9uV0KVF4x5+qiN+IfNp8mpA==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
@@ -11134,7 +11134,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-DzTl+OJjgmbrtC+l0iH4lqHjnc2hlLIzSwxSHYdvL9XedVjpVTXXz0i1tkeka6NOB75308v4XWFxuTBCtaGIfA==
+      integrity: sha512-1Js8y1xeL2z4OUZGq9X13dEhpFr3/9RmQt9dAR31b1VTVwYkGdAyMvzaX/VCqzhX9GDzHkw/jc7jDddmnoInMw==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -11144,7 +11144,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-76K32NjyIy6TYDbYigQQSbPBHjZGH8PZL7W5tWA3til8qxDSuw1lnLC7Z9D+qopOLaGqhKV6xbA+/mtsLJg7SA==
+      integrity: sha512-JqYqCUT6BBPWuIe9/Lv/+m1i2MIh4rfI5BidTu/422D2KiRdT/RgIQxzRemX5+HHE3bf/dAcktSsA3+PHpKj6w==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
@@ -11160,7 +11160,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-SH4dV/DmEVPvT7X291hTSVsM0Jr098ZC9lSXv5MRjIgrkMyo2fgcMROtDHO9WSRiVpPkctfZUJ0xiIM4nqF5PA==
+      integrity: sha512-uOXgzXmcW7lVJfhmvCMO3jvddWAXyvhbal67tPlfqdViQo4alSp5tYB/wslXp/j2vBkFVjX546K15kupg1Ersw==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -11170,7 +11170,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-R4OEo5HglAGjU3Y1Hdevrtq2CkaUteQ4fsARGuDugbzu0AQdofrN8xSvCGqj249BHiD56NVPCiRQIcemgCZagA==
+      integrity: sha512-OsOqQcLEs9GbAVbuxuFWYHpC6ztqEBgCUg/v5/DY+j3FnCrIsYOxNmoFbXWKrbdq8oQ7cYyoJ2KjrzSzQH/ajg==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
@@ -11186,7 +11186,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-vuf0tZt5HPMp76dmNkU5h59WPKuuSMmwkbI2tjZ5g2r2uBHlQL+g/zM3CcMTMw2ibiiWZl9YK5A2inh08ZWG0A==
+      integrity: sha512-qxuFoC1PWIEWSslZrauDhJo6//1dPsjl5bXH71CQLpZL9xZlpZ8icIu2MCKmo+5aP8ypJGlctLcY5iZw5dLtXQ==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -11196,7 +11196,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-l+7vB4kA35ZBjtrYK0cizpjluCO2IqUEYHQ9kNByKGDuPN748JE7Bl6yCIwNn/AzbXkBDdzuUqB/nxBBEP8vIA==
+      integrity: sha512-Np5v34qVdH7NpT8t7PlZJiUwTmRTXmR5doWt3bJl9TJ7JfaiacFINGO8/SfiSm7ICJhlk0PgOh3NMYTD7RXc4g==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
@@ -11212,7 +11212,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-Mju+x+uYiDpETVxkTTUIpsdJhZFsg8vfeRzOJsWM6W/H70lq4HU8XO6VGQRBNRrYUXaUfUe02jsT3qDNUIC13g==
+      integrity: sha512-cR7744VJDOWL5gyz5wUkH+juxxRG9XsRzltCg/5bWpTwAQcgy5S4ogvqRBpTkI8TXJddGR4ce4qA59A8BXwlQA==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -11222,7 +11222,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-yWG5E8TlHWA9bbBFFl9choESfwqb9Lf9uuCji8n3Un16wAZeovSA03wlYJNE4oifnxcE+8TpipdJfn+Kcp3FeQ==
+      integrity: sha512-5C7gi4Jfhu6rJJAtfz+QiiHU7fS6/b4+dbf84mq/oXXhIFy8G3DIEggwwp4AQrcolZZzqhuA9rwv3zCjiEFMbQ==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
@@ -11238,7 +11238,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-yw0DhKF0YhwY8qudvu8+5LX9BaFhGF6OecndMdey5LEgTkbZOFDv+bLZWwcfl1b4PslLZDfsSEP2NH9YYuSfOA==
+      integrity: sha512-CCMMP0m8UXOaidBXYZTQTLoyzkstyRXHQVMgfE4O85Lh340bFeODpyEAxkOgQLQpnAvWpo9D1xq/CviuGscQWg==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -11248,7 +11248,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-f1qvLfSSy1SH+UXscjEdGDqrfxgoyQULjOa49JzJy00uzn0aVWYxpRbdt47KIwLzrbmNPET2DCKzWJphJSthwA==
+      integrity: sha512-kHLxZ79LxMXDdX1KQmGjlqa6/juxSarKQ+jwZaEdGQETVU7OyYXiTyvh6xXBWPgSA/jpHJufqfIX0P84Dmc9+w==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -11264,7 +11264,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-NucK4mWDf+2WOu71hN4zSnShvwK3aIJoPhBa1JOebbWGi3itwgCH5maqyhhllPx5gXOLB1J/lxy9JlNmaeKunw==
+      integrity: sha512-z0r9GqIHDdPhH2Dt0MUEwTwL/NdSNhR4WatRbV9WjYtOjzh4jAnvcCrN3FPe0PXB6V/DeLiH2Xe9RKUTSNdS6A==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.6-library-test.tgz':
@@ -11274,7 +11274,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.6-library-test'
     resolution:
-      integrity: sha512-y48CKkfE/zD7BOZW9cck3l0zsBBPfh2L48Gfk9+8pnDOfaUr0oaRg9VIk+xcouamYgLc6U9wE87HUey7dRYJEg==
+      integrity: sha512-EoPmDVvki4y41mYPWzTs8DFEQb4FsSW7oXydgpqIZIxPP+KO3h6BCYAav9zH4eNJ2kScLS7K1M7yRUE9amFSrA==
       tarball: 'file:projects/rush-stack-compiler-3.6-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.6.tgz':
@@ -11290,7 +11290,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.6'
     resolution:
-      integrity: sha512-6gbsg+OwcnHiATkQgUuOVd3AH4j3bAvFlub+43hChsXKY+q4F9iKBknnTh0SuWp1xOlDsrE5t+3tUpJH7zC6Kw==
+      integrity: sha512-y6jSwbveA95z12IbPpczptFgztgHIPdtuxD3E6EIShcWDv3QxIhsQeVRP+4SjT91WroCMweWLnkuPDQobDL8CA==
       tarball: 'file:projects/rush-stack-compiler-3.6.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.7-library-test.tgz':
@@ -11300,7 +11300,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.7-library-test'
     resolution:
-      integrity: sha512-9EFy2VT350XBlPS17CU6kIAvLimsjHKW5iqp9HrOmjf4HSZ8AehLgZIg677OWGtEeF8PdPpu8cIIksgOewN4Zw==
+      integrity: sha512-jxElbTF/KZZLYnUMBMlLto2H9/P1utFQR4JxfJ2gSQz0ACQefomwunSWtwj6g6odQkPyq6bX4CC3WiFJit5WAg==
       tarball: 'file:projects/rush-stack-compiler-3.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.7.tgz':
@@ -11316,7 +11316,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.7'
     resolution:
-      integrity: sha512-f7sLRV2HvhMFVnTvRKkT/bMRMGLkz67dmLPZIgghSy8X22BJ71Rz635VfogXTM9QgiPG5s+GO0l2r5iF09rJLQ==
+      integrity: sha512-PfXuxOmsRXV7ptHlj4VXz0RQUKydp9ftYMs3yU/u8VFFeV9nKqWNovq6og5BbZZXsA8gQCdPFpSJBecATyOilw==
       tarball: 'file:projects/rush-stack-compiler-3.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -11330,7 +11330,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-9oo8kOu2ZCTHvIADueu6Ro6CE/o8z/zxJRrsN4Lhqqfxf69TuUTtfJKjiL1b8Ba6BMVuQtq2wkD6HKjGxSiyxQ==
+      integrity: sha512-SxO9zKmAOKRGPT7YVs9yuYrFJivHguFv413tMeXD4DswyqTGEFAKpq8Fgwy+EePgbf0eMIqKUsusQQKL5FyW4w==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -11341,7 +11341,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-2YL/uE4vFvl72gFVnOP3X4lCShs5slUiCdvGPOBlHohIWHEsHZ4F3584sw7AczU0/zYHb+17oZxdb1Cu/MU0Rg==
+      integrity: sha512-WMo8/LVkFdBoqjRMRrub3L7EEkDeD5GuaxAEjnAkCcPP5QH/kLtiODutFvMZl7Ifs9HYHE7gVaULSvhdZxXo/g==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -11359,7 +11359,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-4e5bnlGJYbS2FAhqWqEfZIDkvipL4SNk5FXAN3Xns2Bfrc2cd59hyIXIZRYAzWJnWNyVKzeWa0f5XgjEpQJNEA==
+      integrity: sha512-IlFGU4QHQHJOxIHCo6XL+tCT5C0lUIQDS+lZFFQwjBPcQ4D3fIX2Xw930pDbzA9yEL8C97UBiBgB7vGIrh0wEw==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -11372,7 +11372,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-U5qiy7QbqhxWZ3PsE0ztFi5cVf88mNKD504d96AwMILedaCEmA3MwZz7xsuzhUpiKt6jRvaYNszu1jKH+ZwWQw==
+      integrity: sha512-5+3stKRY+5UCVTCeZNiqbyR3lMUEKEDiCz1lzX8bbgUDVe6+AsniWezliRDQrymsTEIqyC3ieH7lNMP5ucORaw==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -11391,7 +11391,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-GlSfb/nLsAlVopv33DMy6gg1w8BEq9ZT1mLdfLkGciZ5pI6Tcz3NmG2kZ2BLHUa47xecuNAj0dnRGDFthM3R3g==
+      integrity: sha512-QjBAkl7b18Y1bI1vb6PcIkW3frZdGYIdmlEErobPUdcAk5Hn2ggUVe9OcwhS/TQQuxEKGbQfV0y1iIHbxRqgMg==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -11406,7 +11406,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-jEAtT0UbTbLgWrA2h6MIe9XEXMS09+Zi9L2K8i87H0/Vcyknvh85rHkDavbSBV+q5/V01gH+Qdh314/1RsQYew==
+      integrity: sha512-A43uEnFskNlEAh3eEfQ9Tvhecy5SRjUNBPL/wbxzVoQxgQxBUhmi1xP5P4AzKxbRcqX+3JQNBbDWGXQgfLgKbA==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -11422,7 +11422,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-sQiw5EgddNOiLwSz7qdU1h+5Ja4XaQ1skHxArnwW1IRgZ30Fq/F0ZP3ikFmVrML3IWx6pCcBf+6S7rRQQxlwTA==
+      integrity: sha512-iqOayxC9l8SK2emo8uYBvUdCUx0b+SewMZq3O509h7Yzr8RsswUYkjviLuKHYY2MTzWVp1XrNO5P/u76sihIrg==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -11434,7 +11434,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-GLpo4nAjq+AlW67wltkEjvDjkoXegleAcEvzl2BcmMhD9ynqHUHtAD+LPIStnwoYSBbv7Cci9flzZWNOwP2zCg==
+      integrity: sha512-meUrScs8yT2Qb5hORwrI6aYzwtB7KlOBQFhxf8QpEuzmtylpJvVKVwo3vs/m84a1Zq0+XJ1uQeFGdQ+3OVNPfw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -11446,7 +11446,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-8bWRieCqXt6IhcW3DtKCs+ii5KCUrMVgf4cQEEN9/3samh8RXBuWbV31xiJHwskza3qURByuvQPzKKEGpYOozQ==
+      integrity: sha512-nLSKhGIcfKWUXfCdKTLgKo6+6offkbvFwRSiYwiZTaWJFbaJ6uZVeZheoYKe8xLkvnDpHTtTjLtQx11XUJSxmA==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 specifiers:
@@ -11646,7 +11646,7 @@ specifiers:
   ts-jest: ~22.4.6
   tslint: ~5.12.1
   tslint-microsoft-contrib: ~5.2.1
-  typescript: ~3.4.3
+  typescript: ~3.5.3
   uglify-js: ~3.0.28
   vinyl: ~2.2.0
   webpack: ~4.31.0

--- a/repo-scripts/repo-toolbox/src/start.ts
+++ b/repo-scripts/repo-toolbox/src/start.ts
@@ -6,4 +6,4 @@ import { ToolboxCommandLine } from './ToolboxCommandLine';
 console.log('repo-toolbox\n');
 
 const commandLine: ToolboxCommandLine = new ToolboxCommandLine();
-commandLine.execute();
+commandLine.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -63,7 +63,7 @@ for every legacy API.  In this situation, the `@rushstack/no-untyped-underscore`
 
 This rule detects expressions that access a member with an underscore prefix, EXCEPT in cases where:
 
-- The object is typed:  specifically, `exampleObject` has a TypeScript type that declares `_privateMember`; OR
+- The object is typed: specifically, `exampleObject` has a TypeScript type that declares `_privateMember`; OR
 - The object expression uses: the `this` or `super` keywords; OR
 - The object expression is a variable named `that`.  (In older ES5 code, `that` was commonly used as an alias
  for `this` in unbound contexts.)

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -5,11 +5,11 @@ which provides a TypeScript ESLint ruleset tailored for large teams and projects
 Please see [that project's documentation](https://www.npmjs.com/package/@rushstack/eslint-config)
 for details.  To learn about Rush Stack, please visit: [https://rushstack.io/](https://rushstack.io/)
 
-## `@rushstack/no-null`
+### `@rushstack/no-null`
 
-Prevents usage of JavaScript's `null` keyword.
+Prevent usage of JavaScript's `null` keyword.
 
-### Rule Details
+#### Rule Details
 
 Most programming languages have a "null" or "nil" value that serves several purposes:
 
@@ -25,7 +25,7 @@ lint suppressions when interacting with these legacy APIs, this rule prohibits `
 in type annotations.  Comparisons with `null` are also allowed.  In other words, this rule aims to tolerate
 preexisting null values but prevents new ones from being introduced.
 
-### Examples
+#### Examples
 
 The following patterns are considered problems when `@rushstack/no-null` is enabled:
 
@@ -47,4 +47,46 @@ let x: number | null = f(); // declaring types as possibly "null" is okay
 if (x === null) {  // comparisons are okay
     x = 0;
 }
+```
+
+### `@rushstack/no-untyped-underscore`
+
+(Optional) Prevent TypeScript code from accessing legacy JavaScript members whose name has an underscore prefix.
+
+#### Rule Details
+
+JavaScript does not provide a straightforward way to restrict access to object members, so API names commonly
+use an underscore prefix to indicate a private member (e.g. `exampleObject._privateMember`).  However, inexperienced
+developers may not be aware of this convention.  In TypeScript we can generally solve this problem by marking the types
+as `private` or omitting them from the typings.  However, when migrating a large legacy code base to TypeScript,
+it may be difficult to author typings for every legacy API.  For this case, you can enable the
+`@rushstack/no-untyped-underscore` rule.
+
+This rule reports access to members whose name has an underscore prefix, EXCEPT in cases where:
+
+- The containing object has a type which declares the member; OR
+- The untyped expression uses privileged names like `this._example` or `that._example` or `super._example`; OR
+
+#### Examples
+
+The following patterns are considered problems when `@rushstack/no-untyped-underscore` is enabled:
+
+```ts
+let x: any;
+x._privateMember = 123;  // error
+
+let x: { [key: string]: number };
+x._privateMember = 123;  // error
+```
+
+The following patterns are NOT considered problems:
+
+```ts
+let x: { _privateMember: any };
+x._privateMember = 123;  // okay because _privateMember is declared by x's type
+
+enum E {
+    _PrivateMember
+}
+let e: E._PrivateMember = E._PrivateMember; // okay because _PrivateMember is declared by E
 ```

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -5,7 +5,7 @@ which provides a TypeScript ESLint ruleset tailored for large teams and projects
 Please see [that project's documentation](https://www.npmjs.com/package/@rushstack/eslint-config)
 for details.  To learn about Rush Stack, please visit: [https://rushstack.io/](https://rushstack.io/)
 
-### `@rushstack/no-null`
+## `@rushstack/no-null`
 
 Prevent usage of JavaScript's `null` keyword.
 
@@ -49,23 +49,24 @@ if (x === null) {  // comparisons are okay
 }
 ```
 
-### `@rushstack/no-untyped-underscore` (Opt-in)
+## `@rushstack/no-untyped-underscore` (Opt-in)
 
 Prevent TypeScript code from accessing legacy JavaScript members whose name has an underscore prefix.
 
 #### Rule Details
 
 JavaScript does not provide a straightforward way to restrict access to object members, so API names commonly
-use an underscore prefix to indicate a private member (e.g. `exampleObject._privateMember`).  However, inexperienced
-developers may not be aware of this convention.  In TypeScript we can generally solve this problem by marking the types
-as `private` or omitting them from the typings.  However, when migrating a large legacy code base to TypeScript,
-it may be difficult to author typings for every legacy API.  For this case, you can enable the
-`@rushstack/no-untyped-underscore` rule.
+indicate a private member by using an underscore prefix (e.g. `exampleObject._privateMember`).  For inexperienced
+developers who may be unfamiliar with this convention, in TypeScript we can mark the APIs as `private` or omit them
+from the typings.  However, when migrating a large code base to TypeScript, it may be difficult to declare types
+for every legacy API.  In this situation, the `@rushstack/no-untyped-underscore` rule can help.
 
-This rule reports access to members whose name has an underscore prefix, EXCEPT in cases where:
+This rule detects expressions that access a member with an underscore prefix, EXCEPT in cases where:
 
-- The containing object has a type which declares the member; OR
-- The untyped expression uses privileged names like `this._example` or `that._example` or `super._example`; OR
+- The object is typed:  specifically, `exampleObject` has a TypeScript type that declares `_privateMember`; OR
+- The object expression uses: the `this` or `super` keywords; OR
+- The object expression is a variable named `that`.  (In older ES5 code, `that` was commonly used as an alias
+ for `this` in unbound contexts.)
 
 #### Examples
 
@@ -73,20 +74,23 @@ The following patterns are considered problems when `@rushstack/no-untyped-under
 
 ```ts
 let x: any;
-x._privateMember = 123;  // error
+x._privateMember = 123;  // error, because x is untyped
 
 let x: { [key: string]: number };
-x._privateMember = 123;  // error
+x._privateMember = 123;  // error, because _privateMember is not a declared member of x's type
 ```
 
 The following patterns are NOT considered problems:
 
 ```ts
 let x: { _privateMember: any };
-x._privateMember = 123;  // okay because _privateMember is declared by x's type
+x._privateMember = 123;  // okay, because _privateMember is declared by x's type
+
+let x = { _privateMember: 0 };
+x._privateMember = 123;  // okay, because _privateMember is part of the inferred type
 
 enum E {
     _PrivateMember
 }
-let e: E._PrivateMember = E._PrivateMember; // okay because _PrivateMember is declared by E
+let e: E._PrivateMember = E._PrivateMember; // okay, because _PrivateMember is declared by E
 ```

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -49,9 +49,9 @@ if (x === null) {  // comparisons are okay
 }
 ```
 
-### `@rushstack/no-untyped-underscore`
+### `@rushstack/no-untyped-underscore` (Opt-in)
 
-(Optional) Prevent TypeScript code from accessing legacy JavaScript members whose name has an underscore prefix.
+Prevent TypeScript code from accessing legacy JavaScript members whose name has an underscore prefix.
 
 #### Rule Details
 

--- a/stack/eslint-plugin/src/index.ts
+++ b/stack/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 import { noNullRule } from './no-null';
+import { noUntypedUnderscoreRule } from './no-untyped-underscore';
 
 interface IPlugin {
   rules: { [ruleName: string]: TSESLint.RuleModule<string, unknown[]> };
@@ -12,7 +13,8 @@ interface IPlugin {
 const plugin: IPlugin = {
   rules: {
     // NOTE: The actual ESLint rule name will be "@rushstack/no-null".
-    'no-null': noNullRule
+    'no-null': noNullRule,
+    'no-untyped-underscore': noUntypedUnderscoreRule
   }
 };
 

--- a/stack/eslint-plugin/src/no-null.ts
+++ b/stack/eslint-plugin/src/no-null.ts
@@ -18,10 +18,10 @@ const noNullRule: TSESLint.RuleModule<MessageIds,Options> = {
     },
     schema: [ ],
     docs: {
-      description: 'Prevents usage of JavaScript\'s "null" keyword.',
+      description: 'Prevent usage of JavaScript\'s "null" keyword',
       category: 'Stylistic Issues',
       recommended: "error",
-      url: 'https://www.npmjs.com/package/@rushstack/eslint-config'
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'
     }
   },
   create: (context: TSESLint.RuleContext<MessageIds, Options>) => {

--- a/stack/eslint-plugin/src/no-null.ts
+++ b/stack/eslint-plugin/src/no-null.ts
@@ -26,9 +26,9 @@ const noNullRule: TSESLint.RuleModule<MessageIds,Options> = {
   },
   create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
     return {
-      Literal: function(node: TSESTree.Node) {
+      Literal: function(node: TSESTree.Literal) {
         // Is it a "null" literal?
-        if (node.type === 'Literal' && node.value === null) {
+        if (node.value === null) {
 
           // Does the "null" appear in a comparison such as "if (x === null)"?
           let isComparison: boolean = false;

--- a/stack/eslint-plugin/src/no-untyped-underscore.ts
+++ b/stack/eslint-plugin/src/no-untyped-underscore.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  TSESTree,
+  TSESLint
+} from '@typescript-eslint/experimental-utils';
+
+type MessageIds = 'error-untyped-underscore';
+type Options = [ ];
+
+const noUntypedUnderscoreRule: TSESLint.RuleModule<MessageIds,Options> = {
+  meta: {
+    type: 'problem',
+    messages: {
+      'error-untyped-underscore':
+        'This expression appears to access a private member "{{memberName}}"; '
+        + 'either remove the underscore prefix or else declare a type for the containing object'
+    },
+    schema: [ ],
+    docs: {
+      description: 'Prevents usage of JavaScript\'s "null" keyword.',
+      category: 'Stylistic Issues',
+      recommended: "error",
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-config'
+    }
+  },
+  create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
+    return {
+      MemberExpression: function(node: TSESTree.MemberExpression) {
+        // Is it an expression like "x.y"?
+        let match: boolean = true;
+
+        // Ignore expressions such as "super.y", "this.y", and "that.y"
+        const memberObject: TSESTree.LeftHandSideExpression = node.object;
+        if (memberObject) {
+          if (memberObject.type === 'Super' || memberObject.type === 'ThisExpression') {
+            match = false;
+          } else {
+            if (memberObject.type === 'Identifier') {
+              if (memberObject.name === 'this' || memberObject.name == 'that') {
+                match = false;
+              }
+            }
+          }
+        }
+
+        // Does the member name start with an underscore?  (e.g. "x._y")
+        if (match && node.property && node.property.type === 'Identifier') {
+          const memberName: string = node.property.name;
+          if (memberName && memberName[0] === '_') {
+            context.report({
+              node,
+              messageId: 'error-untyped-underscore',
+              data: {
+                memberName: memberName
+              }
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export { noUntypedUnderscoreRule };

--- a/stack/eslint-plugin/src/no-untyped-underscore.ts
+++ b/stack/eslint-plugin/src/no-untyped-underscore.ts
@@ -21,10 +21,11 @@ const noUntypedUnderscoreRule: TSESLint.RuleModule<MessageIds,Options> = {
     },
     schema: [ ],
     docs: {
-      description: 'Prevents usage of JavaScript\'s "null" keyword.',
+      description: 'Prevent TypeScript code from accessing legacy JavaScript members'
+        + ' whose name has an underscore prefix',
       category: 'Stylistic Issues',
-      recommended: "error",
-      url: 'https://www.npmjs.com/package/@rushstack/eslint-config'
+      recommended: false,
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'
     }
   },
   create: (context: TSESLint.RuleContext<MessageIds, Options>) => {

--- a/stack/eslint-plugin/src/no-untyped-underscore.ts
+++ b/stack/eslint-plugin/src/no-untyped-underscore.ts
@@ -22,7 +22,7 @@ const noUntypedUnderscoreRule: TSESLint.RuleModule<MessageIds,Options> = {
     schema: [ ],
     docs: {
       description: 'Prevent TypeScript code from accessing legacy JavaScript members'
-        + ' whose name has an underscore prefix',
+        + ' whose names have an underscore prefix',
       category: 'Stylistic Issues',
       recommended: false,
       url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'


### PR DESCRIPTION
This is an opt-in rule for TypeScript code that needs to access legacy JavaScript libraries that have not been migrated to TypeScript yet.

It prevents TypeScript code from accessing legacy JavaScript members whose name has an underscore prefix.

#### Examples

The following patterns are considered problems when `@rushstack/no-untyped-underscore` is enabled:

```ts
let x: any;
x._privateMember = 123;  // error

let x: { [key: string]: number };
x._privateMember = 123;  // error
```

The following patterns are NOT considered problems:

```ts
let x: { _privateMember: any };
x._privateMember = 123;  // okay because _privateMember is declared by x's type

enum E {
    _PrivateMember
}
let e: E._PrivateMember = E._PrivateMember; // okay because _PrivateMember is declared by E
```


CC @jparker-hbo