### PR TITLE
[api-documenter] Separate section for classes and errors in package summary

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -57,6 +57,20 @@ import {
 import { DocumenterConfig } from './DocumenterConfig';
 import { MarkdownDocumenterAccessor } from '../plugin/MarkdownDocumenterAccessor';
 
+function isError(item: ApiClass): boolean {
+  if (item.extendsType && item.extendsType.excerpt) {
+    return item.extendsType.excerpt.tokens.some((token) => {
+      if (token.kind === ExcerptTokenKind.Reference) {
+        if (token.text === 'Error') {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  return false;
+}
+
 /**
  * Renders API documentation in the Markdown file format.
  * For more info:  https://en.wikipedia.org/wiki/Markdown
@@ -468,6 +482,11 @@ export class MarkdownDocumenter {
       headerTitles: ['Type Alias', 'Description']
     });
 
+    const errorsTable: DocTable = new DocTable({
+      configuration,
+      headerTitles: ['Error', 'Description']
+    });
+
     const apiMembers: ReadonlyArray<ApiItem> =
       apiContainer.kind === ApiItemKind.Package
         ? (apiContainer as ApiPackage).entryPoints[0].members
@@ -481,7 +500,11 @@ export class MarkdownDocumenter {
 
       switch (apiMember.kind) {
         case ApiItemKind.Class:
-          classesTable.addRow(row);
+          if (!isError(apiMember as ApiClass)) {
+            classesTable.addRow(row);
+          } else {
+            errorsTable.addRow(row);
+          }
           this._writeApiItemPage(apiMember);
           break;
 
@@ -549,6 +572,11 @@ export class MarkdownDocumenter {
     if (typeAliasesTable.rows.length > 0) {
       output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: 'Type Aliases' }));
       output.appendNode(typeAliasesTable);
+    }
+
+    if (errorsTable.rows.length > 0) {
+      output.appendNode(new DocHeading({ configuration: this._tsdocConfiguration, title: 'Errors' }));
+      output.appendNode(errorsTable);
     }
   }
 

--- a/common/changes/@microsoft/api-documenter/master_2020-07-28-22-18.json
+++ b/common/changes/@microsoft/api-documenter/master_2020-07-28-22-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "[api-documenter] Separate section for classes and errors in package summary",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "johanblumenberg-symphony@users.noreply.github.com"
+}


### PR DESCRIPTION
Differentiate between regular classes and `Error` classes in the package summary page.

Before:
<img width="386" alt="Screen Shot 2020-07-28 at 11 45 32 PM" src="https://user-images.githubusercontent.com/31734333/88728296-a92b2080-d131-11ea-8e96-432691f5061f.png">

After:
<img width="405" alt="Screen Shot 2020-07-29 at 12 03 28 AM" src="https://user-images.githubusercontent.com/31734333/88728305-ae886b00-d131-11ea-9822-5457f421c4ff.png">
