### PR TITLE
[api-extractor] Upgrade compiler engine to TypeScript 3.9

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -40,7 +40,7 @@
     "lodash": "~4.17.15",
     "resolve": "~1.17.0",
     "source-map": "~0.6.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   },
   "devDependencies": {
     "@microsoft/node-library-build": "6.4.10",

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -39,6 +39,7 @@
     "colors": "~1.2.1",
     "lodash": "~4.17.15",
     "resolve": "~1.17.0",
+    "semver": "~5.3.0",
     "source-map": "~0.6.1",
     "typescript": "~3.9.5"
   },
@@ -48,6 +49,7 @@
     "@rushstack/eslint-config": "1.0.2",
     "@types/jest": "25.2.1",
     "@types/lodash": "4.14.116",
+    "@types/semver": "5.3.33",
     "@types/node": "10.17.13",
     "@types/resolve": "1.17.1",
     "gulp": "~4.0.2"

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -427,7 +427,10 @@ export class ExportAnalyzer {
         const exportSpecifier: ts.ExportSpecifier = declaration as ts.ExportSpecifier;
         exportName = (exportSpecifier.propertyName || exportSpecifier.name).getText().trim();
       } else {
-        throw new InternalError('Unimplemented export declaration kind: ' + declaration.getText());
+        throw new InternalError(
+          `Unimplemented export declaration kind: ${declaration.getText()}\n` +
+            SourceFileLocationFormatter.formatDeclaration(declaration)
+        );
       }
 
       // Ignore "export { A }" without a module specifier
@@ -485,9 +488,8 @@ export class ExportAnalyzer {
           // The implementation here only works when importing from an external module.
           // The full solution is tracked by: https://github.com/microsoft/rushstack/issues/1029
           throw new Error(
-            '"import * as ___ from ___;" is not supported yet for local files.' +
-              '\nFailure in: ' +
-              importDeclaration.getSourceFile().fileName
+            '"import * as ___ from ___;" is not supported yet for local files.\n' +
+              SourceFileLocationFormatter.formatDeclaration(importDeclaration)
           );
         }
 
@@ -571,7 +573,10 @@ export class ExportAnalyzer {
           declarationSymbol
         );
       } else {
-        throw new InternalError('Unimplemented import declaration kind: ' + declaration.getText());
+        throw new InternalError(
+          `Unimplemented import declaration kind: ${declaration.getText()}\n` +
+            SourceFileLocationFormatter.formatDeclaration(declaration)
+        );
       }
     }
 
@@ -715,7 +720,10 @@ export class ExportAnalyzer {
       importOrExportDeclaration
     );
     if (!moduleSpecifier) {
-      throw new InternalError('Unable to parse module specifier');
+      throw new InternalError(
+        'Unable to parse module specifier\n' +
+          SourceFileLocationFormatter.formatDeclaration(importOrExportDeclaration)
+      );
     }
 
     // Match:       "@microsoft/sp-lodash-subset" or "lodash/has"
