### PR TITLE
[rush] Support custom environment variables for the underlying package manager install process, expose maxInstallAttempts as a parameter for rush install/update.

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -241,7 +241,7 @@ export interface ICurrentVariantJson {
  *
  * @public
  */
-export class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
+export abstract class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
   /**
    * Enviroment variables for the package manager
    */

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -248,8 +248,8 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
   public readonly environmentVariables?: IConfigurationEnvironment
 
   /** @internal */
-  protected constructor(environmentVariables?: IConfigurationEnvironment) {
-    this.environmentVariables = environmentVariables;
+  protected constructor(json: IPackageManagerOptionsJsonBase) {
+    this.environmentVariables = json.environmentVariables;
   }
 }
 

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -128,7 +128,8 @@ export interface IConfigurationEnvironment {
 }
 
 /**
- * Represents an environment variable
+ * Represents the value of an environment variable, and if the value should be overridden if the variable is set
+ * in the parent environment.
  * @public
  */
 export interface IConfigurationEnvironmentVariable {

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -106,13 +106,32 @@ export interface IRushRepositoryJson {
 export type PnpmStoreOptions = 'local' | 'global';
 
 /**
- * Part of IRushConfigurationJson.
- * @internal
+ * Options for the package manager.
+ * @public
  */
 export interface IPackageManagerOptions {
+  /**
+   * Enviroment variables for the package manager
+   */
   environmentVariables?: {
-    [name: string]: string
-  };
+    [environmentVariableName: string]: IEnvironmentVariable;
+  }
+}
+
+/**
+ * Represents an environment variable
+ * @public
+ */
+export interface IEnvironmentVariable {
+  /**
+   * Value of the environment variable
+   */
+  value: string;
+
+  /**
+   * Set to true to override the environment variable even if it is set on the device
+   */
+  override?: boolean; //
 }
 
 /**
@@ -1039,6 +1058,9 @@ export class RushConfiguration {
     return this._projectFolderMaxDepth;
   }
 
+  /**
+   * {@inheritDoc IPackageManagerOptions}
+   */
   public get packageManagerOptions(): IPackageManagerOptions | undefined {
     return this._packageManagerOptions;
   }

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -174,7 +174,7 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
  * @internal
  */
 export interface IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
-    /**
+  /**
    * If true, then Rush will add the "--ignore-engines" option when invoking Yarn.
    * This allows "rush install" to succeed if there are dependencies with engines defined in
    * package.json which do not match the current environment.

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -140,7 +140,7 @@ export interface IConfigurationEnvironmentVariable {
   /**
    * Set to true to override the environment variable even if it is set on the device
    */
-  override?: boolean; //
+  override?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -265,7 +265,7 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
 export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
   /** @internal */
   public constructor(json: INpmOptionsJson) {
-    super(json.environmentVariables);
+    super(json);
   }
 }
 
@@ -327,7 +327,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
 
   /** @internal */
   public constructor(json: IPnpmOptionsJson, commonTempFolder: string) {
-    super(json.environmentVariables);
+    super(json);
     this.pnpmStore = json.pnpmStore || 'local';
     if (EnvironmentConfiguration.pnpmStorePathOverride) {
       this.pnpmStorePath = EnvironmentConfiguration.pnpmStorePathOverride;
@@ -362,7 +362,7 @@ export class YarnOptionsConfiguration extends PackageManagerOptionsConfiguration
 
   /** @internal */
   public constructor(json: IYarnOptionsJson) {
-    super(json.environmentVariables);
+    super(json);
     this.ignoreEngines = !!json.ignoreEngines;
   }
 }

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -109,6 +109,16 @@ export type PnpmStoreOptions = 'local' | 'global';
  * Part of IRushConfigurationJson.
  * @internal
  */
+export interface IPackageManagerOptions {
+  environmentVariables?: {
+    [name: string]: string
+  };
+}
+
+/**
+ * Part of IRushConfigurationJson.
+ * @internal
+ */
 export interface IPnpmOptionsJson {
   /**
    * The store resolution method for PNPM to use
@@ -160,6 +170,7 @@ export interface IRushConfigurationJson {
   projects: IRushConfigurationProjectJson[];
   eventHooks?: IEventHooksJson;
   hotfixChangeEnabled?: boolean;
+  packageManagerOptions?: IPackageManagerOptions;
   pnpmOptions?: IPnpmOptionsJson;
   yarnOptions?: IYarnOptionsJson;
   ensureConsistentVersions?: boolean;
@@ -351,6 +362,8 @@ export class RushConfiguration {
   private _repositoryDefaultBranch: string;
   private _repositoryDefaultRemote: string;
 
+  private _packageManagerOptions?: IPackageManagerOptions;
+
   private _pnpmOptions: PnpmOptionsConfiguration;
   private _yarnOptions: YarnOptionsConfiguration;
 
@@ -449,6 +462,8 @@ export class RushConfiguration {
         + ` and ${packageManagerFields[1]} `);
     }
 
+    this._packageManagerOptions = rushConfigurationJson.packageManagerOptions;
+
     if (this._packageManager === 'npm') {
       this._packageManagerToolVersion = rushConfigurationJson.npmVersion!;
       this._packageManagerWrapper = new NpmPackageManager(this._packageManagerToolVersion);
@@ -463,10 +478,10 @@ export class RushConfiguration {
     this._shrinkwrapFilename = this._packageManagerWrapper.shrinkwrapFilename;
 
     this._tempShrinkwrapFilename = path.join(
-        this._commonTempFolder, this._shrinkwrapFilename
+      this._commonTempFolder, this._shrinkwrapFilename
     );
     this._packageManagerToolFilename = path.resolve(path.join(
-        this._commonTempFolder, `${this.packageManager}-local`, 'node_modules', '.bin', `${this.packageManager}`
+      this._commonTempFolder, `${this.packageManager}-local`, 'node_modules', '.bin', `${this.packageManager}`
     ));
 
     /// From "C:\repo\common\temp\pnpm-lock.yaml" --> "C:\repo\common\temp\pnpm-lock-preinstall.yaml"
@@ -475,9 +490,9 @@ export class RushConfiguration {
       parsedPath.name + '-preinstall' + parsedPath.ext);
 
     RushConfiguration._validateCommonRushConfigFolder(
-        this._commonRushConfigFolder,
-        this.packageManager,
-        this._shrinkwrapFilename
+      this._commonRushConfigFolder,
+      this.packageManager,
+      this._shrinkwrapFilename
     );
 
     this._projectFolderMinDepth = rushConfigurationJson.projectFolderMinDepth !== undefined
@@ -642,11 +657,11 @@ export class RushConfiguration {
       if (semver.major(Rush.version) !== semver.major(expectedRushVersion)
         || semver.minor(Rush.version) !== semver.minor(expectedRushVersion)) {
 
-          // If the major/minor are different, then make sure it's an older version.
-          if (semver.lt(Rush.version, expectedRushVersion)) {
-            throw new Error(`Unable to load ${rushJsonBaseName} because its RushVersion is`
-              + ` ${rushConfigurationJson.rushVersion}, whereas @microsoft/rush-lib is version ${Rush.version}.`
-              + ` Consider upgrading the library.`);
+        // If the major/minor are different, then make sure it's an older version.
+        if (semver.lt(Rush.version, expectedRushVersion)) {
+          throw new Error(`Unable to load ${rushJsonBaseName} because its RushVersion is`
+            + ` ${rushConfigurationJson.rushVersion}, whereas @microsoft/rush-lib is version ${Rush.version}.`
+            + ` Consider upgrading the library.`);
         }
       }
     }
@@ -741,9 +756,9 @@ export class RushConfiguration {
    * recognized config files.
    */
   private static _validateCommonRushConfigFolder(
-      commonRushConfigFolder: string,
-      packageManager: PackageManagerName,
-      shrinkwrapFilename: string
+    commonRushConfigFolder: string,
+    packageManager: PackageManagerName,
+    shrinkwrapFilename: string
   ): void {
     if (!FileSystem.exists(commonRushConfigFolder)) {
       console.log(`Creating folder: ${commonRushConfigFolder}`);
@@ -1022,6 +1037,10 @@ export class RushConfiguration {
    */
   public get projectFolderMaxDepth(): number {
     return this._projectFolderMaxDepth;
+  }
+
+  public get packageManagerOptions(): IPackageManagerOptions | undefined {
+    return this._packageManagerOptions;
   }
 
   /**

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -138,7 +138,8 @@ export interface IConfigurationEnvironmentVariable {
   value: string;
 
   /**
-   * Set to true to override the environment variable even if it is set on the device
+   * Set to true to override the environment variable even if it is set in the parent environment.
+   * The default value is false.
    */
   override?: boolean;
 }

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -107,7 +107,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 
 /**
  * Options for the package manager.
- * @internal
+ * @public
  */
 export interface IPackageManagerOptionsJsonBase {
   /**
@@ -118,7 +118,7 @@ export interface IPackageManagerOptionsJsonBase {
 
 /**
  * A collection of environment variables
- * @internal
+ * @public
  */
 export interface IConfigurationEnvironment {
   /**
@@ -129,7 +129,7 @@ export interface IConfigurationEnvironment {
 
 /**
  * Represents an environment variable
- * @internal
+ * @public
  */
 export interface IConfigurationEnvironmentVariable {
   /**
@@ -171,8 +171,16 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
 
 /**
  * Part of IRushConfigurationJson.
+ * @internal
  */
 export interface IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
+    /**
+   * If true, then Rush will add the "--ignore-engines" option when invoking Yarn.
+   * This allows "rush install" to succeed if there are dependencies with engines defined in
+   * package.json which do not match the current environment.
+   *
+   * The default value is false.
+   */
   ignoreEngines?: boolean;
 }
 
@@ -233,7 +241,7 @@ export interface ICurrentVariantJson {
  *
  * @public
  */
-class PackageManagerConfigurationBase implements IPackageManagerOptionsJsonBase {
+export class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
   /**
    * Enviroment variables for the package manager
    */
@@ -254,7 +262,7 @@ class PackageManagerConfigurationBase implements IPackageManagerOptionsJsonBase 
  *
  * @public
  */
-export class NpmOptionsConfiguration extends PackageManagerConfigurationBase {
+export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
   /** @internal */
   public constructor(json: INpmOptionsJson) {
     super(json.environmentVariables);
@@ -270,7 +278,7 @@ export class NpmOptionsConfiguration extends PackageManagerConfigurationBase {
  *
  * @public
  */
-export class PnpmOptionsConfiguration extends PackageManagerConfigurationBase {
+export class PnpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
   /**
    * The method used to resolve the store used by PNPM.
    *
@@ -342,7 +350,7 @@ export class PnpmOptionsConfiguration extends PackageManagerConfigurationBase {
  *
  * @public
  */
-export class YarnOptionsConfiguration extends PackageManagerConfigurationBase {
+export class YarnOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
   /**
    * If true, then Rush will add the "--ignore-engines" option when invoking Yarn.
    * This allows "rush install" to succeed if there are dependencies with engines defined in
@@ -1108,13 +1116,6 @@ export class RushConfiguration {
   }
 
   /**
-   * {@inheritDoc INpmOptions}
-   */
-  public get npmOptions(): INpmOptionsJson | undefined {
-    return this._npmOptions;
-  }
-
-  /**
    * The "approvedPackagesPolicy" settings.
    */
   public get approvedPackagesPolicy(): ApprovedPackagesPolicy {
@@ -1224,6 +1225,13 @@ export class RushConfiguration {
 
   public get projectsByName(): Map<string, RushConfigurationProject> {
     return this._projectsByName;
+  }
+
+  /**
+   * {@inheritDoc NpmOptionsConfiguration}
+   */
+  public get npmOptions(): NpmOptionsConfiguration {
+    return this._npmOptions;
   }
 
   /**

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -19,6 +19,7 @@ import { StandardScriptUpdater } from '../../logic/StandardScriptUpdater';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismatchFinder';
 import { Variants } from '../../api/Variants';
+import { RushConstants } from '../../logic/RushConstants';
 
 /**
  * This is the common base class for InstallAction and UpdateAction.
@@ -63,7 +64,8 @@ export abstract class BaseInstallAction extends BaseRushAction {
     this._maxInstallAttempts = this.defineIntegerParameter({
       parameterLongName: '--max-install-attempts',
       argumentName: 'NUMBER',
-      description: 'Overrides the default maximum number of install attempts. The default value is 3.'
+      description: `Overrides the default maximum number of install attempts.`
+        + ` The default value is ${RushConstants.defaultMaxInstallAttempts}.`
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -30,6 +30,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
   protected _noLinkParameter: CommandLineFlagParameter;
   protected _networkConcurrencyParameter: CommandLineIntegerParameter;
   protected _debugPackageManagerParameter: CommandLineFlagParameter;
+  protected _maxInstallAttempts: CommandLineIntegerParameter;
 
   protected onDefineParameters(): void {
     this._purgeParameter = this.defineFlagParameter({
@@ -58,6 +59,11 @@ export abstract class BaseInstallAction extends BaseRushAction {
       parameterLongName: '--debug-package-manager',
       description: 'Activates verbose logging for the package manager. You will probably want to pipe'
         + ' the output of Rush to a file when using this command.'
+    });
+    this._maxInstallAttempts = this.defineIntegerParameter({
+      parameterLongName: '--max-install-attempts',
+      argumentName: 'NUMBER',
+      description: 'Attempts command the specified number of times.'
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }
@@ -94,6 +100,10 @@ export abstract class BaseInstallAction extends BaseRushAction {
         throw new Error(`The "${this._networkConcurrencyParameter.longName}" parameter is`
           + ` only supported when using the PNPM package manager.`);
       }
+    }
+
+    if (this._maxInstallAttempts.value && this._maxInstallAttempts.value < 1) {
+      throw new Error(`The value of "${this._maxInstallAttempts.longName}" must be positive.`);
     }
 
     const installManagerOptions: IInstallManagerOptions = this.buildInstallOptions();

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -64,8 +64,8 @@ export abstract class BaseInstallAction extends BaseRushAction {
     this._maxInstallAttempts = this.defineIntegerParameter({
       parameterLongName: '--max-install-attempts',
       argumentName: 'NUMBER',
-      description: `Overrides the default maximum number of install attempts.`
-        + ` The default value is ${RushConstants.defaultMaxInstallAttempts}.`
+      description: `Overrides the default maximum number of install attempts.`,
+      defaultValue: RushConstants.defaultMaxInstallAttempts
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }
@@ -104,7 +104,9 @@ export abstract class BaseInstallAction extends BaseRushAction {
       }
     }
 
-    if (this._maxInstallAttempts.value && this._maxInstallAttempts.value < 1) {
+    // Because the 'defautltValue' option on the _maxInstallAttempts parameter is set,
+    // it is safe to assume that the value is not null
+    if (this._maxInstallAttempts.value! < 1) {
       throw new Error(`The value of "${this._maxInstallAttempts.longName}" must be positive.`);
     }
 

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -63,7 +63,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     this._maxInstallAttempts = this.defineIntegerParameter({
       parameterLongName: '--max-install-attempts',
       argumentName: 'NUMBER',
-      description: 'Attempts command the specified number of times.'
+      description: 'Overrides the default maximum number of install attempts. The default value is 3.'
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -4,7 +4,6 @@
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/InstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
-import { RushConstants } from '../../logic/RushConstants';
 
 export class InstallAction extends BaseInstallAction {
   public constructor(parser: RushCommandLineParser) {
@@ -36,9 +35,9 @@ export class InstallAction extends BaseInstallAction {
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
       variant: this._variant.value,
-      maxInstallAttempts: this._maxInstallAttempts.value !== undefined
-        ? this._maxInstallAttempts.value
-        : RushConstants.defaultMaxInstallAttempts
+      // Because the 'defautltValue' option on the _maxInstallAttempts parameter is set,
+      // it is safe to assume that the value is not null
+      maxInstallAttempts: this._maxInstallAttempts.value!
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -34,7 +34,8 @@ export class InstallAction extends BaseInstallAction {
       recheckShrinkwrap: false,
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
-      variant: this._variant.value
+      variant: this._variant.value,
+      maxInstallAttempts: this._maxInstallAttempts.value
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -36,8 +36,9 @@ export class InstallAction extends BaseInstallAction {
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
       variant: this._variant.value,
-      maxInstallAttempts: this._maxInstallAttempts.value ? this._maxInstallAttempts.value :
-        RushConstants.defaultMaxInstallAttempts
+      maxInstallAttempts: this._maxInstallAttempts.value !== undefined
+        ? this._maxInstallAttempts.value
+        : RushConstants.defaultMaxInstallAttempts
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -4,6 +4,7 @@
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/InstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
+import { RushConstants } from '../../logic/RushConstants';
 
 export class InstallAction extends BaseInstallAction {
   public constructor(parser: RushCommandLineParser) {
@@ -35,7 +36,8 @@ export class InstallAction extends BaseInstallAction {
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
       variant: this._variant.value,
-      maxInstallAttempts: this._maxInstallAttempts.value
+      maxInstallAttempts: this._maxInstallAttempts.value ? this._maxInstallAttempts.value :
+        RushConstants.defaultMaxInstallAttempts
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -6,6 +6,7 @@ import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/InstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
+import { RushConstants } from '../../logic/RushConstants';
 
 export class UpdateAction extends BaseInstallAction {
   private _fullParameter: CommandLineFlagParameter;
@@ -62,7 +63,9 @@ export class UpdateAction extends BaseInstallAction {
       recheckShrinkwrap: this._recheckParameter.value!,
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
-      variant: this._variant.value
+      variant: this._variant.value,
+      maxInstallAttempts: this._maxInstallAttempts.value ? this._maxInstallAttempts.value :
+        RushConstants.defaultMaxInstallAttempts
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -64,8 +64,9 @@ export class UpdateAction extends BaseInstallAction {
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
       variant: this._variant.value,
-      maxInstallAttempts: this._maxInstallAttempts.value ? this._maxInstallAttempts.value :
-        RushConstants.defaultMaxInstallAttempts
+      maxInstallAttempts: this._maxInstallAttempts.value !== undefined
+        ? this._maxInstallAttempts.value
+        : RushConstants.defaultMaxInstallAttempts
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -6,7 +6,6 @@ import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/InstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
-import { RushConstants } from '../../logic/RushConstants';
 
 export class UpdateAction extends BaseInstallAction {
   private _fullParameter: CommandLineFlagParameter;
@@ -64,9 +63,9 @@ export class UpdateAction extends BaseInstallAction {
       networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!,
       variant: this._variant.value,
-      maxInstallAttempts: this._maxInstallAttempts.value !== undefined
-        ? this._maxInstallAttempts.value
-        : RushConstants.defaultMaxInstallAttempts
+      // Because the 'defautltValue' option on the _maxInstallAttempts parameter is set,
+      // it is safe to assume that the value is not null
+      maxInstallAttempts: this._maxInstallAttempts.value!
     };
   }
 }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -302,7 +302,7 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for each action: install 1`] = `
 "usage: rush install [-h] [-p] [--bypass-policy] [--no-link]
                     [--network-concurrency COUNT] [--debug-package-manager]
-                    [--variant VARIANT]
+                    [--max-install-attempts NUMBER] [--variant VARIANT]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -336,6 +336,8 @@ Optional arguments:
                         Activates verbose logging for the package manager. 
                         You will probably want to pipe the output of Rush to 
                         a file when using this command.
+  --max-install-attempts NUMBER
+                        Attempts command the specified number of times.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively 
                         specified via the RUSH_VARIANT environment variable.
@@ -563,7 +565,8 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for each action: update 1`] = `
 "usage: rush update [-h] [-p] [--bypass-policy] [--no-link]
                    [--network-concurrency COUNT] [--debug-package-manager]
-                   [--variant VARIANT] [--full] [--recheck]
+                   [--max-install-attempts NUMBER] [--variant VARIANT]
+                   [--full] [--recheck]
                    
 
 The \\"rush update\\" command installs the dependencies described in your package.
@@ -596,6 +599,8 @@ Optional arguments:
                         Activates verbose logging for the package manager. 
                         You will probably want to pipe the output of Rush to 
                         a file when using this command.
+  --max-install-attempts NUMBER
+                        Attempts command the specified number of times.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively 
                         specified via the RUSH_VARIANT environment variable.

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -337,7 +337,8 @@ Optional arguments:
                         You will probably want to pipe the output of Rush to 
                         a file when using this command.
   --max-install-attempts NUMBER
-                        Attempts command the specified number of times.
+                        Overrides the default maximum number of install 
+                        attempts. The default value is 3.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively 
                         specified via the RUSH_VARIANT environment variable.
@@ -600,7 +601,8 @@ Optional arguments:
                         You will probably want to pipe the output of Rush to 
                         a file when using this command.
   --max-install-attempts NUMBER
-                        Attempts command the specified number of times.
+                        Overrides the default maximum number of install 
+                        attempts. The default value is 3.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively 
                         specified via the RUSH_VARIANT environment variable.

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -15,6 +15,7 @@ export {
   ITryFindRushJsonLocationOptions,
   ResolutionStrategy,
   PnpmOptionsConfiguration,
+  IPackageManagerOptions as _IPackageManagerOptions,
   IPnpmOptionsJson as _IPnpmOptionsJson,
   PnpmStoreOptions,
   YarnOptionsConfiguration

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -14,13 +14,16 @@ export {
   RushConfiguration,
   ITryFindRushJsonLocationOptions,
   ResolutionStrategy,
-  PnpmOptionsConfiguration,
-  IPackageManagerOptionsJsonBase as _IPackageManagerOptionsJsonBase,
-  IConfigurationEnvironment as _IConfigurationEnvironment,
-  IConfigurationEnvironmentVariable as _IConfigurationEnvironmentVariable,
+  IPackageManagerOptionsJsonBase,
+  IConfigurationEnvironment,
+  IConfigurationEnvironmentVariable,
   INpmOptionsJson as _INpmOptionsJson,
   IPnpmOptionsJson as _IPnpmOptionsJson,
+  IYarnOptionsJson as _IYarnOptionsJson,
   PnpmStoreOptions,
+  PackageManagerOptionsConfigurationBase,
+  PnpmOptionsConfiguration,
+  NpmOptionsConfiguration,
   YarnOptionsConfiguration
 } from './api/RushConfiguration';
 

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -15,8 +15,9 @@ export {
   ITryFindRushJsonLocationOptions,
   ResolutionStrategy,
   PnpmOptionsConfiguration,
-  IPackageManagerOptions,
+  IPackageManagerOptionsBase,
   IEnvironmentVariable,
+  INpmOptions,
   IPnpmOptionsJson as _IPnpmOptionsJson,
   PnpmStoreOptions,
   YarnOptionsConfiguration

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -15,7 +15,8 @@ export {
   ITryFindRushJsonLocationOptions,
   ResolutionStrategy,
   PnpmOptionsConfiguration,
-  IPackageManagerOptions as _IPackageManagerOptions,
+  IPackageManagerOptions,
+  IEnvironmentVariable,
   IPnpmOptionsJson as _IPnpmOptionsJson,
   PnpmStoreOptions,
   YarnOptionsConfiguration

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -15,9 +15,10 @@ export {
   ITryFindRushJsonLocationOptions,
   ResolutionStrategy,
   PnpmOptionsConfiguration,
-  IPackageManagerOptionsBase,
-  IEnvironmentVariable,
-  INpmOptions,
+  IPackageManagerOptionsJsonBase as _IPackageManagerOptionsJsonBase,
+  IConfigurationEnvironment as _IConfigurationEnvironment,
+  IConfigurationEnvironmentVariable as _IConfigurationEnvironmentVariable,
+  INpmOptionsJson as _INpmOptionsJson,
   IPnpmOptionsJson as _IPnpmOptionsJson,
   PnpmStoreOptions,
   YarnOptionsConfiguration

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1080,11 +1080,10 @@ export class InstallManager {
           setEnvironmentVariable = false;
           console.log(colors.yellow(`WARNING: Environment variable already defined:`));
           console.log(`  Name: ${envVar}`);
-          console.log(`  Value set on the device: ${baseEnv[envVar]}`);
+          console.log(`  Existing value: ${baseEnv[envVar]}`);
           console.log(`  Value set in rush.json: ${environmentVariables[envVar].value}`);
 
-          if (environmentVariables[envVar].override &&
-            environmentVariables[envVar].override === true) {
+          if (environmentVariables[envVar].override) {
             setEnvironmentVariable = true;
             console.log(`Overriding the environment variable with the value set in rush.json.`);
           }

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1076,11 +1076,11 @@ export class InstallManager {
         let setEnvironmentVariable: boolean = true;
         console.log(`\nProcessing definition for environment variable: ${envVar}`);
 
-        if (process.env[envVar]) {
+        if (baseEnv.hasOwnProperty(envVar)) {
           setEnvironmentVariable = false;
           console.log(colors.yellow(`WARNING: Environment variable already defined:`));
           console.log(`  Name: ${envVar}`);
-          console.log(`  Value set on the device: ${process.env[envVar]}`);
+          console.log(`  Value set on the device: ${baseEnv[envVar]}`);
           console.log(`  Value set in rush.json: ${environmentVariables[envVar].value}`);
 
           if (environmentVariables[envVar].override &&

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1078,7 +1078,7 @@ export class InstallManager {
 
         if (baseEnv.hasOwnProperty(envVar)) {
           setEnvironmentVariable = false;
-          console.log(colors.yellow(`WARNING: Environment variable already defined:`));
+          console.log(`Environment variable already defined:`);
           console.log(`  Name: ${envVar}`);
           console.log(`  Existing value: ${baseEnv[envVar]}`);
           console.log(`  Value set in rush.json: ${environmentVariables[envVar].value}`);

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -907,8 +907,10 @@ export class InstallManager {
 
           const packageManagerEnv: NodeJS.ProcessEnv = process.env;
 
-          if (this._rushConfiguration.packageManagerOptions &&
-            this._rushConfiguration.packageManagerOptions.environmentVariables) {
+          if (
+            this._rushConfiguration.packageManagerOptions &&
+            this._rushConfiguration.packageManagerOptions.environmentVariables
+          ) {
 
             for (const envVar of Object.keys(this._rushConfiguration.packageManagerOptions.environmentVariables)) {
               packageManagerEnv[envVar] = this._rushConfiguration.packageManagerOptions.environmentVariables[envVar];

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1083,7 +1083,7 @@ export class InstallManager {
 
           if (process.env[envVar]) {
             setEnvironmentVariable = false;
-            console.log(colors.yellow(`WARNING: Environment variable already defined on the device:`));
+            console.log(colors.yellow(`WARNING: Environment variable already defined:`));
             console.log(`  Name: ${envVar}`);
             console.log(`  Value set on the device: ${process.env[envVar]}`);
             console.log(`  Value set in Rush config: ${environmentVariables[envVar].value}`);

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1098,7 +1098,7 @@ export class InstallManager {
             }
           }
 
-          if (setEnvironmentVariable === true) {
+          if (setEnvironmentVariable) {
             console.log(`Setting environment variable for package manager.`);
             console.log(`  Name: ${envVar}`);
             console.log(`  Value: ${environmentVariables[envVar].value}`);

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1091,7 +1091,7 @@ export class InstallManager {
             if (environmentVariables[envVar].override &&
               environmentVariables[envVar].override === true) {
               setEnvironmentVariable = true;
-              console.log(colors.yellow(`WARNING: Overriding the environment variable with the value set in Rush config.`));
+              console.log(colors.yellow(`WARNING: Overriding the environment variable with the value set in rush.json.`));
             }
             else {
               console.log(colors.yellow(`WARNING: Not overriding the value of the environment variable.`));

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1086,7 +1086,7 @@ export class InstallManager {
           if (environmentVariables[envVar].override &&
             environmentVariables[envVar].override === true) {
             setEnvironmentVariable = true;
-            console.log(colors.yellow(`WARNING: Overriding the environment variable with the value set in rush.json.`));
+            console.log(`Overriding the environment variable with the value set in rush.json.`);
           }
           else {
             console.log(colors.yellow(`WARNING: Not overriding the value of the environment variable.`));

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -17,6 +17,7 @@ import { RushGlobalFolder } from '../api/RushGlobalFolder';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { VersionMismatchFinderEntity } from './versionMismatch/VersionMismatchFinderEntity';
 import { VersionMismatchFinderProject } from './versionMismatch/VersionMismatchFinderProject';
+import { RushConstants } from './RushConstants';
 
 /**
  * The type of SemVer range specifier that is prepended to the version
@@ -141,7 +142,8 @@ export class PackageJsonUpdater {
       recheckShrinkwrap: false,
       networkConcurrency: undefined,
       collectLogFile: false,
-      variant: variant
+      variant: variant,
+      maxInstallAttempts: RushConstants.defaultMaxInstallAttempts
     };
     const installManager: InstallManager = new InstallManager(
       this._rushConfiguration,

--- a/apps/rush-lib/src/logic/RushConstants.ts
+++ b/apps/rush-lib/src/logic/RushConstants.ts
@@ -76,6 +76,11 @@ export class RushConstants {
   public static readonly pnpmV1ShrinkwrapFilename: string = 'shrinkwrap.yaml';
 
   /**
+   * Number of installation attempts
+   */
+  public static readonly defaultMaxInstallAttempts: number = 3;
+
+  /**
    * The filename ("pnpm-lock.yaml") used to store an installation plan for the PNPM package manger
    * (PNPM version 3.x and later).
    */

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -53,6 +53,19 @@
       "description": "Allows creation of hotfix changes. This feature is experimental so it is disabled by default. If this is set, \"rush change\" only allows a \"hotfix\" change type to be specified. This change type will be used when publishing subsequent changes from the monorepo.",
       "type": "boolean"
     },
+    "packageManagerOptions": {
+      "description": "Options that apply to the package manager.",
+      "type": "object",
+      "properties": {
+        "environmentVariables": {
+          "description": "Enviroment variables for the package manager",
+          "type": "object",
+           "additionalProperties": {
+             "type": "string"
+           }
+        }
+      }
+    },
     "pnpmOptions": {
       "description": "Options that are only used when the PNPM pacakge manager is selected.",
       "type": "object",

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -3,6 +3,24 @@
   "title": "Rush main config File",
   "description": "The main configuration file for the Rush multi-project build tool. See http://rushjs.io for details.",
   "type": "object",
+  "definitions": {
+    "environmentVariables": {
+      "description": "Enviroment variables for the package manager",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "override": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
   "properties": {
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
@@ -53,20 +71,7 @@
       "type": "object",
       "properties": {
         "environmentVariables": {
-          "description": "Enviroment variables for the package manager",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "override": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": false
-          }
+          "$ref": "#/definitions/environmentVariables"
         }
       },
       "additionalProperties": false
@@ -96,20 +101,7 @@
           ]
         },
         "environmentVariables": {
-          "description": "Enviroment variables for the package manager",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "override": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": false
-          }
+          "$ref": "#/definitions/environmentVariables"
         }
       },
       "additionalProperties": false
@@ -123,20 +115,7 @@
           "type": "boolean"
         },
         "environmentVariables": {
-          "description": "Enviroment variables for the package manager",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "override": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": false
-          }
+          "$ref": "#/definitions/environmentVariables"
         }
       },
       "additionalProperties": false

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -60,16 +60,12 @@
             "properties": {
               "value": {
                 "type": "string"
+              },
+              "override": {
+                "type": "boolean"
               }
             },
-            "additionalProperties": {
-              "type": "boolean",
-              "properties": {
-                "override": {
-                  "type": "boolean"
-                }
-              }
-            }
+            "additionalProperties": false
           }
         }
       }

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -3,31 +3,26 @@
   "title": "Rush main config File",
   "description": "The main configuration file for the Rush multi-project build tool. See http://rushjs.io for details.",
   "type": "object",
-
   "properties": {
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
       "type": "string"
     },
-
     "npmVersion": {
       "description": "If specified, selects NPM as the package manager and specifies the deterministic version to be installed by Rush.",
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
-
     "pnpmVersion": {
       "description": "If specified, selects PNPM as the package manager and specifies the deterministic version to be installed by Rush.",
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
-
     "yarnVersion": {
       "description": "If specified, selects Yarn as the package manager and specifies the deterministic version to be installed by Rush.",
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
-
     "rushVersion": {
       "description": "The version of the Rush tool that will be used to build this repository.",
       "type": "string",
@@ -60,9 +55,22 @@
         "environmentVariables": {
           "description": "Enviroment variables for the package manager",
           "type": "object",
-           "additionalProperties": {
-             "type": "string"
-           }
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": {
+              "type": "boolean",
+              "properties": {
+                "override": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -73,7 +81,10 @@
         "pnpmStore": {
           "description": "Specifies the location of the PNPM store.  There are two possible values:\n\n\"local\" - use the \"pnpm-store\" folder in the current configured temp folder: \"common/temp/pnpm-store\" by default.\n\"global\" - use PNPM's global store, which has the benefit of being shared across multiple repo folders, but the disadvantage of less isolation for builds (e.g. bugs or incompatibilities when two repos use different releases of PNPM)\n\nIn all cases, the store path will be overridden by the environment variable RUSH_PNPM_STORE_PATH.\n\nThe default value is \"local\".",
           "type": "string",
-          "enum": ["local", "global"]
+          "enum": [
+            "local",
+            "global"
+          ]
         },
         "strictPeerDependencies": {
           "description": "If true, then Rush will add the \"--strict-peer-dependencies\" option when invoking PNPM. This causes \"rush install\" to fail if there are unsatisfied peer dependencies, which is an invalid state that can cause build failures or incompatible dependency versions. (For historical reasons, JavaScript package managers generally do not treat this invalid state as an error.) The default value is false.",
@@ -82,7 +93,10 @@
         "resolutionStrategy": {
           "description": "Configures the strategy used to select versions during installation.  This feature requires PNPM version 3.1 or newer.  It corresponds to the \"--resolution-strategy\" command-line option for PNPM.  Possible values are \"fast\" and \"fewer-dependencies\".  PNPM's default is \"fast\", but this may be incompatible with certain packages, for example the \"@types\" packages from DefinitelyTyped.  Rush's default is \"fewer-dependencies\", which causes PNPM to avoid installing a newer version if an already installed version can be reused; this is more similar to NPM's algorithm.",
           "type": "string",
-          "enum": ["fewer-dependencies", "fast"]
+          "enum": [
+            "fewer-dependencies",
+            "fast"
+          ]
         }
       },
       "additionalProperties": false

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -48,8 +48,8 @@
       "description": "Allows creation of hotfix changes. This feature is experimental so it is disabled by default. If this is set, \"rush change\" only allows a \"hotfix\" change type to be specified. This change type will be used when publishing subsequent changes from the monorepo.",
       "type": "boolean"
     },
-    "packageManagerOptions": {
-      "description": "Options that apply to the package manager.",
+    "npmOptions": {
+      "description": "Options that are only used when the NPM pacakge manager is selected.",
       "type": "object",
       "properties": {
         "environmentVariables": {
@@ -68,7 +68,8 @@
             "additionalProperties": false
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "pnpmOptions": {
       "description": "Options that are only used when the PNPM pacakge manager is selected.",
@@ -93,6 +94,22 @@
             "fewer-dependencies",
             "fast"
           ]
+        },
+        "environmentVariables": {
+          "description": "Enviroment variables for the package manager",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "override": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false
@@ -104,6 +121,22 @@
         "ignoreEngines": {
           "description": "If true, then Rush will add the \"--ignore-engines\" option when invoking Yarn. * This allows \"rush install\" to succeed if there are dependencies with engines defined in package.json which do not match the current environment. The default value is false.",
           "type": "boolean"
+        },
+        "environmentVariables": {
+          "description": "Enviroment variables for the package manager",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "override": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/common/changes/@microsoft/rush/sachinjoseph-support-custom-environment-variables-for-install-manager_2020-03-10-18-12.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-support-custom-environment-variables-for-install-manager_2020-03-10-18-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Support custom environment variables for the underlying package manager install process, expose maxInstallAttempts as a parameter for rush install/update.",
+      "comment": "Support setting environment variables for package manager install processes in rush.json and expose --max-install-attempts as a parameter for rush install/update.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/sachinjoseph-support-custom-environment-variables-for-install-manager_2020-03-10-18-12.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-support-custom-environment-variables-for-install-manager_2020-03-10-18-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support custom environment variables for the underlying package manager install process, expose maxInstallAttempts as a parameter for rush install/update.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -268,9 +268,9 @@ export abstract class PackageManager {
 export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
 
 // @public
-export class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
+export abstract class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
     // @internal
-    protected constructor(environmentVariables?: IConfigurationEnvironment);
+    protected constructor(json: IPackageManagerOptionsJsonBase);
     readonly environmentVariables?: IConfigurationEnvironment;
 }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -146,6 +146,14 @@ export class IndividualVersionPolicy extends VersionPolicy {
 }
 
 // @internal
+export interface _IPackageManagerOptions {
+    // (undocumented)
+    environmentVariables?: {
+        [name: string]: string;
+    };
+}
+
+// @internal
 export interface _IPnpmOptionsJson {
     pnpmStore?: PnpmStoreOptions;
     resolutionStrategy?: ResolutionStrategy;
@@ -295,10 +303,10 @@ export class RushConfiguration {
     readonly npmCacheFolder: string;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
-    // Warning: (ae-forgotten-export) The symbol "IPackageManagerOptions" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-incompatible-release-tags) The symbol "packageManagerOptions" is marked as @public, but its signature references "IPackageManagerOptions" which is marked as @internal
     //
     // (undocumented)
-    readonly packageManagerOptions: IPackageManagerOptions | undefined;
+    readonly packageManagerOptions: _IPackageManagerOptions | undefined;
     readonly packageManagerToolFilename: string;
     readonly packageManagerToolVersion: string;
     // @beta

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -152,14 +152,18 @@ export class IndividualVersionPolicy extends VersionPolicy {
 }
 
 // @public
-export interface IPackageManagerOptions {
+export interface INpmOptions extends IPackageManagerOptionsBase {
+}
+
+// @public
+export interface IPackageManagerOptionsBase {
     environmentVariables?: {
         [environmentVariableName: string]: IEnvironmentVariable;
     };
 }
 
 // @internal
-export interface _IPnpmOptionsJson {
+export interface _IPnpmOptionsJson extends IPackageManagerOptionsBase {
     pnpmStore?: PnpmStoreOptions;
     resolutionStrategy?: ResolutionStrategy;
     strictPeerDependencies?: boolean;
@@ -250,9 +254,12 @@ export abstract class PackageManager {
 export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
 
 // @public
-export class PnpmOptionsConfiguration {
+export class PnpmOptionsConfiguration implements IPackageManagerOptionsBase {
     // @internal
     constructor(json: _IPnpmOptionsJson, commonTempFolder: string);
+    readonly environmentVariables?: {
+        [environmentVariableName: string]: IEnvironmentVariable;
+    };
     readonly pnpmStore: PnpmStoreOptions;
     readonly pnpmStorePath: string;
     readonly resolutionStrategy: ResolutionStrategy;
@@ -306,9 +313,9 @@ export class RushConfiguration {
     // (undocumented)
     static loadFromDefaultLocation(options?: ITryFindRushJsonLocationOptions): RushConfiguration;
     readonly npmCacheFolder: string;
+    readonly npmOptions: INpmOptions | undefined;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
-    readonly packageManagerOptions: IPackageManagerOptions | undefined;
     readonly packageManagerToolFilename: string;
     readonly packageManagerToolVersion: string;
     // @beta
@@ -425,6 +432,9 @@ export class YarnOptionsConfiguration {
     //
     // @internal
     constructor(json: IYarnOptionsJson);
+    readonly environmentVariables?: {
+        [environmentVariableName: string]: IEnvironmentVariable;
+    };
     readonly ignoreEngines: boolean;
 }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -120,6 +120,12 @@ export class ExperimentsConfiguration {
     readonly configuration: Readonly<IExperimentsJson>;
     }
 
+// @public
+export interface IEnvironmentVariable {
+    override?: boolean;
+    value: string;
+}
+
 // @beta
 export interface IExperimentsJson {
     legacyIncrementalBuildDependencyDetection?: boolean;
@@ -145,11 +151,10 @@ export class IndividualVersionPolicy extends VersionPolicy {
     validate(versionString: string, packageName: string): void;
 }
 
-// @internal
-export interface _IPackageManagerOptions {
-    // (undocumented)
+// @public
+export interface IPackageManagerOptions {
     environmentVariables?: {
-        [name: string]: string;
+        [environmentVariableName: string]: IEnvironmentVariable;
     };
 }
 
@@ -303,10 +308,7 @@ export class RushConfiguration {
     readonly npmCacheFolder: string;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
-    // Warning: (ae-incompatible-release-tags) The symbol "packageManagerOptions" is marked as @public, but its signature references "IPackageManagerOptions" which is marked as @internal
-    //
-    // (undocumented)
-    readonly packageManagerOptions: _IPackageManagerOptions | undefined;
+    readonly packageManagerOptions: IPackageManagerOptions | undefined;
     readonly packageManagerToolFilename: string;
     readonly packageManagerToolVersion: string;
     // @beta

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -120,8 +120,13 @@ export class ExperimentsConfiguration {
     readonly configuration: Readonly<IExperimentsJson>;
     }
 
-// @public
-export interface IEnvironmentVariable {
+// @internal
+export interface _IConfigurationEnvironment {
+    [environmentVariableName: string]: _IConfigurationEnvironmentVariable;
+}
+
+// @internal
+export interface _IConfigurationEnvironmentVariable {
     override?: boolean;
     value: string;
 }
@@ -151,19 +156,17 @@ export class IndividualVersionPolicy extends VersionPolicy {
     validate(versionString: string, packageName: string): void;
 }
 
-// @public
-export interface INpmOptions extends IPackageManagerOptionsBase {
-}
-
-// @public
-export interface IPackageManagerOptionsBase {
-    environmentVariables?: {
-        [environmentVariableName: string]: IEnvironmentVariable;
-    };
+// @internal
+export interface _INpmOptionsJson extends _IPackageManagerOptionsJsonBase {
 }
 
 // @internal
-export interface _IPnpmOptionsJson extends IPackageManagerOptionsBase {
+export interface _IPackageManagerOptionsJsonBase {
+    environmentVariables?: _IConfigurationEnvironment;
+}
+
+// @internal
+export interface _IPnpmOptionsJson extends _IPackageManagerOptionsJsonBase {
     pnpmStore?: PnpmStoreOptions;
     resolutionStrategy?: ResolutionStrategy;
     strictPeerDependencies?: boolean;
@@ -253,13 +256,12 @@ export abstract class PackageManager {
 // @public
 export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
 
+// Warning: (ae-forgotten-export) The symbol "PackageManagerConfigurationBase" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class PnpmOptionsConfiguration implements IPackageManagerOptionsBase {
+export class PnpmOptionsConfiguration extends PackageManagerConfigurationBase {
     // @internal
     constructor(json: _IPnpmOptionsJson, commonTempFolder: string);
-    readonly environmentVariables?: {
-        [environmentVariableName: string]: IEnvironmentVariable;
-    };
     readonly pnpmStore: PnpmStoreOptions;
     readonly pnpmStorePath: string;
     readonly resolutionStrategy: ResolutionStrategy;
@@ -313,7 +315,11 @@ export class RushConfiguration {
     // (undocumented)
     static loadFromDefaultLocation(options?: ITryFindRushJsonLocationOptions): RushConfiguration;
     readonly npmCacheFolder: string;
-    readonly npmOptions: INpmOptions | undefined;
+    // Warning: (ae-incompatible-release-tags) The symbol "npmOptions" is marked as @public, but its signature references "INpmOptionsJson" which is marked as @internal
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@microsoft/rush-lib" does not have an export "INpmOptions"
+    //
+    // (undocumented)
+    readonly npmOptions: _INpmOptionsJson | undefined;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
     readonly packageManagerToolFilename: string;
@@ -427,14 +433,11 @@ export enum VersionPolicyDefinitionName {
 }
 
 // @public
-export class YarnOptionsConfiguration {
+export class YarnOptionsConfiguration extends PackageManagerConfigurationBase {
     // Warning: (ae-forgotten-export) The symbol "IYarnOptionsJson" needs to be exported by the entry point index.d.ts
     //
     // @internal
     constructor(json: IYarnOptionsJson);
-    readonly environmentVariables?: {
-        [environmentVariableName: string]: IEnvironmentVariable;
-    };
     readonly ignoreEngines: boolean;
 }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -295,6 +295,10 @@ export class RushConfiguration {
     readonly npmCacheFolder: string;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
+    // Warning: (ae-forgotten-export) The symbol "IPackageManagerOptions" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly packageManagerOptions: IPackageManagerOptions | undefined;
     readonly packageManagerToolFilename: string;
     readonly packageManagerToolVersion: string;
     // @beta

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -120,13 +120,13 @@ export class ExperimentsConfiguration {
     readonly configuration: Readonly<IExperimentsJson>;
     }
 
-// @internal
-export interface _IConfigurationEnvironment {
-    [environmentVariableName: string]: _IConfigurationEnvironmentVariable;
+// @public
+export interface IConfigurationEnvironment {
+    [environmentVariableName: string]: IConfigurationEnvironmentVariable;
 }
 
-// @internal
-export interface _IConfigurationEnvironmentVariable {
+// @public
+export interface IConfigurationEnvironmentVariable {
     override?: boolean;
     value: string;
 }
@@ -157,16 +157,16 @@ export class IndividualVersionPolicy extends VersionPolicy {
 }
 
 // @internal
-export interface _INpmOptionsJson extends _IPackageManagerOptionsJsonBase {
+export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
+}
+
+// @public
+export interface IPackageManagerOptionsJsonBase {
+    environmentVariables?: IConfigurationEnvironment;
 }
 
 // @internal
-export interface _IPackageManagerOptionsJsonBase {
-    environmentVariables?: _IConfigurationEnvironment;
-}
-
-// @internal
-export interface _IPnpmOptionsJson extends _IPackageManagerOptionsJsonBase {
+export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     pnpmStore?: PnpmStoreOptions;
     resolutionStrategy?: ResolutionStrategy;
     strictPeerDependencies?: boolean;
@@ -176,6 +176,11 @@ export interface _IPnpmOptionsJson extends _IPackageManagerOptionsJsonBase {
 export interface ITryFindRushJsonLocationOptions {
     showVerbose?: boolean;
     startingFolder?: string;
+}
+
+// @internal
+export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
+    ignoreEngines?: boolean;
 }
 
 // @internal
@@ -204,6 +209,12 @@ export class LockStepVersionPolicy extends VersionPolicy {
     validate(versionString: string, packageName: string): void;
     readonly version: string;
     }
+
+// @public
+export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
+    // @internal
+    constructor(json: _INpmOptionsJson);
+}
 
 // @beta (undocumented)
 export class PackageJsonDependency {
@@ -256,10 +267,15 @@ export abstract class PackageManager {
 // @public
 export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
 
-// Warning: (ae-forgotten-export) The symbol "PackageManagerConfigurationBase" needs to be exported by the entry point index.d.ts
-//
 // @public
-export class PnpmOptionsConfiguration extends PackageManagerConfigurationBase {
+export class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
+    // @internal
+    protected constructor(environmentVariables?: IConfigurationEnvironment);
+    readonly environmentVariables?: IConfigurationEnvironment;
+}
+
+// @public
+export class PnpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
     // @internal
     constructor(json: _IPnpmOptionsJson, commonTempFolder: string);
     readonly pnpmStore: PnpmStoreOptions;
@@ -315,11 +331,7 @@ export class RushConfiguration {
     // (undocumented)
     static loadFromDefaultLocation(options?: ITryFindRushJsonLocationOptions): RushConfiguration;
     readonly npmCacheFolder: string;
-    // Warning: (ae-incompatible-release-tags) The symbol "npmOptions" is marked as @public, but its signature references "INpmOptionsJson" which is marked as @internal
-    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: The package "@microsoft/rush-lib" does not have an export "INpmOptions"
-    //
-    // (undocumented)
-    readonly npmOptions: _INpmOptionsJson | undefined;
+    readonly npmOptions: NpmOptionsConfiguration;
     readonly npmTmpFolder: string;
     readonly packageManager: PackageManagerName;
     readonly packageManagerToolFilename: string;
@@ -433,11 +445,9 @@ export enum VersionPolicyDefinitionName {
 }
 
 // @public
-export class YarnOptionsConfiguration extends PackageManagerConfigurationBase {
-    // Warning: (ae-forgotten-export) The symbol "IYarnOptionsJson" needs to be exported by the entry point index.d.ts
-    //
+export class YarnOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
     // @internal
-    constructor(json: IYarnOptionsJson);
+    constructor(json: _IYarnOptionsJson);
     readonly ignoreEngines: boolean;
 }
 


### PR DESCRIPTION
Provide a way to set environment variables for the underlying package manager install command. Expose maxInstallAttempts as a parameter for rush install and update.

For example, this can be used to set `NODE_OPTIONS=--max-old-space-size=<number>` environment variable to work around package manager running out of memory during installation.

Expose maxInstallAttempts as a parameter for rush install/update: This parameter can be used to retry the installation a specified number of times, and this can greatly increase the chances of the install succeeding especially when the network performance is not great.

Sample usage of new config in rush.json:

```json
  "rushVersion": "5.19.3",
  "pnpmVersion": "4.11.5",
  "pnpmOptions": {
    "environmentVariables": {
      "NODE_OPTIONS": {
        "value": "--max-old-space-size=8192",
        "override": true
      }
    }
  },
```