### PR TITLE
[Heft] Fix an issue with incorrect sourcemaps for Jest

### DIFF
--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@jest/core": "~25.4.0",
     "@jest/reporters": "~25.4.0",
+    "@jest/transform": "~25.4.0",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",
     "@types/tapable": "1.0.5",

--- a/apps/heft/src/cli/actions/BuildAction.ts
+++ b/apps/heft/src/cli/actions/BuildAction.ts
@@ -45,6 +45,11 @@ export class BuildAction extends HeftActionBase {
   }
 
   protected async actionExecuteAsync(): Promise<void> {
+    await this.runCleanIfRequestedAsync();
+    await this.runBuildAsync();
+  }
+
+  protected async runCleanIfRequestedAsync(): Promise<void> {
     if (this._cleanFlag.value) {
       const cleanStage: CleanStage = this.stages.cleanStage;
       const cleanStageOptions: ICleanStageOptions = {};
@@ -56,7 +61,9 @@ export class BuildAction extends HeftActionBase {
         async () => await cleanStage.executeAsync()
       );
     }
+  }
 
+  protected async runBuildAsync(): Promise<void> {
     const buildStage: BuildStage = this.stages.buildStage;
     const buildStageOptions: IBuildStageOptions = {
       ...BuildStage.getOptionsFromStandardParameters(this._buildStandardParameters),

--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -67,10 +67,11 @@ export class TestAction extends BuildAction {
       await testStage.initializeAsync(testStageOptions);
 
       if (watchMode) {
+        await this.runCleanIfRequestedAsync();
+
         // In --watch mode, kick off all stages concurrently with the expectation that the their
         // promises will never resolve and that they will handle watching filesystem changes
-
-        await Promise.all([super.actionExecuteAsync(), testStage.executeAsync()]);
+        await Promise.all([this.runBuildAsync(), testStage.executeAsync()]);
       } else {
         if (shouldBuild) {
           await super.actionExecuteAsync();

--- a/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
@@ -40,7 +40,11 @@ export class JestPlugin implements IHeftPlugin {
   ): Promise<void> {
     const buildFolder: string = heftConfiguration.buildFolder;
 
-    this._validateJestTypeScriptDataFile(buildFolder);
+    // In watch mode, Jest starts up in parallel with the compiler, so there's no
+    // guarantee that the output files would have been written yet.
+    if (!test.properties.watchMode) {
+      this._validateJestTypeScriptDataFile(buildFolder);
+    }
 
     const reporterOptions: IHeftJestReporterOptions = { heftConfiguration };
     const { results: jestResults } = await runCLI(

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -548,24 +548,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
             );
 
             for (const { cacheOutFolderPath, outFolderPath, isPrimary } of this._moduleKindsToEmit) {
+              // Only primary module kinds emit declarations
               if (isPrimary) {
-                // Only primary module kinds emit declarations and sourcemaps
-                if (tsconfig.options.declaration) {
-                  const dtsFilename: string = `${relativeFilenameWithoutExtension}.d.ts`;
-                  queueLinkOrCopy({
-                    linkTargetPath: path.join(cacheOutFolderPath, dtsFilename),
-                    newLinkPath: path.join(outFolderPath, dtsFilename)
-                  });
-                }
-
-                if (tsconfig.options.sourceMap && !sourceFile.isDeclarationFile) {
-                  const jsMapFilename: string = `${relativeFilenameWithoutExtension}.js.map`;
-                  queueLinkOrCopy({
-                    linkTargetPath: path.join(cacheOutFolderPath, jsMapFilename),
-                    newLinkPath: path.join(outFolderPath, jsMapFilename)
-                  });
-                }
-
                 if (tsconfig.options.declarationMap) {
                   const dtsMapFilename: string = `${relativeFilenameWithoutExtension}.d.ts.map`;
                   queueLinkOrCopy({
@@ -573,8 +557,25 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
                     newLinkPath: path.join(outFolderPath, dtsMapFilename)
                   });
                 }
+
+                if (tsconfig.options.declaration) {
+                  const dtsFilename: string = `${relativeFilenameWithoutExtension}.d.ts`;
+                  queueLinkOrCopy({
+                    linkTargetPath: path.join(cacheOutFolderPath, dtsFilename),
+                    newLinkPath: path.join(outFolderPath, dtsFilename)
+                  });
+                }
               }
 
+              if (tsconfig.options.sourceMap && !sourceFile.isDeclarationFile) {
+                const jsMapFilename: string = `${relativeFilenameWithoutExtension}.js.map`;
+                queueLinkOrCopy({
+                  linkTargetPath: path.join(cacheOutFolderPath, jsMapFilename),
+                  newLinkPath: path.join(outFolderPath, jsMapFilename)
+                });
+              }
+
+              // Write the .js file last in case something is watching its timestamp
               if (!sourceFile.isDeclarationFile) {
                 const jsFilename: string = `${relativeFilenameWithoutExtension}.js`;
                 queueLinkOrCopy({
@@ -747,9 +748,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
                 ...tsconfig.options,
                 module: moduleKindToEmit.moduleKind,
 
-                // Don't emit declarations or sourcemaps for secondary module kinds
+                // Don't emit declarations for secondary module kinds
                 declaration: false,
-                sourceMap: false,
                 declarationMap: false
               };
 

--- a/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-01-48.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-01-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue with incorrect source maps for the Jest transform",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-04-10.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-04-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix a watch mode race condition where \"--clean\" ran in parallel with \"heft test\" (GitHub #2078)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-04-12.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-source-maps_2020-08-13-04-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where \"The transpiler output folder does not exist\" was sometimes printed erroneously",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -11,6 +11,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@jest/transform",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@jest/types",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
     dependencies:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
+      '@jest/transform': 25.4.0
       '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
       '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
       '@types/tapable': 1.0.5
@@ -125,6 +126,7 @@ importers:
     specifiers:
       '@jest/core': ~25.4.0
       '@jest/reporters': ~25.4.0
+      '@jest/transform': ~25.4.0
       '@jest/types': ~25.4.0
       '@microsoft/rush-stack-compiler-3.7': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
@@ -2425,6 +2427,29 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==
+  /@jest/transform/25.4.0:
+    dependencies:
+      '@babel/core': 7.10.5
+      '@jest/types': 25.4.0
+      babel-plugin-istanbul: 6.0.0
+      chalk: 3.0.0
+      convert-source-map: 1.7.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.4
+      jest-haste-map: 25.5.1
+      jest-regex-util: 25.2.6
+      jest-util: 25.5.0
+      micromatch: 4.0.2
+      pirates: 4.0.1
+      realpath-native: 2.0.0
+      slash: 3.0.0
+      source-map: 0.6.1
+      write-file-atomic: 3.0.3
+    dev: false
+    engines:
+      node: '>= 8.3'
+    resolution:
+      integrity: sha512-t1w2S6V1sk++1HHsxboWxPEuSpN8pxEvNrZN+Ud/knkROWtf8LeUmz73A4ezE8476a5AM00IZr9a8FO9x1+j3g==
   /@jest/transform/25.5.1:
     dependencies:
       '@babel/core': 7.10.5

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "dff8dec2429efc5f93d8c978a4c1618a52f8fe94",
+  "pnpmShrinkwrapHash": "b96b493cb3b474b9ceec522555873203b8e95f68",
   "preferredVersionsHash": "334ea62b6a2798dcf80917b79555983377e7435e"
 }


### PR DESCRIPTION
Several Jest fixes
- Incorrect source maps
- `heft test --clean watch` error 
- Spurious `"The transpiler output folder does not exist"` error

Fixes https://github.com/microsoft/rushstack/issues/2078
