### PR TITLE
[rush] install-run.js should set PATH correctly on Windows

### DIFF
--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -445,13 +445,12 @@ export function installAndRun(
 
   const binPath: string = _getBinPath(packageInstallFolder, packageBinName);
   const binFolderPath: string = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
+  process.env.PATH = [binFolderPath, process.env.PATH].join(path.delimiter);
+
   const result: childProcess.SpawnSyncReturns<Buffer> = childProcess.spawnSync(binPath, packageBinArgs, {
     stdio: 'inherit',
     cwd: process.cwd(),
-    env: {
-      ...process.env,
-      PATH: [binFolderPath, process.env.PATH].join(path.delimiter)
-    }
+    env: process.env
   });
 
   if (result.status !== null) {

--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -445,14 +445,21 @@ export function installAndRun(
 
   const binPath: string = _getBinPath(packageInstallFolder, packageBinName);
   const binFolderPath: string = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
-  process.env.PATH = [binFolderPath, process.env.PATH].join(path.delimiter);
 
-  const result: childProcess.SpawnSyncReturns<Buffer> = childProcess.spawnSync(binPath, packageBinArgs, {
-    stdio: 'inherit',
-    cwd: process.cwd(),
-    env: process.env
-  });
-
+  // Windows environment variables are case-insensitive.  Instead of using SpawnSyncOptions.env, we need to
+  // assign via the process.env proxy to ensure that we append to the right PATH key.
+  const originalEnvPath: string = process.env.PATH || '';
+  let result: childProcess.SpawnSyncReturns<Buffer>;
+  try {
+    process.env.PATH = [binFolderPath, originalEnvPath].join(path.delimiter);
+    result = childProcess.spawnSync(binPath, packageBinArgs, {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+      env: process.env
+    });
+  } finally {
+    process.env.PATH = originalEnvPath;
+  }
   if (result.status !== null) {
     return result.status;
   } else {

--- a/common/changes/@microsoft/rush/master_2020-08-13-00-46.json
+++ b/common/changes/@microsoft/rush/master_2020-08-13-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Set PATH explicitly and let NodeJS take care of OS-specific case handling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "crhaglun@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2020-08-13-00-46.json
+++ b/common/changes/@microsoft/rush/master_2020-08-13-00-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Set PATH explicitly and let NodeJS take care of OS-specific case handling",
+      "comment": "Fix an issue where install-run.js sometimes assigned the shell PATH incorrectly due to inconsistent character case",
       "type": "none"
     }
   ],


### PR DESCRIPTION
We've observed an interesting bug on some Windows systems where the current approach leads to the environment having _two_ path variables declared, differing only in case (``PATH`` and ``Path``). 

This appears to cause various downstream issues, such as some (but not all) ``git`` commands failing; see #2097 

I can't claim to understand this fully, but leaving it to NodeJS to handle the OS-dependent details around case-sensitivity/insensitivity of environment variables appears to do the trick!