### PR TITLE
[rush] Fix for rush publish / git tagging "too many args" or "Failed to resolve 'v<version>' as a valid ref"

### DIFF
--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -50,7 +50,7 @@ export class PublishGit {
     PublishUtilities.execCommand(
       !!this._targetBranch && shouldExecute,
       'git',
-      ['tag', '-a', tagName, '-m', `"${packageName} v${packageVersion}"`, ...(commitId ? [commitId] : [])]);
+      ['tag', '-a', tagName, '-m', `${packageName} v${packageVersion}`, ...(commitId ? [commitId] : [])]);
   }
 
   public hasTag(packageConfig: RushConfigurationProject): boolean {

--- a/common/changes/@microsoft/rush/master_2020-01-27-23-00.json
+++ b/common/changes/@microsoft/rush/master_2020-01-27-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixing \"too many params\" and \"unable to find ref v<version>\" issues in git tagging while publishing.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chaseholland@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2020-01-27-23-00.json
+++ b/common/changes/@microsoft/rush/master_2020-01-27-23-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fixing \"too many params\" and \"unable to find ref v<version>\" issues in git tagging while publishing.",
+      "comment": "Fixes \"too many params\" and \"unable to find ref v<version>\" issues in git tagging while publishing.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Resolving an issue with rush publishing when git tags are applied. Rush's `PublishUtilities` automatically add quotes around all shell arguments, which is not reflected in the `DRYRUN` output. The quotes added around the quotes will unqoute the `-m` arg to the `git tag` command, which will result in the message reading as too separate arguments.