@@ -740,7 +748,10 @@ export class ExportAnalyzer {
       importOrExportDeclaration
     );
     if (!moduleSpecifier) {
-      throw new InternalError('Unable to parse module specifier');
+      throw new InternalError(
+        'Unable to parse module specifier\n' +
+          SourceFileLocationFormatter.formatDeclaration(importOrExportDeclaration)
+      );
     }
 
     const resolvedModule: ts.ResolvedModuleFull | undefined = TypeScriptInternals.getResolvedModule(
@@ -751,8 +762,11 @@ export class ExportAnalyzer {
     if (resolvedModule === undefined) {
       // This should not happen, since getResolvedModule() specifically looks up names that the compiler
       // found in export declarations for this source file
+      //
+      // Encountered in https://github.com/microsoft/rushstack/issues/1914
       throw new InternalError(
-        'getResolvedModule() could not resolve module name ' + JSON.stringify(moduleSpecifier)
+        `getResolvedModule() could not resolve module name ${JSON.stringify(moduleSpecifier)}\n` +
+          SourceFileLocationFormatter.formatDeclaration(importOrExportDeclaration)
       );
     }
 
@@ -765,7 +779,8 @@ export class ExportAnalyzer {
       // This should not happen, since getResolvedModule() specifically looks up names that the compiler
       // found in export declarations for this source file
       throw new InternalError(
-        'getSourceFile() failed to locate ' + JSON.stringify(resolvedModule.resolvedFileName)
+        `getSourceFile() failed to locate ${JSON.stringify(resolvedModule.resolvedFileName)}\n` +
+          SourceFileLocationFormatter.formatDeclaration(importOrExportDeclaration)
       );
     }
 

--- a/apps/api-extractor/src/api/ConsoleMessageId.ts
+++ b/apps/api-extractor/src/api/ConsoleMessageId.ts
@@ -18,6 +18,12 @@ export const enum ConsoleMessageId {
   Preamble = 'console-preamble',
 
   /**
+   * "The target project appears to use TypeScript ___ which is newer than the bundled compiler engine;
+   * consider upgrading API Extractor."
+   */
+  CompilerVersionNotice = 'console-compiler-version-notice',
+
+  /**
    * "Found metadata in ___"
    */
   FoundTSDocMetadata = 'console-found-tsdoc-metadata',

--- a/apps/api-extractor/src/api/ConsoleMessageId.ts
+++ b/apps/api-extractor/src/api/ConsoleMessageId.ts
@@ -13,6 +13,11 @@
  */
 export const enum ConsoleMessageId {
   /**
+   * "Analysis will use the bundled TypeScript version ___"
+   */
+  Preamble = 'console-preamble',
+
+  /**
    * "Found metadata in ___"
    */
   FoundTSDocMetadata = 'console-found-tsdoc-metadata',

--- a/apps/api-extractor/src/api/Extractor.ts
+++ b/apps/api-extractor/src/api/Extractor.ts
@@ -200,7 +200,13 @@ export class Extractor {
       showDiagnostics: !!options.showDiagnostics
     });
 
+    messageRouter.logInfo(
+      ConsoleMessageId.Preamble,
+      `Analysis will use the bundled TypeScript version ${ts.version}`
+    );
+
     if (messageRouter.showDiagnostics) {
+      messageRouter.logDiagnostic('');
       messageRouter.logDiagnosticHeader('Final prepared ExtractorConfig');
       messageRouter.logDiagnostic(extractorConfig.getDiagnosticDump());
       messageRouter.logDiagnosticFooter();

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -138,7 +138,7 @@ export class RunAction extends CommandLineAction {
         }
       }
 
-      console.log(`Using configuration from ${configFilename}` + os.EOL);
+      console.log(`Using configuration from ${configFilename}`);
     }
 
     const configObjectFullPath: string = path.resolve(configFilename);

--- a/build-tests/api-documenter-test/package.json
+++ b/build-tests/api-documenter-test/package.json
@@ -14,6 +14,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-lib2-test/package.json
+++ b/build-tests/api-extractor-lib2-test/package.json
@@ -13,6 +13,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-lib3-test/package.json
+++ b/build-tests/api-extractor-lib3-test/package.json
@@ -16,6 +16,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-scenarios/package.json
+++ b/build-tests/api-extractor-scenarios/package.json
@@ -19,6 +19,6 @@
     "api-extractor-lib3-test": "1.0.0",
     "colors": "~1.2.1",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-scenarios/src/runScenarios.ts
+++ b/build-tests/api-extractor-scenarios/src/runScenarios.ts
@@ -93,9 +93,15 @@ export function runScenarios(buildConfigPath: string): void {
       localBuild: true,
       showVerboseMessages: true,
       messageCallback: (message: ExtractorMessage) => {
-        if (message.messageId === ConsoleMessageId.ApiReportCreated) {
-          // This script deletes the outputs for a clean build, so don't issue a warning if the file gets created
-          message.logLevel = ExtractorLogLevel.None;
+        switch (message.messageId) {
+          case ConsoleMessageId.ApiReportCreated:
+            // This script deletes the outputs for a clean build, so don't issue a warning if the file gets created
+            message.logLevel = ExtractorLogLevel.None;
+            break;
+          case ConsoleMessageId.Preamble:
+            // Less verbose output
+            message.logLevel = ExtractorLogLevel.None;
+            break;
         }
       },
       compilerState

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -17,6 +17,6 @@
     "@microsoft/api-extractor": "7.8.15",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -17,6 +17,6 @@
     "@microsoft/api-extractor": "7.8.15",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -11,6 +11,6 @@
     "@types/node": "10.17.13",
     "api-extractor-test-02": "1.0.0",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/api-extractor-test-04/package.json
+++ b/build-tests/api-extractor-test-04/package.json
@@ -12,6 +12,6 @@
     "@microsoft/api-extractor": "7.8.15",
     "api-extractor-lib1-test": "1.0.0",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/build-tests/ts-command-line-test/package.json
+++ b/build-tests/ts-command-line-test/package.json
@@ -11,6 +11,6 @@
     "@rushstack/ts-command-line": "4.4.5",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.5"
   }
 }

--- a/common/changes/@microsoft/api-extractor/octogonz-upgrade-ae_2020-07-03-01-09.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-upgrade-ae_2020-07-03-01-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade the bundled compiler engine to TypeScript 3.9",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-upgrade-ae_2020-07-03-01-11.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-upgrade-ae_2020-07-03-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Log the TypeScript bundled compiler version, and warn if it is outdated",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.8"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-2.9"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.0"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.1"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.2"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.3"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.5"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.6"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.8"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-upgrade-ae_2020-07-03-03-23.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-upgrade-ae_2020-07-03-03-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the \"--typescript-compiler-folder\" setting for API Extractor, since it was causing errors with the latest TypeScript engine",
+      "type": "minor",
+      "packageName": "@microsoft/rush-stack-compiler-3.9"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/octogonz-upgrade-ae_2020-07-03-01-09.json
+++ b/common/changes/@rushstack/ts-command-line/octogonz-upgrade-ae_2020-07-03-01-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Improve formatting of errors reported by CommandLineParser.execute()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14210,7 +14210,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-xPShjp3CMqTNozpd0NQ7gszqAyFosMF30f7CXeVhG8uchtKyCTRxCWCSTybLNT7FZyYFgQ6IgzJYk8ZDPCPP2Q==
+      integrity: sha512-oSQHe/WAGn2pGDzHNxy/ebbHwgV5EkUiaHoDC5mFveZi/YbZt8DfhcFzCAIzP/7M19h4bhhD9dkmDencC/4Q/A==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -14228,7 +14228,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-zZAUZWVAnR5l55npmqTmaJGdxA5c2mANCAjX/0063z3BYwjRAoeyFE4zWMzIal0QoGDwnV6l35P0NR448U4jBQ==
+      integrity: sha512-NP2auGxTmo90sgiJQaYfXT7rAr6LM//a9D2cwZOC8ll0AZrI1Zj7mkLiqGQzEkZ0E0qVqoM2RHbl4AeJqq4XOg==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -14239,7 +14239,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-gi8v35mfZ1UjiRMMVrfqEvqWTlzwFk0+ShIsuznGPFXHQho0k7WLJXK1/PL9dG6Lud+pfwFtT18LKESMi+gvHw==
+      integrity: sha512-j4cGvRknTDXwBbM7rx7X+V62UfeTK9kAGkSpT3GpaZrRTwbtZhzPWyqY9lzw6tN43xlX/Iuc1g4FmnVDe1lqWA==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -14251,7 +14251,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-IyG00gC1rU0u25g9CcxtzoxGAZOd271AXBjfyyBU6iXb4a1GTBafsDhmC6CyjeIe4IMi0jzmwjkevBGV4SYVAw==
+      integrity: sha512-d/guVZZpVbV7X0N8WYQfltz0frTUO/Al4vq73fb9AF22TcWTmA+lFxlc7bMuXi/UZNtmpkH/kJ27YCSbeCuMkg==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -14263,7 +14263,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-qWYKmJAZMWzI5Lya19W4LflIxStoHG7gHZHWTIscAL8TSqy+d/PTZh2Ecea4PnB8vgPiRzGryae1m6cRv714tQ==
+      integrity: sha512-B3J22QVJJC5kWnBLgDh6XjcwyEwwFRKvdA43oi1wPCvlqLW6RTrH8YA2SJVAMNf3rVSYWJHnFpwekfeGuqJ0Kg==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -14277,7 +14277,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-uFOBdEdczwM8LEOJ1KOKL4KePdBiK/ttx19crBxcCW4nEQb1/Or8/CXj1mkcZvrepI/d/PHUSS2Kx+6YSwggTA==
+      integrity: sha512-95livdaJE9QL2skP3yC8c+7rU6JIWBK+satYaGNMs9wSe6ls3thHy8l9w07Y2fyNdyoO2/ETvmFU8r/Dgm1aMQ==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -14291,7 +14291,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-z6z6d06x4oGbWUh/k/eK90f7NcfbF4VmejAUZtekcCRg0QZdRTPmAkLmyHWzsz8vgl550XdojFPPXNWz8MR7oA==
+      integrity: sha512-dioxOVTQZgT+tuCvtcottdkiVTOvej/eLPIiz+W+vp71jbjzComxaKwxXokzw3XmvqIiW/HJajG55q+B0O+WDw==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -14305,7 +14305,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-gOjcaQLOaF/QOdFTRwAHSBCF3ybI7+oIqk6Rd0JtEtGO4BcPSqwnLHD9LX+zD3uGEWJziRs0BgeafQzWiZZOwQ==
+      integrity: sha512-gRBxDF1RjKcabsNcInRgWQ0cll2J0+XInXCpvuemXNl/oIRBPDbB6R8Hhfm5q7mw5mVOympHX9fRSnTeIw9fJg==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -14318,7 +14318,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-PZX/gxMwF5VNQixMkt4/dw5QOE9VlGgH1G4JbWcapHMG+hprMw4PZDT75ztE3+HPlVoyXOH8w3oV4lz4ibgCxQ==
+      integrity: sha512-zioYlIsu+02fcftni+oXlINztGuAgxLhxQiO3l3OJ5pmeZ6T3XZUmMsiLWY2fbIKsNxqm1R5UMfsdX7Z5Jo14A==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -14340,7 +14340,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-xEYRuLo3KBPCTEvhyyALCtUfUTezX1HrxOdft9O3DACXsBawFHPVqZUbnN6IwISU9wuPl0p4jB0e9mzYvWpcxw==
+      integrity: sha512-JwMGU3lYK4vjLm/0SnnM632y3lJNxBALjTcjnNQGVaT1DbLUS7wNWit9PM+cG7Wf4RUxxsRnLYLgEYVv12/SnQ==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -14357,11 +14357,11 @@ packages:
       lodash: 4.17.15
       resolve: 1.17.0
       source-map: 0.6.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-dWZrORWaZuwFZRqm0DsNRMgwU/oWDr+L/G7Rq/uhpZkk3z8t1BhpfRhL2Z51IpCOapi15rm4fseal7gSGyOktA==
+      integrity: sha512-mVkgO7tYenwk5eQ1scHQeO6eL1vCjwQz3ht+4Btc+MJ1VVfSrtoSTHzpNtE3hOKXqkGxU2cdXC/kVPgiChd9sA==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/debug-certificate-manager.tgz':
@@ -14376,7 +14376,7 @@ packages:
     dev: false
     name: '@rush-temp/debug-certificate-manager'
     resolution:
-      integrity: sha512-IvSBa1p0MZmX/znNDbEXovD0pXQDLvUpjDg13z0b9zNzOph2gGir0RY2qP3HoePFbhO0mCPkB2BfKmElFV+LlA==
+      integrity: sha512-RCmD4L/QRni3fAbW7QQIZWxgQ2BxCoaMBHhJNl+MN7Bt4mBZ7jZf1770fNzTba8TTXpq5RasjUU7ihGEL7qsOQ==
       tarball: 'file:projects/debug-certificate-manager.tgz'
     version: 0.0.0
   'file:projects/doc-plugin-rush-stack.tgz':
@@ -14389,7 +14389,7 @@ packages:
     dev: false
     name: '@rush-temp/doc-plugin-rush-stack'
     resolution:
-      integrity: sha512-67rl8eDnQoRJyBiS5rVmOILtlE9uwD4KhAzE9hegqlvvescIkZdnbDk/WpjvtwPpt5MV7AbFr3Qd0YXuB5XHPA==
+      integrity: sha512-N6qFz5WIhWV7dvh2FWM8knYWOx7AHQHg8LYJWTTXnfWHeJx74XlKiK+EzVYmOEMNXKCFj8ihIvNmUMBNZpUlzw==
       tarball: 'file:projects/doc-plugin-rush-stack.tgz'
     version: 0.0.0
   'file:projects/eslint-config.tgz':
@@ -14446,7 +14446,7 @@ packages:
     dev: false
     name: '@rush-temp/generate-api-docs'
     resolution:
-      integrity: sha512-EdMtO2cbdAOc2YMasycDyYvdhF3hVXEITM0q4W300CzRuoo18ygd4Fd6jFq+gv4r4WUuHABR/v1uhNZFDYMeig==
+      integrity: sha512-kYuy0KhmbVlRgzysnD3WPVUVnWCIELSGDkiyY9ggRdvrTAbBacjYEPbYp7qep6BXAzdqd7eDPuWv6e3mzwvVvg==
       tarball: 'file:projects/generate-api-docs.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -14467,7 +14467,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-r5zagOwKFMJIT08EmGOkouD3RBbzBjoMQaj+DH0BuhrwtnF8S0O0LVmvCbZtSnss1x/QsibTt0xILNBZJU9BUQ==
+      integrity: sha512-Xqz8CqQ8rJ5Xw1N2Ip4kOg0upYTuCVl0MbXWBfPWoEyTQtM7mDjoRwD+x20X+7Cq/CkXxkm2TxLBKDN8GSO/uA==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -14490,7 +14490,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-LP8ALd6fp6blk8Fva7axAFB9M8T5YPjcnbYfjnNFfZPh3C8tQZKvSEFeKVR5oEv5t37zLZ5NUgIyEsdD90DJyw==
+      integrity: sha512-Mlna3VhrcK35LdQBockrHzexTwQj1LnjHrL+vlhi70m9UcCgrXSucynGMPNvGDHCv9O0mUC2O/XIFoUXdf8eeQ==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -14513,7 +14513,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-JX6RAbeJmH0AJ6VF2m1ieATu38qlK70vznNv2YkvDrMlmxhuz5PxdqAxTYLeComn9OitBe8H1b2i7RWSOlBGiA==
+      integrity: sha512-EcDZupb0dv3v+0Yve3aVwNEK0amNhR8o7nwaVOx+gOxhxXdUW1D2gv0ekKomJhO+m2xnWngGiCIY4qBGQlnwPA==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -14532,7 +14532,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-BTIoKXLaSalUvLyNEtpr6Nsz1SC/9cVJN2odHdiy29GDWVYQvhxWdO+4vDiAWm2AhjK1a23qZ+Oe4E7yAP/N3Q==
+      integrity: sha512-6wSeAy3PrwsXxBCmWnAtqK/xVuu40Nb42vQ/ym0fQ50mTTRDB6qhTgY+Yl3wseHBtf4UvVX8JaZExsaQdLhqqg==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -14550,7 +14550,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-7DHcxPmoDQGDoYgf9PPuclHNPLb53GUC0aa+Dz64CxGizUkn0KU9Mqi8hf+U5ugMqZgcMzvVY0ol705k8x1fBA==
+      integrity: sha512-QC5XgdjN+DvNrs3GkM/txMlLSL+cWXdSrVyr4x4VKCaZtTUrdePomtnC0EptxRLIiDHdkP7L8kPxcJi5uGE69A==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -14603,7 +14603,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-UQKOv9ZjOtOBH5Eb+zWyYVNs9vMnumse9cOaWVeFavzVPkkVDIO2yMJNq1zON6nkMKfZu8kLlHwuqBPXucB0ng==
+      integrity: sha512-h8DdNgMxQdLqlazyoNc0dKWCguq14N09od1C9pRC3QTL3nBEtmoAQY/cbFiAu5gu3s5DE3O1FD+s4c+4jJ7zBA==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/heft.tgz':
@@ -14617,11 +14617,12 @@ packages:
       glob-escape: 0.0.2
       resolve: 1.17.0
       tapable: 1.1.3
+      true-case-path: 2.2.1
       typescript: 3.7.5
     dev: false
     name: '@rush-temp/heft'
     resolution:
-      integrity: sha512-1YmGkE2mFH4N6qovgib/WnBGop0omzNJ2jMPndigl3bVgLTS2miSt84JxGGpaTmLD0ZDBSmB5o0jReMYM6S+oA==
+      integrity: sha512-of6kz/4U9YQ+9xvHtrXWg1hQYlCEyrHJdUIptbeBpwJgBxS7DLn2ffzvWHm4Rts2Vs2NLiXm3OZS96tAoG5qSQ==
       tarball: 'file:projects/heft.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -14635,7 +14636,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-Yf0DHJF1N+ymVmX/r3NJDpZNKsCOPvtOvPdzASM4xo1tFepqGeuzD0BoK0KpsXz5REiZ2haSicwUYfyfGqA7hg==
+      integrity: sha512-01vIZKCCPY6M/uPP94vTdUGrFllQ7PFfmmdy/mY8oGDwETMqhahB08al3DizNfnf4mGCuWbvogPd3QvpLHQqlA==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -14651,7 +14652,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-p4TOB+3wfySAQeAZknsW7mX2I8sZAKcxtq1MVOulih9t41GA991OGiOCZfGF2nQrGvCFFK9i8H26mR2hB8Y8pA==
+      integrity: sha512-p7Iw5IsjI2eu+A2NgaOiqndBPJ46DHdd/cpykA7DoS8nF8geTM6/74DuTnAWRzrVSbbEHT44+04zCeMZeu9Mrg==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -14666,7 +14667,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-yJrch7k+buHOl6UFsDY+DjgV92AJmEr5E4J2SlC5yPNcV8pBQHrBDdimavO82XRdkOVmIPtWRPgL6zLum/J24w==
+      integrity: sha512-g0YMLdY/Df2nQnUg3tP4osBSxrXDliwTFR8sD3qw5wrh7xtuF2JhsUXjMMeheAe31igxYUI2mYhPIsTUnDi1YQ==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/localization-plugin-test-01.tgz':
@@ -14681,7 +14682,7 @@ packages:
     dev: false
     name: '@rush-temp/localization-plugin-test-01'
     resolution:
-      integrity: sha512-Gz89FBD3tp2YeGik3bbt/r96RSW3RxlN58sAsrIRZZov4RMfeq/McfWT6kC6JMDAbJlSYCmkuKeoN5ySOwcymQ==
+      integrity: sha512-T1h640rfmZr9IjXFfJU79OBnKR24s3d/T63izdP7l5QQSx0+ypQ3nZJX8cNK1LbuFPto31C7A0vcf/RjbM5j6w==
       tarball: 'file:projects/localization-plugin-test-01.tgz'
     version: 0.0.0
   'file:projects/localization-plugin-test-02.tgz':
@@ -14698,7 +14699,7 @@ packages:
     dev: false
     name: '@rush-temp/localization-plugin-test-02'
     resolution:
-      integrity: sha512-dGZN+v0pir0xAJfDWD8RrNzaLUf7Q+ap52M8kX/3WSc8o4A/IM+1VGhC2mDCOoTWGFqnV+l85hyFJYsV4WnkpA==
+      integrity: sha512-oI6y8e286Uk1W1/153DjcpIWF+0hSST/JhOxzG83DI7SVNN49k/VWaM4YAXXmGe2WdhUsQDqh8sopm0HAhNq0w==
       tarball: 'file:projects/localization-plugin-test-02.tgz'
     version: 0.0.0
   'file:projects/localization-plugin-test-03.tgz':
@@ -14713,7 +14714,7 @@ packages:
     dev: false
     name: '@rush-temp/localization-plugin-test-03'
     resolution:
-      integrity: sha512-fddgjDB89amP+XGWvRjSYn+pvw37w66YPNXEf5qm3veACqO6mAxtksJrm+/SG/XjCsCwIsSMdFonYr1SLqm+mg==
+      integrity: sha512-1FZYUFCd91HyzzVV656MKZS/Pce9++sM5L6NhXZmKzFfKsDwFWhD3TbruN3L7qfDJ4fEAH9m64hVgYLcjA6Biw==
       tarball: 'file:projects/localization-plugin-test-03.tgz'
     version: 0.0.0
   'file:projects/localization-plugin.tgz':
@@ -14734,7 +14735,7 @@ packages:
     dev: false
     name: '@rush-temp/localization-plugin'
     resolution:
-      integrity: sha512-Li3TTe8AaM1T9XSURG9Jy0LrSAQ5US5lywbNogPs2Ds8Zpt+KxBikEkv9gzXkjGYAWCtwmokbIMS5NbqvL0FdQ==
+      integrity: sha512-NGBE5WLIbTDgzylanE3T46NtyiIzG1HhUKNIDwpmVQy8ZxD+IIqeWNHOM9utBEz/KzBVBMuKlfPg3vl+gOxMIw==
       tarball: 'file:projects/localization-plugin.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -14758,7 +14759,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-IR4UV7p21U2xKefe3EhOzhBd0WyclbgfGs+2yMXORuzSaME+TrbJ1QBICRc7OnJCWk6zSqIhWhkQ/M0J7IyLkw==
+      integrity: sha512-N7DPoPcUe2jkYGGaJa3MgkilIglNa2QZwGr0JSjzCGEsV0HfHl4T3k4kAdYD5l77b+iL/qdVzGviiaHlwOQQ6g==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build-eslint-test.tgz':
@@ -14771,7 +14772,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-eslint-test'
     resolution:
-      integrity: sha512-H5dimoozdurJLKJAlmR/QgvE4Oac8+DqxRoOKIyLn/lUy6VViV5w+M/Rf2J8oYh898RUS0BIKa8zswnXsO+kKg==
+      integrity: sha512-hOP/rEc21giPwlkAXL9oMWM1kWDOwQfFbucvUvwFtnIvwRW5BU5hwfLUpLsjgiC5tQ1XBCLFojZqoGY8G9vRPQ==
       tarball: 'file:projects/node-library-build-eslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build-tslint-test.tgz':
@@ -14784,7 +14785,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-tslint-test'
     resolution:
-      integrity: sha512-QbDVKOK6Wk1xXCFs3TC25g+R8fJqVWw1kv6mPfmKpdJ3ohzjBBV+FV+XQ61Zes2ReWP7xLUFNZVpnQ0loeTUWQ==
+      integrity: sha512-OSj8uA034CdrDT/08Nlptckd168hDytKHXXXUPAXQ6QiMBfKm8Z2g577vZyH1lfE9WWK9yRpVljs7+7DtFIMWg==
       tarball: 'file:projects/node-library-build-tslint-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -14795,7 +14796,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-bfyal8ttTMbaHL8CDzfisVkILcsdKXWMcgWsis+x/TkL9le1XVygP/6iIVGmRu5/In7aeyDfRrPFcH+Zbmv6Yw==
+      integrity: sha512-3x3En+KDCO8RFVxwvrzP614SP8nUTc9R/5eAfUC5Gm0mzmLZaNHBFOXHANDWvbM6nCH09p7hK2QXmu93wHcw1A==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -14809,7 +14810,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-Lj0sEKoxaNfD3wyhE0Gg55i/0b9aXvkKBHPNirPiDn3AeB0mtlDH/vCAQ1mSzJVGuAwD7UUjw0qysQTz49bNsw==
+      integrity: sha512-HvlJgTBK1wsoSq697epvJWYsuF0tu85yD+IXlBqkc77oub2YgpjP9An3CNxo7Kvm+FUnYCq3AoJFn62MVjgTSA==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/repo-toolbox.tgz':
@@ -14819,7 +14820,7 @@ packages:
     dev: false
     name: '@rush-temp/repo-toolbox'
     resolution:
-      integrity: sha512-He9VmESCwDZ85Mxyfl1BSjh+ZGhTHXbhp8l7u6nZ8WgLrYSkkEfy0abzPAohWGTrtftHijK191QgCEwQ03aStQ==
+      integrity: sha512-YQulqxSmK0+VHyzZO8qHNVmkapqqZ7m2znjnH0pWmc75loYrUHMUFjxUPOIA6ZL5TK43/MtX/EHfOaxGVUqpXw==
       tarball: 'file:projects/repo-toolbox.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -14830,7 +14831,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-H2yEXGCk732wAS2draTBfqWKaSZOS9CAQVHarzWLd3yceZ4NSvsEJLn+/oxtFrFmdIYnOj+dphihUtvpTErxNQ==
+      integrity: sha512-5z4k+kvvd7xBlG51bsnNCMBJTbCgoHzv8zzH5l8qNQoeS9MZ1K24xYvl4dfsq4OvGiOHwCEoX/zAzZH1LQTxbw==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -14882,7 +14883,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-WAaqSfE1T7FXyFDHizZ5OX14d+8oIM+CgjCIKn1pSt5VpDtD9DYK3pzKEadlHSDSrUl1qyIcnO4KlwEmHWUcbQ==
+      integrity: sha512-wf96rkDvqiVcl0GQkxIzgkGVxWmY2A/dEZJorW6QSuU63gMXDDewvdM5o7hnraAVSPDJccTta4GhNkJ2+BXWdA==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -14892,7 +14893,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-vEtfkpGJDydXvzQeQgxigFVSnsnTaGtWzbgeoCzuVooYf2Np1d0YEopxGjdc6lEk+/W1UTOr0axeyARxq7CLaQ==
+      integrity: sha512-4VhQoGUInk8shJLdM6lCb9GsOll3oWH4OcJVQ6cAwgK6YKdFb1eH23Tw/ZooOeb6MxnUu7fLZV2vYLZeBGWieg==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
@@ -14909,7 +14910,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-2u4kMMgfm6QZ+bhQJHnrt4TsHnrkqza20u5uA5t5tGFRVRndhYSVG+nNGFEw6EpsMmQTbhyuH/s7godEIhBC4w==
+      integrity: sha512-hG1r5yVDkBfx71HPn3Mev3yLwwOW95hi5Lr252mIkJnm+ahdIWalooVao0FD7iobjbBSDiLOHTytiJU4B32Igg==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -14919,7 +14920,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-ei2oKEmYe2F9vQ6eri8gshc7Gv9APqJGkzCHRwWN1cVfD90lYMu1QcjlmYPs8VHGhLtWKaTsFrC6xjh4cZWupA==
+      integrity: sha512-srXLgtPwX+/ohQ8xpWKCPF8QbMBuNpSyG35DhKK3KhrMOhcgjT391Hgk1x1WIeZQtV5PlPphoc3VNqO6ouZb6w==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
@@ -14936,7 +14937,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-DgIclv7qN6x0/JtVq8wUIxdWCC229x7WrEOubw05fyWemmcfWSKtts2WXlZrRsLqu8xXZhI7o7eMxlbKXAEztA==
+      integrity: sha512-rMrR8wum1C9L+d3rTjiWk6XCec7lVJvYiaHhjIXtTd0ES4dLdosgCia3uq9ajD0+NToY4QAAwoq+Y+gsTaT+3A==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -14946,7 +14947,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-XkTLBTH5WYLV+KxS1fn4Z7cWzu0lWu4PnGk6d8hp9+sd1NwAf45YVo+TwJ8H422PIZCm4h1TkhD12pcqFLYONw==
+      integrity: sha512-AXRaABTMx4u38YP67laQmqB+9Q5nLVnxAzQgC3Tz2ukUtg7VOwW78aSbJS6tWi6r40koxf0kjza1xaJys/LbEg==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
@@ -14963,7 +14964,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-abjnIbLrSv00emrPGaycjyEjBZDBuMhNn0d7NsxnZ675tLZtR3s+SfMZk5Po2h+Lv1eXgyUgU4c07ZZcGI4sow==
+      integrity: sha512-BgpuKWwcQsUPz/CnVlSa5I0RCHt14HtoVDsxSgts+OftigNAqwbYDS+bLIIaPH13CVWJj4hXkY+8SVUGtBtHpw==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -14973,7 +14974,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-Zyl1Uyhk5+eTGnf6QPid80qRCcPqrEW+ZqWRVn+E+YRHuk/wvKyJe+AmK4c3toIRm5ufkdBb/OQIosBOIwINeg==
+      integrity: sha512-COU64dI/gxMf5Fde2Hpk+XCkcB64qzY47rIJ9qZWTp7b42rEPkqBZCCmOvdprCV1QRXezeY+E+SYSxirN/1f/w==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
@@ -14990,7 +14991,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-OUEqzQUeXV9w0+I3eFdTkjt4jaUp4S7bDE7Rtp4Hq7mjjd6Cw+sMzVVAwnQmViuYyr1iH2P/+FoCVb1FeNee7w==
+      integrity: sha512-Tq6IFsZBQvwJfaRARpw7a51TXHUlPeHJT2MX69eXN1vXQQWle9pIoSpq4iQS5CWy7J8f+j2honpUy6DpuCEzlQ==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -15000,7 +15001,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-862U2HfyQ8n+j0YWrwY96DfbBH1IUfPoJrw+Tr4sYws2OftDUtFkADqv+pWLbkkY9B7YBsrNjLviKJ+jB21VtA==
+      integrity: sha512-KbHGX9685/56jgLK+OXEphJa7PATxHNUrmNadMkKFTejTky68+PqpqZd/aV9HPC/XW+TuHwH5/vYq3Ih5tUXDQ==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
@@ -15017,7 +15018,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-02CucPcTZ1sVaBDLP0IXaA7Mn8wq1Mrrgtdqp0lncIpWIcawjFn9sTDp0X75qJfhioxmW0z+1BYG8mrytZ81jg==
+      integrity: sha512-vMLB2XFdd0LGxgFcllFuQSvzzwXn6TqFdmb4xeki/2mSbYZku1AQaV3a8IWybiX59Xh9XpPanNhMsuu0iqiNog==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -15027,7 +15028,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-+miwHsekIONtsPn9ZwXUIOmreG9i24ERtOmqtf+iZQ8CyxQRMtMOs2IunirwrppHUbQAQ5TMWtztBHCALGQkBg==
+      integrity: sha512-FdL2pswO0WrPpMYll+E3Wg2TA97tOm7wFPOklI+Z+Y4Zw8FuGO7eG0lRMC76skBwyeaM7K/ZRYcX8MFQWvNBJA==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
@@ -15044,7 +15045,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-YmW5vnSMzKeuq5iP9golciP0liwNUAF+A0cWQHugIfmTKUyj7qBFXUHCi1tJnh08MGz96jFFx59XXH8x0n3K5A==
+      integrity: sha512-/ti1UbntA4cFzQr0ZgG9rqUIQXqNGydcjmhMXpn/p9hEjZaQdJ/R+xTCQcwt14vLiaXZqkwziad+cDM2GAQyKQ==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -15054,7 +15055,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-Mdrm5KwuT5jEY8Tgrka+upc2kfIK3LEH8inc8XSaoDLGW0DvgQdcyaogBBnjTR4SzFtDnG/xzF1akXLeWjFkEg==
+      integrity: sha512-aniHkRDpldzVnHxvrXBtXjbAHxh3swMCIo9vEnB0hHw9FFFUdFWxKVowmAj4lj7os2cLgimq3URLfom1k2kWzQ==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
@@ -15071,7 +15072,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-uxteVLfkazD+6nEcqUlHcwLJEgXQ/qAyniTmPBpO4FOrJW+akphLyB+ot2yEZVNFfIlZpDlBoV7IdZWU3E2o/w==
+      integrity: sha512-cU/RSNyebjIUmJfbnWZQW96KoMAFKEFtyehPVguTA9vSalA+kTfFAQ9gkGwlmCQ3aTpM4f9z3VJgew/4QM2ifw==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -15081,7 +15082,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-phW34yARVqS3nP3QhY8QkdaUl7v1HuYVRhFOxS7LUZDnI37eCyM8Zotqvs6mLWMU5ykWnfd4OzSed6Ubots02A==
+      integrity: sha512-efsGPnFV/RsutIBBRgyLx2Zq0C15rNtxN9lY6VJXhS5CA8wPA0H9MrIxDrMZo4t4Slxu2y61XMYbU6J/opelXw==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
@@ -15098,7 +15099,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-7e2S7uwrVKaCJOqD8cONo+EtEzjhytnX7nxoZoTzQJxP+S3MrgYuN/DABNf/ffNIo9OMock6CPf9BuwFlFcEvw==
+      integrity: sha512-b7NF93lucZ3408ZIizqdda01HqEGoFbaDrGSf89B6gN1i88WrrXoQ2K+17v+vc4dLY32+HDM0mgw6xy8rYCMVQ==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -15108,7 +15109,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-tILR2VCYYTTVc8srHOxz+3vLpyjWCeQNwZnGkJXFtwrgMbje9cq1cJVRp0rQY9yQwJ2v4U4HFrzdVrIf6hPIfw==
+      integrity: sha512-R4TRjNCH5A+ER7bucWPT4+NlyD6MFumjSrMak2KLYDg33KXbJN051fzieqJQoltfNHGkQDIgXCh/6qZR8OFISg==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
@@ -15125,7 +15126,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-BKmp2cuXiWypxYZ/u2OOi5JmH7wpmW0C1rFNlcON/qupOZqQJVHk68OY1dE3GcvbieYN7db3oAvl/Dp9Wakvug==
+      integrity: sha512-LdDJIHD+jg+T2JsfdquoatKkxL8hHnH6Tt/1IcOxku7ZIqTWpFeQ+g3Et5eGQ99ki33u2jN5zCLijR3NPGQYxA==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -15135,7 +15136,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-V9ZgxNxuccf0p8JZxpPkU/ht//HbTFXhvSBfirfDSN37FiqvPJkc+AEbdbjzDbeK/hqnsm1OEZP82luE7cdWwA==
+      integrity: sha512-fyZKZsfcBG+y2FEzqfVyMgykQf6OceXQ9nGviE6WAwKBtz0Q0+PMPIYUuUmYDLXwSYaDSr5teXUk1rcva1vSag==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -15152,7 +15153,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-Jl3P0UMFqTAA9Gy+z8eNvQ4SthMzlKEf4FCaCpVy72cwHJDaZbj13WWpobmf3WYKFEvy49veC9f2ucmwBM4dfA==
+      integrity: sha512-JTxecGPqctAodYS7PndNd7oncQ5bk6WTx9wxIjLnm00BG0mvPcksngOEQ81GT7c9Gi65S3OF6/5tZpN3Yf/ADA==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.6-library-test.tgz':
@@ -15162,7 +15163,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.6-library-test'
     resolution:
-      integrity: sha512-lDRf3c807YzaPWjpIGvxqZnA1NVQzhqiBkP2Rq6kTS7Bx4shpMyILjransKJsT5nNGtyTA/Y+ARTOSbI6sTK1Q==
+      integrity: sha512-8JdP1KV8bF0cjH6CORh+D+dRzW6ekO0TTFpEdcysnR/eUcDcNlDYhyifOqymkp/xfsCB8zRZh2uwi51N5v4P1g==
       tarball: 'file:projects/rush-stack-compiler-3.6-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.6.tgz':
@@ -15179,7 +15180,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.6'
     resolution:
-      integrity: sha512-bHtrtA9lrfoLBJy72sx8arVUYNSeUlh+FOwISQ5aS/OAQGuIMu6RlXxxzfOoK1EoGfrjvkRPdl4Wz65T1imnUw==
+      integrity: sha512-+2EQQ8/YMqzqc/bi2CiUwpQnKUpvGzTepNtVdtodO+zkUy5fLElf+5nzmet3dPEWCreR1pAc/ce16MHE6qVTnA==
       tarball: 'file:projects/rush-stack-compiler-3.6.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.7-library-test.tgz':
@@ -15189,7 +15190,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.7-library-test'
     resolution:
-      integrity: sha512-HqWRokq5BdOC3xzofbfw/vtHqZJm1vl1tuZe3vJGlD7q82gkn/L5PYYQng9tJOWujlgVMm0BG9fAJmLlcUWyVA==
+      integrity: sha512-s4Sh6RDfa/jml/8XxxYA2XpGSHZubZGnFtiy+nYuzUyKeqlZITaZ21lmK3/SMKBrvFhLRHsopk1YdWFPARRVhw==
       tarball: 'file:projects/rush-stack-compiler-3.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.7.tgz':
@@ -15206,7 +15207,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.7'
     resolution:
-      integrity: sha512-5nQB/tO5Ek7pljMcFu128hIQHK2c6EzzeAKBSumUW4UdMMzYa/3ZQs1y39ekvfIJ0YKvya7MmMjTvtiEvSa8rw==
+      integrity: sha512-rLsIDtuo9SRh3D64477T1JQWJ+xgK4M9PU1MDaK46iAWNyAjohUcKSaaiAcSROfgthWtWRMo/bKOIJ+nDwFAlQ==
       tarball: 'file:projects/rush-stack-compiler-3.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.8-library-test.tgz':
@@ -15216,7 +15217,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.8-library-test'
     resolution:
-      integrity: sha512-uvh/8A31sF4IR1VNoL5/8DeUFTJxZLOIF5AAxiPnZeu/57zuZFRnJSYHU6fj1PaF43lbOwEj4UY+QWJpNHWLuQ==
+      integrity: sha512-2SuQ8Q166CtI6gUn4EDk4noGJvM1z3Lf+S9T2Qdeq9U/2phIXbdvlvDU3Uas6HmCIfOazBifOz+Kg2K/r1uN5Q==
       tarball: 'file:projects/rush-stack-compiler-3.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.8.tgz':
@@ -15233,7 +15234,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.8'
     resolution:
-      integrity: sha512-aSs99GPY2h+h/AnEXwLfuUjBSl7oZwamaaPO3YHgfQm9IV2H1Bon1djRikmA8UQY5s8atjYwZj1XGdpkg3dFlw==
+      integrity: sha512-H/wZFsTyYIq7c0crHhDXDoct6T5+l3NvyrzkZBinRNv11EZgYLsbpYb/504HhFGGMSgXc8iwltLNlc/JA8TDmQ==
       tarball: 'file:projects/rush-stack-compiler-3.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.9-library-test.tgz':
@@ -15243,7 +15244,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.9-library-test'
     resolution:
-      integrity: sha512-iFdnUuhu0Yz46cU0VObpRWcN7jksPu+n9jK50jPhaeUXBmrnuR4FGYCjFGp/CA1SA3VYPQsXZaoDetxLmhx5Og==
+      integrity: sha512-e4zCSyw0fH/N1UmJiHkIcSvfzH8P01fIrf9MeEuSW+xG+BGXp73GHcNvJTsMcj9xNO/MIPOqZhW5YDLz5KNQug==
       tarball: 'file:projects/rush-stack-compiler-3.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.9.tgz':
@@ -15260,7 +15261,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.9'
     resolution:
-      integrity: sha512-/DQtIGWOa1k1XZRPap03pxX6+Kz9ZBgCMwFqsJLUuNu8J9xuAjX/d0/WH1A4t22TtnbkB6h7Lm88WduqQKHkEA==
+      integrity: sha512-xVJGjTvwoKsEaL4jZSCOazIX148/7CLF0IVh7kplkm2mGuHfoHRWMOXV5Y5I1DQRBw6d1CF/yOtRxgafd85EZw==
       tarball: 'file:projects/rush-stack-compiler-3.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -15286,7 +15287,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-SNu/yq7tulo0q4SQO2agROhH4FNws2wCbUQYleuCWcscK1TSW50hmeZY3pHlRYquKFEGLG7F3+osH6ggCD3UbA==
+      integrity: sha512-8p/3ugfWriL5cPcBzZDEUWDTKca1DMoNUWBaspRJRm2Qcp1AMjuX+sy+J03UnLUrSUnzSeTnLJs3nYzWd3mgPg==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -15299,7 +15300,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-5sXiTl7Usc1/FKUfE/P4VNEgLPFJlxYyLeWHZtjr5/lqe23umbq8gjUZLlVNHloNUbjmdgjrZQhEp5sqiENfdA==
+      integrity: sha512-sj5UrwwDh615gbhQbi8VgtSHhI89Ze+12DPBixnsa7sXZwYTQ+YVJ0dOBSYqITUyed/ZpPR70ADeW5hf90MCKg==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -15319,7 +15320,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-hWFUISDs0hR53pbCC+h5M9i8ftfYzHEUrHvax/Ir7BLwijPJarr5kOeSdhM+KqcaSPoUzA/ek5Ttc0WVPLBmBQ==
+      integrity: sha512-yOQKXWQq3wS4mYOeM5yhKJetDcASn5jaOpPfpI6OByacPGdSvT0bUBWM8pxuPGGp0cchdq2+yAYYsDWJ1rbJ1g==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -15335,7 +15336,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-t4VFdRKP6sb75hacRiamRhr7vTxiLn6m1bqr0yef8oL1gU5+m3X0qZN95XwX3LnExWMCbP7fR4BQ9pk2ZNQ24Q==
+      integrity: sha512-Nm5Bfyl1i2EnfGG7ijwlP2TBmti/JSJmgS14pl0FtRMDWOP599DOh36N5jw/z0krrYfieaF2zYOJBRqiHl+pzw==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line-test.tgz':
@@ -15346,7 +15347,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line-test'
     resolution:
-      integrity: sha512-3Q9mruEsrLmdAzMoUJ4jjLPQ3WZk7AzblOoS+uDfGb+STekssyRyVb6oqY4Oofic0s6sseltAm0iCDQMygpttw==
+      integrity: sha512-BXoCr1E3CZHjcqlnDYLLP1F18ExjaJ8/m2qUTxBHEnayfy0Xmt9L3ZmslWzt6hFWSkuUEt5NlxkdGBXlFFNZfQ==
       tarball: 'file:projects/ts-command-line-test.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -15362,7 +15363,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-pQ48un6TgpznXL/QpbQ/93V6t04qgL39FRBdIyT92rH0+pIrjxWX3DENe7l6jpOOfEdDLvoR+eq7YYacsJPghQ==
+      integrity: sha512-Cj1urGxlYlcJQHPcUscx1jfRreiKbGCT04pqdo0QDEopcmL74h14ptjNgt6Q/UOO+a0s2Ou4OtVVv3het2xR8A==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/typings-generator.tgz':
@@ -15375,7 +15376,7 @@ packages:
     dev: false
     name: '@rush-temp/typings-generator'
     resolution:
-      integrity: sha512-jK9tg+WJwC5GM6G8KAMvLeQGaisFiG21Kj+t9vxUrK51vPvz4OxP9C8H8Hwe1gJ95Snq0UrYgtLsowa/jpzKUw==
+      integrity: sha512-NAT3Xv0oy0P4+NDUceFMc9vlJ4O1C/JZkH5cEBmNS0iQQ3hAo+SO1SFkJ4ihTNMPBVd0DS5b7XGm5xgRODLxjA==
       tarball: 'file:projects/typings-generator.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -15387,7 +15388,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-p0F5e4DX1O8WhT62D7YCoHLe5E9HTFS31CZYhR28tTosH5/oQ8D7dzBxC6oeCCP39u82OGqlmMCckt/hOr+AQw==
+      integrity: sha512-zK8JowWRhZ4Lbwzec4wvWmLqSWg4xY0xalIitKd1WHz3VoxW50BY/kJM/iWtcvjKtxCoYIdNbGNuDkOKkgzEIw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -15399,7 +15400,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-ZSVMR6xUJS8F5U+D7H6Ir0aBqXklwhAMYB5JHvwBkJUv9qo/T+BIPTfnFab09HHKKdSKlA/B8wtU/jNwYuYRlg==
+      integrity: sha512-2I0Hk+AmU4AtPc0R1PUNdsIewWhTvMuK0XDQBLYIg9XMWm5W41ValoiQV6mhxmPKNsg4MJvfhsktN6VltyUJgA==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: ''
@@ -15636,4 +15637,4 @@ specifiers:
   xmldoc: ~1.1.2
   yargs: ~4.6.0
   z-schema: ~3.18.3
-# shrinkwrap hash: c1b3ae14106bc9909931c76716eb2ae7b07b6735
+# shrinkwrap hash: 5dbb16ec43a73e51b9dc3633732be8e124ae6574

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14206,11 +14206,11 @@ packages:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-oSQHe/WAGn2pGDzHNxy/ebbHwgV5EkUiaHoDC5mFveZi/YbZt8DfhcFzCAIzP/7M19h4bhhD9dkmDencC/4Q/A==
+      integrity: sha512-Qk1biNNk3nWYenDTiIqYW70vLuReSnw31Rc2Fd85le2izmqMzpVYoisw+KF8ja6Xt9ypQd1h0eUvDy31hTEyDQ==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -14247,11 +14247,11 @@ packages:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-d/guVZZpVbV7X0N8WYQfltz0frTUO/Al4vq73fb9AF22TcWTmA+lFxlc7bMuXi/UZNtmpkH/kJ27YCSbeCuMkg==
+      integrity: sha512-0u0G7fscl+qgsZ7GNjTcRgAKGFVUvrk8UhgIe0bHUQhwruHEjrTvpjdM0HbsdOhfVt63fn+AkP4q0JCK15ZxKQ==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -14259,11 +14259,11 @@ packages:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-B3J22QVJJC5kWnBLgDh6XjcwyEwwFRKvdA43oi1wPCvlqLW6RTrH8YA2SJVAMNf3rVSYWJHnFpwekfeGuqJ0Kg==
+      integrity: sha512-W+ZrYIx1rYjFin/GB0CmDltXHLL3OsJ9xxoPcH5wuZQWODiP6bBD6rpeREeoZ3webIwF7yz5RWKZ27PDgUCJDg==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -14287,11 +14287,11 @@ packages:
       '@types/node': 10.17.13
       colors: 1.2.5
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-dioxOVTQZgT+tuCvtcottdkiVTOvej/eLPIiz+W+vp71jbjzComxaKwxXokzw3XmvqIiW/HJajG55q+B0O+WDw==
+      integrity: sha512-eUE0t2GtLcGwT3WjFlgrRtxwNKaizkYauWQew1fRglDIMQp+KBwslGEVkqq60fy9vUQF5ccnP+Vp9l42kxrXAw==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -14301,11 +14301,11 @@ packages:
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       long: 4.0.0
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-gRBxDF1RjKcabsNcInRgWQ0cll2J0+XInXCpvuemXNl/oIRBPDbB6R8Hhfm5q7mw5mVOympHX9fRSnTeIw9fJg==
+      integrity: sha512-gtQg1x+6BbSPaQJzE2lXPhYuASORkogG94ctPkiyst6rEYlHifzW0rPB8TyEo+SjzcsVNil6Q8UygxxtBkR/dg==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -14314,11 +14314,11 @@ packages:
       '@types/semver': 5.3.33
       fs-extra: 7.0.1
       semver: 5.3.0
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-zioYlIsu+02fcftni+oXlINztGuAgxLhxQiO3l3OJ5pmeZ6T3XZUmMsiLWY2fbIKsNxqm1R5UMfsdX7Z5Jo14A==
+      integrity: sha512-Omu2+uEnL+lWKpDSyzZITCAMVmH8rx6Y18u84GNt5CYiVHatjpOTco0mt0vgXE6BZn4/W9SCNtSirUZt6hDzWA==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -14326,21 +14326,21 @@ packages:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-test-03'
     resolution:
-      integrity: sha512-ZvlDjrJG25V7ogORzsOPh4nVRVeG/nrL76fjzlBBgloKTx8/IDbpesiwir9eFgL6mZKjW7Tsl69ueatf2x5NQQ==
+      integrity: sha512-18X0hgAkdqA62AK05QDSJhrdxEa29yRZ+lZ98jFzISa4ae0oovpvHfdkELnZCpzaSpDrsGO/iC8D2SRlPhWQ1w==
       tarball: 'file:projects/api-extractor-test-03.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-04.tgz':
     dependencies:
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-JwMGU3lYK4vjLm/0SnnM632y3lJNxBALjTcjnNQGVaT1DbLUS7wNWit9PM+cG7Wf4RUxxsRnLYLgEYVv12/SnQ==
+      integrity: sha512-kuJ7xZ9rFAB1Xha/iTothhJRqXIUF2s3t+c6hj6Ls8jufjpo+jwnk2ho4TrjzCI7hzGP7ydLnXywFKZhZ0GuIQ==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -14352,16 +14352,18 @@ packages:
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
+      '@types/semver': 5.3.33
       colors: 1.2.5
       gulp: 4.0.2
       lodash: 4.17.15
       resolve: 1.17.0
+      semver: 5.3.0
       source-map: 0.6.1
       typescript: 3.9.5
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-mVkgO7tYenwk5eQ1scHQeO6eL1vCjwQz3ht+4Btc+MJ1VVfSrtoSTHzpNtE3hOKXqkGxU2cdXC/kVPgiChd9sA==
+      integrity: sha512-SPDsuk+UHLaWEUHD7HIjB4jisVMV/JgIstW5vjnQADDENYwSEicA0vnH6j4CIfZHDMq8Gf2y73XMLLmtdS5DeQ==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/debug-certificate-manager.tgz':
@@ -15343,11 +15345,11 @@ packages:
     dependencies:
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.7.5
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/ts-command-line-test'
     resolution:
-      integrity: sha512-BXoCr1E3CZHjcqlnDYLLP1F18ExjaJ8/m2qUTxBHEnayfy0Xmt9L3ZmslWzt6hFWSkuUEt5NlxkdGBXlFFNZfQ==
+      integrity: sha512-AQxi+9T6peEEsJWdyCZVEzd6r4jQaQ5EVbQEoWAZ9NOIIVEpjUZLaiEO/d93ggEGQqKvHB479OgtbgJbUyXhFg==
       tarball: 'file:projects/ts-command-line-test.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -15637,4 +15639,4 @@ specifiers:
   xmldoc: ~1.1.2
   yargs: ~4.6.0
   z-schema: ~3.18.3
-# shrinkwrap hash: 5dbb16ec43a73e51b9dc3633732be8e124ae6574
+# shrinkwrap hash: bab8e24cea983bf1cf2b941875a9fe13cf462d64

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -24,6 +24,7 @@ export const enum ConsoleMessageId {
     ApiReportUnchanged = "console-api-report-unchanged",
     Diagnostics = "console-diagnostics",
     FoundTSDocMetadata = "console-found-tsdoc-metadata",
+    Preamble = "console-preamble",
     WritingDocModelFile = "console-writing-doc-model-file",
     WritingDtsRollup = "console-writing-dts-rollup"
 }

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -22,6 +22,7 @@ export const enum ConsoleMessageId {
     ApiReportFolderMissing = "console-api-report-folder-missing",
     ApiReportNotCopied = "console-api-report-not-copied",
     ApiReportUnchanged = "console-api-report-unchanged",
+    CompilerVersionNotice = "console-compiler-version-notice",
     Diagnostics = "console-diagnostics",
     FoundTSDocMetadata = "console-found-tsdoc-metadata",
     Preamble = "console-preamble",

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -150,8 +150,16 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
             process.exitCode = err.exitCode;
           }
         } else {
-          const message: string = (err.message || 'An unknown error occurred').trim();
-          console.error(colors.red('Error: ' + message));
+          let message: string = (err.message || 'An unknown error occurred').trim();
+
+          // If the message doesn't already start with "Error:" then add a prefix
+          if (!/^(error|internal error|warning)\b/i.test(message)) {
+            message = 'Error: ' + message;
+          }
+
+          console.error();
+          console.error(colors.red(message));
+
           if (!process.exitCode) {
             process.exitCode = 1;
           }

--- a/stack/rush-stack-compiler-shared/src/shared/ApiExtractorRunner.ts
+++ b/stack/rush-stack-compiler-shared/src/shared/ApiExtractorRunner.ts
@@ -5,7 +5,6 @@ import { ITerminalProvider } from '@rushstack/node-core-library';
 
 import { RushStackCompilerBase, IRushStackCompilerBaseOptions } from './RushStackCompilerBase';
 import { ApiExtractor } from './index';
-import { ToolPaths } from './ToolPaths';
 import { LoggingUtilities } from './LoggingUtilities';
 
 /**
@@ -116,8 +115,11 @@ export class ApiExtractorRunner extends RushStackCompilerBase {
             }
           }
           message.handled = true;
-        },
-        typescriptCompilerFolder: ToolPaths.typescriptPackagePath
+        }
+        // In the past we configured API Extractor to use the TypeScript runtime declarations from
+        // the local compiler, however lately it seems to work better without this option.
+        //
+        // typescriptCompilerFolder: ToolPaths.typescriptPackagePath
       };
 
       // NOTE: ExtractorResult.succeeded indicates whether errors or warnings occurred, however we


### PR DESCRIPTION
This PR doesn't specifically add support for new TypeScript language features, but it does upgrade the compiler engine, allowing many new constructs to be parsed successfuly.

I also added a version check, to make it more easy to identify problems where people are trying to analyze projects built with a newer TypeScript compiler than API Extractor itself.