### PR TITLE
[Module Minifier Plugin] Add support for external modules

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/dmichon-compress_2020-07-17-00-27.json
+++ b/common/changes/@rushstack/module-minifier-plugin/dmichon-compress_2020-07-17-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Support external modules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -23,6 +23,7 @@ export function generateLicenseFileForAsset(compilation: webpack.compilation.Com
 // @public
 export interface IAssetInfo {
     chunk: webpack.compilation.Chunk;
+    externalNames: Map<string, string>;
     extractedComments: string[];
     fileName: string;
     modules: (string | number)[];
@@ -46,6 +47,7 @@ export const IDENTIFIER_TRAILING_DIGITS: string;
 
 // @public
 export interface IExtendedModule extends webpack.compilation.Module, webpack.Module {
+    external?: boolean;
     id: string | number | null;
     identifier(): string;
     readableIdentifier(requestShortener: unknown): string;
@@ -81,6 +83,7 @@ export interface IModuleMinificationErrorResult {
 // @public
 export interface IModuleMinificationRequest {
     code: string;
+    externals: string[] | undefined;
     hash: string;
     nameForMap: string | undefined;
 }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -18,6 +18,7 @@ import {
   STAGE_BEFORE,
   STAGE_AFTER
 } from './Constants';
+import { getIdentifier } from './MinifiedIdentifier';
 import {
   IModuleMinifier,
   IModuleMinifierPluginOptions,
@@ -258,7 +259,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
               {
                 hash,
                 code: wrappedCode,
-                nameForMap: useSourceMaps ? nameForMap : undefined
+                nameForMap: useSourceMaps ? nameForMap : undefined,
+                externals: undefined
               },
               (result: IModuleMinificationResult) => {
                 if (isMinificationResultError(result)) {
@@ -327,6 +329,11 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
         async (chunks: webpack.compilation.Chunk[]): Promise<void> => {
           // Still need to minify the rendered assets
           for (const chunk of chunks) {
+            const externals: string[] = [];
+            const externalNames: Map<string, string> = new Map();
+            // Skip the first two parameters to not collide with the module function arguments
+            let nextOrdinal: number = 1;
+
             const chunkModules: (string | number)[] = [];
             const allChunkModules: Iterable<IExtendedModule> = chunk.modulesIterable;
             let hasNonNumber: boolean = false;
@@ -336,6 +343,16 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                   hasNonNumber = true;
                 }
                 chunkModules.push(mod.id);
+
+                if (mod.external) {
+                  const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
+                    `${mod.id}`
+                  )}__`;
+                  const ordinal: number = ++nextOrdinal;
+                  const miniId: string = getIdentifier(ordinal);
+                  externals.push(key);
+                  externalNames.set(key, miniId);
+                }
               }
             }
 
@@ -358,7 +375,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                   {
                     hash,
                     code: rawCode,
-                    nameForMap: useSourceMaps ? nameForMap : undefined
+                    nameForMap: useSourceMaps ? nameForMap : undefined,
+                    externals
                   },
                   (result: IModuleMinificationResult) => {
                     if (isMinificationResultError(result)) {
@@ -395,7 +413,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                           extractedComments,
                           modules: chunkModules,
                           chunk,
-                          fileName: assetName
+                          fileName: assetName,
+                          externalNames
                         });
                       } catch (err) {
                         compilation.errors.push(err);
@@ -413,7 +432,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                   extractedComments: [],
                   modules: chunkModules,
                   chunk,
-                  fileName: assetName
+                  fileName: assetName,
+                  externalNames
                 });
               }
             }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -331,8 +331,6 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
           for (const chunk of chunks) {
             const externals: string[] = [];
             const externalNames: Map<string, string> = new Map();
-            // Skip the first two parameters to not collide with the module function arguments
-            let nextOrdinal: number = 1;
 
             const chunkModules: (string | number)[] = [];
             const allChunkModules: Iterable<IExtendedModule> = chunk.modulesIterable;
@@ -348,7 +346,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                   const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
                     `${mod.id}`
                   )}__`;
-                  const ordinal: number = ++nextOrdinal;
+                  // The first two identifiers are used for function (module, exports) at the module site
+                  const ordinal: number = 2 + externals.length;
                   const miniId: string = getIdentifier(ordinal);
                   externals.push(key);
                   externalNames.set(key, miniId);

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -23,6 +23,10 @@ export interface IModuleMinificationRequest {
    * File name to show for the source code in the source map
    */
   nameForMap: string | undefined;
+  /**
+   * Reserved variable names, e.g. __WEBPACK_EXTERNAL_MODULE_1__
+   */
+  externals: string[] | undefined;
 }
 
 /**
@@ -122,6 +126,11 @@ export interface IAssetInfo {
    * The raw chunk object from Webpack, in case information from it is necessary for reconstruction
    */
   chunk: webpack.compilation.Chunk;
+
+  /**
+   * The set of external names to postprocess
+   */
+  externalNames: Map<string, string>;
 }
 
 /**
@@ -150,6 +159,10 @@ export interface IModuleInfo {
  * @public
  */
 export interface IExtendedModule extends webpack.compilation.Module, webpack.Module {
+  /**
+   * Is this module external?
+   */
+  external?: boolean;
   /**
    * Id for the module
    */

--- a/webpack/module-minifier-plugin/src/RehydrateAsset.ts
+++ b/webpack/module-minifier-plugin/src/RehydrateAsset.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Template } from 'webpack';
 import { CachedSource, ConcatSource, ReplaceSource, Source } from 'webpack-sources';
 
 import { CHUNK_MODULES_TOKEN } from './Constants';
-import { getIdentifier } from './MinifiedIdentifier';
-import { IAssetInfo, IModuleMap, IModuleInfo, IExtendedModule } from './ModuleMinifierPlugin.types';
+import { IAssetInfo, IModuleMap, IModuleInfo } from './ModuleMinifierPlugin.types';
 
 /**
  * Rehydrates an asset with minified modules.
@@ -139,19 +137,6 @@ export function rehydrateAsset(asset: IAssetInfo, moduleMap: IModuleMap, banner:
   }
 
   source.add(suffix);
-
-  const externals: Map<string, string> = new Map();
-  let nextOrdinal: number = 0;
-  for (const id of modules) {
-    const item: IModuleInfo | undefined = moduleMap.get(id);
-    const mod: IExtendedModule | undefined = item && item.module;
-    if (mod && mod.external) {
-      const key: string = `${Template.toIdentifier(`${mod.id}`)}__`;
-      const ordinal: number = ++nextOrdinal;
-      const miniId: string = getIdentifier(ordinal);
-      externals.set(key, miniId);
-    }
-  }
 
   const cached: CachedSource = new CachedSource(source);
 

--- a/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
+++ b/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
@@ -14,6 +14,21 @@ modules.set('b', {
   extractedComments: [],
   module: undefined!
 });
+modules.set('0b', {
+  source: new RawSource('baz'),
+  extractedComments: [],
+  module: undefined!
+});
+modules.set('=', {
+  source: new RawSource('bak'),
+  extractedComments: [],
+  module: undefined!
+});
+modules.set('a0', {
+  source: new RawSource('bal'),
+  extractedComments: [],
+  module: undefined!
+});
 modules.set(0, {
   source: new RawSource('fizz'),
   extractedComments: [],
@@ -21,6 +36,11 @@ modules.set(0, {
 });
 modules.set(2, {
   source: new RawSource('buzz'),
+  extractedComments: [],
+  module: undefined!
+});
+modules.set(255, {
+  source: new RawSource('__WEBPACK_EXTERNAL_MODULE_fizz__'),
   extractedComments: [],
   module: undefined!
 });
@@ -52,14 +72,15 @@ describe('rehydrateAsset', () => {
   it('uses an object for non-numeric ids', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
-      modules: ['a', 'b'],
+      modules: ['a', 'b', '0b', '=', 'a0'],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
-    const expected: string = `/* fnord */\n<before>{"a":foo,"b":bar}<after>`;
+    const expected: string = `/* fnord */\n<before>{a:foo,b:bar,"0b":baz,"=":bak,a0:bal}<after>`;
 
     if (result !== expected) {
       throw new Error(`Expected ${expected} but received ${result}`);
@@ -72,7 +93,8 @@ describe('rehydrateAsset', () => {
       modules: [0, 25],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
@@ -89,7 +111,8 @@ describe('rehydrateAsset', () => {
       modules: [2],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
@@ -106,7 +129,8 @@ describe('rehydrateAsset', () => {
       modules: [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
@@ -123,7 +147,8 @@ describe('rehydrateAsset', () => {
       modules: [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
@@ -140,11 +165,30 @@ describe('rehydrateAsset', () => {
       modules: [0, 2, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
       extractedComments: [],
       fileName: 'test',
-      chunk: undefined!
+      chunk: undefined!,
+      externalNames: new Map()
     };
 
     const result: string = rehydrateAsset(asset, modules, banner).source();
     const expected: string = `/* fnord */\n<before>[fizz,,buzz].concat(Array(997),[b1000,b1001,b1002,b1003,b1004,b1005,b1006,b1007,b1008,b1009])<after>`;
+
+    if (result !== expected) {
+      throw new Error(`Expected ${expected} but received ${result}`);
+    }
+  });
+
+  it('reprocesses external names', () => {
+    const asset: IAssetInfo = {
+      source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
+      modules: [255],
+      extractedComments: [],
+      fileName: 'test',
+      chunk: undefined!,
+      externalNames: new Map([['__WEBPACK_EXTERNAL_MODULE_fizz__', 'TREBLE']])
+    };
+
+    const result: string = rehydrateAsset(asset, modules, banner).source();
+    const expected: string = `/* fnord */\n<before>{255:TREBLE}<after>`;
 
     if (result !== expected) {
       throw new Error(`Expected ${expected} but received ${result}`);


### PR DESCRIPTION
Support routing external modules via marking the identifiers as "reserved" to Terser during the initial minification process, then following up after rehydration by converting the `__WEBPACK_EXTERNAL_MODULE_*` identifiers to more compact identifiers.