### PR TITLE
Bump cyclic dependencies

### DIFF
--- a/apps/api-extractor-model/package.json
+++ b/apps/api-extractor-model/package.json
@@ -18,9 +18,9 @@
     "@microsoft/tsdoc": "0.12.19"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13"
   }

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -46,9 +46,9 @@
     "typescript": "~3.9.5"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@types/jest": "25.2.1",
     "@types/lodash": "4.14.116",
     "@types/semver": "~7.3.1",

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -61,7 +61,7 @@
     "@types/webpack-dev-server": "3.11.0",
     "@microsoft/rush-stack-compiler-3.7": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "colors": "~1.2.1"
   }
 }

--- a/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor-model"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/gulp-core-build-mocha"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/gulp-core-build-typescript"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/gulp-core-build"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-2.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-2.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-2.8"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-2.9"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.0"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.1"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.2"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.3"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.4"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.5"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.6"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.7"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.8"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.8",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush-stack-compiler-3.9"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.9",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-patch/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@rushstack/eslint-patch/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@rushstack/eslint-plugin/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@rushstack/heft/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
+++ b/common/changes/@rushstack/ts-command-line/octogonz-bump-cyclics-eslint_2020-08-24-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/ts-command-line"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -48,20 +48,20 @@ importers:
       source-map: 0.6.1
       typescript: 3.9.7
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/jest': 25.2.1
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
     specifiers:
       '@microsoft/api-extractor-model': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@microsoft/tsdoc': 0.12.19
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/ts-command-line': 'workspace:*'
       '@types/jest': 25.2.1
@@ -80,16 +80,16 @@ importers:
       '@microsoft/tsdoc': 0.12.19
       '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
     specifiers:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@microsoft/tsdoc': 0.12.19
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
@@ -116,13 +116,13 @@ importers:
       '@jest/types': 25.4.0
       '@microsoft/rush-stack-compiler-3.7': 'link:../../stack/rush-stack-compiler-3.7'
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/eslint': 7.2.0
       '@types/glob': 7.1.1
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       '@types/webpack-dev-server': 3.11.0
       colors: 1.2.5
     specifiers:
@@ -132,7 +132,7 @@ importers:
       '@jest/types': ~25.4.0
       '@microsoft/rush-stack-compiler-3.7': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/ts-command-line': 'workspace:*'
       '@types/eslint': 7.2.0
@@ -187,7 +187,7 @@ importers:
       '@rushstack/heft': 'link:../heft'
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       '@types/sinon': 1.16.34
       chai: 3.5.0
       sinon: 1.17.7
@@ -227,7 +227,7 @@ importers:
       '@types/node': 10.17.13
   ../../apps/rush-lib:
     dependencies:
-      '@pnpm/link-bins': 5.3.11
+      '@pnpm/link-bins': 5.3.12
       '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
       '@rushstack/package-deps-hash': 'link:../../libraries/package-deps-hash'
       '@rushstack/stream-collator': 'link:../../libraries/stream-collator'
@@ -274,7 +274,7 @@ importers:
       '@types/npm-packlist': 1.1.1
       '@types/read-package-tree': 5.1.0
       '@types/resolve': 1.17.1
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       '@types/ssri': 7.1.0
       '@types/strict-uri-encode': 2.0.0
       '@types/tar': 4.0.3
@@ -435,7 +435,7 @@ importers:
       typescript: ~3.9.5
   ../../build-tests/api-extractor-test-02:
     dependencies:
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       api-extractor-test-01: 'link:../api-extractor-test-01'
       semver: 7.3.2
     devDependencies:
@@ -905,7 +905,7 @@ importers:
       '@types/node': 10.17.13
       '@types/node-notifier': 0.0.28
       '@types/orchestrator': 0.0.30
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       '@types/through2': 2.0.32
       '@types/vinyl': 2.0.3
       '@types/yargs': 0.0.34
@@ -937,7 +937,7 @@ importers:
       z-schema: 3.18.4
     devDependencies:
       '@microsoft/node-library-build': 6.4.31
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
       '@types/glob': 7.1.1
       '@types/z-schema': 3.16.31
@@ -945,7 +945,7 @@ importers:
       '@jest/core': ~25.4.0
       '@jest/reporters': ~25.4.0
       '@microsoft/node-library-build': 6.4.31
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'workspace:*'
       '@rushstack/node-core-library': 'workspace:*'
       '@types/chalk': 0.4.31
@@ -996,7 +996,7 @@ importers:
       gulp-mocha: 6.0.0
     devDependencies:
       '@microsoft/node-library-build': 6.4.31
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
@@ -1007,7 +1007,7 @@ importers:
     specifiers:
       '@microsoft/gulp-core-build': 'workspace:*'
       '@microsoft/node-library-build': 6.4.31
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'workspace:*'
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
@@ -1125,7 +1125,7 @@ importers:
       '@microsoft/api-extractor': 'link:../../apps/api-extractor'
       '@microsoft/node-library-build': 6.4.31
       '@microsoft/rush-stack-compiler-3.1': 'link:../../stack/rush-stack-compiler-3.1'
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
       '@types/glob': 7.1.1
       '@types/resolve': 1.17.1
@@ -1136,7 +1136,7 @@ importers:
       '@microsoft/gulp-core-build': 'workspace:*'
       '@microsoft/node-library-build': 6.4.31
       '@microsoft/rush-stack-compiler-3.1': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'workspace:*'
       '@rushstack/node-core-library': 'workspace:*'
       '@types/glob': 7.1.1
