### PR TITLE
[heft] Fix source map paths

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -5,13 +5,15 @@ import * as path from 'path';
 import * as semver from 'semver';
 import {
   Colors,
+  Path,
   FileSystemStats,
   IFileSystemCreateLinkOptions,
   IColorableSequence,
   Terminal,
   ITerminalProvider,
   JsonFile,
-  IPackageJson
+  IPackageJson,
+  InternalError
 } from '@rushstack/node-core-library';
 import * as crypto from 'crypto';
 import { Typescript as TTypescript } from '@microsoft/rush-stack-compiler-3.7';
@@ -424,11 +426,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
 
     //#region EMIT
     const filesToWrite: IFileToWrite[] = [];
-    const writeFileCallback: TTypescript.WriteFileCallback = (filePath: string, data: string) => {
-      filesToWrite.push({ filePath, data });
-    };
-
-    const emitResult: IExtendedEmitResult = this._emit(ts, tsconfig, genericProgram, writeFileCallback);
+    const emitResult: IExtendedEmitResult = this._emit(ts, tsconfig, genericProgram, filesToWrite);
     //#endregion
 
     this._typescriptTerminal.writeVerboseLine(`Bind: ${ts.performance.getDuration('Bind')}ms`);
@@ -668,41 +666,43 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
     ts: ExtendedTypeScript,
     tsconfig: TTypescript.ParsedCommandLine,
     genericProgram: TTypescript.BuilderProgram | TTypescript.Program,
-    writeFile: TTypescript.WriteFileCallback
+    filesToWrite: IFileToWrite[]
   ): IExtendedEmitResult {
     let foundPrimary: boolean = false;
-    const moduleKindCompilerOptions: Map<TTypescript.ModuleKind, TTypescript.CompilerOptions> = new Map();
     let defaultModuleKind: TTypescript.ModuleKind;
-    for (const { moduleKind, cacheOutFolderPath, isPrimary } of this._moduleKindsToEmit) {
-      if (isPrimary) {
+
+    for (const moduleKindToEmit of this._moduleKindsToEmit) {
+      if (moduleKindToEmit.isPrimary) {
         if (foundPrimary) {
           throw new Error('Multiple primary module emit kinds encountered.');
         } else {
           foundPrimary = true;
         }
-
-        moduleKindCompilerOptions.set(moduleKind, {
-          ...tsconfig.options,
-          outDir: cacheOutFolderPath
-        });
-        defaultModuleKind = moduleKind;
-      } else {
-        moduleKindCompilerOptions.set(moduleKind, {
-          ...tsconfig.options,
-          outDir: cacheOutFolderPath,
-          module: moduleKind,
-
-          // Don't emit declarations or sourcemaps for secondary module kinds
-          declaration: false,
-          sourceMap: false,
-          declarationMap: false
-        });
+        defaultModuleKind = moduleKindToEmit.moduleKind;
       }
     }
 
     const baseEmitFiles: typeof ts.emitFiles = ts.emitFiles;
 
     const changedFiles: Set<IExtendedSourceFile> = new Set<IExtendedSourceFile>();
+
+    let originalOutDir: string | undefined = undefined;
+    let redirectedOutDir: string | undefined = undefined;
+    const writeFileCallback: TTypescript.WriteFileCallback = (filePath: string, data: string) => {
+      // Redirect from "path/to/lib" --> "path/to/.heft/build-cache/lib"
+      let redirectedFilePath: string = filePath;
+      if (redirectedOutDir !== undefined) {
+        if (Path.isUnderOrEqual(filePath, originalOutDir!)) {
+          redirectedFilePath = path.resolve(redirectedOutDir, path.relative(originalOutDir!, filePath));
+        } else {
+          // The compiler is writing some other output, for example:
+          // ./.heft/build-cache/ts_a7cd263b9f06b2440c0f2b2264746621c192f2e2.json
+        }
+      }
+
+      filesToWrite.push({ filePath: redirectedFilePath, data });
+    };
+
     // Override the underlying file emitter to run itself once for each flavor
     // This is a rather inelegant way to convince the TypeScript compiler not to duplicate parse/link/check
     ts.emitFiles = (
@@ -732,7 +732,29 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
 
         let defaultModuleKindResult: TTypescript.EmitResult;
         let emitSkipped: boolean = false;
-        for (const [moduleKind, compilerOptions] of moduleKindCompilerOptions.entries()) {
+        for (const moduleKindToEmit of this._moduleKindsToEmit) {
+          const compilerOptions: TTypescript.CompilerOptions = moduleKindToEmit.isPrimary
+            ? {
+                ...tsconfig.options
+              }
+            : {
+                ...tsconfig.options,
+                module: moduleKindToEmit.moduleKind,
+
+                // Don't emit declarations or sourcemaps for secondary module kinds
+                declaration: false,
+                sourceMap: false,
+                declarationMap: false
+              };
+
+          if (!compilerOptions.outDir) {
+            throw new InternalError('Expected compilerOptions.outDir to be assigned');
+          }
+
+          // Redirect from "path/to/lib" --> "path/to/.heft/build-cache/lib"
+          originalOutDir = compilerOptions.outDir;
+          redirectedOutDir = moduleKindToEmit.cacheOutFolderPath;
+
           const flavorResult: TTypescript.EmitResult = baseEmitFiles(
             resolver,
             {
@@ -747,9 +769,12 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
           );
 
           emitSkipped = emitSkipped || flavorResult.emitSkipped;
-          if (moduleKind === defaultModuleKind) {
+          if (moduleKindToEmit.moduleKind === defaultModuleKind) {
             defaultModuleKindResult = flavorResult;
           }
+
+          originalOutDir = undefined;
+          redirectedOutDir = undefined;
           // Should results be aggregated, in case for whatever reason the diagnostics are not the same?
         }
         return {
@@ -761,7 +786,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
 
     const result: TTypescript.EmitResult = genericProgram.emit(
       undefined, // Target source file
-      writeFile
+      writeFileCallback
     );
 
     ts.emitFiles = baseEmitFiles;

--- a/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
@@ -139,8 +139,4 @@ export interface IExtendedTypeScript {
   ): string;
 }
 
-export interface IExtendedEmitResult extends TTypescript.EmitResult {
-  changedSourceFiles: Set<IExtendedSourceFile>;
-}
-
 export type ExtendedTypeScript = typeof TTypescript & IExtendedTypeScript;

--- a/common/changes/@rushstack/heft/octogonz-heft-issue-2086_2020-08-10-05-47.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-issue-2086_2020-08-10-05-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where emitted .js.map sourcemaps had an incorrect relative path (GitHub #2086)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2086

The problem is that Heft was redirecting the **tsconfig.json** `"outDir"` setting in order to write files into `./.heft/build-cache/lib` instead of `./lib`, but this causes the source maps to have a relative path with an extra `../..`.

I solved it by preserving the real  `"outDir"`, and instead performing the mapping later inside the `writeFileCallback()` for `ts.Program.emit()`.

CC @iclanton 