### PR TITLE
[Heft] Improve TypeScript/Jest interaction in watch mode

### DIFF
--- a/apps/heft/.vscode/launch.json
+++ b/apps/heft/.vscode/launch.json
@@ -28,7 +28,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "heft-node-basic-test build",
+      "name": "node-basic build",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/heft-node-basic-test/",
       "args": ["--debug", "build", "--clean"],
@@ -38,7 +38,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "heft-node-basic-test test",
+      "name": "node-basic test",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/heft-node-basic-test/",
       "args": ["--debug", "test", "--clean"],
@@ -48,7 +48,17 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "heft-webpack-basic-test build",
+      "name": "node-basic test --watch",
+      "program": "${workspaceFolder}/lib/start.js",
+      "cwd": "${workspaceFolder}/../../build-tests/heft-node-basic-test/",
+      "args": ["--debug", "test", "--watch", "--clean"],
+      "console": "integratedTerminal",
+      "sourceMaps": false
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "webpack-basic build",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/heft-webpack-basic-test/",
       "args": ["--debug", "build", "--clean"],
@@ -58,10 +68,20 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "heft-webpack-basic-test test",
+      "name": "webpack-basic test",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/heft-webpack-basic-test/",
       "args": ["--debug", "test", "--clean"],
+      "console": "integratedTerminal",
+      "sourceMaps": false
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "webpack-basic start",
+      "program": "${workspaceFolder}/lib/start.js",
+      "cwd": "${workspaceFolder}/../../build-tests/heft-webpack-basic-test/",
+      "args": ["--debug", "start", "--clean"],
       "console": "integratedTerminal",
       "sourceMaps": false
     }

--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { Path, FileSystem } from '@rushstack/node-core-library';
+import { Path, FileSystem, FileSystemStats } from '@rushstack/node-core-library';
 import { InitialOptionsWithRootDir } from '@jest/types/build/Config';
 import { TransformedSource } from '@jest/transform';
 
@@ -11,6 +11,11 @@ import { JestTypeScriptDataFile, IJestTypeScriptDataFileJson } from './JestTypeS
 // This caches jest-typescript-data.json file contents.
 // Map from jestOptions.rootDir --> IJestTypeScriptDataFileJson
 const dataFileJsonCache: Map<string, IJestTypeScriptDataFileJson> = new Map();