@@ -1233,13 +1233,13 @@ importers:
       '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
       '@types/node': 10.17.13
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.7': 0.6.4
+      '@microsoft/rush-stack-compiler-3.7': 0.6.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
     specifiers:
-      '@microsoft/rush-stack-compiler-3.7': 0.6.4
+      '@microsoft/rush-stack-compiler-3.7': 0.6.8
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@types/node': 10.17.13
   ../../libraries/debug-certificate-manager:
@@ -1290,19 +1290,19 @@ importers:
       timsort: 0.3.0
       z-schema: 3.18.4
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/fs-extra': 7.0.0
       '@types/jest': 25.2.1
       '@types/jju': 1.4.1
-      '@types/semver': 7.3.2
+      '@types/semver': 7.3.3
       '@types/timsort': 0.3.0
       '@types/z-schema': 3.16.31
     specifiers:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/fs-extra': 7.0.0
       '@types/jest': 25.2.1
       '@types/jju': 1.4.1
@@ -1376,15 +1376,15 @@ importers:
       colors: 1.2.5
       string-argv: 0.3.1
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
     specifiers:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@types/argparse': 1.0.38
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
@@ -1494,17 +1494,17 @@ importers:
       typescript: ~3.7.2
   ../../stack/eslint-patch:
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
-      '@rushstack/heft': 0.5.1
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
+      '@rushstack/heft': 0.6.5
       '@types/node': 10.17.13
     specifiers:
-      '@microsoft/rush-stack-compiler-3.5': 0.8.4
-      '@rushstack/heft': 0.5.1
+      '@microsoft/rush-stack-compiler-3.5': 0.8.8
+      '@rushstack/heft': 0.6.5
       '@types/node': 10.17.13
   ../../stack/eslint-plugin:
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 0.4.4
-      '@rushstack/heft': 0.5.1
+      '@microsoft/rush-stack-compiler-3.9': 0.4.8
+      '@rushstack/heft': 0.6.5
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/jest': 25.2.1
@@ -1515,8 +1515,8 @@ importers:
       eslint: 7.2.0
       typescript: 3.9.7
     specifiers:
-      '@microsoft/rush-stack-compiler-3.9': 0.4.4
-      '@rushstack/heft': 0.5.1
+      '@microsoft/rush-stack-compiler-3.9': 0.4.8
+      '@rushstack/heft': 0.6.5
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/jest': 25.2.1
@@ -1540,14 +1540,14 @@ importers:
     devDependencies:
       '@microsoft/rush-stack-compiler-3.5': 'link:../rush-stack-compiler-3.5'
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-3.5': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1570,14 +1570,14 @@ importers:
     devDependencies:
       '@microsoft/rush-stack-compiler-3.5': 'link:../rush-stack-compiler-3.5'
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-3.5': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1600,14 +1600,14 @@ importers:
     devDependencies:
       '@microsoft/rush-stack-compiler-3.5': 'link:../rush-stack-compiler-3.5'
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-3.5': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1630,14 +1630,14 @@ importers:
     devDependencies:
       '@microsoft/rush-stack-compiler-3.5': 'link:../rush-stack-compiler-3.5'
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-3.5': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1659,13 +1659,13 @@ importers:
       typescript: 3.0.3
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1687,13 +1687,13 @@ importers:
       typescript: 3.1.6
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1715,13 +1715,13 @@ importers:
       typescript: 3.2.4
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1743,13 +1743,13 @@ importers:
       typescript: 3.3.4000
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1771,13 +1771,13 @@ importers:
       typescript: 3.4.5
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1799,13 +1799,13 @@ importers:
       typescript: 3.5.3
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1827,13 +1827,13 @@ importers:
       typescript: 3.6.5
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1855,13 +1855,13 @@ importers:
       typescript: 3.7.5
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1883,13 +1883,13 @@ importers:
       typescript: 3.8.3
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -1911,13 +1911,13 @@ importers:
       typescript: 3.9.7
     devDependencies:
       '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'link:../../heft-plugins/pre-compile-hardlink-or-copy-plugin'
     specifiers:
       '@microsoft/api-extractor': 'workspace:*'
       '@microsoft/rush-stack-compiler-shared': 'workspace:*'
       '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 0.5.1
+      '@rushstack/heft': 0.6.5
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/pre-compile-hardlink-or-copy-plugin': 'workspace:*'
       '@types/node': 10.17.13
@@ -2067,13 +2067,13 @@ packages:
       '@babel/highlight': 7.10.4
     resolution:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  /@babel/core/7.11.1:
+  /@babel/core/7.11.4:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.11.0
+      '@babel/generator': 7.11.4
       '@babel/helper-module-transforms': 7.11.0
       '@babel/helpers': 7.10.4
-      '@babel/parser': 7.11.3
+      '@babel/parser': 7.11.4
       '@babel/template': 7.10.4
       '@babel/traverse': 7.11.0
       '@babel/types': 7.11.0
@@ -2088,14 +2088,14 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
-  /@babel/generator/7.11.0:
+      integrity: sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==
+  /@babel/generator/7.11.4:
     dependencies:
       '@babel/types': 7.11.0
       jsesc: 2.5.2
       source-map: 0.5.7
     resolution:
-      integrity: sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==
+      integrity: sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==
   /@babel/helper-function-name/7.10.4:
     dependencies:
       '@babel/helper-get-function-arity': 7.10.4
@@ -2173,95 +2173,95 @@ packages:
       js-tokens: 4.0.0
     resolution:
       integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
