### PR TITLE
[Module Minifier Plugin] Make @types/webpack peer dependency optional

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/dmichon-optional-peer_2020-07-22-22-30.json
+++ b/common/changes/@rushstack/module-minifier-plugin/dmichon-optional-peer_2020-07-22-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Make @types/webpack optional, fix Module",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -46,7 +46,7 @@ export const IDENTIFIER_LEADING_DIGITS: string;
 export const IDENTIFIER_TRAILING_DIGITS: string;
 
 // @public
-export interface IExtendedModule extends webpack.compilation.Module, webpack.Module {
+export interface IExtendedModule extends webpack.compilation.Module {
     external?: boolean;
     id: string | number | null;
     identifier(): string;

--- a/webpack/module-minifier-plugin/package.json
+++ b/webpack/module-minifier-plugin/package.json
@@ -17,10 +17,13 @@
   },
   "peerDependencies": {
     "webpack": "^4.31.0",
-    "webpack-sources": "~1.4.3"
-  },
-  "optionalPeerDependencies": {
+    "webpack-sources": "~1.4.3",
     "@types/webpack": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/webpack": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@types/node": "10.17.13",

--- a/webpack/module-minifier-plugin/package.json
+++ b/webpack/module-minifier-plugin/package.json
@@ -17,7 +17,9 @@
   },
   "peerDependencies": {
     "webpack": "^4.31.0",
-    "webpack-sources": "~1.4.3",
+    "webpack-sources": "~1.4.3"
+  },
+  "optionalPeerDependencies": {
     "@types/webpack": "*"
   },
   "dependencies": {

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -158,7 +158,7 @@ export interface IModuleInfo {
  * Extension of the webpack Module typings with members that are used by this Plugin
  * @public
  */
-export interface IExtendedModule extends webpack.compilation.Module, webpack.Module {
+export interface IExtendedModule extends webpack.compilation.Module {
   /**
    * Is this module external?
    */


### PR DESCRIPTION
Move `@types/webpack` to optional peer dependency.
Fix base type of `IExtendedModule` to only be based on `webpack.compilation.Module`, not `webpack.Module`, since the latter is the webpack configuration "module" section, which is completely irrelevant.