### PR TITLE
Publish tombstone versions for 2 packages that were retired

### DIFF
--- a/repo-scripts/tombstones/resolve-chunk-plugin/README.md
+++ b/repo-scripts/tombstones/resolve-chunk-plugin/README.md
@@ -1,0 +1,7 @@
+# @microsoft/resolve-chunk-plugin
+
+The `@microsoft/resolve-chunk-plugin` package has been retired.
+
+It is no longer developed or supported.  Please do not use it.
+
+For better alternatives, please visit https://rushstack.io/ for help.

--- a/repo-scripts/tombstones/resolve-chunk-plugin/package.json
+++ b/repo-scripts/tombstones/resolve-chunk-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@microsoft/resolve-chunk-plugin",
+  "version": "3.0.0",
+  "description": "(This package is deprecated.)",
+  "license": "MIT",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  }
+}

--- a/repo-scripts/tombstones/resolve-chunk-plugin/postinstall.js
+++ b/repo-scripts/tombstones/resolve-chunk-plugin/postinstall.js
@@ -1,0 +1,21 @@
+
+function writeErrorInRed(message) {
+  console.error('');
+  console.error('\u001b[31m' + message + '\u001b[39m');
+}
+
+writeErrorInRed(
+`* * * * * * * * * * * * * THIS PACKAGE IS DEPRECATED! * * * * * * * * * * * * *`);
+
+console.error(`
+The "@microsoft/resolve-chunk-plugin" package has been retired.
+
+It is no longer developed or supported.  Please do not use it.
+
+For better alternatives, please visit https://rushstack.io/ for help.`
+);
+
+writeErrorInRed(
+`* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n`);
+
+process.exit(1);

--- a/repo-scripts/tombstones/rush-stack/README.md
+++ b/repo-scripts/tombstones/rush-stack/README.md
@@ -1,0 +1,8 @@
+# @microsoft/rush-stack
+
+This NPM package has been retired.  It was an early prototype of a tool chain that has since
+evolved into an entire family of projects under the "Rush Stack" umbrella.
+
+But there's good news:  **Rush Stack** is going strong!
+
+To learn more, please visit https://rushstack.io/

--- a/repo-scripts/tombstones/rush-stack/package.json
+++ b/repo-scripts/tombstones/rush-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush-stack",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "(This package is deprecated.)",
   "license": "MIT",
   "scripts": {

--- a/repo-scripts/tombstones/rush-stack/package.json
+++ b/repo-scripts/tombstones/rush-stack/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@microsoft/rush-stack",
+  "version": "0.2.5",
+  "description": "(This package is deprecated.)",
+  "license": "MIT",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  }
+}

--- a/repo-scripts/tombstones/rush-stack/postinstall.js
+++ b/repo-scripts/tombstones/rush-stack/postinstall.js
@@ -1,0 +1,23 @@
+
+function writeErrorInRed(message) {
+  console.error('');
+  console.error('\u001b[31m' + message + '\u001b[39m');
+}
+
+writeErrorInRed(
+`* * * * * * * * * * * * * THIS PACKAGE WAS RENAMED! * * * * * * * * * * * * * *`);
+
+console.error(`
+The "@microsoft/rush-stack" package has been retired.  It was an early
+prototype of a tool chain that has since evolved into an entire family of
+projects under the "Rush Stack" umbrella.
+
+But there's good news:  Rush Stack is going strong!
+
+To learn more, please visit https://rushstack.io/`
+);
+
+writeErrorInRed(
+`* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n`);
+
+process.exit(1);


### PR DESCRIPTION
Publish tombstone releases for these two projects that are no longer maintained:

- `@microsoft/rush-stack`
- `@microsoft/resolve-chunk-plugin`

We won't merge this PR. Instead we'll run a special CI job that invokes npm publish in each of the 2 folders.