### PR TITLE
Move RushConfiguration access in action to unblock Init

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -66,12 +66,6 @@ export class PublishAction extends BaseRushAction {
       'changes and publish packages, you must use the --commit flag and/or the --publish flag.',
       parser
     });
-
-    // Example: "common\temp\publish-home"
-    this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');
-
-    // Example: "common\temp\publish-home\.npmrc"
-    this._targetNpmrcPublishPath = path.join(this._targetNpmrcPublishFolder, '.npmrc');
   }
 
   protected onDefineParameters(): void {
@@ -210,6 +204,12 @@ export class PublishAction extends BaseRushAction {
   protected run(): Promise<void> {
     return Promise.resolve().then(() => {
       PolicyValidator.validatePolicy(this.rushConfiguration, false);
+
+      // Example: "common\temp\publish-home"
+      this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');
+
+      // Example: "common\temp\publish-home\.npmrc"
+      this._targetNpmrcPublishPath = path.join(this._targetNpmrcPublishFolder, '.npmrc');
 
       const allPackages: Map<string, RushConfigurationProject> = this.rushConfiguration.projectsByName;
 

--- a/common/changes/@microsoft/rush/danade-fixBrokenInit_2020-02-12-02-01.json
+++ b/common/changes/@microsoft/rush/danade-fixBrokenInit_2020-02-12-02-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix broken init command caused by early RushConfiguration access",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/danade-fixBrokenInit_2020-02-12-02-01.json
+++ b/common/changes/@microsoft/rush/danade-fixBrokenInit_2020-02-12-02-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix broken init command caused by early RushConfiguration access",
+      "comment": "",
       "type": "none"
     }
   ],


### PR DESCRIPTION
`rush init` was broken by attempting to access RushConfiguration in the constructor of the publish action. I've moved the initialization into the run() method to initialize when the action is actually run.