### PR TITLE
[rush] deploy step, try/catch resolve.sync to allow optional dependencies to pass

### DIFF
--- a/common/changes/@microsoft/rush/fix-optionalDependencies-required-for-deploy_2020-06-02-13-21.json
+++ b/common/changes/@microsoft/rush/fix-optionalDependencies-required-for-deploy_2020-06-02-13-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Expect error when trying to resolve optional dependency during deploy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "jlsjonas@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes #1908

note: note sure if the pre-existing ` if (!resolvedDependency) {` would still be required for different use-cases/tool combo's, so kept both on purpose.
Feel free to remove in an edit if not required.