### PR TITLE
[package-deps-hash] Do not hash files that are deleted in working tree

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/bewegger-package-deps-ignore-del-files-untracked_2020-08-21-13-10.json
+++ b/common/changes/@rushstack/package-deps-hash/bewegger-package-deps-ignore-del-files-untracked_2020-08-21-13-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Do not attempt to hash files that are deleted in the working tree.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "bewegger@microsoft.com"
+}

--- a/libraries/package-deps-hash/src/getPackageDeps.ts
+++ b/libraries/package-deps-hash/src/getPackageDeps.ts
@@ -109,6 +109,8 @@ export function parseGitStatus(output: string, packagePath: string): Map<string,
        *   - '??' == untracked
        *   - 'R' == rename
        *   - 'RM' == rename with modifications
+       *   - '[MARC]D' == deleted in work tree
+       * Full list of examples: https://git-scm.com/docs/git-status#_short_format
        */
       const match: RegExpMatchArray | null = line.match(/("(\\"|[^"])+")|(\S+\s*)/g);
 
@@ -258,7 +260,8 @@ export function getPackageDeps(packagePath: string = process.cwd(), excludedPath
 
   const filesToHash: string[] = [];
   currentlyChangedFiles.forEach((changeType: string, filename: string) => {
-    if (changeType.endsWith('D')) {
+    // See comments inside parseGitStatus() for more information
+    if (changeType === 'D' || (changeType.length === 2 && changeType.charAt(1) === 'D')) {
       delete changes.files[filename];
     } else {
       if (!excludedHashes[filename]) {

--- a/libraries/package-deps-hash/src/getPackageDeps.ts
+++ b/libraries/package-deps-hash/src/getPackageDeps.ts
@@ -258,7 +258,7 @@ export function getPackageDeps(packagePath: string = process.cwd(), excludedPath
 
   const filesToHash: string[] = [];
   currentlyChangedFiles.forEach((changeType: string, filename: string) => {
-    if (changeType === 'D') {
+    if (changeType.endsWith('D')) {
       delete changes.files[filename];
     } else {
       if (!excludedHashes[filename]) {


### PR DESCRIPTION
If I modify a file, stage it, and delete it, I won't be able to create a hash using `getPackageDeps`. This PR removes any file from hash consideration when it is marked as deleted in the working tree or is deleted and staged with no additional changes in the working tree.

Here's a repro with the current implementation:

```sh
$ echo "console.log('Hello world')" > foo.js
$ git add foo.js
$ rm foo.js

$ git status -s -u
AD foo.js

$ node -e 'console.log(require("@rushstack/package-deps-hash").getPackageDeps())'
~/git/rushstack/libraries/package-deps-hash/lib/getPackageDeps.js:132
            throw new Error(`git hash-object exited with status ${result.status}: ${result.stderr}`);
            ^

Error: git hash-object exited with status 128: fatal: Cannot open '~/dev/package-deps-hash-removed-in-unstaged/foo.js': No such file or directory

    at getGitHashForFiles (~/git/rushstack/libraries/package-deps-hash/lib/getPackageDeps.js:132:19)
    at getPackageDeps (~/git/rushstack/libraries/package-deps-hash/lib/getPackageDeps.js:225:5)
    at Object.<anonymous> (~/dev/package-deps-hash-removed-in-unstaged/index.js:3:13)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
```


Here's a table listing the various statuses a file can have, according to `git status --help`:

```
          X          Y     Meaning
-------------------------------------------------
        [AMD]   not updated
M        [ MD]   updated in index
A        [ MD]   added to index
D                deleted from index
R        [ MD]   renamed in index
C        [ MD]   copied in index
[MARC]           index and work tree matches
[ MARC]     M    work tree changed since index
[ MARC]     D    deleted in work tree
[ D]        R    renamed in work tree
[ D]        C    copied in work tree
-------------------------------------------------
D           D    unmerged, both deleted
A           U    unmerged, added by us
U           D    unmerged, deleted by them
U           A    unmerged, added by them
D           U    unmerged, deleted by us
A           A    unmerged, both added
U           U    unmerged, both modified
-------------------------------------------------
?           ?    untracked
!           !    ignored
-------------------------------------------------
```