### PR TITLE
[ts-command-line] Fix a typo in the supplementary notes

### DIFF
--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -123,8 +123,8 @@ Optional arguments:
                         count that is equal to the number of CPU cores. If 
                         this parameter is omitted, then the default value 
                         depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively specified via 
-                        the RUSH_PARALLELISM environment variable.
+                        cores. This parameter may alternatively be specified 
+                        via the RUSH_PARALLELISM environment variable.
   -t PROJECT1, --to PROJECT1
                         Run command in the specified project and all of its 
                         dependencies. \\".\\" can be used as shorthand to specify 
@@ -216,7 +216,7 @@ are of the same version throughout the repository.
 Optional arguments:
   -h, --help         Show this help message and exit.
   --variant VARIANT  Run command using a variant installation configuration. 
-                     This parameter may alternatively specified via the 
+                     This parameter may alternatively be specified via the 
                      RUSH_VARIANT environment variable.
   --json             If this flag is specified, output will be in JSON format.
 "
@@ -256,8 +256,8 @@ Optional arguments:
                         count that is equal to the number of CPU cores. If 
                         this parameter is omitted, then the default value 
                         depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively specified via 
-                        the RUSH_PARALLELISM environment variable.
+                        cores. This parameter may alternatively be specified 
+                        via the RUSH_PARALLELISM environment variable.
   -t PROJECT1, --to PROJECT1
                         Run command in the specified project and all of its 
                         dependencies. \\".\\" can be used as shorthand to specify 
@@ -346,7 +346,7 @@ Optional arguments:
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
   --variant VARIANT     Run command using a variant installation 
