### PR TITLE
[Module Minifier Plugin] Fix invalid reference in API extractor emitted types

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/dmichon-module-minifier-typings_2020-07-14-21-01.json
+++ b/common/changes/@rushstack/module-minifier-plugin/dmichon-module-minifier-typings_2020-07-14-21-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Fix external typings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -48,7 +48,7 @@ export const IDENTIFIER_TRAILING_DIGITS: string;
 export interface IExtendedModule extends webpack.compilation.Module, webpack.Module {
     id: string | number | null;
     identifier(): string;
-    readableIdentifier(requestShortener: webpack.compilation.RequestShortener): string;
+    readableIdentifier(requestShortener: unknown): string;
     resource?: string;
     skipMinification?: boolean;
 }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -161,7 +161,7 @@ export interface IExtendedModule extends webpack.compilation.Module, webpack.Mod
   /**
    * Gets a friendly identifier for the module.
    */
-  readableIdentifier(requestShortener: webpack.compilation.RequestShortener): string;
+  readableIdentifier(requestShortener: unknown): string;
   /**
    * Path to the physical file this module represents
    */


### PR DESCRIPTION
`@types/webpack` does not expose `webpack.compilation.RequestShortener`, which was referenced within `ModuleMinifierPlugin.types.ts` and therefore rolled up into the public API surface. It was internally extended to facilitate its usage within the plugin, but this breaks for official consumers of the plugin.