+
+// Synchronous delay that doesn't burn CPU cycles
+function delayMs(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
 
 /**
  * This Jest transformer maps TS files under a 'src' folder to their compiled equivalent under 'lib'
@@ -34,34 +39,94 @@ export function process(
   const srcFolder: string = path.join(jestOptions.rootDir, 'src');
 
   if (Path.isUnder(filename, srcFolder)) {
+    const srcFilePath: string = filename;
+
     // Example: /path/to/project/src/folder1/folder2/Example.ts
-    const parsedFilename: path.ParsedPath = path.parse(filename);
+    const parsedFilename: path.ParsedPath = path.parse(srcFilePath);
 
     // Example: folder1/folder2
     const srcRelativeFolderPath: string = path.relative(srcFolder, parsedFilename.dir);
 
     // Example: /path/to/project/lib/folder1/folder2/Example.js
-    const libFilename: string = path.join(
+    const libFilePath: string = path.join(
       jestOptions.rootDir,
       jestTypeScriptDataFile.emitFolderPathForJest,
       srcRelativeFolderPath,
       `${parsedFilename.name}.js`
     );
 
+    const startOfLoopMs: number = new Date().getTime();
+    let stalled: boolean = false;
+
+    for (;;) {
+      let srcFileStatistics: FileSystemStats;
+      try {
+        srcFileStatistics = FileSystem.getStatistics(srcFilePath);
+      } catch {
+        // If the source file was deleted, then fall through and allow readFile() to fail
+        break;
+      }
+      let libFileStatistics: FileSystemStats | undefined = undefined;
+      try {
+        libFileStatistics = FileSystem.getStatistics(libFilePath);
+      } catch {
+        // ignore errors
+      }
+
+      const nowMs: number = new Date().getTime();
+      if (libFileStatistics) {
+        // The lib/*.js timestamp must not be older than the src/*.ts timestamp, otherwise the transpiler
+        // is not done writing its outputs.
+        if (libFileStatistics.ctimeMs + 15 - srcFileStatistics.ctimeMs > 0) {
+          // allow 100ms of slop for clock issues
+          // Also, the lib/*.js timestamp must not be too recent, otherwise the transpiler may not have
+          // finished flushing its output to disk.
+          if (nowMs > libFileStatistics.ctimeMs + 500) {
+            // The .js file is newer than the .ts file, and is old enough to have been flushed
+            break;
+          }
+        }
+      }
+
+      if (nowMs - startOfLoopMs > 4000) {
+        // Something is wrong -- why hasn't the compiler updated the .js file?
+        if (libFileStatistics) {
+          throw new Error(
+            'jest-build-transform: Gave up waiting for the transpiler to update its output file:\n' +
+              libFilePath
+          );
+        } else {
+          throw new Error(
+            'jest-build-transform: Gave up waiting for the transpiler to write its output file:\n' +
+              libFilePath
+          );
+        }
+      }
+
+      // Jest's transforms are synchronous, so our only option here is to sleep synchronously. Bad Jest. :-(
+      // TODO: The better solution is to change how Jest's watch loop is notified.
+      stalled = true;
+      delayMs(100);
+    }
+    if (stalled) {
+      const nowMs: number = new Date().getTime();
+      console.log(`Waited ${nowMs - startOfLoopMs} ms for .js file`);
+    }
+
     let code: string;
     try {
-      code = FileSystem.readFile(libFilename);
+      code = FileSystem.readFile(libFilePath);
     } catch (error) {
       if (FileSystem.isNotExistError(error)) {
         throw new Error(
-          'jest-build-transform: The expected transpiler output file does not exist:\n' + libFilename
+          'jest-build-transform: The expected transpiler output file does not exist:\n' + libFilePath
         );
       } else {
         throw error;
       }
     }
 
-    const sourceMapFilename: string = libFilename + '.map';
+    const sourceMapFilename: string = libFilePath + '.map';
 
     let sourceMap: string;
     try {

--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -79,7 +79,7 @@ export function process(
       if (libFileStatistics) {
         // The lib/*.js timestamp must not be older than the src/*.ts timestamp, otherwise the transpiler
         // is not done writing its outputs.
-        if (libFileStatistics.ctimeMs + 15 - srcFileStatistics.ctimeMs > 0) {
+        if (libFileStatistics.ctimeMs + 15 > srcFileStatistics.ctimeMs) {
           // allow 100ms of slop for clock issues
           // Also, the lib/*.js timestamp must not be too recent, otherwise the transpiler may not have
           // finished flushing its output to disk.

--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -17,6 +17,8 @@ function delayMs(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
+const DEBUG_TRANSFORM: boolean = false;
+
 /**
  * This Jest transformer maps TS files under a 'src' folder to their compiled equivalent under 'lib'
  */
@@ -108,9 +110,11 @@ export function process(
       stalled = true;
       delayMs(100);
     }
-    if (stalled) {
+
+    if (stalled && DEBUG_TRANSFORM) {
       const nowMs: number = new Date().getTime();
       console.log(`Waited ${nowMs - startOfLoopMs} ms for .js file`);
+      delayMs(2000);
     }
 
     let code: string;

--- a/apps/heft/src/plugins/TypeScriptPlugin/EmitFilesPatch.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/EmitFilesPatch.ts
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { Path, InternalError } from '@rushstack/node-core-library';
+import { Typescript as TTypescript } from '@microsoft/rush-stack-compiler-3.7';
+import {
+  ExtendedTypeScript,
+  IEmitResolver,
+  IEmitHost,
+  IEmitTransformers,
+  IExtendedSourceFile
+} from './internalTypings/TypeScriptInternals';
+import { IEmitModuleKindBase } from '../../stages/BuildStage';
+
+export interface ICachedEmitModuleKind<TModuleKind> extends IEmitModuleKindBase<TModuleKind> {
+  /**
+   * TypeScript's output is placed in the \<project root\>/.heft/build-cache folder.
+   * This is the the path to the subfolder in the build-cache folder that this emit kind
+   * written to.
+   */
+  cacheOutFolderPath: string;
+
+  /**
+   * Set to true if this is the emit kind that is specified in the tsconfig.json.
+   * Sourcemaps and declarations are only emitted for the primary module kind.
+   */
+  isPrimary: boolean;
+}
+
+export class EmitFilesPatch {
+  private static _patchedTs: ExtendedTypeScript | undefined = undefined;
+
+  // eslint-disable-next-line
+  private static _baseEmitFiles: any | undefined = undefined;
+
+  private static _originalOutDir: string | undefined = undefined;
+  private static _redirectedOutDir: string | undefined = undefined;
+
+  public static install(
+    ts: ExtendedTypeScript,
+    tsconfig: TTypescript.ParsedCommandLine,
+    moduleKindsToEmit: ICachedEmitModuleKind<TTypescript.ModuleKind>[],
+    changedFiles: Set<IExtendedSourceFile>
+  ): void {
+    if (EmitFilesPatch._patchedTs !== undefined) {
+      throw new Error(
+        'EmitFilesPatch.install() cannot be called without first uninstalling the existing patch'
+      );
+    }
+    EmitFilesPatch._patchedTs = ts;
+    EmitFilesPatch._baseEmitFiles = ts.emitFiles;
+
+    let foundPrimary: boolean = false;
+    let defaultModuleKind: TTypescript.ModuleKind;
+
+    for (const moduleKindToEmit of moduleKindsToEmit) {
+      if (moduleKindToEmit.isPrimary) {
+        if (foundPrimary) {
+          throw new Error('Multiple primary module emit kinds encountered.');
+        } else {
+          foundPrimary = true;
+        }
+        defaultModuleKind = moduleKindToEmit.moduleKind;
+      }
+    }
+
+    // Override the underlying file emitter to run itself once for each flavor
+    // This is a rather inelegant way to convince the TypeScript compiler not to duplicate parse/link/check
+    ts.emitFiles = (
+      resolver: IEmitResolver,
+      host: IEmitHost,
+      targetSourceFile: IExtendedSourceFile | undefined,
+      emitTransformers: IEmitTransformers,
+      emitOnlyDtsFiles?: boolean,
+      onlyBuildInfo?: boolean,
+      forceDtsEmit?: boolean
+    ): TTypescript.EmitResult => {
+      if (onlyBuildInfo || emitOnlyDtsFiles) {
+        // There should only be one tsBuildInfo and one set of declaration files
+        return EmitFilesPatch._baseEmitFiles(
+          resolver,
+          host,
+          targetSourceFile,
+          emitTransformers,
+          emitOnlyDtsFiles,
+          onlyBuildInfo,
+          forceDtsEmit
+        );
+      } else {
+        if (targetSourceFile) {
+          changedFiles.add(targetSourceFile);
+        }
+
+        let defaultModuleKindResult: TTypescript.EmitResult;
+        let emitSkipped: boolean = false;
+        for (const moduleKindToEmit of moduleKindsToEmit) {
+          const compilerOptions: TTypescript.CompilerOptions = moduleKindToEmit.isPrimary
+            ? {
+                ...tsconfig.options
+              }
+            : {
+                ...tsconfig.options,
+                module: moduleKindToEmit.moduleKind,
+
+                // Don't emit declarations for secondary module kinds
+                declaration: false,
+                declarationMap: false
+              };
+
+          if (!compilerOptions.outDir) {
+            throw new InternalError('Expected compilerOptions.outDir to be assigned');
+          }
+
+          // Redirect from "path/to/lib" --> "path/to/.heft/build-cache/lib"
+          EmitFilesPatch._originalOutDir = compilerOptions.outDir;
+          EmitFilesPatch._redirectedOutDir = moduleKindToEmit.cacheOutFolderPath;
+
+          const flavorResult: TTypescript.EmitResult = EmitFilesPatch._baseEmitFiles(
+            resolver,
+            {
+              ...host,
+              getCompilerOptions: () => compilerOptions
+            },
+            targetSourceFile,
+            ts.getTransformers(compilerOptions, undefined, emitOnlyDtsFiles),
+            emitOnlyDtsFiles,
+            onlyBuildInfo,
+            forceDtsEmit
+          );
+
+          emitSkipped = emitSkipped || flavorResult.emitSkipped;
+          if (moduleKindToEmit.moduleKind === defaultModuleKind) {
+            defaultModuleKindResult = flavorResult;
+          }
+
+          EmitFilesPatch._originalOutDir = undefined;
+          EmitFilesPatch._redirectedOutDir = undefined;
+          // Should results be aggregated, in case for whatever reason the diagnostics are not the same?
+        }
+        return {
+          ...defaultModuleKindResult!,
+          emitSkipped
+        };
+      }
+    };
+  }
+
+  public static getRedirectedFilePath(filePath: string): string {
+    // Redirect from "path/to/lib" --> "path/to/.heft/build-cache/lib"
+    let redirectedFilePath: string = filePath;
+    if (EmitFilesPatch._redirectedOutDir !== undefined) {
+      if (Path.isUnderOrEqual(filePath, EmitFilesPatch._originalOutDir!)) {
+        redirectedFilePath = path.resolve(
+          EmitFilesPatch._redirectedOutDir,
+          path.relative(EmitFilesPatch._originalOutDir!, filePath)
+        );
+      } else {
+        // The compiler is writing some other output, for example:
+        // ./.heft/build-cache/ts_a7cd263b9f06b2440c0f2b2264746621c192f2e2.json
+      }
+    }
+    return redirectedFilePath;
+  }
+
+  public static uninstall(ts: ExtendedTypeScript): void {
+    if (EmitFilesPatch._patchedTs === undefined) {
+      throw new Error('EmitFilesPatch.uninstall() cannot be called if no patch was installed');
+    }
+    if (ts !== EmitFilesPatch._patchedTs) {
+      throw new Error('EmitFilesPatch.uninstall() called for the wrong object');
+    }
+
+    ts.emitFiles = EmitFilesPatch._baseEmitFiles;
+
+    EmitFilesPatch._patchedTs = undefined;
+    EmitFilesPatch._baseEmitFiles = undefined;
+  }
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-47.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix a race condition where .js files were sometimes read by Jest before they were written by TypeScript",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-50.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where the TypeScript incremental build cache sometimes did not work correctly in \"--watch\" mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-51.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-transform-race_2020-08-13-08-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add support for \"additionalModuleKindsToEmit\" in watch mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
- Fix a race condition where .js files were sometimes read by Jest before they were written by TypeScript
- Disable the build cache in watch mode
- Add support for `additionalModuleKindsToEmit` in watch mode