### PR TITLE
[node-core-library] Add FileSystem.readLink() API

### DIFF
--- a/common/changes/@rushstack/eslint-config/octogonz-ncl-fs_2020-05-27-04-09.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-ncl-fs_2020-05-27-04-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Relax \"max-lines\" lint rule to 2,000 lines instead of 1,000 lines",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-ncl-fs_2020-05-27-04-09.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-ncl-fs_2020-05-27-04-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add an \"FileSystemStats\" alias to avoid the need to import \"fs\" when using the FileSystem API",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-ncl-fs_2020-05-27-04-10.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-ncl-fs_2020-05-27-04-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add FileSystem.readLink() and readLinkAsync()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -161,6 +161,8 @@ export class FileSystem {
     static readFileToBufferAsync(filePath: string): Promise<Buffer>;
     static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): string[];
     static readFolderAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]>;
+    static readLink(path: string): string;
+    static readLinkAsync(path: string): Promise<string>;
     static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
     static updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void>;
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -141,14 +141,14 @@ export class FileSystem {
     static ensureFolderAsync(folderPath: string): Promise<void>;
     static exists(path: string): boolean;
     static formatPosixModeBits(modeBits: PosixModeBits): string;
-    static getLinkStatistics(path: string): fs.Stats;
-    static getLinkStatisticsAsync(path: string): Promise<fs.Stats>;
+    static getLinkStatistics(path: string): FileSystemStats;
+    static getLinkStatisticsAsync(path: string): Promise<FileSystemStats>;
     static getPosixModeBits(path: string): PosixModeBits;
     static getPosixModeBitsAsync(path: string): Promise<PosixModeBits>;
     static getRealPath(linkPath: string): string;
     static getRealPathAsync(linkPath: string): Promise<string>;
-    static getStatistics(path: string): fs.Stats;
-    static getStatisticsAsync(path: string): Promise<fs.Stats>;
+    static getStatistics(path: string): FileSystemStats;
+    static getStatisticsAsync(path: string): Promise<FileSystemStats>;
     static isErrnoException(error: Error): error is NodeJS.ErrnoException;
     static isFileDoesNotExistError(error: Error): boolean;
     static isFolderDoesNotExistError(error: Error): boolean;
@@ -166,6 +166,9 @@ export class FileSystem {
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
     static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void>;
 }
+
+// @public
+export type FileSystemStats = fs.Stats;
 
 // @public
 export class FileWriter {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -8,6 +8,13 @@ import * as fsx from 'fs-extra';
 import { Text, NewlineKind, Encoding } from './Text';
 import { PosixModeBits } from './PosixModeBits';
 
+/**
+ * An alias for the Node.js `fs.Stats` object.
+ * @remarks
+ * This avoids the need to import the `fs` package when using the {@link FileSystem} API.
+ */
+export type FileSystemStats = fs.Stats;
+
 // The PosixModeBits are intended to be used with bitwise operations.
 /* eslint-disable no-bitwise */
 
@@ -232,7 +239,7 @@ export class FileSystem {
    * Behind the scenes it uses `fs.statSync()`.
    * @param path - The absolute or relative path to the filesystem object.
    */
-  public static getStatistics(path: string): fs.Stats {
+  public static getStatistics(path: string): FileSystemStats {
     return FileSystem._wrapException(() => {
       return fsx.statSync(path);
     });
@@ -241,7 +248,7 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getStatistics}.
    */
-  public static getStatisticsAsync(path: string): Promise<fs.Stats> {
+  public static getStatisticsAsync(path: string): Promise<FileSystemStats> {
     return FileSystem._wrapExceptionAsync(() => {
       return fsx.stat(path);
     });
@@ -791,7 +798,7 @@ export class FileSystem {
    * Behind the scenes it uses `fs.lstatSync()`.
    * @param path - The absolute or relative path to the filesystem object.
    */
-  public static getLinkStatistics(path: string): fs.Stats {
+  public static getLinkStatistics(path: string): FileSystemStats {
     return FileSystem._wrapException(() => {
       return fsx.lstatSync(path);
     });
@@ -800,7 +807,7 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getLinkStatistics}.
    */
-  public static getLinkStatisticsAsync(path: string): Promise<fs.Stats> {
+  public static getLinkStatisticsAsync(path: string): Promise<FileSystemStats> {
     return FileSystem._wrapExceptionAsync(() => {
       return fsx.lstat(path);
     });

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -10,8 +10,10 @@ import { PosixModeBits } from './PosixModeBits';
 
 /**
  * An alias for the Node.js `fs.Stats` object.
+ *
  * @remarks
  * This avoids the need to import the `fs` package when using the {@link FileSystem} API.
+ * @public
  */
 export type FileSystemStats = fs.Stats;
 
@@ -810,6 +812,32 @@ export class FileSystem {
   public static getLinkStatisticsAsync(path: string): Promise<FileSystemStats> {
     return FileSystem._wrapExceptionAsync(() => {
       return fsx.lstat(path);
+    });
+  }
+
+  /**
+   * If `path` refers to a symbolic link, this returns the path of the link target, which may be
+   * an absolute or relative path.
+   *
+   * @remarks
+   * If `path` refers to a filesystem object that is not a symbolic link, then an `ErrnoException` is thrown
+   * with code 'UNKNOWN'.  If `path` does not exist, then an `ErrnoException` is thrown with code `ENOENT`.
+   *
+   * @param path - The absolute or relative path to the symbolic link.
+   * @returns the path of the link target
+   */
+  public static readLink(path: string): string {
+    return FileSystem._wrapException(() => {
+      return fsx.readlinkSync(path);
+    });
+  }
+
+  /**
+   * An async version of {@link FileSystem.readLink}.
+   */
+  public static readLinkAsync(path: string): Promise<string> {
+    return FileSystem._wrapExceptionAsync(() => {
+      return fsx.readlink(path);
     });
   }
 

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -68,6 +68,7 @@ export {
 export { Sort } from './Sort';
 export {
   FileSystem,
+  FileSystemStats,
   IFileSystemReadFolderOptions,
   IFileSystemWriteFileOptions,
   IFileSystemReadFileOptions,

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -58,7 +58,7 @@ module.exports = {
         // CONFIGURATION:     By default, these are banned: String, Boolean, Number, Object, Symbol
         "@typescript-eslint/ban-types": [
           "error",
-          {          
+          {
             types: {
               String: {
                 message: "Use 'string' instead",
@@ -78,8 +78,8 @@ module.exports = {
               Symbol: {
                 message: "Use 'symbol' instead",
                 fixWith: "symbol"
-              }     
-            }                  
+              }
+            }
           }
         ],
 
@@ -298,9 +298,9 @@ module.exports = {
         // RATIONALE:         Catches a common coding mistake.
         "guard-for-in": "error",
 
-        // RATIONALE:         If you have more than 1,000 lines in a single source file, it's probably time
+        // RATIONALE:         If you have more than 2,000 lines in a single source file, it's probably time
         //                    to split up your code.
-        "max-lines": ["error", { "max": 1000 }],
+        "max-lines": ["error", { "max": 2000 }],
 
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "no-async-promise-executor": "error",


### PR DESCRIPTION
This PR also adds an `FileSystemStats` alias. And relaxes a lint rule that was too strict.