### PR TITLE
[heft] Fix build.js error on Mac/Linux

### DIFF
--- a/apps/heft/build.js
+++ b/apps/heft/build.js
@@ -38,7 +38,7 @@ try {
   callNodeScript(path.join(ToolPaths.eslintPackagePath, 'bin', 'eslint'), [
     '-f',
     'unix',
-    'src/**/*.{ts,tsx}'
+    '"src/**/*.{ts,tsx}"'
   ]);
 
   process.exitCode = 0;


### PR DESCRIPTION
The `build.js` script was failing when invoked using the Bash shell.

Interesting that our CI did not catch this, since it uses Linux, but it failed on my local Linux box.