### PR TITLE
[api-extractor] Fix missing documentation hyperlinks when using the "bundledPackages" setting

### DIFF
--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -96,7 +96,7 @@ export class AstSymbolTable {
     program: ts.Program,
     typeChecker: ts.TypeChecker,
     packageJsonLookup: PackageJsonLookup,
-    bundledPackageNames: Set<string>,
+    bundledPackageNames: ReadonlySet<string>,
     messageRouter: MessageRouter
   ) {
     this._program = program;

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -63,7 +63,7 @@ export class ExportAnalyzer {
 
   private readonly _program: ts.Program;
   private readonly _typeChecker: ts.TypeChecker;
-  private readonly _bundledPackageNames: Set<string>;
+  private readonly _bundledPackageNames: ReadonlySet<string>;
   private readonly _astSymbolTable: IAstSymbolTable;
 
   private readonly _astModulesByModuleSymbol: Map<ts.Symbol, AstModule> = new Map<ts.Symbol, AstModule>();
@@ -76,7 +76,7 @@ export class ExportAnalyzer {
   public constructor(
     program: ts.Program,
     typeChecker: ts.TypeChecker,
-    bundledPackageNames: Set<string>,
+    bundledPackageNames: ReadonlySet<string>,
     astSymbolTable: IAstSymbolTable
   ) {
     this._program = program;

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -63,6 +63,11 @@ export class Collector {
 
   public readonly extractorConfig: ExtractorConfig;
 
+  /**
+   * The `ExtractorConfig.bundledPackages` names in a set.
+   */
+  public readonly bundledPackageNames: ReadonlySet<string>;
+
   private readonly _program: ts.Program;
 
   private readonly _tsdocParser: tsdoc.TSDocParser;
@@ -117,13 +122,13 @@ export class Collector {
 
     this._tsdocParser = new tsdoc.TSDocParser(AedocDefinitions.tsdocConfiguration);
 
-    const bundledPackageNames: Set<string> = new Set<string>(this.extractorConfig.bundledPackages);
+    this.bundledPackageNames = new Set<string>(this.extractorConfig.bundledPackages);
 
     this.astSymbolTable = new AstSymbolTable(
       this.program,
       this.typeChecker,
       this.packageJsonLookup,
-      bundledPackageNames,
+      this.bundledPackageNames,
       this.messageRouter
     );
     this.astReferenceResolver = new AstReferenceResolver(this);

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -53,7 +53,8 @@ export class ApiModelGenerator {
       collector.packageJsonLookup,
       collector.workingPackage.name,
       collector.program,
-      collector.typeChecker
+      collector.typeChecker,
+      collector.bundledPackageNames
     );
   }
 

--- a/apps/api-extractor/src/generators/DeclarationReferenceGenerator.ts
+++ b/apps/api-extractor/src/generators/DeclarationReferenceGenerator.ts
@@ -21,17 +21,20 @@ export class DeclarationReferenceGenerator {
   private _workingPackageName: string;
   private _program: ts.Program;
   private _typeChecker: ts.TypeChecker;
+  private _bundledPackageNames: ReadonlySet<string>;
 
   public constructor(
     packageJsonLookup: PackageJsonLookup,
     workingPackageName: string,
     program: ts.Program,
-    typeChecker: ts.TypeChecker
+    typeChecker: ts.TypeChecker,
+    bundledPackageNames: ReadonlySet<string>
   ) {
     this._packageJsonLookup = packageJsonLookup;
     this._workingPackageName = workingPackageName;
     this._program = program;
     this._typeChecker = typeChecker;
+    this._bundledPackageNames = bundledPackageNames;
   }
 
   /**
@@ -320,7 +323,16 @@ export class DeclarationReferenceGenerator {
 
   private _sourceFileToModuleSource(sourceFile: ts.SourceFile | undefined): GlobalSource | ModuleSource {
     if (sourceFile && ts.isExternalModule(sourceFile)) {
-      return new ModuleSource(this._getPackageName(sourceFile));
+      const packageName: string = this._getPackageName(sourceFile);
+
+      if (this._bundledPackageNames.has(packageName)) {
+        // The api-extractor.json config file has a "bundledPackages" setting, which causes imports from
+        // certain NPM packages to be treated as part of the working project.  In this case, we need to
+        // substitute the working package name.
+        return new ModuleSource(this._workingPackageName);
+      } else {
+        return new ModuleSource(packageName);
+      }
     }
     return GlobalSource.instance;
   }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -74,6 +74,87 @@
             }
           ],
           "name": "f"
+        },
+        {
+          "kind": "Class",
+          "canonicalReference": "api-extractor-scenarios!Lib1Class:class",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class Lib1Class extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "Lib1ForgottenExport",
+              "canonicalReference": "api-extractor-lib1-test!Lib1ForgottenExport:class"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "Lib1Class",
+          "members": [
+            {
+              "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Lib1Class#readonlyProperty:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly readonlyProperty: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "readonlyProperty",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Lib1Class#writeableProperty:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "writeableProperty: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "writeableProperty",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            }
+          ],
+          "extendsTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "implementsTokenRanges": []
         }
       ]
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -27,7 +27,7 @@
             {
               "kind": "Reference",
               "text": "Lib1Class",
-              "canonicalReference": "api-extractor-lib1-test!Lib1Class:class"
+              "canonicalReference": "api-extractor-scenarios!Lib1Class:class"
             },
             {
               "kind": "Content",
@@ -87,7 +87,7 @@
             {
               "kind": "Reference",
               "text": "Lib1ForgottenExport",
-              "canonicalReference": "api-extractor-lib1-test!Lib1ForgottenExport:class"
+              "canonicalReference": "api-extractor-scenarios!Lib1ForgottenExport:class"
             },
             {
               "kind": "Content",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.md
@@ -6,10 +6,20 @@
 
 import { Lib2Class } from 'api-extractor-lib2-test/lib/index';
 
-// Warning: (ae-forgotten-export) The symbol "Lib1Class" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function f(arg1: Lib1Class, arg2: Lib2Class): void;
+
+// Warning: (ae-forgotten-export) The symbol "Lib1ForgottenExport" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export class Lib1Class extends Lib1ForgottenExport {
+    // (undocumented)
+    readonly readonlyProperty: string;
+    // (undocumented)
+    writeableProperty: string;
+}
+
+export { Lib2Class }
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/rollup.d.ts
@@ -4,12 +4,13 @@ import { Lib2Class } from 'api-extractor-lib2-test/lib/index';
 export declare function f(arg1: Lib1Class, arg2: Lib2Class): void;
 
 /** @public */
-declare class Lib1Class extends Lib1ForgottenExport {
+export declare class Lib1Class extends Lib1ForgottenExport {
     readonly readonlyProperty: string;
     writeableProperty: string;
 }
 
 declare class Lib1ForgottenExport {
 }
+export { Lib2Class }
 
 export { }

--- a/build-tests/api-extractor-scenarios/src/bundledPackages/index.ts
+++ b/build-tests/api-extractor-scenarios/src/bundledPackages/index.ts
@@ -6,3 +6,5 @@ import { Lib2Class } from 'api-extractor-lib2-test/lib/index';
 
 /** @public */
 export function f(arg1: Lib1Class, arg2: Lib2Class): void {}
+
+export { Lib1Class, Lib2Class };

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-issue1933_2020-06-15-21-49.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-issue1933_2020-06-15-21-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where documentation hyperlinks were sometimes missing when using the \"bundledPackages\" feature (GitHub #1933)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/1933