### PR TITLE
[Module Minifier Plugin] Fix issue with missing module ids at start of array

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/dmichon-concat-start_2020-08-14-23-10.json
+++ b/common/changes/@rushstack/module-minifier-plugin/dmichon-concat-start_2020-08-14-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Fix handling of missing leading ids",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/webpack/module-minifier-plugin/config/jest.config.json
+++ b/webpack/module-minifier-plugin/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/webpack/module-minifier-plugin/src/RehydrateAsset.ts
+++ b/webpack/module-minifier-plugin/src/RehydrateAsset.ts
@@ -105,7 +105,7 @@ export function rehydrateAsset(asset: IAssetInfo, moduleMap: IModuleMap, banner:
     const enoughCommas: string = ',,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,';
 
     const useConcatAtStart: boolean = useConcat && minId > 8;
-    lastId = useConcat ? minId : 0;
+    lastId = useConcatAtStart ? minId : 0;
     // TODO: Just because we want to use concat elsewhere doesn't mean its optimal to use at the start
     let separator: string = useConcatAtStart ? `Array(${minId}).concat([` : '[';
     let concatInserted: boolean = useConcatAtStart;

--- a/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
+++ b/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
@@ -177,6 +177,24 @@ describe('rehydrateAsset', () => {
     }
   });
 
+  it('supports a concat spacer and leading ids', () => {
+    const asset: IAssetInfo = {
+      source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
+      modules: [2, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
+      extractedComments: [],
+      fileName: 'test',
+      chunk: undefined!,
+      externalNames: new Map()
+    };
+
+    const result: string = rehydrateAsset(asset, modules, banner).source();
+    const expected: string = `/* fnord */\n<before>[,,buzz].concat(Array(997),[b1000,b1001,b1002,b1003,b1004,b1005,b1006,b1007,b1008,b1009])<after>`;
+
+    if (result !== expected) {
+      throw new Error(`Expected ${expected} but received ${result}`);
+    }
+  });
+
   it('reprocesses external names', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),


### PR DESCRIPTION
When `useConcat` is enabled during asset rehydration, but there are ids between 0 and `minId`, the array is improperly constructed. Specifically, the leading elements are omitted completely, resulting in a shift to all ids in the array.