### PR TITLE
[api-documenter] Show "extends" and "implements" links for class/interface APIs

### DIFF
--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
@@ -11,6 +11,9 @@ This is an example class.
 ```typescript
 export declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 
 ```
+<b>Extends:</b> [DocBaseClass](./api-documenter-test.docbaseclass.md)
+
+<b>Implements:</b> [IDocInterface1](./api-documenter-test.idocinterface1.md)<!-- -->, [IDocInterface2](./api-documenter-test.idocinterface2.md)
 
 ## Remarks
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.md
@@ -10,6 +10,7 @@
 ```typescript
 export interface IDocInterface2 extends IDocInterface1 
 ```
+<b>Extends:</b> [IDocInterface1](./api-documenter-test.idocinterface1.md)
 
 ## Methods
 

--- a/common/changes/@microsoft/api-documenter/octogonz-ad-heritage-types_2020-06-19-22-14.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-ad-heritage-types_2020-06-19-22-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Improve the Markdown target to show hyperlinked \"extends\" and \"implements\" types for class and interface APIs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/1944