-  /@babel/parser/7.11.3:
+  /@babel/parser/7.11.4:
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.1:
+      integrity: sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.1:
+  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.11.1:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.1:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.1:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.1:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2270,17 +2270,17 @@ packages:
   /@babel/template/7.10.4:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/parser': 7.11.3
+      '@babel/parser': 7.11.4
       '@babel/types': 7.11.0
     resolution:
       integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
   /@babel/traverse/7.11.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.11.0
+      '@babel/generator': 7.11.4
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-split-export-declaration': 7.11.0
-      '@babel/parser': 7.11.3
+      '@babel/parser': 7.11.4
       '@babel/types': 7.11.0
       debug: 4.1.1
       globals: 11.12.0
@@ -2459,7 +2459,7 @@ packages:
       integrity: sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==
   /@jest/transform/25.4.0:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@jest/types': 25.4.0
       babel-plugin-istanbul: 6.0.0
       chalk: 3.0.0
@@ -2481,7 +2481,7 @@ packages:
       integrity: sha512-t1w2S6V1sk++1HHsxboWxPEuSpN8pxEvNrZN+Ud/knkROWtf8LeUmz73A4ezE8476a5AM00IZr9a8FO9x1+j3g==
   /@jest/transform/25.5.1:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@jest/types': 25.5.0
       babel-plugin-istanbul: 6.0.0
       chalk: 3.0.0
@@ -2521,19 +2521,19 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  /@microsoft/api-extractor-model/7.8.15:
+  /@microsoft/api-extractor-model/7.8.17:
     dependencies:
       '@microsoft/tsdoc': 0.12.19
-      '@rushstack/node-core-library': 3.27.0
+      '@rushstack/node-core-library': 3.29.0
     dev: true
     resolution:
-      integrity: sha512-z81RLrvZdCxPMDBH6JVtZAMMrxDsDGz4mW7GM6OGxPlooTtSVtPH9RNhZFbA6zp7/4ANgBlqURl8zIsxvFeppA==
-  /@microsoft/api-extractor/7.9.5:
+      integrity: sha512-iyVdA1WTlwgddDJwJTedTFcpGjDoV9grq/JGP7rK2t4yo4kOE5XhLbi+BlZ3t5vuggFJf8LawDyomEb8tGtwRQ==
+  /@microsoft/api-extractor/7.9.9:
     dependencies:
-      '@microsoft/api-extractor-model': 7.8.15
+      '@microsoft/api-extractor-model': 7.8.17
       '@microsoft/tsdoc': 0.12.19
-      '@rushstack/node-core-library': 3.27.0
-      '@rushstack/ts-command-line': 4.4.8
+      '@rushstack/node-core-library': 3.29.0
+      '@rushstack/ts-command-line': 4.6.2
       colors: 1.2.5
       lodash: 4.17.20
       resolve: 1.17.0
@@ -2543,7 +2543,7 @@ packages:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-vqatQEp62zi+kjWzAbQZHR1/BHuM9EdLvH6yJX+TRrgY3qONJmZ4cMP6hc5QdqkW8V8fDR8B559nQOxmRQfXHg==
+      integrity: sha512-alqX4qmrSSS2HZHU6HivGv39/8Mknbew4L+qL3D3q6gWQhmDj7cLNOzS7pBp7yZrbt0jQfb/o8EgeTsRQL2T1A==
   /@microsoft/gulp-core-build-mocha/3.8.20:
     dependencies:
       '@microsoft/gulp-core-build': 3.16.11
@@ -2622,11 +2622,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-2BT2gnJ+isO7d2tmhqoUA1t2g8w19ZqOd9bzYURfen18iQpZi0hLzu3E8+/isS8xE9PU++ggEaYDSz75XsgrjA==
-  /@microsoft/rush-stack-compiler-3.5/0.8.4:
+  /@microsoft/rush-stack-compiler-3.5/0.8.8:
     dependencies:
-      '@microsoft/api-extractor': 7.9.5
-      '@rushstack/eslint-config': 1.1.0_eslint@7.2.0+typescript@3.5.3
-      '@rushstack/node-core-library': 3.27.0
+      '@microsoft/api-extractor': 7.9.9
+      '@rushstack/eslint-config': 1.2.0_eslint@7.2.0+typescript@3.5.3
+      '@rushstack/node-core-library': 3.29.0
       '@types/node': 10.17.13
       eslint: 7.2.0
       import-lazy: 4.0.0
@@ -2636,12 +2636,12 @@ packages:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-pxDgt+crQS6V7Yc/jdvcsMcL4aF6KA2DeSdrghdbZyNn1mlTaGc4B0fKxHXX4PltX7cJD6SUHGu/2Cp0SVMFWg==
-  /@microsoft/rush-stack-compiler-3.7/0.6.4:
+      integrity: sha512-PmqdlpH5aGpe5+OCgUJceZ2RbwOH+qdbbUlQRA1Mc3c5lFZpR21lXC34RXB8BCvlYnBPgsqQ8SZvNO8xuJk62Q==
+  /@microsoft/rush-stack-compiler-3.7/0.6.8:
     dependencies:
-      '@microsoft/api-extractor': 7.9.5
-      '@rushstack/eslint-config': 1.1.0_eslint@7.2.0+typescript@3.7.5
-      '@rushstack/node-core-library': 3.27.0
+      '@microsoft/api-extractor': 7.9.9
+      '@rushstack/eslint-config': 1.2.0_eslint@7.2.0+typescript@3.7.5
+      '@rushstack/node-core-library': 3.29.0
       '@types/node': 10.17.13
       eslint: 7.2.0
       import-lazy: 4.0.0
