### PR TITLE
[eslint-config] Improve error message for "ban-types" rule

### DIFF
--- a/common/changes/@rushstack/eslint-config/octogonz-clarify-ban-types-message_2020-04-06-23-51.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-clarify-ban-types-message_2020-04-06-23-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Improve the error message text for the \"ban-types\" rule",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -56,7 +56,32 @@ module.exports = {
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         //
         // CONFIGURATION:     By default, these are banned: String, Boolean, Number, Object, Symbol
-        "@typescript-eslint/ban-types": "error",
+        "@typescript-eslint/ban-types": [
+          "error",
+          {          
+            types: {
+              String: {
+                message: "Use 'string' instead",
+                fixWith: "string"
+              },
+              Boolean: {
+                message: "Use 'boolean' instead",
+                fixWith: "boolean"
+              },
+              Number: {
+                message: "Use 'number' instead",
+                fixWith: "number"
+              },
+              Object: {
+                message: "Use 'object' instead, or else define a proper TypeScript type:"
+              },
+              Symbol: {
+                message: "Use 'symbol' instead",
+                fixWith: "symbol"
+              }     
+            }                  
+          }
+        ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/camelcase": [


### PR DESCRIPTION
**Old message:**
```
src/index.ts(7,22): error @typescript-eslint/ban-types: Don't use 'Object' as a type. Use Record<string, any> instead
```

This advice produces other errors about the `any` type.

**New message:**
```
src/index.ts(7,22): error @typescript-eslint/ban-types: Don't use 'Object' as a type. Use 'object' instead, or else define a proper TypeScript type
```

@manderso-hbo