### PR TITLE
[api-extractor] Fix an issue where chained compiler diagnostic messages were formatted incorrectly

### DIFF
--- a/apps/api-extractor/src/api/CompilerState.ts
+++ b/apps/api-extractor/src/api/CompilerState.ts
@@ -80,7 +80,7 @@ export class CompilerState {
     const program: ts.Program = ts.createProgram(analysisFilePaths, commandLine.options, compilerHost);
 
     if (commandLine.errors.length > 0) {
-      const errorText: string = `${commandLine.errors[0].messageText}`;
+      const errorText: string = ts.flattenDiagnosticMessageText(commandLine.errors[0].messageText, '\n');
       throw new Error(`Error parsing tsconfig.json content: ${errorText}`);
     }
 

--- a/apps/api-extractor/src/collector/MessageRouter.ts
+++ b/apps/api-extractor/src/collector/MessageRouter.ts
@@ -182,7 +182,7 @@ export class MessageRouter {
         return; // ignore noise
     }
 
-    const messageText: string = `${diagnostic.messageText}`;
+    const messageText: string = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
     const options: IExtractorMessageOptions = {
       category: ExtractorMessageCategory.Compiler,
       messageId: `TS${diagnostic.code}`,

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-diagnostic-formatting_2020-07-03-05-20.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-diagnostic-formatting_2020-07-03-05-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where chained compiler errors were not formatted correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fix an issue with newer TypeScript release, where an error is supposed to look like this:
```
Warning: node_modules/@uifabric/merge-styles/lib/concatStyleSets.d.ts:12:248 - (TS2344) Type 'TStyleSet1 & TStyleSet2' does not satisfy the constraint 'IStyleSet<TStyleSet1 & TStyleSet2>'.
  Type 'TStyleSet1 & TStyleSet2' is not assignable to type '{ subComponentStyles?: { [P in keyof (TStyleSet1 & TStyleSet2)["subComponentStyles"]]: IStyleFunctionOrObject<any, IStyleSet<any>>; } | undefined; }'.
    Types of property 'subComponentStyles' are incompatible.
      Type '({ [P in keyof TStyleSet1["subComponentStyles"]]: IStyleFunctionOrObject<any, IStyleSet<any>>; } & { [P in keyof TStyleSet2["subComponentStyles"]]: IStyleFunctionOrObject<...>; }) | undefined' is not assignable to type '{ [P in keyof (TStyleSet1 & TStyleSet2)["subComponentStyles"]]: IStyleFunctionOrObject<any, IStyleSet<any>>; } | undefined'.
        Type '{ [P in keyof TStyleSet1["subComponentStyles"]]: IStyleFunctionOrObject<any, IStyleSet<any>>; } & { [P in keyof TStyleSet2["subComponentStyles"]]: IStyleFunctionOrObject<...>; }' is not assignable to type '{ [P in keyof (TStyleSet1 & TStyleSet2)["subComponentStyles"]]: IStyleFunctionOrObject<any, IStyleSet<any>>; } | undefined'.
```
...but instead it looks like this:
```
Warning: node_modules/@uifabric/merge-styles/lib/concatStyleSets.d.ts:12:248 - (TS2344) [object Object]
```
