### PR TITLE
[gcb-sass] Change default post/preamble to eslint

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-sass/patch-1_2020-12-02-00-42.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/patch-1_2020-12-02-00-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Add both ESLint and TSLint supressions for generated .scss.ts files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -94,8 +94,8 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     super(
       'sass',
       {
-        preamble: '/* tslint:disable */',
-        postamble: '/* tslint:enable */',
+        preamble: '/* eslint-disable */',
+        postamble: '/* eslint-enable */',
         sassMatch: [
           'src/**/*.scss',
           'src/**/*.sass'

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -94,8 +94,8 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     super(
       'sass',
       {
-        preamble: '/* eslint-disable */',
-        postamble: '/* eslint-enable */',
+        preamble: '/* eslint-disable */\n/* tslint-disable */',
+        postamble: '/* tslint-enable */\n/* eslint-enable */',
         sassMatch: [
           'src/**/*.scss',
           'src/**/*.sass'


### PR DESCRIPTION
By default the SassTask config is current set to ts-lint, however, as I understand the default linter has been update to @rushstack/eslint-config. Is there any reason this hasn't been updated?