### PR TITLE
[rush] Make default branch and origin name configurable

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -220,7 +220,9 @@
      * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
      * to retrieve the latest activity for the remote master branch.
      */
-    /*[LINE "HYPOTHETICAL"]*/ "url": "https://github.com/microsoft/rush-example"
+    /*[LINE "HYPOTHETICAL"]*/ "url": "https://github.com/microsoft/rush-example",
+    /*[LINE "HYPOTHETICAL"]*/ "defaultBranch": "master",
+    /*[LINE "HYPOTHETICAL"]*/ "defaultRemote": "origin"
   },
 
   /**

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -1045,7 +1045,7 @@ export class RushConfiguration {
   /**
    * The default fully-qualified git remote of the repository. This helps "rush change" find the right remote to compare against.
    */
-  public get repositoryDefaultFullyQualifiedRemote(): string {
+  public get repositoryDefaultFullyQualifiedRemoteBranch(): string {
     return `${this.repositoryDefaultRemote}/${this.repositoryDefaultBranch}`;
   }
 

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -83,6 +83,8 @@ export interface IRushRepositoryJson {
    * The remote url of the repository. This helps "rush change" find the right remote to compare against.
    */
   url: string;
+  defaultBranch: string;
+  defaultRemote: string;
 }
 
 /**
@@ -293,6 +295,8 @@ export class RushConfiguration {
 
   // Repository info
   private _repositoryUrl: string;
+  private _repositoryDefaultBranch: string;
+  private _repositoryDefaultRemote: string;
 
   private _pnpmOptions: PnpmOptionsConfiguration;
   private _yarnOptions: YarnOptionsConfiguration;
@@ -465,6 +469,8 @@ export class RushConfiguration {
 
     if (rushConfigurationJson.repository) {
       this._repositoryUrl = rushConfigurationJson.repository.url;
+      this._repositoryDefaultBranch = rushConfigurationJson.repository.defaultBranch || "master";
+      this._repositoryDefaultRemote = rushConfigurationJson.repository.defaultRemote || "origin";
     }
 
     this._telemetryEnabled = !!rushConfigurationJson.telemetryEnabled;
@@ -1020,6 +1026,27 @@ export class RushConfiguration {
    */
   public get repositoryUrl(): string {
     return this._repositoryUrl;
+  }
+
+  /**
+   * The default git branch of the repository. This helps "rush change" find the right remote to compare against.
+   */
+  public get repositoryDefaultBranch(): string {
+    return this._repositoryDefaultBranch;
+  }
+
+  /**
+   * The default git remote of the repository. This helps "rush change" find the right remote to compare against.
+   */
+  public get repositoryDefaultRemote(): string {
+    return this._repositoryDefaultRemote;
+  }
+
+  /**
+   * The default fully-qualified git remote of the repository. This helps "rush change" find the right remote to compare against.
+   */
+  public get repositoryDefaultFullyQualifiedRemote(): string {
+    return `${this.repositoryDefaultRemote}/${this.repositoryDefaultBranch}`;
   }
 
   /**

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -1043,7 +1043,7 @@ export class RushConfiguration {
   }
 
   /**
-   * The default fully-qualified git remote of the repository. This helps "rush change" find the right remote to compare against.
+   * The default fully-qualified git remote branch of the repository. This helps "rush change" find the right branch to compare against.
    */
   public get repositoryDefaultFullyQualifiedRemoteBranch(): string {
     return `${this.repositoryDefaultRemote}/${this.repositoryDefaultBranch}`;

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -308,7 +308,7 @@ export class ChangeAction extends BaseRushAction {
   private get _targetBranch(): string {
     if (!this._targetBranchName) {
       this._targetBranchName = (
-        this._targetBranchParameter.value || VersionControl.getRemoteMasterBranch(this.rushConfiguration.repositoryUrl)
+        this._targetBranchParameter.value || VersionControl.getRemoteMasterBranch(this.rushConfiguration)
       );
     }
 

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -156,6 +156,14 @@
         "url": {
           "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against.",
           "type": "string"
+        },
+        "defaultBranch": {
+          "description": "The default git branch name. If a value is provided, \"rush change\" will use it as a remote git branch to compare against. The default value is \"master\"",
+          "type": "string"
+        },
+        "defaultRemote": {
+          "description": "The default git remote name. If a value is provided, \"rush change\" will use it as a git remote to compare against. The default value is \"origin\"",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -128,13 +128,13 @@ export class VersionControl {
           'Detected changes are likely to be incorrect.'
         ));
 
-        return rushConfiguration.repositoryDefaultFullyQualifiedRemote;
+        return rushConfiguration.repositoryDefaultFullyQualifiedRemoteBranch;
       }
     } else {
       console.log(colors.yellow(
         'A git remote URL has not been specified in rush.json. Setting the baseline remote URL is recommended.'
       ));
-      return rushConfiguration.repositoryDefaultFullyQualifiedRemote;
+      return rushConfiguration.repositoryDefaultFullyQualifiedRemoteBranch;
     }
   }
 

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -7,7 +7,7 @@ import {
   Executable,
   Path
 } from '@microsoft/node-core-library';
-import {RushConfiguration} from '..';
+import { RushConfiguration } from '../RushConfiguration';
 
 export class VersionControl {
   public static getRepositoryRootPath(): string | undefined {

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -7,10 +7,7 @@ import {
   Executable,
   Path
 } from '@microsoft/node-core-library';
-
-const DEFAULT_BRANCH: string = 'master';
-const DEFAULT_REMOTE: string = 'origin';
-const DEFAULT_FULLY_QUALIFIED_BRANCH: string = `${DEFAULT_REMOTE}/${DEFAULT_BRANCH}`;
+import {RushConfiguration} from '..';
 
 export class VersionControl {
   public static getRepositoryRootPath(): string | undefined {
@@ -83,14 +80,14 @@ export class VersionControl {
    * master branch 'origin/master'.
    * If there are more than one matches, returns the first remote's master branch.
    *
-   * @param repositoryUrl - repository url
+   * @param rushConfiguration - rush configuration
    */
-  public static getRemoteMasterBranch(repositoryUrl?: string): string {
-    if (repositoryUrl) {
+  public static getRemoteMasterBranch(rushConfiguration: RushConfiguration): string {
+    if (rushConfiguration.repositoryUrl) {
       const output: string = child_process
         .execSync(`git remote`)
         .toString();
-      const normalizedRepositoryUrl: string = repositoryUrl.toUpperCase();
+      const normalizedRepositoryUrl: string = rushConfiguration.repositoryUrl.toUpperCase();
       const matchingRemotes: string[] = output.split('\n').filter((remoteName) => {
         if (remoteName) {
           const remoteUrl: string = child_process.execSync(`git remote get-url ${remoteName}`)
@@ -124,20 +121,20 @@ export class VersionControl {
           );
         }
 
-        return `${matchingRemotes[0]}/${DEFAULT_BRANCH}`;
+        return `${matchingRemotes[0]}/${rushConfiguration.repositoryDefaultBranch}`;
       } else {
         console.log(colors.yellow(
-          `Unable to find a git remote matching the repository URL (${repositoryUrl}). ` +
+          `Unable to find a git remote matching the repository URL (${rushConfiguration.repositoryUrl}). ` +
           'Detected changes are likely to be incorrect.'
         ));
 
-        return DEFAULT_FULLY_QUALIFIED_BRANCH;
+        return rushConfiguration.repositoryDefaultFullyQualifiedRemote;
       }
     } else {
       console.log(colors.yellow(
         'A git remote URL has not been specified in rush.json. Setting the baseline remote URL is recommended.'
       ));
-      return DEFAULT_FULLY_QUALIFIED_BRANCH;
+      return rushConfiguration.repositoryDefaultFullyQualifiedRemote;
     }
   }
 

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -7,7 +7,7 @@ import {
   Executable,
   Path
 } from '@microsoft/node-core-library';
-import { RushConfiguration } from '../RushConfiguration';
+import { RushConfiguration } from '../api/RushConfiguration';
 
 export class VersionControl {
   public static getRepositoryRootPath(): string | undefined {

--- a/common/changes/@microsoft/rush/add-git-properties_2020-01-20-16-47.json
+++ b/common/changes/@microsoft/rush/add-git-properties_2020-01-20-16-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add support of defaultBranch and defaultOrigin as repo configuration properties",
+      "comment": "Make the default branch and default remote configurable.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/add-git-properties_2020-01-20-16-47.json
+++ b/common/changes/@microsoft/rush/add-git-properties_2020-01-20-16-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support of defaultBranch and defaultOrigin as repo configuration properties",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "jabher@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -31,7 +31,7 @@ export class ApprovedPackagesItem {
 // @public
 export class ApprovedPackagesPolicy {
     // Warning: (ae-forgotten-export) The symbol "IRushConfigurationJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(rushConfiguration: RushConfiguration, rushConfigurationJson: IRushConfigurationJson);
     readonly browserApprovedPackages: ApprovedPackagesConfiguration;
@@ -106,7 +106,7 @@ export enum Event {
 // @beta
 export class EventHooks {
     // Warning: (ae-forgotten-export) The symbol "IEventHooksJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(eventHooksJson: IEventHooksJson);
     get(event: Event): string[];
@@ -133,7 +133,7 @@ export interface ILaunchOptions {
 // @beta
 export class IndividualVersionPolicy extends VersionPolicy {
     // Warning: (ae-forgotten-export) The symbol "IIndividualVersionJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(versionPolicyJson: IIndividualVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
@@ -162,7 +162,7 @@ export class _LastInstallFlag {
 // @beta
 export class LockStepVersionPolicy extends VersionPolicy {
     // Warning: (ae-forgotten-export) The symbol "ILockStepVersionJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(versionPolicyJson: ILockStepVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
@@ -230,7 +230,7 @@ export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
 // @public
 export class PnpmOptionsConfiguration {
     // Warning: (ae-forgotten-export) The symbol "IPnpmOptionsJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(json: IPnpmOptionsJson);
     readonly resolutionStrategy: ResolutionStrategy;
@@ -295,6 +295,9 @@ export class RushConfiguration {
     readonly projects: RushConfigurationProject[];
     // (undocumented)
     readonly projectsByName: Map<string, RushConfigurationProject>;
+    readonly repositoryDefaultBranch: string;
+    readonly repositoryDefaultFullyQualifiedRemote: string;
+    readonly repositoryDefaultRemote: string;
     readonly repositoryUrl: string;
     readonly rushJsonFile: string;
     readonly rushJsonFolder: string;
@@ -317,7 +320,7 @@ export class RushConfiguration {
 // @public
 export class RushConfigurationProject {
     // Warning: (ae-forgotten-export) The symbol "IRushConfigurationProjectJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(projectJson: IRushConfigurationProjectJson, rushConfiguration: RushConfiguration, tempProjectName: string);
     readonly cyclicDependencyProjects: Set<string>;
@@ -354,7 +357,7 @@ export class _RushGlobalFolder {
 // @beta
 export abstract class VersionPolicy {
     // Warning: (ae-forgotten-export) The symbol "IVersionPolicyJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(versionPolicyJson: IVersionPolicyJson);
     abstract bump(bumpType?: BumpType, identifier?: string): void;
@@ -394,7 +397,7 @@ export enum VersionPolicyDefinitionName {
 // @public
 export class YarnOptionsConfiguration {
     // Warning: (ae-forgotten-export) The symbol "IYarnOptionsJson" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @internal
     constructor(json: IYarnOptionsJson);
     readonly ignoreEngines: boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -296,7 +296,7 @@ export class RushConfiguration {
     // (undocumented)
     readonly projectsByName: Map<string, RushConfigurationProject>;
     readonly repositoryDefaultBranch: string;
-    readonly repositoryDefaultFullyQualifiedRemote: string;
+    readonly repositoryDefaultFullyQualifiedRemoteBranch: string;
     readonly repositoryDefaultRemote: string;
     readonly repositoryUrl: string;
     readonly rushJsonFile: string;


### PR DESCRIPTION
I've been looking through sources and accidentally understood that moving this constanted variables to configuration will take me around 20 minutes, so why not.

This can be useful for a lot of people.