### PR TITLE
[rush-stack-compiler] Update tsconfig-node.json to target es2017

### DIFF
--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.8"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.9"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.0"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.1"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.2"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.3"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.5"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.6"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update tsconfig-node.json to target es2017 (supported by Node 8); this enables native async/await, and will show complete callstacks when using Node 12",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-rsc-es2017_2020-05-27-05-35.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-rsc-es2017_2020-05-27-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve async callstacks for FileSystem API (when using Node 12)",
+      "type": "patch",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -250,8 +250,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getStatistics}.
    */
-  public static getStatisticsAsync(path: string): Promise<FileSystemStats> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async getStatisticsAsync(path: string): Promise<FileSystemStats> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.stat(path);
     });
   }
@@ -272,8 +272,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.updateTimes}.
    */
-  public static updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       // This cast is needed because the fs-extra typings require both parameters
       // to have the same type (number or Date), whereas Node.js does not require that.
       return fsx.utimes(path, times.accessedTime as number, times.modifiedTime as number);
@@ -296,8 +296,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.changePosixModeBits}.
    */
-  public static changePosixModeBitsAsync(path: string, mode: PosixModeBits): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async changePosixModeBitsAsync(path: string, mode: PosixModeBits): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.chmod(path, mode);
     });
   }
@@ -321,8 +321,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getPosixModeBits}.
    */
-  public static getPosixModeBitsAsync(path: string): Promise<PosixModeBits> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async getPosixModeBitsAsync(path: string): Promise<PosixModeBits> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       return (await FileSystem.getStatisticsAsync(path)).mode;
     });
   }
@@ -384,8 +384,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.move}.
    */
-  public static moveAsync(options: IFileSystemMoveOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async moveAsync(options: IFileSystemMoveOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...MOVE_DEFAULT_OPTIONS,
         ...options
@@ -429,8 +429,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.ensureFolder}.
    */
-  public static ensureFolderAsync(folderPath: string): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async ensureFolderAsync(folderPath: string): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.ensureDir(folderPath);
     });
   }
@@ -461,8 +461,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.readFolder}.
    */
-  public static readFolderAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async readFolderAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...READ_FOLDER_DEFAULT_OPTIONS,
         ...options
@@ -494,8 +494,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.deleteFolder}.
    */
-  public static deleteFolderAsync(folderPath: string): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async deleteFolderAsync(folderPath: string): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.remove(folderPath);
     });
   }
@@ -517,8 +517,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.ensureEmptyFolder}.
    */
-  public static ensureEmptyFolderAsync(folderPath: string): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async ensureEmptyFolderAsync(folderPath: string): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.emptyDir(folderPath);
     });
   }
@@ -568,8 +568,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.writeFile}.
    */
-  public static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...WRITE_FILE_DEFAULT_OPTIONS,
         ...options
@@ -638,8 +638,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.appendToFile}.
    */
-  public static appendToFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async appendToFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...APPEND_TO_FILE_DEFAULT_OPTIONS,
         ...options
@@ -692,8 +692,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.readFile}.
    */
-  public static readFileAsync(filePath: string, options?: IFileSystemReadFileOptions): Promise<string> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async readFileAsync(filePath: string, options?: IFileSystemReadFileOptions): Promise<string> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...READ_FILE_DEFAULT_OPTIONS,
         ...options
@@ -722,8 +722,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.readFileToBuffer}.
    */
-  public static readFileToBufferAsync(filePath: string): Promise<Buffer> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async readFileToBufferAsync(filePath: string): Promise<Buffer> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.readFile(filePath);
     });
   }
@@ -742,8 +742,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.copyFile}.
    */
-  public static copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.copy(options.sourcePath, options.destinationPath);
     });
   }
@@ -774,8 +774,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.deleteFile}.
    */
-  public static deleteFileAsync(filePath: string, options?: IFileSystemDeleteFileOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(async () => {
+  public static async deleteFileAsync(filePath: string, options?: IFileSystemDeleteFileOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...DELETE_FILE_DEFAULT_OPTIONS,
         ...options
@@ -809,8 +809,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getLinkStatistics}.
    */
-  public static getLinkStatisticsAsync(path: string): Promise<FileSystemStats> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async getLinkStatisticsAsync(path: string): Promise<FileSystemStats> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.lstat(path);
     });
   }
@@ -835,8 +835,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.readLink}.
    */
-  public static readLinkAsync(path: string): Promise<string> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async readLinkAsync(path: string): Promise<string> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.readlink(path);
     });
   }
@@ -855,8 +855,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.createSymbolicLinkJunction}.
    */
-  public static createSymbolicLinkJunctionAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async createSymbolicLinkJunctionAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       // For directories, we use a Windows "junction".  On POSIX operating systems, this produces a regular symlink.
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'junction');
     });
@@ -875,8 +875,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.createSymbolicLinkFile}.
    */
-  public static createSymbolicLinkFileAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async createSymbolicLinkFileAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'file');
     });
   }
@@ -894,8 +894,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.createSymbolicLinkFolder}.
    */
-  public static createSymbolicLinkFolderAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async createSymbolicLinkFolderAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'dir');
     });
   }
@@ -913,8 +913,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.createHardLink}.
    */
-  public static createHardLinkAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async createHardLinkAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.link(options.linkTargetPath, options.newLinkPath);
     });
   }
