### PR TITLE
[eslint-plugin] Add no-new-nulls rule re: #2017

### DIFF
--- a/stack/eslint-plugin/src/index.ts
+++ b/stack/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 import { noNullRule } from './no-null';
+import { noNewNullRule } from './no-new-null';
 import { noUntypedUnderscoreRule } from './no-untyped-underscore';
 
 interface IPlugin {
@@ -14,6 +15,7 @@ const plugin: IPlugin = {
   rules: {
     // NOTE: The actual ESLint rule name will be "@rushstack/no-null".
     'no-null': noNullRule,
+    'no-new-null': noNewNullRule,
     'no-untyped-underscore': noUntypedUnderscoreRule
   }
 };

--- a/stack/eslint-plugin/src/no-new-null.test.ts
+++ b/stack/eslint-plugin/src/no-new-null.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { noNewNullRule } from './no-new-null';
+
+const { RuleTester } = ESLintUtils;
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser'
+});
+
+ruleTester.run('no-new-null', noNewNullRule, {
+  invalid: [
+    {
+      code: 'type FuncAlias = (args: string | null) => void',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'type Alias = null',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'type ObjAlias = { field: string | null; }',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'type Constructor = {new (args: string | null)}',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'function nullTypeArgs(args: string | null): void {}',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'function nullReturn(args: string): (err: Error | null) => void {}',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'function (args: null): void {}',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'const arrow = (args: null) => {}',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'interface I { field: null; }',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: 'const v: string | null = "hello"',
+      errors: [{ messageId: 'error-new-usage-of-null' }]
+    },
+    {
+      code: `
+                class PublicNulls {
+                    property: string | null;
+                    propertyFunc: (val: string | null) => void;
+                    legacyImplicitPublic(hello: string | null): void {}
+                    public legacyExplicitPublic(hello: string | null): void {}
+                }
+            `,
+      errors: [
+        {
+          messageId: 'error-new-usage-of-null'
+        },
+        {
+          messageId: 'error-new-usage-of-null'
+        },
+        {
+          messageId: 'error-new-usage-of-null'
+        },
+        {
+          messageId: 'error-new-usage-of-null'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: `
+              export function wrapLegacy(hello: string): void {
+                const innerCallback: (err: NodeJS.ErrnoException | null) => void = (e) => {};
+                return innerCallback(null);
+              }
+            `
+    },
+    {
+      code: `
+              class PrivateNulls {
+                  // private pField: string | null;
+                  private pFunc: (val: string | null) => void;
+                  l = this.legacyPrivate(null);
+                  // field = this.legacyPrivate('null');
+                  private legacyPrivate(hello: string | null): void {
+                    // this.pFunc(this.pField)
+                    this.pFunc('hello')
+                  }
+              }
+            `
+    }
+  ]
+});

--- a/stack/eslint-plugin/src/no-new-null.ts
+++ b/stack/eslint-plugin/src/no-new-null.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+
+type MessageIds = 'error-new-usage-of-null';
+type Options = [];
+
+type Accessible = {
+  accessibility?: TSESTree.Accessibility;
+};
+
+const noNewNullRule: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'problem',
+    messages: {
+      'error-new-usage-of-null':
+        'New usage of "null" in type definitions is deprecated; use "undefined" instead'
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false
+      }
+    ],
+    docs: {
+      description:
+        'Prevent usage of JavaScript\'s "null" keyword in new type definitions. It ignores when that definition is not accessible, e.g. private or not exportable',
+      category: 'Stylistic Issues',
+      recommended: 'error',
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'
+    }
+  },
+
+  create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
+    /**
+     * Returns true if the accessibility is not explicitly set to private or protected, e.g. class properties, methods.
+     */
+    function isPubliclyAccessible(node?: Accessible): boolean {
+      const accessibility = node?.accessibility;
+      return !(accessibility === 'private' || accessibility === 'protected');
+    }
+
+    /**
+     * Let's us check the accessibility field of certain types of nodes
+     */
+    function isAccessible(node?: unknown): node is Accessible {
+      if (!node) {
+        return false;
+      }
+      switch ((node as TSESTree.Node).type) {
+        case AST_NODE_TYPES.MethodDefinition:
+          return true;
+        case AST_NODE_TYPES.ClassProperty:
+          return true;
+        case AST_NODE_TYPES.TSIndexSignature:
+          return true;
+        case AST_NODE_TYPES.TSParameterProperty:
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    /**
+     * Checks if the type declaration is lifted to be exportable to others
+     */
+    function isDefinitionExportable(node?: TSESTree.Node): boolean {
+      switch (node?.type) {
+        case undefined: // base case
+          return false;
+        case AST_NODE_TYPES.BlockStatement: // we are an inline function, scope is not exportable
+          return false;
+        case AST_NODE_TYPES.ExportNamedDeclaration: // our definition is being exported
+          return true;
+        case AST_NODE_TYPES.Program: // our definition can be exported
+          return true;
+        default:
+          if (isAccessible(node)) {
+            // only fail when class method/constructor is accessible publicly
+            return isPubliclyAccessible(node);
+          }
+          return isDefinitionExportable(node?.parent);
+      }
+    }
+
+    /**
+     * Returns true if this type definition exposes a null type
+     */
+    function isNewNull(node?: TSESTree.Node): boolean {
+      switch (node?.type) {
+        case undefined:
+          return false;
+        case AST_NODE_TYPES.TSTypeAnnotation:
+          return isDefinitionExportable(node.parent);
+        case AST_NODE_TYPES.TSTypeAliasDeclaration:
+          return isDefinitionExportable(node.parent);
+        default:
+          return isNewNull(node?.parent);
+      }
+    }
+
+    return {
+      TSNullKeyword(node): void {
+        if (isNewNull(node.parent)) {
+          context.report({ node, messageId: 'error-new-usage-of-null' });
+        }
+      }
+    };
+  }
+};
+
+export { noNewNullRule };


### PR DESCRIPTION
This introduces a new eslint rule which makes introducing new APIs with nulls
in them an error. Further, it doesn't complain about using APIs which use
`null`, like `node` or React hooks -- instead only looking to enforce the
propagation of those APIs (or new APIs) to the codebase.

## Note to reviewers

1. This is my first eslint rule - I tried to look around at conventions, but I'm sure I missed something.
1. Tests do not actually run - the gulp config explicitly disables them. I had trouble trying to get the tests to run in general.
1. I attempted to test this against the new private fields in Typescript 3.8, but was unable to