### PR TITLE
[heft] Add new "emitFolderPathForJest" setting in typescript.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ temp
 lib
 lib-amd
 lib-es6
+lib-esnext
+lib-commonjs
 dist
 *.scss.ts
 *.sass.ts

--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -28,7 +28,7 @@ export class JestTypeScriptDataFile {
     projectFolder: string,
     typeScriptConfiguration: ITypeScriptConfiguration
   ): void {
-    const jsonFilePath: string = JestTypeScriptDataFile._getConfigFilePath(projectFolder);
+    const jsonFilePath: string = JestTypeScriptDataFile.getConfigFilePath(projectFolder);
 
     const json: IJestTypeScriptDataFileJson = {
       emitFolderPathForJest: typeScriptConfiguration.emitFolderPathForJest || 'lib'
@@ -40,11 +40,11 @@ export class JestTypeScriptDataFile {
    * Called by jest-build-transform.js to read the file.
    */
   public static loadForProject(projectFolder: string): IJestTypeScriptDataFileJson {
-    const jsonFilePath: string = JestTypeScriptDataFile._getConfigFilePath(projectFolder);
+    const jsonFilePath: string = JestTypeScriptDataFile.getConfigFilePath(projectFolder);
     return JsonFile.load(jsonFilePath);
   }
 
-  private static _getConfigFilePath(projectFolder: string): string {
+  public static getConfigFilePath(projectFolder: string): string {
     return path.join(projectFolder, '.heft', 'build-cache', 'jest-typescript-data.json');
   }
 }

--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -33,7 +33,11 @@ export class JestTypeScriptDataFile {
     const json: IJestTypeScriptDataFileJson = {
       emitFolderPathForJest: typeScriptConfiguration.emitFolderPathForJest || 'lib'
     };
-    JsonFile.save(json, jsonFilePath);
+    JsonFile.save(json, jsonFilePath, {
+      ensureFolderExists: true,
+      onlyIfChanged: true,
+      headerComment: '// THIS DATA FILE IS INTERNAL TO HEFT; DO NOT MODIFY IT OR RELY ON ITS CONTENTS'
+    });
   }
 
   /**

--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { JsonFile } from '@rushstack/node-core-library';
+import { ITypeScriptConfiguration } from '../../stages/BuildStage';
+
+/**
+ * Schema for jest-typescript-data.json
+ */
+export interface IJestTypeScriptDataFileJson {
+  /**
+   * The "emitFolderPathForJest" from .heft/typescript.json
+   */
+  emitFolderPathForJest: string;
+}
+
+/**
+ * Manages loading/saving the "jest-typescript-data.json" data file.  This file communicates
+ * configuration information from Heft to jest-build-transform.js.  The jest-build-transform.js script gets
+ * loaded dynamically by the Jest engine, so it does not have access to the normal HeftConfiguration objects.
+ */
+export class JestTypeScriptDataFile {
+  /**
+   * Called by TypeScriptPlugin to write the file.
+   */
+  public static saveForProject(
+    projectFolder: string,
+    typeScriptConfiguration: ITypeScriptConfiguration
+  ): void {
+    const jsonFilePath: string = JestTypeScriptDataFile._getConfigFilePath(projectFolder);
+
+    const json: IJestTypeScriptDataFileJson = {
+      emitFolderPathForJest: typeScriptConfiguration.emitFolderPathForJest || 'lib'
+    };
+    JsonFile.save(json, jsonFilePath);
+  }
+
+  /**
+   * Called by jest-build-transform.js to read the file.
+   */
+  public static loadForProject(projectFolder: string): IJestTypeScriptDataFileJson {
+    const jsonFilePath: string = JestTypeScriptDataFile._getConfigFilePath(projectFolder);
+    return JsonFile.load(jsonFilePath);
+  }
+
+  private static _getConfigFilePath(projectFolder: string): string {
+    return path.join(projectFolder, '.heft', 'build-cache', 'jest-typescript-data.json');
+  }
+}

--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -4,30 +4,48 @@
 import * as path from 'path';
 import { Path, FileSystem } from '@rushstack/node-core-library';
 import { InitialOptionsWithRootDir } from '@jest/types/build/Config';
+import { JestTypeScriptDataFile, IJestTypeScriptDataFileJson } from './JestTypeScriptDataFile';
 
 /**
  * This Jest transformer maps TS files under a 'src' folder to their compiled equivalent under 'lib'
  */
 export function process(src: string, filename: string, jestOptions: InitialOptionsWithRootDir): string {
+  // Read typescript-jest-config.json, which is created by Heft's TypeScript plugin.  It tells us
+  // which emitted output folder to use for Jest.
+  const jestTypeScriptConfig: IJestTypeScriptDataFileJson = JestTypeScriptDataFile.loadForProject(
+    jestOptions.rootDir
+  );
+
+  // Is the input file under the "src" folder?
   const srcFolder: string = path.join(jestOptions.rootDir, 'src');
+
   if (Path.isUnder(filename, srcFolder)) {
-    const fileBasename: string = path.basename(filename, path.extname(filename));
-    const srcRelativeFolderPath: string = path.dirname(path.relative(srcFolder, filename));
+    // Example: /path/to/project/src/folder1/folder2/Example.ts
+    const parsedFilename: path.ParsedPath = path.parse(filename);
+
+    // Example: folder1/folder2
+    const srcRelativeFolderPath: string = path.relative(srcFolder, parsedFilename.dir);
+
+    // Example: /path/to/project/lib/folder1/folder2/Example.js
     const libFilename: string = path.join(
       jestOptions.rootDir,
-      'lib',
+      jestTypeScriptConfig.emitFolderPathForJest,
       srcRelativeFolderPath,
-      `${fileBasename}.js`
+      `${parsedFilename.name}.js`
     );
 
     try {
       return FileSystem.readFile(libFilename);
     } catch (error) {
-      if (!FileSystem.isNotExistError(error)) {
+      if (FileSystem.isNotExistError(error)) {
+        throw new Error(
+          'jest-build-transform: The expected transpiler output file does not exist:\n' + libFilename
+        );
+      } else {
         throw error;
       }
     }
+  } else {
+    throw new Error('jest-build-transform: The input path is not under the "src" folder:\n' + filename);
   }
-
-  return src;
 }

--- a/apps/heft/src/plugins/JsonConfigurationLoaders/JsonConfigurationFilesPluginBase.ts
+++ b/apps/heft/src/plugins/JsonConfigurationLoaders/JsonConfigurationFilesPluginBase.ts
@@ -124,6 +124,10 @@ export abstract class JsonConfigurationFilesPluginBase implements IHeftPlugin {
         typeScriptConfigurationJson.additionalModuleKindsToEmit || undefined;
     }
 
+    if (typeScriptConfigurationJson?.emitFolderPathForJest !== undefined) {
+      typeScriptConfiguration.emitFolderPathForJest = typeScriptConfigurationJson?.emitFolderPathForJest;
+    }
+
     if (typeScriptConfigurationJson?.disableTslint !== undefined) {
       typeScriptConfiguration.isLintingEnabled = !typeScriptConfigurationJson.disableTslint;
     }

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -17,6 +17,7 @@ import {
   ICompileSubstage
 } from '../../stages/BuildStage';
 import { TaskPackageResolver, ITaskPackageResolution } from '../../utilities/TaskPackageResolver';
+import { JestTypeScriptDataFile } from '../JestPlugin/JestTypeScriptDataFile';
 
 const PLUGIN_NAME: string = 'typescript';
 
@@ -95,6 +96,8 @@ export class TypeScriptPlugin implements IHeftPlugin {
       watchMode: watchMode,
       maxWriteParallelism: typeScriptConfiguration.maxWriteParallelism
     };
+
+    JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, typeScriptConfiguration);
 
     const tsconfigFilePaths: string[] = typeScriptConfiguration.tsconfigPaths;
     if (tsconfigFilePaths.length === 1) {

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -38,6 +38,11 @@
       }
     },
 
+    "emitFolderPathForJest": {
+      "description": "Specifies the intermediary folder that Jest will use for its input.  Because Jest uses the Node.js runtime to execute tests, the module format must be CommonJS. The default value is \"lib\".",
+      "type": "string"
+    },
+
     "disableTslint": {
       "description": "If set to \"true\", disable TSlint.",
       "type": "boolean"

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -110,6 +110,14 @@ export interface ISharedTypeScriptConfiguration {
   additionalModuleKindsToEmit?: IEmitModuleKind[] | undefined;
 
   /**
+   * Specifies the intermediary folder that Jest will use for its input.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  emitFolderPathForJest?: string;
+
+  /**
    * Set this to change the maximum number of file handles that will be opened concurrently for writing.
    * The default is 50.
    */

--- a/apps/heft/src/templates/typescript.json
+++ b/apps/heft/src/templates/typescript.json
@@ -31,6 +31,14 @@
   ]
 
   /**
+   * Specifies the intermediary folder that Jest will use for its input.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  // "emitFolderPathForJest": "lib-commonjs",
+
+  /**
    * If set to "true", the TSlint task will not be invoked.
    */
   // "disableTslint": true,

--- a/build-tests/heft-webpack-basic-test/.heft/clean.json
+++ b/build-tests/heft-webpack-basic-test/.heft/clean.json
@@ -7,5 +7,5 @@
   /**
    * Glob patterns to be deleted by the "heft clean" action.  The paths are resolved relative to the project folder.
    */
-  "pathsToDelete": ["dist", "lib", "temp"]
+  "pathsToDelete": ["dist", "lib", "lib-esnext", "temp"]
 }

--- a/build-tests/heft-webpack-basic-test/.heft/clean.json
+++ b/build-tests/heft-webpack-basic-test/.heft/clean.json
@@ -7,5 +7,5 @@
   /**
    * Glob patterns to be deleted by the "heft clean" action.  The paths are resolved relative to the project folder.
    */
-  "pathsToDelete": ["dist", "lib", "lib-esnext", "temp"]
+  "pathsToDelete": ["dist", "lib", "lib-commonjs", "temp"]
 }

--- a/build-tests/heft-webpack-basic-test/.heft/typescript.json
+++ b/build-tests/heft-webpack-basic-test/.heft/typescript.json
@@ -29,10 +29,18 @@
     //    "outFolderPath": "lib-amd"
     // }
     {
-      "moduleKind": "esnext",
-      "outFolderPath": "lib-esnext"
+      "moduleKind": "commonjs",
+      "outFolderPath": "lib-commonjs"
     }
-  ]
+  ],
+
+  /**
+   * Specifies the intermediary folder that Jest will use for its input.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  "emitFolderPathForJest": "lib-commonjs"
 
   /**
    * If set to "true", the TSlint task will not be invoked.

--- a/build-tests/heft-webpack-basic-test/.heft/typescript.json
+++ b/build-tests/heft-webpack-basic-test/.heft/typescript.json
@@ -1,0 +1,47 @@
+/**
+ * Configures the TypeScript plugin for Heft.  This plugin also manages linting.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/typescript.schema.json",
+
+  /**
+   * Can be set to "copy" or "hardlink". If set to "copy", copy files from cache.
+   * If set to "hardlink", files will be hardlinked to the cache location.
+   * This option is useful when producing a tarball of build output as TAR files don't
+   * handle these hardlinks correctly. "hardlink" is the default behavior.
+   */
+  // "copyFromCacheMode": "copy",
+
+  /**
+   * If provided, emit these module kinds in addition to the modules specified in the tsconfig.
+   * Note that this option only applies to the main tsconfig.json configuration.
+   */
+  "additionalModuleKindsToEmit": [
+    // {
+    //   /**
+    //    * (Required) Must be one of "commonjs", "amd", "umd", "system", "es2015", "esnext"
+    //    */
+    //  "moduleKind": "amd",
+    //
+    //   /**
+    //    * (Required) The path where the output will be written.
+    //    */
+    //    "outFolderPath": "lib-amd"
+    // }
+    {
+      "moduleKind": "esnext",
+      "outFolderPath": "lib-esnext"
+    }
+  ]
+
+  /**
+   * If set to "true", the TSlint task will not be invoked.
+   */
+  // "disableTslint": true,
+
+  /**
+   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
+   * The default is 50.
+   */
+  // "maxWriteParallelism": 50
+}