@@ -2651,12 +2651,12 @@ packages:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-86s0qNCyKA4DAMYA9WE3c2p2KcPZ/vVGlM6gYC+uSjCbeIvML29Yr13ah6Cz8KOBIkT4RTXHyVKZI+Zq41GR4g==
-  /@microsoft/rush-stack-compiler-3.9/0.4.4:
+      integrity: sha512-PtXBWr0R73qHXPd94QhBKiu9ZtEmYBg0q1k49V0C17Ew7EONYS9NBIUlDx/U4rDyauGvsqBvXKQgs9XZNho8BA==
+  /@microsoft/rush-stack-compiler-3.9/0.4.8:
     dependencies:
-      '@microsoft/api-extractor': 7.9.5
-      '@rushstack/eslint-config': 1.1.0_eslint@7.2.0+typescript@3.9.7
-      '@rushstack/node-core-library': 3.27.0
+      '@microsoft/api-extractor': 7.9.9
+      '@rushstack/eslint-config': 1.2.0_eslint@7.2.0+typescript@3.9.7
+      '@rushstack/node-core-library': 3.29.0
       '@types/node': 10.17.13
       eslint: 7.2.0
       import-lazy: 4.0.0
@@ -2666,7 +2666,7 @@ packages:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-0DtsLjdfQNOHcOZ0Jde4kzE5KNWUQP0OumxvX+CN6EUiJMjd+L9Z1yxW8NHcgUJtFmdTw3JR0nfX+S6EHmNV0w==
+      integrity: sha512-ruVU30oHTs24m1zFHwOPCkh+vYvAA5KWMZvNCY9S6tpxkG6WW6uGLvMkrFPpOfhe1GpNp53BKxM8hJBIjobIOw==
   /@microsoft/teams-js/1.3.0-beta.4:
     dev: true
     resolution:
@@ -2691,12 +2691,12 @@ packages:
       node: '>=10.13'
     resolution:
       integrity: sha512-JLUGDY0F6PJcMNKW92kIsXj0iYV/j1RmZfdCD/eN+E73bId0WSaPGEb0z9hVnzjAEG0g0e4OOfZVyJYHAmDtAw==
-  /@pnpm/link-bins/5.3.11:
+  /@pnpm/link-bins/5.3.12:
     dependencies:
       '@pnpm/error': 1.3.0
       '@pnpm/package-bins': 4.0.7
       '@pnpm/read-modules-dir': 2.0.3
-      '@pnpm/read-package-json': 3.1.3
+      '@pnpm/read-package-json': 3.1.4
       '@pnpm/read-project-manifest': 1.0.12
       '@pnpm/types': 6.2.0
       '@zkochan/cmd-shim': 5.0.0
@@ -2710,7 +2710,7 @@ packages:
     engines:
       node: '>=10.13'
     resolution:
-      integrity: sha512-rnFW6hwl2G2EJDuQeViSaT0Jcuk19aOUi8SMfMI1Nazr8HjoR0r+WMYGIPeclSw2W0p1PCf/HCgB5tffkOXZWw==
+      integrity: sha512-buOF8BzWAzIa0ycxJdNCZWx33Yp4rEx++bM0iJy1/i0zgIhVvktvBGmqKErzsnNRTzbAKt0Nx1yTHpSkC1kEAA==
   /@pnpm/package-bins/4.0.7:
     dependencies:
       '@pnpm/types': 6.2.0
@@ -2730,15 +2730,15 @@ packages:
       node: '>=10.13'
     resolution:
       integrity: sha512-i9OgRvSlxrTS9a2oXokhDxvQzDtfqtsooJ9jaGoHkznue5aFCTSrNZFQ6M18o8hC03QWfnxaKi0BtOvNkKu2+A==
-  /@pnpm/read-package-json/3.1.3:
+  /@pnpm/read-package-json/3.1.4:
     dependencies:
       '@pnpm/types': 6.2.0
-      read-package-json: 2.1.1
+      read-package-json: 2.1.2
     dev: false
     engines:
       node: '>=10.13'
     resolution:
-      integrity: sha512-MhMpBO6Pa56QnqY59eeYVfSUO5Jgz+S4j2ldvX8mWF7tSZnk2tfz/tLAOQAdsLrjES/Apbru8Vj6A4cbPTPwyA==
+      integrity: sha512-UjDpGheuGSkwvb6xKgqFH/cgHojbHEQQFaI5OM/MIIcLKI7Jc5HzvaCzSiLONKRdEyjYSrRianrp06MNV2Qe3A==
   /@pnpm/read-project-manifest/1.0.12:
     dependencies:
       '@pnpm/error': 1.3.0
@@ -2749,7 +2749,7 @@ packages:
       graceful-fs: 4.2.4
       is-windows: 1.0.2
       json5: 2.1.3
-      parse-json: 5.0.1
+      parse-json: 5.1.0
       read-yaml-file: 2.0.0
       sort-keys: 4.0.0
       strip-bom: 4.0.0
@@ -2776,10 +2776,10 @@ packages:
       node: '>=10.13'
     resolution:
       integrity: sha512-diiSQt85CJ2mEf06NSKN/T2LNpfabVg9yDz7ysZ7J9h+SFHc/yKR+AgQYUHlNwGHFqZoO09JS755hlHHM2f+lg==
