### PR TITLE
[rush] Update rush init and add 'myrush' binary that invokes globally installed Rush version

### DIFF
--- a/apps/rush-lib/assets/rush-init/[dot]gitignore
+++ b/apps/rush-lib/assets/rush-init/[dot]gitignore
@@ -55,6 +55,14 @@ jspm_packages/
 # next.js build output
 .next
 
+# Common toolchain intermediate files
+lib
+temp
+
+# Rush files
+common/temp/**
+package-deps.json
+
 # OS X temporary files
 .DS_Store
 

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "2.15.1",
+  "pnpmVersion": "4.8.0",
 
   /*[LINE "HYPOTHETICAL"]*/ "npmVersion": "4.5.0",
   /*[LINE "HYPOTHETICAL"]*/ "yarnVersion": "1.9.4",

--- a/apps/rush/bin/myrush
+++ b/apps/rush/bin/myrush
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/start.js')

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -27,7 +27,8 @@
   },
   "bin": {
     "rush": "./bin/rush",
-    "rushx": "./bin/rushx"
+    "rushx": "./bin/rushx",
+    "myrush": "./bin/myrush"
   },
   "license": "MIT",
   "dependencies": {

--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -5,7 +5,7 @@ import * as colors from 'colors';
 import * as path from 'path';
 import * as rushLib from '@microsoft/rush-lib';
 
-type CommandName = 'rush' | 'rushx' | undefined;
+type CommandName = 'rush' | 'rushx' | 'myrush' | undefined;
 
 /**
  * Both "rush" and "rushx" share the same src/start.ts entry point.  This makes it
@@ -59,7 +59,8 @@ export class RushCommandSelector {
     return process.exit(1);
   }
 
-  private static _getCommandName(): CommandName {
+  // TODO: Can we expose this function as so, is it safe?
+  public static _getCommandName(): CommandName {
     if (process.argv.length >= 2) {
       // Example:
       // argv[0]: "C:\\Program Files\\nodejs\\node.exe"
@@ -70,6 +71,9 @@ export class RushCommandSelector {
       }
       if (basename === 'RUSH') {
         return 'rush';
+      }
+      if (basename === 'MYRUSH') {
+        return 'myrush';
       }
     }
     return undefined;

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -90,7 +90,7 @@ const launchOptions: rushLib.ILaunchOptions = { isManaged, alreadyReportedNodeTo
 
 // If we're inside a repo folder, and it's requesting a different version, then use the RushVersionManager to
 // install it
-if (rushVersionToLoad && rushVersionToLoad !== currentPackageVersion) {
+if ( RushCommandSelector._getCommandName() !== 'myrush' && (rushVersionToLoad && rushVersionToLoad !== currentPackageVersion)) {
   const versionSelector: RushVersionSelector = new RushVersionSelector(currentPackageVersion);
   versionSelector.ensureRushVersionInstalled(rushVersionToLoad, configuration, launchOptions)
     .catch((error: Error) => {

--- a/common/changes/@microsoft/rush/updateRushInit_2020-03-08-23-01.json
+++ b/common/changes/@microsoft/rush/updateRushInit_2020-03-08-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add new binary 'myrush' that invokes the globally installed version of Rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "darsi-an@users.noreply.github.com"
+}


### PR DESCRIPTION
I bypass version selector just checking if command name is 'myrush' if not it falls back to the old behavior. 

**WIP (Please comment if I need to any any more)**
- Print errors for 'rush' init if not latest rush
- Add .npmrc-publish template and copy over logic in `InitAction`

**Questions**
- Running `rush init --overwrite-existing` will still older version in rush.json. Is this necessary?
- Init action with `--overwrite-existing` over writes everything. What if you just want to update versions in the Rush,json to the globally installed Rush version, without overwriting other properties? 
