### PR TITLE
[rush] Ensure Git hook scripts use LF newlines

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -20,7 +20,8 @@ import {
   FileConstants,
   Sort,
   PosixModeBits,
-  JsonObject
+  JsonObject,
+  NewlineKind
 } from '@rushstack/node-core-library';
 
 import { ApprovedPackagesChecker } from '../logic/ApprovedPackagesChecker';
@@ -304,10 +305,12 @@ export class InstallManager {
         // Only copy files that look like Git hook names
         const filteredHookFilenames: string[] = hookFilenames.filter((x) => /^[a-z\-]+/.test(x));
         for (const filename of filteredHookFilenames) {
-          FileSystem.copyFile({
-            sourcePath: path.join(hookSource, filename),
-            destinationPath: path.join(hookDestination, filename)
+          // Copy the file.  Important: For Bash scripts, the EOL must not be CRLF.
+          const hookFileContent: string = FileSystem.readFile(path.join(hookSource, filename));
+          FileSystem.writeFile(path.join(hookDestination, filename), hookFileContent, {
+            convertLineEndings: NewlineKind.Lf
           });
+
           FileSystem.changePosixModeBits(
             path.join(hookDestination, filename),
             PosixModeBits.UserRead | PosixModeBits.UserExecute

--- a/common/changes/@microsoft/rush/octogonz-git-hooks-linux_2020-06-11-05-20.json
+++ b/common/changes/@microsoft/rush/octogonz-git-hooks-linux_2020-06-11-05-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Git hook scripts failed in some environments due to CRLF newlines",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/git-hooks/commit-msg.sample
+++ b/common/git-hooks/commit-msg.sample
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# This is an example Git hook for use with Rush.  To enable this hook, rename this file
+# to "commit-msg" and then run "rush install", which will copy it from common/git-hooks
+# to the .git/hooks folder.
+#
+# TO LEARN MORE ABOUT GIT HOOKS
+#
+# The Git documentation is here: https://git-scm.com/docs/githooks
+# Some helpful resources: https://githooks.com
+#
+# ABOUT THIS EXAMPLE
+#
+# The commit-msg hook is called by "git commit" with one argument, the name of the file
+# that has the commit message.  The hook should exit with non-zero status after issuing
+# an appropriate message if it wants to stop the commit.  The hook is allowed to edit
+# the commit message file.
+
+# This example enforces that commit message should contain a minimum amount of
+# description text.
+if [ `cat $1 | wc -w` -lt 3 ]; then
+  echo ""
+  echo "Invalid commit message: The message must contain at least 3 words."
+	exit 1
+fi

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.25.0",
+  "rushVersion": "5.25.1",
 
   /**
    * The next field selects which package manager should be installed and determines its version.


### PR DESCRIPTION
This PR also upgrades us to Rush 5.25.1