--- a/build-tests/heft-webpack-basic-test/tsconfig.json
+++ b/build-tests/heft-webpack-basic-test/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": true,
     "types": ["jest", "webpack-env"],
 
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "target": "es5",
     "lib": ["es5", "scripthost", "es2015.collection", "es2015.promise", "es2015.iterable", "dom"]

--- a/build-tests/heft-webpack-basic-test/tsconfig.json
+++ b/build-tests/heft-webpack-basic-test/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": true,
     "types": ["jest", "webpack-env"],
 
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",
     "lib": ["es5", "scripthost", "es2015.collection", "es2015.promise", "es2015.iterable", "dom"]

--- a/build-tests/heft-webpack-basic-test/webpack.config.js
+++ b/build-tests/heft-webpack-basic-test/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extensions: ['.js', '.jsx', '.json']
   },
   entry: {
-    'heft-test': path.join(__dirname, 'lib-esnext', 'index.js')
+    'heft-test': path.join(__dirname, 'lib', 'index.js')
   },
   output: {
     path: path.join(__dirname, 'dist'),

--- a/build-tests/heft-webpack-basic-test/webpack.config.js
+++ b/build-tests/heft-webpack-basic-test/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extensions: ['.js', '.jsx', '.json']
   },
   entry: {
-    'heft-test': path.join(__dirname, 'lib', 'index.js')
+    'heft-test': path.join(__dirname, 'lib-esnext', 'index.js')
   },
   output: {
     path: path.join(__dirname, 'dist'),

--- a/build-tests/heft-webpack-everything-test/.heft/clean.json
+++ b/build-tests/heft-webpack-everything-test/.heft/clean.json
@@ -7,5 +7,5 @@
   /**
    * Glob patterns to be deleted by the "heft clean" action.  The paths are resolved relative to the project folder.
    */
-  "pathsToDelete": ["dist", "lib", "temp"]
+  "pathsToDelete": ["dist", "lib", "lib-commonjs", "temp"]
 }

