### PR TITLE
[node-core-library] Add a FileSystem.copyFiles() API

### DIFF
--- a/common/changes/@rushstack/node-core-library/octogonz-ncl-copyfiles_2020-05-29-05-13.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-ncl-copyfiles_2020-05-29-05-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a FileSystem.copyFiles() API for recursively copying folders, and clarify that FileSystem.copyFile() only copies a single file",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -235,6 +235,7 @@ export interface IExecutableSpawnSyncOptions extends IExecutableResolveOptions {
 
 // @public
 export interface IFileSystemCopyFileOptions {
+    alreadyExistsBehavior?: AlreadyExistsBehavior;
     destinationPath: string;
     sourcePath: string;
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -7,6 +7,13 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 
+// @public
+export const enum AlreadyExistsBehavior {
+    Error = "error",
+    Ignore = "ignore",
+    Overwrite = "overwrite"
+}
+
 // @beta
 export class Colors {
     // (undocumented)
@@ -123,6 +130,8 @@ export class FileSystem {
     static changePosixModeBitsAsync(path: string, mode: PosixModeBits): Promise<void>;
     static copyFile(options: IFileSystemCopyFileOptions): void;
     static copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void>;
+    static copyFiles(options: IFileSystemCopyFilesOptions): void;
+    static copyFilesAsync(options: IFileSystemCopyFilesOptions): Promise<void>;
     static createHardLink(options: IFileSystemCreateLinkOptions): void;
     static createHardLinkAsync(options: IFileSystemCreateLinkOptions): Promise<void>;
     static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void;
@@ -168,6 +177,12 @@ export class FileSystem {
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
     static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void>;
 }
+
+// @public
+export type FileSystemCopyFilesAsyncFilter = (sourcePath: string, destinationPath: string) => Promise<boolean>;
+
+// @public
+export type FileSystemCopyFilesFilter = (sourcePath: string, destinationPath: string) => boolean;
 
 // @public
 export type FileSystemStats = fs.Stats;
@@ -222,6 +237,21 @@ export interface IExecutableSpawnSyncOptions extends IExecutableResolveOptions {
 export interface IFileSystemCopyFileOptions {
     destinationPath: string;
     sourcePath: string;
+}
+
+// @public
+export interface IFileSystemCopyFilesAsyncOptions {
+    alreadyExistsBehavior?: AlreadyExistsBehavior;
+    dereferenceSymlinks?: boolean;
+    destinationPath: string;
+    filter?: FileSystemCopyFilesAsyncFilter | FileSystemCopyFilesFilter;
+    preserveTimestamps?: boolean;
+    sourcePath: string;
+}
+
+// @public
+export interface IFileSystemCopyFilesOptions extends IFileSystemCopyFilesAsyncOptions {
+    filter?: FileSystemCopyFilesFilter;
 }
 
 // @public

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -123,6 +123,7 @@ export interface IFileSystemCopyFileOptions {
 
   /**
    * Specifies what to do if the target object already exists.
+   * @defaultValue {@link AlreadyExistsBehavior.Overwrite}
    */
   alreadyExistsBehavior?: AlreadyExistsBehavior;
 }
@@ -280,6 +281,14 @@ const APPEND_TO_FILE_DEFAULT_OPTIONS: Partial<IFileSystemWriteFileOptions> = {
 const READ_FILE_DEFAULT_OPTIONS: Partial<IFileSystemReadFileOptions> = {
   encoding: Encoding.Utf8,
   convertLineEndings: undefined
+};
+
+const COPY_FILE_DEFAULT_OPTIONS: Partial<IFileSystemCopyFileOptions> = {
+  alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
+};
+
+const COPY_FILES_DEFAULT_OPTIONS: Partial<IFileSystemCopyFilesOptions> = {
+  alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
 };
 
 const DELETE_FILE_DEFAULT_OPTIONS: Partial<IFileSystemDeleteFileOptions> = {
@@ -828,8 +837,10 @@ export class FileSystem {
    * The implementation is based on `copySync()` from the `fs-extra` package.
    */
   public static copyFile(options: IFileSystemCopyFileOptions): void {
-    const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
-      ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Overwrite;
+    options = {
+      ...COPY_FILE_DEFAULT_OPTIONS,
+      ...options
+    };
 
     if (FileSystem.getStatistics(options.sourcePath).isDirectory()) {
       throw new Error('The specified path refers to a folder; this operation expects a file object:\n'
@@ -838,8 +849,8 @@ export class FileSystem {
 
     FileSystem._wrapException(() => {
       fsx.copySync(options.sourcePath, options.destinationPath, {
-        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
-        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite
+        errorOnExist: options.alreadyExistsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: options.alreadyExistsBehavior === AlreadyExistsBehavior.Overwrite
       });
     });
   }
@@ -848,8 +859,10 @@ export class FileSystem {
    * An async version of {@link FileSystem.copyFile}.
    */
   public static async copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void> {
-    const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
-      ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Overwrite;
+    options = {
+      ...COPY_FILE_DEFAULT_OPTIONS,
+      ...options
+    };
 
     if (FileSystem.getStatistics(options.sourcePath).isDirectory()) {
       throw new Error('The specified path refers to a folder; this operation expects a file object:\n'
@@ -858,8 +871,8 @@ export class FileSystem {
 
     await FileSystem._wrapExceptionAsync(() => {
       return fsx.copy(options.sourcePath, options.destinationPath, {
-        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
-        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite
+        errorOnExist: options.alreadyExistsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: options.alreadyExistsBehavior === AlreadyExistsBehavior.Overwrite
       });
     });
   }
@@ -875,14 +888,16 @@ export class FileSystem {
    * The implementation is based on `copySync()` from the `fs-extra` package.
    */
   public static copyFiles(options: IFileSystemCopyFilesOptions): void {
-    const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
-      ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Overwrite;
+    options = {
+      ...COPY_FILES_DEFAULT_OPTIONS,
+      ...options
+    };
 
     FileSystem._wrapException(() => {
       fsx.copySync(options.sourcePath, options.destinationPath, {
         dereference: !!options.dereferenceSymlinks,
-        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
-        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite,
+        errorOnExist: options.alreadyExistsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: options.alreadyExistsBehavior === AlreadyExistsBehavior.Overwrite,
         preserveTimestamps: !!options.preserveTimestamps,
         filter: options.filter
       });
@@ -893,14 +908,16 @@ export class FileSystem {
    * An async version of {@link FileSystem.copyFiles}.
    */
   public static async copyFilesAsync(options: IFileSystemCopyFilesOptions): Promise<void> {
-    const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
-      ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Overwrite;
+    options = {
+      ...COPY_FILES_DEFAULT_OPTIONS,
+      ...options
+    };
 
     await FileSystem._wrapExceptionAsync(async () => {
       fsx.copySync(options.sourcePath, options.destinationPath, {
         dereference: !!options.dereferenceSymlinks,
-        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
-        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite,
+        errorOnExist: options.alreadyExistsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: options.alreadyExistsBehavior === AlreadyExistsBehavior.Overwrite,
         preserveTimestamps: !!options.preserveTimestamps,
         filter: options.filter
       });

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -21,7 +21,7 @@ export type FileSystemStats = fs.Stats;
 /* eslint-disable no-bitwise */
 
 /**
- * The options for FileSystem.readFolder()
+ * The options for {@link FileSystem.readFolder}
  * @public
  */
 export interface IFileSystemReadFolderOptions {
@@ -33,7 +33,7 @@ export interface IFileSystemReadFolderOptions {
 }
 
 /**
- * The options for FileSystem.writeFile()
+ * The options for {@link FileSystem.writeFile}
  * @public
  */
 export interface IFileSystemWriteFileOptions {
@@ -57,7 +57,7 @@ export interface IFileSystemWriteFileOptions {
 }
 
 /**
- * The options for FileSystem.readFile()
+ * The options for {@link FileSystem.readFile}
  * @public
  */
 export interface IFileSystemReadFileOptions {
@@ -75,7 +75,7 @@ export interface IFileSystemReadFileOptions {
 }
 
 /**
- * The options for FileSystem.move()
+ * The options for {@link FileSystem.move}
  * @public
  */
 export interface IFileSystemMoveOptions {
@@ -105,7 +105,7 @@ export interface IFileSystemMoveOptions {
 }
 
 /**
- * The options for FileSystem.copyFile()
+ * The options for {@link FileSystem.copyFile}
  * @public
  */
 export interface IFileSystemCopyFileOptions {
@@ -123,7 +123,89 @@ export interface IFileSystemCopyFileOptions {
 }
 
 /**
- * The options for FileSystem.deleteFile()
+ * Specifies the behavior of {@link FileSystem.copyFiles} in a situation where the target object
+ * already exists.
+ */
+export const enum AlreadyExistsBehavior {
+  /**
+   * If the destination object exists, report an error.  This is the default behavior.
+   */
+  Error = 'error',
+
+  /**
+   * If the destination object exists, overwrite it.
+   */
+  Overwrite = 'overwrite',
+
+  /**
+   * If the destination object exists, skip it and continue the operation.
+   */
+  Ignore = 'ignore'
+}
+
+/**
+ * Callback function type for {@link IFileSystemCopyFilesAsyncOptions.filter}
+ * @public
+ */
+export type FileSystemCopyFilesAsyncFilter = (sourcePath: string, destinationPath: string) => Promise<boolean>;
+
+/**
+ * Callback function type for {@link IFileSystemCopyFilesOptions.filter}
+ * @public
+ */
+export type FileSystemCopyFilesFilter = (sourcePath: string, destinationPath: string) => boolean;
+
+/**
+ * The options for {@link FileSystem.copyFilesAsync}
+ * @public
+ */
+export interface IFileSystemCopyFilesAsyncOptions {
+  /**
+   * The starting path of the file or folder to be copied.
+   * The path may be absolute or relative.
+   */
+  sourcePath: string;
+
+  /**
+   * The path that the files will be copied to.
+   * The path may be absolute or relative.
+   */
+  destinationPath: string;
+
+  /**
+   * If true, then when copying symlinks, copy the target object instead of copying the link.
+   */
+  dereferenceSymlinks?: boolean;
+
+  /**
+   * Specifies what to do if the target object already exists.
+   */
+  alreadyExistsBehavior?: AlreadyExistsBehavior;
+
+  /**
+   * If true, then the target object will be assigned "last modification" and "last access" timestamps
+   * that are the same as the source.  Otherwise, the OS default timestamps are assigned.
+   */
+  preserveTimestamps?: boolean;
+
+  /**
+   * A callback that will be invoked for each path that is copied.  The callback can return `false`
+   * to cause the object to be excluded from the operation.
+   */
+  filter?: FileSystemCopyFilesAsyncFilter | FileSystemCopyFilesFilter;
+}
+
+/**
+ * The options for {@link FileSystem.copyFiles}
+ * @public
+ */
+export interface IFileSystemCopyFilesOptions extends IFileSystemCopyFilesAsyncOptions {
+  /**  {@inheritdoc IFileSystemCopyFilesAsyncOptions.filter} */
+  filter?: FileSystemCopyFilesFilter; // narrow the type to exclude FileSystemCopyFilesAsyncFilter
+}
+
+/**
+ * The options for {@link FileSystem.deleteFile}
  * @public
 */
 export interface IFileSystemDeleteFileOptions {
@@ -135,7 +217,7 @@ export interface IFileSystemDeleteFileOptions {
 }
 
 /**
- * The parameters for `updateTimes()`.
+ * The options for {@link FileSystem.updateTimes}
  * Both times must be specified.
  * @public
  */
@@ -152,8 +234,8 @@ export interface IFileSystemUpdateTimeParameters {
 }
 
 /**
- * The options for `FileSystem.createSymbolicLinkJunction()`, `createSymbolicLinkFile()`,
- * `createSymbolicLinkFolder()`,  and `createHardLink()`.
+ * The options for {@link FileSystem.createSymbolicLinkJunction}, {@link FileSystem.createSymbolicLinkFile},
+ * {@link FileSystem.createSymbolicLinkFolder}, and {@link FileSystem.createHardLink}.
  *
  * @public
  */
@@ -745,6 +827,45 @@ export class FileSystem {
   public static async copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void> {
     await FileSystem._wrapExceptionAsync(() => {
       return fsx.copy(options.sourcePath, options.destinationPath);
+    });
+  }
+
+  /**
+   * Copies a file from one location to another.
+   * By default, destinationPath is overwritten if it already exists.
+   * Behind the scenes it uses `fs.copyFileSync()`.
+   */
+  public static copyFiles(options: IFileSystemCopyFilesOptions): void {
+    const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
+      ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Error;
+
+    FileSystem._wrapException(() => {
+      fsx.copySync(options.sourcePath, options.destinationPath, {
+        dereference: !!options.dereferenceSymlinks,
+        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite,
+        preserveTimestamps: !!options.preserveTimestamps,
+        filter: options.filter
+      });
+    });
+  }
+
+  /**
+   * An async version of {@link FileSystem.copyFile}.
+   */
+  public static async copyFilesAsync(options: IFileSystemCopyFilesOptions): Promise<void> {
+    await FileSystem._wrapExceptionAsync(async () => {
+
+      const existsBehavior: AlreadyExistsBehavior = options.alreadyExistsBehavior !== undefined
+        ? options.alreadyExistsBehavior : AlreadyExistsBehavior.Error;
+
+      fsx.copySync(options.sourcePath, options.destinationPath, {
+        dereference: !!options.dereferenceSymlinks,
+        errorOnExist: existsBehavior === AlreadyExistsBehavior.Error,
+        overwrite: existsBehavior === AlreadyExistsBehavior.Overwrite,
+        preserveTimestamps: !!options.preserveTimestamps,
+        filter: options.filter
+      });
     });
   }
 

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -67,6 +67,7 @@ export {
 } from './Text';
 export { Sort } from './Sort';
 export {
+  AlreadyExistsBehavior,
   FileSystem,
   FileSystemStats,
   IFileSystemReadFolderOptions,
@@ -76,7 +77,11 @@ export {
   IFileSystemCopyFileOptions,
   IFileSystemDeleteFileOptions,
   IFileSystemUpdateTimeParameters,
-  IFileSystemCreateLinkOptions
+  IFileSystemCreateLinkOptions,
+  IFileSystemCopyFilesAsyncOptions,
+  IFileSystemCopyFilesOptions,
+  FileSystemCopyFilesAsyncFilter,
+  FileSystemCopyFilesFilter,
 } from './FileSystem';
 export {
   FileWriter,


### PR DESCRIPTION
This adds an API for recursively copying files. It was motivated by PR https://github.com/microsoft/rushstack/pull/1898 which does this:

https://github.com/microsoft/rushstack/blob/de1443cb43d9d08ce6017499a30e2d33050b288a/apps/rush-lib/src/logic/deploy/DeployManager.ts#L159-L175

I also added some validation to clarify that `FileSystem.copyFile()` was never intended to work with folders.  Previously if a folder was specified, it would have recursively copied it, which is counterintuitive.