### PR TITLE
[rush] fix: allow URLs to start with @ prefix to support new pnpm tarball URL format

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -154,9 +154,10 @@ export function parsePnpmDependencyKey(
   }
 
   if (!semver.valid(parsedVersionPart)) {
-    const urlRegex: RegExp = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\/([^\/\\]+\/?)*([^\/\\]+)$/i;
+    const urlRegex: RegExp = /^(@?)([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\/([^\/\\]+\/?)*([^\/\\]+)$/i;
     // Test for urls:
     // Examples:
+    //     @github.com/abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2
     //     github.com/abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2
     //     github.com.au/abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2
     //     bitbucket.com/abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2

--- a/apps/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
@@ -160,6 +160,9 @@ describe('extractVersionFromPnpmVersionSpecifier', () => {
   });
   it('detects urls', () => {
     expect(
+      testParsePnpmDependencyKey('example', '@github.com/abc/def/abcdef2fbd0260e6e56ed5ba34df0f5b6599bbe64')
+    ).toEqual('@github.com/abc/def/abcdef2fbd0260e6e56ed5ba34df0f5b6599bbe64');
+    expect(
       testParsePnpmDependencyKey('example', 'github.com/abc/def/abcdef2fbd0260e6e56ed5ba34df0f5b6599bbe64')
     ).toEqual('github.com/abc/def/abcdef2fbd0260e6e56ed5ba34df0f5b6599bbe64');
     expect(

--- a/common/changes/@microsoft/rush/fix-github-pnpm-shrinkwrap-error_2020-07-03-04-30.json
+++ b/common/changes/@microsoft/rush/fix-github-pnpm-shrinkwrap-error_2020-07-03-04-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Added support for new format used by pnpm for tarball URLs that now begin with an @ symbol",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "arri-cc@users.noreply.github.com"
+}


### PR DESCRIPTION
closes #1984

I updated the regex to match URLs that begin with an `@` symbol to support the new URL format for tarball packages added in `pnpm v5.x` here: https://github.com/pnpm/pnpm/pull/2620

I also updated the unit tests to confirm it works as expected.