### PR TITLE
fix(pnpm5): explicitly assign the value of --resolution-strategy

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1341,7 +1341,7 @@ export class InstallManager {
       }
 
       if ((this._rushConfiguration.packageManagerWrapper as PnpmPackageManager).supportsResolutionStrategy) {
-        args.push('--resolution-strategy', this._rushConfiguration.pnpmOptions.resolutionStrategy);
+        args.push(`--resolution-strategy=${this._rushConfiguration.pnpmOptions.resolutionStrategy}`);
       }
     } else if (this._rushConfiguration.packageManager === 'yarn') {
       args.push('--link-folder', 'yarn-link');


### PR DESCRIPTION
The --resolution-strategy option is deprecated in pnpm v5.
It doesn't fail the installation but it should be written as
--resolution-strategy=<value>. Otherwise, pnpm cannot tell that
the argument is the value of the deprecated option.

ref #1892