### PR TITLE
WIP: Replace z-schema for Ajv

### DIFF
--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -18,7 +18,7 @@
     "jju": "~1.4.0",
     "semver": "~7.3.0",
     "timsort": "~0.3.0",
-    "z-schema": "~3.18.3"
+    "ajv": "~6.12.0"
   },
   "devDependencies": {
     "@microsoft/node-library-build": "6.4.31",
@@ -29,7 +29,6 @@
     "@types/jju": "1.4.1",
     "@types/semver": "~7.3.1",
     "@types/timsort": "0.3.0",
-    "@types/z-schema": "3.16.31",
     "gulp": "~4.0.2"
   }
 }


### PR DESCRIPTION
[As per conversation with *Pete Gonzalez*][gitter-convo], about replacing [z-schema][npmjs-zschema] to [Ajv][npmjs-ajv]

[npmjs-ajv]: https://www.npmjs.com/package/z-schema
[npmjs-zschema]: https://www.npmjs.com/package/z-schema
[gitter-convo]: https://gitter.im/rushstack/rushstack?at=5f16783c9360cb1f465c4bcf "octogonz: No, I think we'd just update the main JsonSchema API to use ajv and eliminate our dependency on z-schema entirely."