-  /@rushstack/eslint-config/1.1.0_eslint@7.2.0+typescript@3.5.3:
+  /@rushstack/eslint-config/1.2.0_eslint@7.2.0+typescript@3.5.3:
     dependencies:
       '@rushstack/eslint-patch': 1.0.3
-      '@rushstack/eslint-plugin': 0.4.2_eslint@7.2.0
+      '@rushstack/eslint-plugin': 0.5.0_eslint@7.2.0
       '@typescript-eslint/eslint-plugin': 3.4.0_cda7146ea5fa41161805b85f9284f6bd
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.2.0+typescript@3.5.3
       '@typescript-eslint/parser': 3.4.0_eslint@7.2.0+typescript@3.5.3
@@ -2795,11 +2795,11 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
       typescript: '>=3.0.0'
     resolution:
-      integrity: sha512-GR/RUn4uVRM2bu/hlhMhxHcU5v0kzUirzy4qhK6b/BpwvqA18Dw8O6rRyUF31Jub3hEAZQqRIOu8N/u9irgQdw==
-  /@rushstack/eslint-config/1.1.0_eslint@7.2.0+typescript@3.7.5:
+      integrity: sha512-KITyuEDXLr3CQTsNTawOeQbMqVJCfzJLy7PJ2SPucY/xGLJlTTFnOljOFy7RGOmsKu6eyk768DGK7zpIVlhJ3Q==
+  /@rushstack/eslint-config/1.2.0_eslint@7.2.0+typescript@3.7.5:
     dependencies:
       '@rushstack/eslint-patch': 1.0.3
-      '@rushstack/eslint-plugin': 0.4.2_eslint@7.2.0
+      '@rushstack/eslint-plugin': 0.5.0_eslint@7.2.0
       '@typescript-eslint/eslint-plugin': 3.4.0_43170e314695d1b0876b4d3c3574f4a4
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.2.0+typescript@3.7.5
       '@typescript-eslint/parser': 3.4.0_eslint@7.2.0+typescript@3.7.5
@@ -2815,11 +2815,11 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
       typescript: '>=3.0.0'
     resolution:
-      integrity: sha512-GR/RUn4uVRM2bu/hlhMhxHcU5v0kzUirzy4qhK6b/BpwvqA18Dw8O6rRyUF31Jub3hEAZQqRIOu8N/u9irgQdw==
-  /@rushstack/eslint-config/1.1.0_eslint@7.2.0+typescript@3.9.7:
+      integrity: sha512-KITyuEDXLr3CQTsNTawOeQbMqVJCfzJLy7PJ2SPucY/xGLJlTTFnOljOFy7RGOmsKu6eyk768DGK7zpIVlhJ3Q==
+  /@rushstack/eslint-config/1.2.0_eslint@7.2.0+typescript@3.9.7:
     dependencies:
       '@rushstack/eslint-patch': 1.0.3
-      '@rushstack/eslint-plugin': 0.4.2_eslint@7.2.0
+      '@rushstack/eslint-plugin': 0.5.0_eslint@7.2.0
       '@typescript-eslint/eslint-plugin': 3.4.0_def47c0014fd51b1497b94bf8e50ada2
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.2.0+typescript@3.9.7
       '@typescript-eslint/parser': 3.4.0_eslint@7.2.0+typescript@3.9.7
@@ -2835,26 +2835,26 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
       typescript: '>=3.0.0'
     resolution:
-      integrity: sha512-GR/RUn4uVRM2bu/hlhMhxHcU5v0kzUirzy4qhK6b/BpwvqA18Dw8O6rRyUF31Jub3hEAZQqRIOu8N/u9irgQdw==
+      integrity: sha512-KITyuEDXLr3CQTsNTawOeQbMqVJCfzJLy7PJ2SPucY/xGLJlTTFnOljOFy7RGOmsKu6eyk768DGK7zpIVlhJ3Q==
   /@rushstack/eslint-patch/1.0.3:
     dev: true
     resolution:
       integrity: sha512-Oq5EYosOGfqE8r2tuRMfJSeZKO+M3QozrYKs5bPuqyWB9pHhclS/Kp8boyu/pPwskE9PtPkagc+qwW+yO2b9Kw==
-  /@rushstack/eslint-plugin/0.4.2_eslint@7.2.0:
+  /@rushstack/eslint-plugin/0.5.0_eslint@7.2.0:
     dependencies:
       eslint: 7.2.0
     dev: true
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-GCKdyithyOFpE0mjcWzPqUBeeLU8My8Z4zzvAMQaEQsef1zoK8gb+B3nLVZwZ6//n4bAlQg1yuHvGR7QBKW0Ww==
-  /@rushstack/heft/0.5.1:
+      integrity: sha512-acmWhiFgUreQ13hgfSvH1iHzm47llpiCYjbX+7CFHMfodmTJObUJzw9ZCVL/JiiWfRsgEloofZp9S5CVnY9hpw==
+  /@rushstack/heft/0.6.5:
     dependencies:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
       '@jest/transform': 25.4.0
-      '@rushstack/node-core-library': 3.27.0
-      '@rushstack/ts-command-line': 4.4.8
+      '@rushstack/node-core-library': 3.29.0
+      '@rushstack/ts-command-line': 4.6.2
       '@types/tapable': 1.0.5
       '@types/webpack': 4.39.8
       chokidar: 3.4.2
@@ -2872,7 +2872,7 @@ packages:
       node: '>=10.13.0'
     hasBin: true
     resolution:
-      integrity: sha512-XvCG+RhXFXieOMw9ofHMH908j6WZW6u09usJTtE/uCZi58POsO5Z78mnv0ZuYLk/pI1PVj32pA+kduNZbcCbPQ==
+      integrity: sha512-eA685w/tChXBa06oTxa2cnhEv/hbWvxttYjyAyJ/yeZBwE76e4zcVnERni5afqTqe9GqeazmSIwrYWLoM0Glcw==
   /@rushstack/node-core-library/3.24.4:
     dependencies:
       '@types/node': 10.17.13
@@ -2885,26 +2885,28 @@ packages:
     dev: true
     resolution:
       integrity: sha512-h8XQjpI78o5Mq7mJKX/rSfV9R02CJXBzxgqQ4EnptUP1StZ/BvyzwAp5VHvvNoJKXlFgqJwwOt8TE4d7bHGLgg==
-  /@rushstack/node-core-library/3.27.0:
+  /@rushstack/node-core-library/3.29.0:
     dependencies:
       '@types/node': 10.17.13
       colors: 1.2.5
       fs-extra: 7.0.1
+      import-lazy: 4.0.0
       jju: 1.4.0
       semver: 7.3.2
       timsort: 0.3.0
       z-schema: 3.18.4
     dev: true
     resolution:
-      integrity: sha512-6fS7wqcxL4XGVFkhECMCqsqXouPRDWKMgNpyrmXJRS0PPumRMW+9m2knVK/kgTrMwcnbGysqxX/77PiFErw8wg==
-  /@rushstack/ts-command-line/4.4.8:
+      integrity: sha512-8mEfn7mUqqzANnOvi4/xTc0tJ6coQs3qywlOl86jiqZUaB4sRLo0MtzUQz0VtyRfan2fFuxKzIleJGtNTAwYQQ==
+  /@rushstack/ts-command-line/4.6.2:
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       colors: 1.2.5
+      string-argv: 0.3.1
     dev: true
     resolution:
-      integrity: sha512-giyVXuyI2BAID0BINp8TbxcTf5MEao+UPadAMfCuuS64mSE1E76S8wzhjqEy3WaTSpgyRDi7dMlEegNnD/97Gw==
+      integrity: sha512-wMjCrgiVYO5L1VkRKWv6EmisxduWuthOP4OghUPkl1kbbw9z2yZzQd9uk9rIqmGwOg8hjFX+0HrZCCXGHtABIQ==
   /@sinonjs/commons/1.8.1:
     dependencies:
       type-detect: 4.0.8
@@ -2925,7 +2927,7 @@ packages:
       integrity: sha512-QX7U7YW3zX3ex6MECtWO9folTGsXeP4b8bSjTq3I1ODM+H+sFHwGKuof+T+qBcDClGlCGtDb3SVfiTVfmcxw4g==
   /@types/babel__core/7.1.9:
     dependencies:
-      '@babel/parser': 7.11.3
+      '@babel/parser': 7.11.4
       '@babel/types': 7.11.0
       '@types/babel__generator': 7.6.1
       '@types/babel__template': 7.0.2
@@ -2939,7 +2941,7 @@ packages:
       integrity: sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.11.3
+      '@babel/parser': 7.11.4
       '@babel/types': 7.11.0
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
@@ -3309,9 +3311,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-UwrBgjsRS8BSsckIEdrAhIAmdh0MJidtKTvD3S6tpMq6qHLY3uGaNYcRDUjPxpF4hOAOEbMNSXhhfxmNHB1QNQ==
-  /@types/semver/7.3.2:
+  /@types/semver/7.3.3:
     resolution:
-      integrity: sha512-WrIesso5O0K9S/T87Uct2AvmEFqul11PnprQ98BZEyWILz8QYJt6/tlmqSOVKLNUtAgYHU7D9WGsOFVDb35nPA==
+      integrity: sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q==
   /@types/serve-static/1.13.1:
     dependencies:
       '@types/express-serve-static-core': 4.11.0
@@ -4248,7 +4250,7 @@ packages:
   /autoprefixer/9.8.6:
     dependencies:
       browserslist: 4.14.0
-      caniuse-lite: 1.0.30001114
+      caniuse-lite: 1.0.30001117
       colorette: 1.2.1
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -4272,14 +4274,14 @@ packages:
   /aws4/1.10.1:
     resolution:
       integrity: sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
-  /babel-jest/25.5.1_@babel+core@7.11.1:
+  /babel-jest/25.5.1_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@jest/transform': 25.5.1
       '@jest/types': 25.5.0
       '@types/babel__core': 7.1.9
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 25.5.0_@babel+core@7.11.1
+      babel-preset-jest: 25.5.0_@babel+core@7.11.4
       chalk: 3.0.0
       graceful-fs: 4.2.4
       slash: 3.0.0
@@ -4309,29 +4311,29 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==
-  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.11.1:
+  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.1
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.1
+      '@babel/core': 7.11.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.4
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.11.4
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.4
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.11.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.4
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==
-  /babel-preset-jest/25.5.0_@babel+core@7.11.1:
+  /babel-preset-jest/25.5.0_@babel+core@7.11.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       babel-plugin-jest-hoist: 25.5.0
-      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.11.1
+      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.11.4
     engines:
       node: '>= 8.3'
     peerDependencies:
@@ -4603,8 +4605,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/4.14.0:
     dependencies:
-      caniuse-lite: 1.0.30001114
-      electron-to-chromium: 1.3.533
+      caniuse-lite: 1.0.30001117
+      electron-to-chromium: 1.3.542
       escalade: 3.0.2
       node-releases: 1.1.60
     dev: false