-                        configuration. This parameter may alternatively 
+                        configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
 "
 `;
@@ -515,8 +515,8 @@ Optional arguments:
                         count that is equal to the number of CPU cores. If 
                         this parameter is omitted, then the default value 
                         depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively specified via 
-                        the RUSH_PARALLELISM environment variable.
+                        cores. This parameter may alternatively be specified 
+                        via the RUSH_PARALLELISM environment variable.
   -t PROJECT1, --to PROJECT1
                         Run command in the specified project and all of its 
                         dependencies. \\".\\" can be used as shorthand to specify 
@@ -613,7 +613,7 @@ Optional arguments:
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
   --variant VARIANT     Run command using a variant installation 
-                        configuration. This parameter may alternatively 
+                        configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
   --full                Normally \\"rush update\\" tries to preserve your 
                         existing installed versions and only makes the 

--- a/common/changes/@microsoft/rush/octogonz-tsc-description-fix_2020-05-31-07-46.json
+++ b/common/changes/@microsoft/rush/octogonz-tsc-description-fix_2020-05-31-07-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/octogonz-tsc-description-fix_2020-05-31-07-46.json
+++ b/common/changes/@rushstack/ts-command-line/octogonz-tsc-description-fix_2020-05-31-07-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Fix a typo in the supplementary notes for parameters with environment variable mappings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -108,7 +108,7 @@ export abstract class CommandLineParameter {
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void { // virtual
     if (this.environmentVariable !== undefined) {
-      supplementaryNotes.push('This parameter may alternatively specified via the ' + this.environmentVariable
+      supplementaryNotes.push('This parameter may alternatively be specified via the ' + this.environmentVariable
       + ' environment variable.');
     }
   }

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -292,7 +292,7 @@ export abstract class CommandLineParameterProvider {
     parameter._getSupplementaryNotes(supplementaryNotes);
     if (supplementaryNotes.length > 0) {
       // If they left the period off the end of their sentence, then add one.
-      if (finalDescription.match(/[a-z0-9]\s*$/i)) {
+      if (finalDescription.match(/[a-z0-9]"?\s*$/i)) {
         finalDescription = finalDescription.trimRight() + '.';
       }
       // Append the supplementary text

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -35,7 +35,7 @@ function createParser(): DynamicCommandLineParser {
   });
   action.defineChoiceParameter({
     parameterLongName: '--choice-with-default',
-    description: 'A choice with a default',
+    description: 'A choice with a default. This description ends with a "quoted word"',
     alternatives: [ 'one', 'two', 'three', 'default' ],
     environmentVariable: 'ENV_CHOICE2',
     defaultValue: 'default'

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -413,7 +413,7 @@ Optional arguments:
                         specified via the ENV_CHOICE environment variable.
   --choice-with-default {one,two,three,default}
                         A choice with a default. This description ends with a 
-                        \\"quoted word\\" This parameter may alternatively be 
+                        \\"quoted word\\". This parameter may alternatively be 
                         specified via the ENV_CHOICE2 environment variable. 
                         The default value is \\"default\\".
   -f, --flag            A flag. This parameter may alternatively be specified 

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -409,33 +409,33 @@ a longer description
 Optional arguments:
   -h, --help            Show this help message and exit.
   -c {one,two,three,default}, --choice {one,two,three,default}
-                        A choice. This parameter may alternatively specified 
-                        via the ENV_CHOICE environment variable.
+                        A choice. This parameter may alternatively be 
+                        specified via the ENV_CHOICE environment variable.
   --choice-with-default {one,two,three,default}
                         A choice with a default. This parameter may 
-                        alternatively specified via the ENV_CHOICE2 
+                        alternatively be specified via the ENV_CHOICE2 
                         environment variable. The default value is \\"default\\".
-  -f, --flag            A flag. This parameter may alternatively specified 
+  -f, --flag            A flag. This parameter may alternatively be specified 
                         via the ENV_FLAG environment variable.
   -i NUMBER, --integer NUMBER
-                        An integer. This parameter may alternatively 
+                        An integer. This parameter may alternatively be 
                         specified via the ENV_INTEGER environment variable.
   --integer-with-default NUMBER
                         An integer with a default. This parameter may 
-                        alternatively specified via the ENV_INTEGER2 
+                        alternatively be specified via the ENV_INTEGER2 
                         environment variable. The default value is 123.
   --integer-required NUMBER
                         An integer
   -s TEXT, --string TEXT
-                        A string. This parameter may alternatively specified 
-                        via the ENV_STRING environment variable.
+                        A string. This parameter may alternatively be 
+                        specified via the ENV_STRING environment variable.
   --string-with-default TEXT
                         A string with a default. This parameter may 
-                        alternatively specified via the ENV_STRING2 
+                        alternatively be specified via the ENV_STRING2 
                         environment variable. The default value is \\"123\\".
   -l LIST_ITEM, --string-list LIST_ITEM
                         This parameter be specified multiple times to make a 
-                        list of strings. This parameter may alternatively 
+                        list of strings. This parameter may alternatively be 
                         specified via the ENV_STRING_LIST environment 
                         variable.
 "

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -34,7 +34,7 @@ exports[`CommandLineParameter parses an input with ALL parameters 3`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": "default",
-  "description": "A choice with a default",
+  "description": "A choice with a default. This description ends with a \\"quoted word\\"",
   "environmentVariable": "ENV_CHOICE2",
   "kind": 0,
   "longName": "--choice-with-default",
@@ -220,7 +220,7 @@ exports[`CommandLineParameter parses an input with NO parameters 3`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": "default",
-  "description": "A choice with a default",
+  "description": "A choice with a default. This description ends with a \\"quoted word\\"",
   "environmentVariable": "ENV_CHOICE2",
   "kind": 0,
   "longName": "--choice-with-default",
@@ -412,9 +412,10 @@ Optional arguments:
                         A choice. This parameter may alternatively be 
                         specified via the ENV_CHOICE environment variable.
   --choice-with-default {one,two,three,default}
-                        A choice with a default. This parameter may 
-                        alternatively be specified via the ENV_CHOICE2 
-                        environment variable. The default value is \\"default\\".
+                        A choice with a default. This description ends with a 
+                        \\"quoted word\\" This parameter may alternatively be 
+                        specified via the ENV_CHOICE2 environment variable. 
+                        The default value is \\"default\\".
   -f, --flag            A flag. This parameter may alternatively be specified 
                         via the ENV_FLAG environment variable.
   -i NUMBER, --integer NUMBER


### PR DESCRIPTION
This sentence was missing the word "be":

*"This parameter may alternatively specified via the ______ environment variable."*

Also the code that appends a period before this sentence did not consider sentences that end with a quoted word.