### PR TITLE
[rush] Load and validate local projects lazily

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -998,6 +998,8 @@ export class RushConfiguration {
 
   /**
    * Gets the JSON data structure for the "rush.json" configuration file.
+   *
+   * @internal
    */
   public get rushConfigurationJson(): IRushConfigurationJson {
     return this._rushConfigurationJson;

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -450,9 +450,7 @@ export class RushConfiguration {
   private _allowMostlyStandardPackageNames: boolean;
   private _ensureConsistentVersions: boolean;
   private _suppressNodeLtsWarning: boolean;
-  private _variants: {
-    [variantName: string]: boolean;
-  };
+  private _variants: Set<string>;
 
   // "approvedPackagesPolicy" feature
   private _approvedPackagesPolicy: ApprovedPackagesPolicy;
@@ -698,23 +696,19 @@ export class RushConfiguration {
     );
     this._versionPolicyConfiguration = new VersionPolicyConfiguration(versionPolicyConfigFile);
 
-    const variants: {
-      [variantName: string]: boolean;
-    } = {};
+    this._variants = new Set<string>();
 
     if (rushConfigurationJson.variants) {
       for (const variantOptions of rushConfigurationJson.variants) {
         const { variantName } = variantOptions;
 
-        if (variants[variantName]) {
+        if (this._variants.has(variantName)) {
           throw new Error(`Duplicate variant named '${variantName}' specified in configuration.`);
         }
 
-        variants[variantName] = true;
+        this._variants.add(variantName);
       }
     }
-
-    this._variants = variants;
   }
 
   private _initializeAndValidateLocalProjects(): void {
@@ -1499,11 +1493,11 @@ export class RushConfiguration {
    */
   public getCommittedShrinkwrapFilename(variant?: string | undefined): string {
     if (variant) {
-      if (!this._variants[variant]) {
+      if (!this._variants.has(variant)) {
         throw new Error(
           `Invalid variant name '${variant}'. The provided variant parameter needs to be ` +
             `one of the following from rush.json: ` +
-            `${Object.keys(this._variants)
+            `${Array.from(this._variants.values())
               .map((name: string) => `"${name}"`)
               .join(', ')}.`
         );
@@ -1625,11 +1619,11 @@ export class RushConfiguration {
 
   private _getVariantConfigFolderPath(variant?: string | undefined): string {
     if (variant) {
-      if (!this._variants[variant]) {
+      if (!this._variants.has(variant)) {
         throw new Error(
           `Invalid variant name '${variant}'. The provided variant parameter needs to be ` +
             `one of the following from rush.json: ` +
-            `${Object.keys(this._variants)
+            `${Array.from(this._variants.values())
               .map((name: string) => `"${name}"`)
               .join(', ')}.`
         );

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -223,9 +223,7 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const scopedNames: string[] = [];
 
-    const projectJsons: IRushConfigurationProjectJson[] = this.rushConfiguration.rushConfigurationJson.projects.slice(
-      0
-    );
+    const projectJsons: IRushConfigurationProjectJson[] = [...this.rushConfiguration.rushConfigurationJson.projects];
 
     for (const projectJson of projectJsons) {
       scopedNames.push(projectJson.packageName);

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -24,6 +24,7 @@ import { Utilities } from '../../utilities/Utilities';
 import { RushConstants } from '../../logic/RushConstants';
 import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
 import { LastLinkFlag, LastLinkFlagFactory } from '../../api/LastLinkFlag';
+import { IRushConfigurationProjectJson } from '../../api/RushConfigurationProject';
 
 /**
  * Constructor parameters for BulkScriptAction.
@@ -221,10 +222,14 @@ export class BulkScriptAction extends BaseScriptAction {
     const unscopedNamesMap: Map<string, number> = new Map<string, number>();
 
     const scopedNames: string[] = [];
-    for (const project of this.rushConfiguration.projects) {
-      scopedNames.push(project.packageName);
 
-      const unscopedName: string = PackageName.getUnscopedName(project.packageName);
+    const projectJsons: IRushConfigurationProjectJson[] = this.rushConfiguration.rushConfigurationJson.projects.slice(
+      0
+    );
+
+    for (const projectJson of projectJsons) {
+      scopedNames.push(projectJson.packageName);
+      const unscopedName: string = PackageName.getUnscopedName(projectJson.packageName);
       let count: number = 0;
       if (unscopedNamesMap.has(unscopedName)) {
         count = unscopedNamesMap.get(unscopedName)!;

--- a/common/changes/@microsoft/rush/sachinjoseph-lazyLoadLocalProjects_2020-08-19-18-36.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-lazyLoadLocalProjects_2020-08-19-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Load and validate local projects lazily to further improve Rush startup times.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/sachinjoseph-lazyLoadLocalProjects_2020-08-19-18-36.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-lazyLoadLocalProjects_2020-08-19-18-36.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Load and validate local projects lazily to further improve Rush startup times.",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/rush",

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -375,6 +375,7 @@ export class RushConfiguration {
     readonly repositoryDefaultFullyQualifiedRemoteBranch: string;
     readonly repositoryDefaultRemote: string;
     readonly repositoryUrl: string | undefined;
+    // @internal
     readonly rushConfigurationJson: IRushConfigurationJson;
     readonly rushJsonFile: string;
     readonly rushJsonFolder: string;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -375,6 +375,7 @@ export class RushConfiguration {
     readonly repositoryDefaultFullyQualifiedRemoteBranch: string;
     readonly repositoryDefaultRemote: string;
     readonly repositoryUrl: string | undefined;
+    readonly rushConfigurationJson: IRushConfigurationJson;
     readonly rushJsonFile: string;
     readonly rushJsonFolder: string;
     // @deprecated


### PR DESCRIPTION
This further improves Rush startup times, especially on large monorepos with hundreds of projects.