### PR TITLE
[rush] Fix for "An unrecognized file .DS_Store was found in the Rush config folder"

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -931,6 +931,11 @@ export class RushConfiguration {
         continue;
       }
 
+      // Ignore hidden files such as ".DS_Store"
+      if (filename.startsWith('.')) {
+        continue;
+      }
+
       if (filename.startsWith('deploy-') && fileExtension === '.json') {
         // Ignore "rush deploy" files, which use the naming pattern "deploy-<scenario-name>.json".
         continue;

--- a/common/changes/@microsoft/rush/master_2020-08-07-16-19.json
+++ b/common/changes/@microsoft/rush/master_2020-08-07-16-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Mac OS sometimes reported \"An unrecognized file .DS_Store was found in the Rush config folder\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Mac OS creates .DS_Store hidden files to track metadata for the Finder application.  Rush was complaining about those files.

@ARamachaHBO 