### PR TITLE
[rush] Fix an issue with error reporting in executeLifecycleCommand.

### DIFF
--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -411,7 +411,7 @@ export class Utilities {
       Utilities._processResult(result);
     }
 
-    if (result.status) {
+    if (result.status !== null) {
       return result.status;
     } else {
       throw result.error || new Error('An unknown error occurred.');

--- a/common/changes/@microsoft/rush/ianc-fix-rushx_2020-01-26-01-59.json
+++ b/common/changes/@microsoft/rush/ianc-fix-rushx_2020-01-26-01-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the rushx command will always report error.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
The `rushx` command in Rush 5.19.1 currently reports errors on every command. This PR fixes that.