@@ -4768,10 +4770,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
-  /caniuse-lite/1.0.30001114:
+  /caniuse-lite/1.0.30001117:
     dev: false
     resolution:
-      integrity: sha512-ml/zTsfNBM+T1+mjglWRPgVsu2L76GAaADKX5f4t0pbhttEp0WMawJsHDYlFkVZkoA+89uvBRrVrEE4oqenzXQ==
+      integrity: sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -5752,10 +5754,10 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-  /electron-to-chromium/1.3.533:
+  /electron-to-chromium/1.3.542:
     dev: false
     resolution:
-      integrity: sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A==
+      integrity: sha512-9Wm4o9h2CE/h4PDBkE5Ff2ha4frgltV/BgVCwFK8Tc9DKF19xJK85zA82JFah0/+oe8SU3rYRWtlYZH58pC6Ng==
   /elliptic/6.5.3:
     dependencies:
       bn.js: 4.11.9
@@ -6016,7 +6018,7 @@ packages:
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
       eslint-visitor-keys: 1.3.0
-      espree: 7.2.0
+      espree: 7.3.0
       esquery: 1.3.1
       esutils: 2.0.3
       file-entry-cache: 5.0.1
@@ -6048,7 +6050,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==
-  /espree/7.2.0:
+  /espree/7.3.0:
     dependencies:
       acorn: 7.4.0
       acorn-jsx: 5.2.0_acorn@7.4.0
@@ -6056,7 +6058,7 @@ packages:
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
-      integrity: sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
+      integrity: sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
   /esprima/1.2.5:
     engines:
       node: '>=0.4.0'
@@ -6138,9 +6140,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==
-  /eventemitter3/4.0.4:
+  /eventemitter3/4.0.5:
     resolution:
-      integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+      integrity: sha512-QR0rh0YiPuxuDQ6+T9GAO/xWTExXpxIes1Nl9RykNGTnE1HJmkuEfxJH9cubjIOQZ/GH4qNBR4u8VSHaKiWs4g==
   /events/3.2.0:
     engines:
       node: '>=0.8.x'
@@ -6316,7 +6318,7 @@ packages:
       integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
   /ext/1.4.0:
     dependencies:
-      type: 2.0.0
+      type: 2.1.0
     resolution:
       integrity: sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
   /extend-shallow/2.0.1:
@@ -6396,7 +6398,7 @@ packages:
       integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
   /faye-websocket/0.10.0:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.6.5
     engines:
       node: '>=0.4.0'
     resolution:
@@ -7404,7 +7406,7 @@ packages:
       depd: 1.1.2
       inherits: 2.0.3
       setprototypeof: 1.1.0
-      statuses: 1.4.0
+      statuses: 1.5.0
     engines:
       node: '>= 0.6'
     resolution:
@@ -7446,7 +7448,7 @@ packages:
       integrity: sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
   /http-proxy/1.18.1:
     dependencies:
-      eventemitter3: 4.0.4
+      eventemitter3: 4.0.5
       follow-redirects: 1.13.0
       requires-port: 1.0.0
     engines:
@@ -8064,7 +8066,7 @@ packages:
       integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@istanbuljs/schema': 0.1.2
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -8190,10 +8192,10 @@ packages:
       integrity: sha512-usyrj1lzCJZMRN1r3QEdnn8e6E6yCx/QN7+B1sLoA68V7f3WlsxSSQfy0+BAwRiF4Hz2eHauf11GZG3PIfWTXQ==
   /jest-config/25.5.4:
     dependencies:
-      '@babel/core': 7.11.1
+      '@babel/core': 7.11.4
       '@jest/test-sequencer': 25.5.4
       '@jest/types': 25.5.0
-      babel-jest: 25.5.1_@babel+core@7.11.1
+      babel-jest: 25.5.1_@babel+core@7.11.4
       chalk: 3.0.0
       deepmerge: 4.2.2
       glob: 7.1.6
@@ -8669,6 +8671,9 @@ packages:
   /json-parse-better-errors/1.0.2:
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+  /json-parse-even-better-errors/2.3.0:
+    resolution:
+      integrity: sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==
   /json-schema-traverse/0.4.1:
     resolution:
       integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
@@ -10114,16 +10119,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-json/5.0.1:
+  /parse-json/5.1.0:
     dependencies:
       '@babel/code-frame': 7.10.4
       error-ex: 1.3.2
-      json-parse-better-errors: 1.0.2
+      json-parse-even-better-errors: 2.3.0
       lines-and-columns: 1.1.6
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==
+      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   /parse-node-version/1.0.1:
     engines:
       node: '>= 0.10'
@@ -10612,9 +10617,9 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-  /querystringify/2.1.1:
+  /querystringify/2.2.0:
     resolution:
-      integrity: sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+      integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
   /ramda/0.27.1:
     dev: false
     resolution:
@@ -10697,23 +10702,21 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  /read-package-json/2.1.1:
+  /read-package-json/2.1.2:
     dependencies:
       glob: 7.1.6
-      json-parse-better-errors: 1.0.2
+      json-parse-even-better-errors: 2.3.0
       normalize-package-data: 2.5.0
       npm-normalize-package-bin: 1.0.1
     dev: false
-    optionalDependencies:
-      graceful-fs: 4.2.4
     resolution:
-      integrity: sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==
+      integrity: sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==
   /read-package-tree/5.1.6:
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
       once: 1.4.0
