### PR TITLE
[rush] Fix an issue where "rushx" did not pass additional parameters to the shell script

### DIFF
--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -102,11 +102,17 @@ export class RushXCommandLine {
         return;
       }
 
-      console.log('Executing: ' + JSON.stringify(scriptBody) + os.EOL);
+      const remainingArgs: string[] = args.slice(1);
+      let commandWithArgs: string = scriptBody;
+      if (remainingArgs.length > 0) {
+        commandWithArgs += ' ' + remainingArgs.join(' ');
+      }
+
+      console.log('Executing: ' + JSON.stringify(commandWithArgs) + os.EOL);
 
       const packageFolder: string = path.dirname(packageJsonFilePath);
 
-      const exitCode: number = Utilities.executeLifecycleCommand(scriptBody, {
+      const exitCode: number = Utilities.executeLifecycleCommand(commandWithArgs, {
         rushConfiguration,
         workingDirectory: packageFolder,
         // If there is a rush.json then use its .npmrc from the temp folder.

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -19,4 +19,22 @@ describe('CLI', () => {
       });
     }).not.toThrow();
   });
+
+  it('rushx should pass args to scripts', () => {
+    // Invoke "rushx"
+    const startPath: string = path.resolve(path.join(__dirname, '../../../lib/startx.js'));
+
+    // Run "rushx show-args 1 2 -x" in the "repo/rushx-project" folder
+    const output: string = Utilities.executeCommandAndCaptureOutput(
+      'node',
+      [startPath, 'show-args', '1', '2', '-x'],
+      path.join(__dirname, 'repo', 'rushx-project')
+    );
+    const lastLine: string =
+      output
+        .split(/\s*\n\s*/)
+        .filter((x) => x)
+        .pop() || '';
+    expect(lastLine).toEqual('build.js: ARGS=[]');
+  });
 });

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -35,6 +35,6 @@ describe('CLI', () => {
         .split(/\s*\n\s*/)
         .filter((x) => x)
         .pop() || '';
-    expect(lastLine).toEqual('build.js: ARGS=[]');
+    expect(lastLine).toEqual('build.js: ARGS=["1","2","-x"]');
   });
 });

--- a/apps/rush-lib/src/cli/test/repo/rushx-project/build.js
+++ b/apps/rush-lib/src/cli/test/repo/rushx-project/build.js
@@ -1,0 +1,2 @@
+// slice(2) trims away "node.exe" and "build.js" from the array
+console.log('build.js: ARGS=' + JSON.stringify(process.argv.slice(2)));

--- a/apps/rush-lib/src/cli/test/repo/rushx-project/package.json
+++ b/apps/rush-lib/src/cli/test/repo/rushx-project/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rushx-project",
+  "version": "0.0.0",
+  "scripts": {
+    "show-args": "node ./build.js"
+  }
+}

--- a/apps/rush-lib/src/startx.ts
+++ b/apps/rush-lib/src/startx.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Rush } from './api/Rush';
+
+Rush.launchRushX(Rush.version, { isManaged: false });

--- a/common/changes/@microsoft/rush/octogonz-better-rushx_2020-08-12-07-58.json
+++ b/common/changes/@microsoft/rush/octogonz-better-rushx_2020-08-12-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rushx\" did not pass additional command-line arguments to the package.json script (GitHub #1232)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/1232

Consider this script:

**package.json**
```js
   . . .
  "scripts": {
    "build": "rm -f lib && node ./build.js"
  }
   . . .
```

Suppose that you invoke this command:
```
$ rushx build a b c --production
```

BEFORE this PR, the shell would execute: `rm -f lib && node ./build.js`

AFTER this PR, the shell will execute: `rm -f lib && node ./build.js a b c --production`

Ideally we want a different design, where `rushx` has full syntax validation and `--help` for every parameter.  But until that ideal is realized, this PR lets people pass subcommands to their shell scripts similar to how NPM and Yarn do.