### PR TITLE
[rush-lib] Adds yellow output on event hook fail

### DIFF
--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -45,8 +45,10 @@ export class EventHooksManager {
             }
           );
         } catch (error) {
-          console.error(`${os.EOL} Event hook "${script}" failed. Run "rush" with --debug` +
-            ` to see detailed error information.`);
+          console.error(
+            os.EOL + colors.yellow(`Event hook "${script}" failed. Run "rush" with --debug`) +
+            ` to see detailed error information.`
+          );
           if (isDebug) {
             console.error(os.EOL + error.message);
           }

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -46,8 +46,8 @@ export class EventHooksManager {
           );
         } catch (error) {
           console.error(
-            os.EOL + colors.yellow(`Event hook "${script}" failed. Run "rush" with --debug`) +
-            colors.yellow(` to see detailed error information.`)
+            os.EOL + colors.yellow(`Event hook "${script}" failed. Run "rush" with --debug` +
+            ` to see detailed error information.`)
           );
           if (isDebug) {
             console.error(os.EOL + error.message);

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -47,7 +47,7 @@ export class EventHooksManager {
         } catch (error) {
           console.error(
             os.EOL + colors.yellow(`Event hook "${script}" failed. Run "rush" with --debug`) +
-            ` to see detailed error information.`
+            colors.yellow(` to see detailed error information.`)
           );
           if (isDebug) {
             console.error(os.EOL + error.message);

--- a/common/changes/@microsoft/rush/fix-event-hook-fail-color_2020-02-14-12-22.json
+++ b/common/changes/@microsoft/rush/fix-event-hook-fail-color_2020-02-14-12-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds yellow output on event hook fail",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "1504027+VincentSurelle@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/fix-event-hook-fail-color_2020-02-14-12-22.json
+++ b/common/changes/@microsoft/rush/fix-event-hook-fail-color_2020-02-14-12-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Adds yellow output on event hook fail",
+      "comment": "Make the event hook failure message print in yellow.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
This PR adds a yellow coloring when an event hook fails.

It has been discussed on #1745 