### PR TITLE
[rush-lib] Use `command` instead of `which`

### DIFF
--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -138,7 +138,7 @@ export function getNpmPath(): string {
         _npmPath = lines[lines.length - 1];
       } else {
         // We aren't on Windows - assume we're on *NIX or Darwin
-        _npmPath = childProcess.execSync('which npm', { stdio: [] }).toString();
+        _npmPath = childProcess.execSync('command -v npm', { stdio: [] }).toString();
       }
     } catch (e) {
       throw new Error(`Unable to determine the path to the NPM tool: ${e}`);

--- a/common/changes/@microsoft/rush/patch-1_2020-04-11-10-11.json
+++ b/common/changes/@microsoft/rush/patch-1_2020-04-11-10-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "mail@jkroepke.de"
+}

--- a/common/changes/@microsoft/rush/patch-1_2020-04-11-10-11.json
+++ b/common/changes/@microsoft/rush/patch-1_2020-04-11-10-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "",
+      "comment": "Fix an issue where, on some minimal systems, Rush used a missing shell command to detect an application path.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Hi,

in some certain minimalistic build environments, `@microsoft/rush` can't installed because the command line tool `which` is not available. 

```
 Installing @microsoft/rush...
 Error: Unable to install package: Error: Unable to determine the path to the NPM tool: Error: Command failed: which npm
 /bin/sh: which: command not found
```

While we could fix this issue by our own by just installing `which` I would like to improve this cool project a little bit.

In shell scripting it's preferred to use `command -v` instead `which` because the first one is a POSIX shell built-in. It looks like `childProcess.execSync` already opens a shell internally, we could use just the built-in helpers instead an external small utility. 

Related resources:
* https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script