-      read-package-json: 2.1.1
+      read-package-json: 2.1.2
       readdir-scoped-modules: 1.1.0
     dev: false
     resolution:
@@ -10757,7 +10760,7 @@ packages:
     dependencies:
       '@types/normalize-package-data': 2.4.0
       normalize-package-data: 2.5.0
-      parse-json: 5.0.1
+      parse-json: 5.1.0
       type-fest: 0.6.0
     engines:
       node: '>=8'
@@ -11693,6 +11696,7 @@ packages:
     resolution:
       integrity: sha1-3e1FzBglbVHtQK7BQkidXGECbSg=
   /statuses/1.4.0:
+    dev: false
     engines:
       node: '>= 0.6'
     resolution:
@@ -11757,7 +11761,6 @@ packages:
     resolution:
       integrity: sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
   /string-argv/0.3.1:
-    dev: false
     engines:
       node: '>=0.6.19'
     resolution:
@@ -13135,9 +13138,9 @@ packages:
   /type/1.2.0:
     resolution:
       integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-  /type/2.0.0:
+  /type/2.1.0:
     resolution:
-      integrity: sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+      integrity: sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
   /typedarray-to-buffer/3.1.5:
     dependencies:
       is-typedarray: 1.0.0
@@ -13358,7 +13361,7 @@ packages:
       integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
   /url-parse/1.4.7:
     dependencies:
-      querystringify: 2.1.1
+      querystringify: 2.2.0
       requires-port: 1.0.0
     resolution:
       integrity: sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
@@ -14107,4 +14110,3 @@ packages:
       commander: 2.20.3
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
-registry: ''

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0ce92c259808418ec9fe9431841baed01364c3ba",
+  "pnpmShrinkwrapHash": "cf9445c8792bc022a9ec57c3acc649171bb036a1",
   "preferredVersionsHash": "334ea62b6a2798dcf80917b79555983377e7435e"
 }

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@microsoft/node-library-build": "6.4.31",
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
     "@types/glob": "7.1.1",
     "@types/gulp": "4.0.6",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -25,7 +25,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@microsoft/node-library-build": "6.4.31",
     "@microsoft/rush-stack-compiler-3.1": "workspace:*",
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
     "@types/glob": "7.1.1",
     "@types/resolve": "1.17.1",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@microsoft/node-library-build": "6.4.31",
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
     "@types/glob": "7.1.1",
     "@types/jest": "25.2.1",

--- a/heft-plugins/pre-compile-hardlink-or-copy-plugin/package.json
+++ b/heft-plugins/pre-compile-hardlink-or-copy-plugin/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@microsoft/rush-stack-compiler-3.7": "0.6.4",
-    "@rushstack/heft": "0.5.1"
+    "@microsoft/rush-stack-compiler-3.7": "0.6.8",
+    "@rushstack/heft": "0.6.5"
   }
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -22,9 +22,9 @@
     "z-schema": "~3.18.3"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@types/fs-extra": "7.0.0",
     "@types/jest": "25.2.1",
     "@types/jju": "1.4.1",

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -19,9 +19,9 @@
     "string-argv": "~0.3.1"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13"
   }

--- a/stack/eslint-patch/package.json
+++ b/stack/eslint-patch/package.json
@@ -24,7 +24,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "10.17.13",
-    "@microsoft/rush-stack-compiler-3.5": "0.8.4",
-    "@rushstack/heft": "0.5.1"
+    "@microsoft/rush-stack-compiler-3.5": "0.8.8",
+    "@rushstack/heft": "0.6.5"
   }
 }

--- a/stack/eslint-plugin/package.json
+++ b/stack/eslint-plugin/package.json
@@ -24,12 +24,12 @@
     "eslint": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@microsoft/rush-stack-compiler-3.9": "0.4.4",
+    "@microsoft/rush-stack-compiler-3.9": "0.4.8",
     "@types/eslint": "7.2.0",
     "@types/estree": "0.0.44",
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",

--- a/stack/rush-stack-compiler-2.4/package.json
+++ b/stack/rush-stack-compiler-2.4/package.json
@@ -33,7 +33,7 @@
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-2.7/package.json
+++ b/stack/rush-stack-compiler-2.7/package.json
@@ -33,7 +33,7 @@
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-2.8/package.json
+++ b/stack/rush-stack-compiler-2.8/package.json
@@ -33,7 +33,7 @@
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-2.9/package.json
+++ b/stack/rush-stack-compiler-2.9/package.json
@@ -33,7 +33,7 @@
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.0/package.json
+++ b/stack/rush-stack-compiler-3.0/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.1/package.json
+++ b/stack/rush-stack-compiler-3.1/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.2/package.json
+++ b/stack/rush-stack-compiler-3.2/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.3/package.json
+++ b/stack/rush-stack-compiler-3.3/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.4/package.json
+++ b/stack/rush-stack-compiler-3.4/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.5/package.json
+++ b/stack/rush-stack-compiler-3.5/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.6/package.json
+++ b/stack/rush-stack-compiler-3.6/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.7/package.json
+++ b/stack/rush-stack-compiler-3.7/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.8/package.json
+++ b/stack/rush-stack-compiler-3.8/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }

--- a/stack/rush-stack-compiler-3.9/package.json
+++ b/stack/rush-stack-compiler-3.9/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.5.1",
+    "@rushstack/heft": "0.6.5",
     "@rushstack/pre-compile-hardlink-or-copy-plugin": "workspace:*"
   }
 }


### PR DESCRIPTION
Upgrading Heft fixes an issue where a CI build sometimes did not catch test failures