### PR TITLE
[rush] Fix "already exists" error for "rush deploy" command

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-rush-deploy-2121_2020-08-20-17-47.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-deploy-2121_2020-08-20-17-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush deploy\" would sometimes report an \"already exists\" when using the \"files\" setting in package.json (GitHub #2121)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2121