@@ -933,8 +933,8 @@ export class FileSystem {
   /**
    * An async version of {@link FileSystem.getRealPath}.
    */
-  public static getRealPathAsync(linkPath: string): Promise<string> {
-    return FileSystem._wrapExceptionAsync(() => {
+  public static async getRealPathAsync(linkPath: string): Promise<string> {
+    return await FileSystem._wrapExceptionAsync(() => {
       return fsx.realpath(linkPath);
     });
   }

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -297,7 +297,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.changePosixModeBits}.
    */
   public static async changePosixModeBitsAsync(path: string, mode: PosixModeBits): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.chmod(path, mode);
     });
   }
@@ -385,7 +385,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.move}.
    */
   public static async moveAsync(options: IFileSystemMoveOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(async () => {
+    await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...MOVE_DEFAULT_OPTIONS,
         ...options
@@ -430,7 +430,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.ensureFolder}.
    */
   public static async ensureFolderAsync(folderPath: string): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.ensureDir(folderPath);
     });
   }
@@ -495,7 +495,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.deleteFolder}.
    */
   public static async deleteFolderAsync(folderPath: string): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.remove(folderPath);
     });
   }
@@ -518,7 +518,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.ensureEmptyFolder}.
    */
   public static async ensureEmptyFolderAsync(folderPath: string): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.emptyDir(folderPath);
     });
   }
@@ -569,7 +569,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.writeFile}.
    */
   public static async writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(async () => {
+    await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...WRITE_FILE_DEFAULT_OPTIONS,
         ...options
@@ -639,7 +639,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.appendToFile}.
    */
   public static async appendToFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(async () => {
+    await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...APPEND_TO_FILE_DEFAULT_OPTIONS,
         ...options
@@ -743,7 +743,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.copyFile}.
    */
   public static async copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.copy(options.sourcePath, options.destinationPath);
     });
   }
@@ -775,7 +775,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.deleteFile}.
    */
   public static async deleteFileAsync(filePath: string, options?: IFileSystemDeleteFileOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(async () => {
+    await FileSystem._wrapExceptionAsync(async () => {
       options = {
         ...DELETE_FILE_DEFAULT_OPTIONS,
         ...options
@@ -856,7 +856,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.createSymbolicLinkJunction}.
    */
   public static async createSymbolicLinkJunctionAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       // For directories, we use a Windows "junction".  On POSIX operating systems, this produces a regular symlink.
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'junction');
     });
@@ -876,7 +876,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.createSymbolicLinkFile}.
    */
   public static async createSymbolicLinkFileAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'file');
     });
   }
@@ -895,7 +895,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.createSymbolicLinkFolder}.
    */
   public static async createSymbolicLinkFolderAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.symlink(options.linkTargetPath, options.newLinkPath, 'dir');
     });
   }
@@ -914,7 +914,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.createHardLink}.
    */
   public static async createHardLinkAsync(options: IFileSystemCreateLinkOptions): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       return fsx.link(options.linkTargetPath, options.newLinkPath);
     });
   }

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -273,7 +273,7 @@ export class FileSystem {
    * An async version of {@link FileSystem.updateTimes}.
    */
   public static async updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void> {
-    return await FileSystem._wrapExceptionAsync(() => {
+    await FileSystem._wrapExceptionAsync(() => {
       // This cast is needed because the fs-extra typings require both parameters
       // to have the same type (number or Date), whereas Node.js does not require that.
       return fsx.utimes(path, times.accessedTime as number, times.modifiedTime as number);

--- a/stack/rush-stack-compiler-2.4/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-2.4/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-2.7/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-2.7/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-2.8/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-2.8/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-2.9/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-2.9/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.0/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.0/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.1/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.1/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.2/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.2/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.3/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.3/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.4/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.4/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.5/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.5/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.6/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.6/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }

--- a/stack/rush-stack-compiler-3.7/includes/tsconfig-node.json
+++ b/stack/rush-stack-compiler-3.7/includes/tsconfig-node.json
@@ -4,12 +4,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
-    "lib": [
-      "es5",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.promise"
-    ]
+    "target": "es2017",
+    "lib": [ "es2017" ]
   }
 }


### PR DESCRIPTION
This PR updates **tsconfig-node.json** to target `es2017` (supported by Node 8).  This is recommended by the TypeScript wiki here:

https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

Transpiling for `es2017` enables native `async`/`await`.  When using Node 12, this produces complete call stacks like this:
```
caught: Error: oops!
    at C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:465:19
    at async Function._wrapExceptionAsync (C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:715:20)
    at async test2 (C:\Git\rushstack2\apps\api-extractor\lib\start.js:7:12)
    at async test (C:\Git\rushstack2\apps\api-extractor\lib\start.js:10:12)
```

This PR also adds the `async` keyword to the FileSystem APIs, which adds them to the callstack like this:
```
caught: Error: oops!
    at C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:465:19
    at async Function._wrapExceptionAsync (C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:715:20)
    at async Function.readFileAsync (C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:459:16)
                      ^^^^^^^^^^^^^
    at async test2 (C:\Git\rushstack2\apps\api-extractor\lib\start.js:7:12)
    at async test (C:\Git\rushstack2\apps\api-extractor\lib\start.js:10:12)
```

Note that when running under Node 8 or 10, the callstacks unfortunately still look like this (sad trombone noise):
```
caught: Error: oops!
    at Function.<anonymous> (C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:474:23)
    at Generator.next (<anonymous>)
    at fulfilled (C:\Git\rushstack2\libraries\node-core-library\lib\FileSystem.js:6:58)
```