### PR TITLE
[heft] Add the --notest parameter back to heft test, omitted from documentation.

### DIFF
--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -37,7 +37,8 @@ export class TestAction extends BuildAction {
 
     this._noTestFlag = this.defineFlagParameter({
       parameterLongName: '--no-test',
-      description: 'If specified, run the build without testing.'
+      description: 'If specified, run the build without testing.',
+      undocumentedSynonyms: ['--notest'] // To be removed
     });
 
     this._noBuildFlag = this.defineFlagParameter({

--- a/common/changes/@rushstack/debug-certificate-manager/ianc-heft-notest_2020-08-20-06-44.json
+++ b/common/changes/@rushstack/debug-certificate-manager/ianc-heft-notest_2020-08-20-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ianc-heft-notest_2020-08-20-06-44.json
+++ b/common/changes/@rushstack/heft/ianc-heft-notest_2020-08-20-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add the --notest parameter back to \"heft test\" temporarily.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/package-deps-hash/ianc-heft-notest_2020-08-20-06-44.json
+++ b/common/changes/@rushstack/package-deps-hash/ianc-heft-notest_2020-08-20-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/stream-collator/ianc-heft-notest_2020-08-20-06-44.json
+++ b/common/changes/@rushstack/stream-collator/ianc-heft-notest_2020-08-20-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/stream-collator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/stream-collator",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/ianc-heft-notest_2020-08-20-06-44.json
+++ b/common/changes/@rushstack/ts-command-line/ianc-heft-notest_2020-08-20-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Add a feature for specifying \"undocumented synonyms\" for parameters.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -96,6 +96,7 @@ export abstract class CommandLineParameter {
     // @internal
     abstract _setValue(data: any): void;
     readonly shortName: string | undefined;
+    readonly undocumentedSynonyms: string[] | undefined;
     // (undocumented)
     protected validateDefaultValue(hasDefaultValue: boolean): void;
 }
@@ -217,6 +218,7 @@ export interface IBaseCommandLineDefinition {
     parameterLongName: string;
     parameterShortName?: string;
     required?: boolean;
+    undocumentedSynonyms?: string[];
 }
 
 // @public

--- a/libraries/debug-certificate-manager/config/jest.config.json
+++ b/libraries/debug-certificate-manager/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/libraries/debug-certificate-manager/config/jest.json
+++ b/libraries/debug-certificate-manager/config/jest.json
@@ -1,3 +1,0 @@
-{
-  "isEnabled": true
-}

--- a/libraries/package-deps-hash/config/jest.config.json
+++ b/libraries/package-deps-hash/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/libraries/package-deps-hash/config/jest.json
+++ b/libraries/package-deps-hash/config/jest.json
@@ -1,3 +1,0 @@
-{
-  "isEnabled": true
-}

--- a/libraries/rushell/config/jest.config.json
+++ b/libraries/rushell/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/libraries/rushell/config/jest.json
+++ b/libraries/rushell/config/jest.json
@@ -1,3 +1,0 @@
-{
-  "isEnabled": true
-}

--- a/libraries/stream-collator/config/jest.config.json
+++ b/libraries/stream-collator/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/libraries/stream-collator/config/jest.json
+++ b/libraries/stream-collator/config/jest.json
@@ -1,3 +1,0 @@
-{
-  "isEnabled": true
-}

--- a/libraries/ts-command-line/config/jest.config.json
+++ b/libraries/ts-command-line/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+}

--- a/libraries/ts-command-line/config/jest.json
+++ b/libraries/ts-command-line/config/jest.json
@@ -1,3 +1,0 @@
-{
-  "isEnabled": true
-}

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -58,6 +58,9 @@ export abstract class CommandLineParameter {
   /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
 
+  /** {@inheritDoc IBaseCommandLineDefinition.undocumentedSynonyms } */
+  public readonly undocumentedSynonyms: string[] | undefined;
+
   /** @internal */
   public constructor(definition: IBaseCommandLineDefinition) {
     this.longName = definition.parameterLongName;
@@ -65,6 +68,7 @@ export abstract class CommandLineParameter {
     this.description = definition.description;
     this.required = !!definition.required;
     this.environmentVariable = definition.environmentVariable;
+    this.undocumentedSynonyms = definition.undocumentedSynonyms;
 
     if (!CommandLineParameter._longNameRegExp.test(this.longName)) {
       throw new Error(
@@ -97,6 +101,22 @@ export abstract class CommandLineParameter {
           `Invalid environment variable name: "${this.environmentVariable}". The name must` +
             ` consist only of upper-case letters, numbers, and underscores. It may not start with a number.`
         );
+      }
+    }
+
+    if (this.undocumentedSynonyms) {
+      for (const undocumentedSynonym of this.undocumentedSynonyms) {
+        if (this.longName === undocumentedSynonym) {
+          throw new Error(
+            `Invalid name: "${undocumentedSynonym}". Undocumented Synonyms must not be the same` +
+              ` as the the long name.`
+          );
+        } else if (!CommandLineParameter._longNameRegExp.test(undocumentedSynonym)) {
+          throw new Error(
+            `Invalid name: "${undocumentedSynonym}". All undocumented Synonyms name must be` +
+              ` lower-case and use dash delimiters (e.g. "--do-a-thing")`
+          );
+        }
       }
     }
   }

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -104,7 +104,11 @@ export abstract class CommandLineParameter {
       }
     }
 
-    if (this.undocumentedSynonyms) {
+    if (this.undocumentedSynonyms && this.undocumentedSynonyms.length > 0) {
+      if (this.required) {
+        throw new Error('Undocumented synonyms are not allowed on required parameters.');
+      }
+
       for (const undocumentedSynonym of this.undocumentedSynonyms) {
         if (this.longName === undocumentedSynonym) {
           throw new Error(

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -64,11 +64,13 @@ export interface IBaseCommandLineDefinition {
   environmentVariable?: string;
 
   /**
-   * This option can be used in cases where a command-line parameter may have
-   * synonyms that the application developer doesn't want to be visible in documentation.
-   * These can be useful when a command-line parameter is renamed, but the developer
-   * doesn't want to break backwards compatibility with systems still invoking the old
-   * longName for the parameter.
+   * Specifies additional names for this parameter that are accepted but not displayed
+   * in the command line help.
+   *
+   * @remarks
+   * This option can be used in cases where a command-line parameter may have been renamed,
+   * but the developer doesn't want to break backwards compatibility with systems that may
+   * still be using the old name. Only the `parameterLongName` syntax is currently allowed.
    */
   undocumentedSynonyms?: string[];
 }

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -62,6 +62,15 @@ export interface IBaseCommandLineDefinition {
    *   ordinary String Parameter:  Any value is accepted, including an empty string.
    */
   environmentVariable?: string;
+
+  /**
+   * This option can be used in cases where a command-line parameter may have
+   * synonyms that the application developer doesn't want to be visible in documentation.
+   * These can be useful when a command-line parameter is renamed, but the developer
+   * doesn't want to break backwards compatibility with systems still invoking the old
+   * longName for the parameter.
+   */
+  undocumentedSynonyms?: string[];
 }
 
 /**

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -333,7 +333,14 @@ export abstract class CommandLineParameterProvider {
         break;
     }
 
-    this._getArgumentParser().addArgument(names, argparseOptions);
+    const argumentParser: argparse.ArgumentParser = this._getArgumentParser();
+    argumentParser.addArgument(names, argparseOptions);
+    if (parameter.undocumentedSynonyms && parameter.undocumentedSynonyms.length > 0) {
+      argumentParser.addArgument(parameter.undocumentedSynonyms, {
+        ...argparseOptions,
+        help: argparse.Const.SUPPRESS
+      });
+    }
 
     this._parameters.push(parameter);
     this._parametersByLongName.set(parameter.longName, parameter);

--- a/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
@@ -12,9 +12,8 @@ export class DynamicCommandLineAction extends CommandLineAction {
     // (handled by the external code)
   }
 
-  protected onExecute(): Promise<void> {
+  protected async onExecute(): Promise<void> {
     // abstract
     // (handled by the external code)
-    return Promise.resolve();
   }
 }

--- a/libraries/ts-command-line/src/test/ActionlessParser.test.ts
+++ b/libraries/ts-command-line/src/test/ActionlessParser.test.ts
@@ -22,26 +22,26 @@ class TestCommandLine extends CommandLineParser {
 }
 
 describe('Actionless CommandLineParser', () => {
-  it('parses a flag', () => {
+  it('parses a flag', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
-    return commandLineParser.execute(['--flag']).then(() => {
-      expect(commandLineParser.selectedAction).toBeUndefined();
-      expect(commandLineParser.flag.value).toBe(true);
-    });
+    await commandLineParser.execute(['--flag']);
+
+    expect(commandLineParser.selectedAction).toBeUndefined();
+    expect(commandLineParser.flag.value).toBe(true);
   });
 
-  it('parses a flag and remainder', () => {
+  it('parses a flag and remainder', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
     commandLineParser.defineCommandLineRemainder({
       description: 'remainder description'
     });
 
-    return commandLineParser.execute(['--flag', 'the', 'remaining', 'args']).then(() => {
-      expect(commandLineParser.selectedAction).toBeUndefined();
-      expect(commandLineParser.flag.value).toBe(true);
-      expect(commandLineParser.remainder!.values).toEqual(['the', 'remaining', 'args']);
-    });
+    await commandLineParser.execute(['--flag', 'the', 'remaining', 'args']);
+
+    expect(commandLineParser.selectedAction).toBeUndefined();
+    expect(commandLineParser.flag.value).toBe(true);
+    expect(commandLineParser.remainder!.values).toEqual(['the', 'remaining', 'args']);
   });
 });

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -140,7 +140,7 @@ describe('CommandLineParameter', () => {
     expect(helpText).toMatchSnapshot();
   });
 
-  it('parses an input with ALL parameters', () => {
+  it('parses an input with ALL parameters', async () => {
     const commandLineParser: CommandLineParser = createParser();
     const action: CommandLineAction = commandLineParser.getAction('do:the-job');
 
@@ -162,90 +162,84 @@ describe('CommandLineParameter', () => {
       'second'
     ];
 
-    return commandLineParser.execute(args).then(() => {
-      expect(commandLineParser.selectedAction).toBe(action);
+    await commandLineParser.execute(args);
 
-      expectPropertiesToMatchSnapshot(
-        commandLineParser.getFlagParameter('--global-flag'),
-        snapshotPropertyNames
-      );
+    expect(commandLineParser.selectedAction).toBe(action);
 
-      expectPropertiesToMatchSnapshot(action.getChoiceParameter('--choice'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getChoiceParameter('--choice-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getFlagParameter('--flag'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getIntegerParameter('--integer-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(
-        action.getIntegerParameter('--integer-required'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getStringParameter('--string'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getStringParameter('--string-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getStringListParameter('--string-list'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      commandLineParser.getFlagParameter('--global-flag'),
+      snapshotPropertyNames
+    );
 
-      const copiedArgs: string[] = [];
-      for (const parameter of action.parameters) {
-        copiedArgs.push(`### ${parameter.longName} output: ###`);
-        parameter.appendToArgList(copiedArgs);
-      }
-      expect(copiedArgs).toMatchSnapshot();
-    });
+    expectPropertiesToMatchSnapshot(action.getChoiceParameter('--choice'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getChoiceParameter('--choice-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getFlagParameter('--flag'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getIntegerParameter('--integer-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer-required'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(action.getStringParameter('--string'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getStringParameter('--string-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getStringListParameter('--string-list'), snapshotPropertyNames);
+
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
+    expect(copiedArgs).toMatchSnapshot();
   });
 
-  it('parses an input with NO parameters', () => {
+  it('parses an input with NO parameters', async () => {
     const commandLineParser: CommandLineParser = createParser();
     const action: CommandLineAction = commandLineParser.getAction('do:the-job');
     const args: string[] = ['do:the-job', '--integer-required', '123'];
 
-    return commandLineParser.execute(args).then(() => {
-      expect(commandLineParser.selectedAction).toBe(action);
+    await commandLineParser.execute(args);
 
-      expectPropertiesToMatchSnapshot(
-        commandLineParser.getFlagParameter('--global-flag'),
-        snapshotPropertyNames
-      );
+    expect(commandLineParser.selectedAction).toBe(action);
 
-      expectPropertiesToMatchSnapshot(action.getChoiceParameter('--choice'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getChoiceParameter('--choice-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getFlagParameter('--flag'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getIntegerParameter('--integer-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(
-        action.getIntegerParameter('--integer-required'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getStringParameter('--string'), snapshotPropertyNames);
-      expectPropertiesToMatchSnapshot(
-        action.getStringParameter('--string-with-default'),
-        snapshotPropertyNames
-      );
-      expectPropertiesToMatchSnapshot(action.getStringListParameter('--string-list'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      commandLineParser.getFlagParameter('--global-flag'),
+      snapshotPropertyNames
+    );
 
-      const copiedArgs: string[] = [];
-      for (const parameter of action.parameters) {
-        copiedArgs.push(`### ${parameter.longName} output: ###`);
-        parameter.appendToArgList(copiedArgs);
-      }
-      expect(copiedArgs).toMatchSnapshot();
-    });
+    expectPropertiesToMatchSnapshot(action.getChoiceParameter('--choice'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getChoiceParameter('--choice-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getFlagParameter('--flag'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getIntegerParameter('--integer-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getIntegerParameter('--integer-required'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(action.getStringParameter('--string'), snapshotPropertyNames);
+    expectPropertiesToMatchSnapshot(
+      action.getStringParameter('--string-with-default'),
+      snapshotPropertyNames
+    );
+    expectPropertiesToMatchSnapshot(action.getStringListParameter('--string-list'), snapshotPropertyNames);
+
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
+    expect(copiedArgs).toMatchSnapshot();
   });
 
-  it('parses each parameter from an environment variable', () => {
+  it('parses each parameter from an environment variable', async () => {
     const commandLineParser: CommandLineParser = createParser();
     const action: CommandLineAction = commandLineParser.getAction('do:the-job');
 
@@ -269,16 +263,17 @@ describe('CommandLineParameter', () => {
     process.env.ENV_STRING_LIST = 'simple text';
     process.env.ENV_JSON_STRING_LIST = ' [ 1, true, "Hello, world!" ] ';
 
-    return commandLineParser.execute(args).then(() => {
-      expect(commandLineParser.selectedAction).toBe(action);
+    await commandLineParser.execute(args);
 
-      const copiedArgs: string[] = [];
-      for (const parameter of action.parameters) {
-        copiedArgs.push(`### ${parameter.longName} output: ###`);
-        parameter.appendToArgList(copiedArgs);
-      }
-      expect(copiedArgs).toMatchSnapshot();
-    });
+    expect(commandLineParser.selectedAction).toBe(action);
+
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
+    expect(copiedArgs).toMatchSnapshot();
+  });
 
   it('allows an undocumented synonym', async () => {
     const commandLineParser: CommandLineParser = createParser();

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -86,6 +86,12 @@ function createParser(): DynamicCommandLineParser {
     environmentVariable: 'ENV_STRING2',
     defaultValue: '123'
   });
+  action.defineStringParameter({
+    parameterLongName: '--string-with-undocumented-synonym',
+    description: 'A string with an undocumented synonym',
+    argumentName: 'TEXT',
+    undocumentedSynonyms: ['--undocumented-synonym']
+  });
 
   // String List
   action.defineStringListParameter({
@@ -273,5 +279,28 @@ describe('CommandLineParameter', () => {
       }
       expect(copiedArgs).toMatchSnapshot();
     });
+
+  it('allows an undocumented synonym', async () => {
+    const commandLineParser: CommandLineParser = createParser();
+    const action: CommandLineAction = commandLineParser.getAction('do:the-job');
+
+    const args: string[] = [
+      'do:the-job',
+      '--undocumented-synonym',
+      'undocumented-value',
+      '--integer-required',
+      '6'
+    ];
+
+    await commandLineParser.execute(args);
+
+    expect(commandLineParser.selectedAction).toBe(action);
+
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
+    expect(copiedArgs).toMatchSnapshot();
   });
 });

--- a/libraries/ts-command-line/src/test/CommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParser.test.ts
@@ -15,10 +15,9 @@ class TestAction extends CommandLineAction {
     });
   }
 
-  protected onExecute(): Promise<void> {
+  protected async onExecute(): Promise<void> {
     expect(this._flag.value).toEqual(true);
     this.done = true;
-    return Promise.resolve();
   }
 
   protected onDefineParameters(): void {
@@ -45,15 +44,15 @@ class TestCommandLine extends CommandLineParser {
 }
 
 describe('CommandLineParser', () => {
-  it('executes an action', () => {
+  it('executes an action', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
-    return commandLineParser.execute(['do:the-job', '--flag']).then(() => {
-      expect(commandLineParser.selectedAction).toBeDefined();
-      expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');
+    await commandLineParser.execute(['do:the-job', '--flag']);
 
-      const action: TestAction = commandLineParser.selectedAction as TestAction;
-      expect(action.done).toBe(true);
-    });
+    expect(commandLineParser.selectedAction).toBeDefined();
+    expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');
+
+    const action: TestAction = commandLineParser.selectedAction as TestAction;
+    expect(action.done).toBe(true);
   });
 });

--- a/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
@@ -52,24 +52,24 @@ describe('CommandLineRemainder', () => {
     expect(helpText).toMatchSnapshot();
   });
 
-  it('parses an action input with remainder', () => {
+  it('parses an action input with remainder', async () => {
     const commandLineParser: CommandLineParser = createParser();
     const action: CommandLineAction = commandLineParser.getAction('run');
     const args: string[] = ['run', '--title', 'The title', 'the', 'remaining', 'args'];
 
-    return commandLineParser.execute(args).then(() => {
-      expect(commandLineParser.selectedAction).toBe(action);
+    await commandLineParser.execute(args);
 
-      const copiedArgs: string[] = [];
-      for (const parameter of action.parameters) {
-        copiedArgs.push(`### ${parameter.longName} output: ###`);
-        parameter.appendToArgList(copiedArgs);
-      }
+    expect(commandLineParser.selectedAction).toBe(action);
 
-      copiedArgs.push(`### remainder output: ###`);
-      action.remainder!.appendToArgList(copiedArgs);
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
 
-      expect(copiedArgs).toMatchSnapshot();
-    });
+    copiedArgs.push(`### remainder output: ###`);
+    action.remainder!.appendToArgList(copiedArgs);
+
+    expect(copiedArgs).toMatchSnapshot();
   });
 });

--- a/libraries/ts-command-line/src/test/DynamicCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/DynamicCommandLineParser.test.ts
@@ -4,7 +4,7 @@
 import { DynamicCommandLineParser, DynamicCommandLineAction, CommandLineFlagParameter } from '..';
 
 describe('DynamicCommandLineParser', () => {
-  it('parses an action', () => {
+  it('parses an action', async () => {
     const commandLineParser: DynamicCommandLineParser = new DynamicCommandLineParser({
       toolFilename: 'example',
       toolDescription: 'An example project'
@@ -21,11 +21,11 @@ describe('DynamicCommandLineParser', () => {
       description: 'The flag'
     });
 
-    return commandLineParser.execute(['do:the-job', '--flag']).then(() => {
-      expect(commandLineParser.selectedAction).toEqual(action);
+    await commandLineParser.execute(['do:the-job', '--flag']);
 
-      const retrievedParameter: CommandLineFlagParameter = action.getFlagParameter('--flag');
-      expect(retrievedParameter.value).toBe(true);
-    });
+    expect(commandLineParser.selectedAction).toEqual(action);
+
+    const retrievedParameter: CommandLineFlagParameter = action.getFlagParameter('--flag');
+    expect(retrievedParameter.value).toBe(true);
   });
 });

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CommandLineParameter allows an undocumented synonym 1`] = `
+Array [
+  "### --choice output: ###",
+  "--choice",
+  "one",
+  "### --choice-with-default output: ###",
+  "--choice-with-default",
+  "two",
+  "### --flag output: ###",
+  "--flag",
+  "### --integer output: ###",
+  "--integer",
+  "111",
+  "### --integer-with-default output: ###",
+  "--integer-with-default",
+  "222",
+  "### --integer-required output: ###",
+  "--integer-required",
+  "6",
+  "### --string output: ###",
+  "--string",
+  "Hello, world!",
+  "### --string-with-default output: ###",
+  "--string-with-default",
+  "Hello, world!",
+  "### --string-with-undocumented-synonym output: ###",
+  "--string-with-undocumented-synonym",
+  "undocumented-value",
+  "### --string-list output: ###",
+  "--string-list",
+  "simple text",
+]
+`;
+
 exports[`CommandLineParameter parses an input with ALL parameters 1`] = `
 Object {
   "argumentName": undefined,
@@ -178,6 +212,7 @@ Array [
   "### --string-with-default output: ###",
   "--string-with-default",
   "123",
+  "### --string-with-undocumented-synonym output: ###",
   "### --string-list output: ###",
   "--string-list",
   "first",
@@ -354,6 +389,7 @@ Array [
   "### --string-with-default output: ###",
   "--string-with-default",
   "123",
+  "### --string-with-undocumented-synonym output: ###",
   "### --string-list output: ###",
 ]
 `;
@@ -383,6 +419,7 @@ Array [
   "### --string-with-default output: ###",
   "--string-with-default",
   "Hello, world!",
+  "### --string-with-undocumented-synonym output: ###",
   "### --string-list output: ###",
   "--string-list",
   "simple text",
@@ -401,7 +438,9 @@ exports[`CommandLineParameter prints the action help 1`] = `
                           [--choice-with-default {one,two,three,default}] [-f]
                           [-i NUMBER] [--integer-with-default NUMBER]
                           --integer-required NUMBER [-s TEXT]
-                          [--string-with-default TEXT] [-l LIST_ITEM]
+                          [--string-with-default TEXT]
+                          [--string-with-undocumented-synonym TEXT]
+                          [-l LIST_ITEM]
                           
 
 a longer description
@@ -434,6 +473,8 @@ Optional arguments:
                         A string with a default. This parameter may 
                         alternatively be specified via the ENV_STRING2 
                         environment variable. The default value is \\"123\\".
+  --string-with-undocumented-synonym TEXT
+                        A string with an undocumented synonym
   -l LIST_ITEM, --string-list LIST_ITEM
                         This parameter be specified multiple times to make a 
                         list of strings. This parameter may alternatively be 


### PR DESCRIPTION
This change also includes support for an `undocumentedSynonyms` option for parameters.