### PR TITLE
[rush[ Add "--no-verify" for commits performed by "rush version"

### DIFF
--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -86,7 +86,7 @@ export class PublishGit {
   }
 
   public commit(commitMessage: string): void {
-    PublishUtilities.execCommand(!!this._targetBranch, 'git', ['commit', '-m', commitMessage]);
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', ['commit', '-m', commitMessage, '--no-verify']);
   }
 
   public push(branchName: string | undefined): void {

--- a/common/changes/@microsoft/rush/octogonz-rush-version-no-verify_2020-06-11-04-52.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-version-no-verify_2020-06-11-04-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add \"--no-verify\" for commits performed by \"rush version\", since Git hook scripts may fail on CI machines",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes this error during publishing:

```
* EXECUTING: git add :/**/CHANGELOG.json 
warning: LF will be replaced by CRLF in apps/rush/CHANGELOG.json.
The file will have its original line endings in your working directory

* EXECUTING: git add :/**/CHANGELOG.md 
warning: LF will be replaced by CRLF in apps/rush/CHANGELOG.md.
The file will have its original line endings in your working directory

* EXECUTING: git commit -m Deleting change files and updating change logs for package updates. 
fatal: cannot run .git/hooks/pre-commit: No such file or directory

ERROR: The command failed with exit code 1


##[error]Bash exited with code '1'.
Finishing: Rush Version
```