--- a/build-tests/heft-webpack-everything-test/.heft/typescript.json
+++ b/build-tests/heft-webpack-everything-test/.heft/typescript.json
@@ -28,7 +28,19 @@
     //    */
     //    "outFolderPath": "lib-amd"
     // }
-  ]
+    {
+      "moduleKind": "commonjs",
+      "outFolderPath": "lib-commonjs"
+    }
+  ],
+
+  /**
+   * Specifies the intermediary folder that Jest will use for its input.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  "emitFolderPathForJest": "lib-commonjs"
 
   /**
    * If set to "true", the TSlint task will not be invoked.

--- a/build-tests/heft-webpack-everything-test/package.json
+++ b/build-tests/heft-webpack-everything-test/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "heft build --clean",
+    "build": "heft test --clean",
     "start": "heft start"
   },
   "devDependencies": {

--- a/common/changes/@rushstack/heft/octogonz-heft-jest-with-webpack2_2020-08-03-00-27.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-jest-with-webpack2_2020-08-03-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add new \"emitFolderPathForJest\" setting in typescript.json, which simplifies how Webpack projects emit CommonJS for Jest",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-heft-jest-with-webpack2_2020-08-03-06-31.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-heft-jest-with-webpack2_2020-08-03-06-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Added IJsonFileStringifyOptions.headerComment",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -282,6 +282,7 @@ export interface ISharedCopyStaticAssetsConfiguration {
 export interface ISharedTypeScriptConfiguration {
     additionalModuleKindsToEmit?: IEmitModuleKind[] | undefined;
     copyFromCacheMode?: CopyFromCacheMode | undefined;
+    emitFolderPathForJest?: string;
     maxWriteParallelism: number;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -313,6 +313,7 @@ export interface IJsonFileSaveOptions extends IJsonFileStringifyOptions {
 
 // @public
 export interface IJsonFileStringifyOptions {
+    headerComment?: string;
     newlineConversion?: NewlineKind;
     prettyFormatting?: boolean;
 }

--- a/libraries/node-core-library/src/test/JsonFile.test.ts
+++ b/libraries/node-core-library/src/test/JsonFile.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { JsonFile } from '../JsonFile';
+
+// The PosixModeBits are intended to be used with bitwise operations.
+/* eslint-disable no-bitwise */
+
+describe('JsonFile tests', () => {
+  it('adds a header comment', () => {
+    expect(
+      JsonFile.stringify(
+        { abc: 123 },
+        {
+          headerComment: '// header\n// comment'
+        }
+      )
+    ).toMatchSnapshot();
+  });
+  it('adds an empty header comment', () => {
+    expect(
+      JsonFile.stringify(
+        { abc: 123 },
+        {
+          headerComment: ''
+        }
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JsonFile tests adds a header comment 1`] = `
+"// header
+// comment
+{
+  \\"abc\\": 123
+}
+"
+`;
+
+exports[`JsonFile tests adds an empty header comment 1`] = `
+"{
+  \\"abc\\": 123
+}
+"
+`;


### PR DESCRIPTION
This builds upon PR https://github.com/microsoft/rushstack/pull/2064 to make Jest work better with Webpack.

When TypeScript is emitting multiple output folders (e.g. `commonjs` for Jest and `esnext` for Webpack), this PR provides a way to tell Jest which folder to consume.  The actual processing happens inside the **jest-build-transform.js** script, which cannot access the normal Heft context.  Therefore the TypeScript stage stores the `emitFolderPathForJest` path in a temporary file **.heft/build-cache/jest-typescript-data.json**, which the transform reads.

_Note: Ideally `JestPlugin` should have the job of writing **jest-typescript-data.json**, but currently there is no easy way for `JestPlugin` to access the TypeScript configuration.  (We can improve that as part of the design discussion around PR https://github.com/microsoft/rushstack/pull/2054)_