### PR TITLE
[rush] Patch pnpm last-install error handling

### DIFF
--- a/apps/rush-lib/src/api/LastInstallFlag.ts
+++ b/apps/rush-lib/src/api/LastInstallFlag.ts
@@ -61,12 +61,10 @@ export class LastInstallFlag {
         const pkgManager: PackageManagerName = newState.packageManager;
         if (pkgManager === 'pnpm') {
           if (
-            ( // Only throw an error if the package manager hasn't changed from PNPM
-              oldState.packageManager === pkgManager
-            ) && ( // Throw if the store path changed
-              oldState.storePath &&
-              oldState.storePath !== newState.storePath
-            )
+            // Only throw an error if the package manager hasn't changed from PNPM
+            oldState.packageManager === pkgManager &&
+            // Throw if the store path changed
+            oldState.storePath !== newState.storePath
           ) {
             const oldStorePath: string = oldState.storePath || '<global>';
             const newStorePath: string = newState.storePath || '<global>';

--- a/common/changes/@microsoft/rush/patch-pnpm-store-options_2020-03-07-23-18.json
+++ b/common/changes/@microsoft/rush/patch-pnpm-store-options_2020-03-07-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix false-negative condition when pnpm store path has changed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "1935258+Js-Brecht@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/patch-pnpm-store-options_2020-03-07-23-18.json
+++ b/common/changes/@microsoft/rush/patch-pnpm-store-options_2020-03-07-23-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix false-negative condition when pnpm store path has changed",
+      "comment": "Fix a case where an exception wouldn't have been thrown if the pnpm store path had been set after it had previously been unset.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
There's a small bug in the work done in #1657 that I missed.  It's probably not something that would be encountered frequently, but it is there nonetheless.

If somebody switches from a global default path for pnpm's store, to a static path using the `local` option, or `RUSH_PNPM_STORE_PATH`, then the condition that checks for an error will return false, so it won't handle the error gracefully.  Since the store path DID change, though, it will fall through to PNPM, which will throw an exception.

The value for the global default is an empty string, which, of course, is falsy.  The error occurs here:
https://github.com/microsoft/rushstack/blob/15f796370e964876f7c28dba6680cf09244ac9bc/apps/rush-lib/src/api/LastInstallFlag.ts#L64-L69
If `oldState.storePath` evaluates to false, then it will not handle the error state.  That's erroneous, and that check is redundant, anyway.  That was just supposed to be a check to ensure that the `storePath` existed before, meaning the package manager hadn't been changed TO pnpm.  It would have been valid if it said `oldState.storePath !== undefined`... but that condition is handled by `oldState.packageManager === pkgManager` already.