### PR TITLE
Make autoprefixer configuration non-static

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-sass/keco-configurable-autoprefixer_2020-05-29-20-27.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/keco-configurable-autoprefixer_2020-05-29-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Fix static autoprefixer configuration options",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -91,9 +91,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     'src/**/*.scss.ts'
   ];
 
-  private _postCSSPlugins: postcss.AcceptedPlugin[] = [
-    autoprefixer(this.taskConfig.autoprefixerOptions)
-  ];
+  private get _postCSSPlugins(): postcss.AcceptedPlugin[] {
+    return [autoprefixer(this.taskConfig.autoprefixerOptions)];
+  }
 
   public constructor() {
     super(


### PR DESCRIPTION
https://github.com/microsoft/rushstack/pull/1891 had a mistake in that the configuration is not applied due to `autoprefixer` being a static instance.