### PR TITLE
[api-documenter] remove documenter plugin instanceof check

### DIFF
--- a/apps/api-documenter/src/plugin/PluginLoader.ts
+++ b/apps/api-documenter/src/plugin/PluginLoader.ts
@@ -89,9 +89,6 @@ export class PluginLoader {
             } catch (e) {
               throw new Error(`Failed to construct feature subclass:\n` + e.toString());
             }
-            if (!(markdownDocumenterFeature instanceof MarkdownDocumenterFeature)) {
-              throw new Error('The constructed subclass was not an instance of MarkdownDocumenterFeature');
-            }
 
             try {
               markdownDocumenterFeature.onInitialized();


### PR DESCRIPTION
this check fails when using a 3rd party plugin (probably due to the fact that the imports aren't the same).

When transposed to js the deleted code was turning into:

```js
if (!(markdownDocumenterFeature instanceof MarkdownDocumenterFeature_1.MarkdownDocumenterFeature)) {
    throw new Error('The constructed subclass was not an instance of MarkdownDocumenterFeature');
}
```

I tried to load the rushstack.io plugin from the outside to test and it was failing, throwing an error.