### PR TITLE
[eslint-plugin] Add a new rule @rushstack/hoist-jest-mock

### DIFF
--- a/common/changes/@rushstack/eslint-plugin/octogonz-jest-eslint_2020-08-23-00-51.json
+++ b/common/changes/@rushstack/eslint-plugin/octogonz-jest-eslint_2020-08-23-00-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Add new rule @rushstack/hoist-jest-mock",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -5,6 +5,48 @@ which provides a TypeScript ESLint ruleset tailored for large teams and projects
 Please see [that project's documentation](https://www.npmjs.com/package/@rushstack/eslint-config)
 for details.  To learn about Rush Stack, please visit: [https://rushstack.io/](https://rushstack.io/)
 
+## `@rushstack/hoist-jest-mock`
+
+Require Jest module mocking APIs to be called before any other statements in their code block.
+
+#### Rule Details
+
+Jest module mocking APIs such as "jest.mock(\'./example\')" must be called before the associated module
+is imported, otherwise they will have no effect. Transpilers such as ts-jest and babel-jest automatically
+"hoist" these calls, however this can produce counterintuitive results. Instead, the hoist-jest-mocks
+lint rule requires developers to manually hoist these calls.
+
+The following APIs are affected: 'jest.mock()', 'jest.unmock()', 'jest.enableAutomock()', 'jest.disableAutomock()',
+'jest.deepUnmock()'.
+
+For technical background, please read the Jest documentation here: https://jestjs.io/docs/en/es6-class-mocks
+
+#### Examples
+
+The following patterns are considered problems when `@rushstack/hoist-jest-mock` is enabled:
+
+```ts
+import * as file from './file';
+jest.mock('./file'); // error
+
+test("example", () => {
+  const file2: typeof import('./file2') = require('./file2');
+  jest.mock('./file2'); // error
+});
+```
+
+The following patterns are NOT considered problems:
+
+```ts
+jest.mock('./file');
+import * as file from './file';
+
+test("example", () => {
+  jest.mock('./file2');
+  const file2: typeof import('./file2') = require('./file2');
+});
+```
+
 ## `@rushstack/no-new-null`
 
 Prevent usage of the JavaScript `null` value, while allowing code to access existing APIs that

--- a/stack/eslint-plugin/README.md
+++ b/stack/eslint-plugin/README.md
@@ -11,10 +11,10 @@ Require Jest module mocking APIs to be called before any other statements in the
 
 #### Rule Details
 
-Jest module mocking APIs such as "jest.mock(\'./example\')" must be called before the associated module
-is imported, otherwise they will have no effect. Transpilers such as ts-jest and babel-jest automatically
-"hoist" these calls, however this can produce counterintuitive results. Instead, the hoist-jest-mocks
-lint rule requires developers to manually hoist these calls.
+Jest module mocking APIs such as "jest.mock()" must be called before the associated module is imported, otherwise
+they will have no effect. Transpilers such as `ts-jest` and `babel-jest` automatically "hoist" these calls, however
+this can produce counterintuitive behavior. Instead, the `hoist-jest-mocks` lint rule simply requires developers
+to write the statements in the correct order.
 
 The following APIs are affected: 'jest.mock()', 'jest.unmock()', 'jest.enableAutomock()', 'jest.disableAutomock()',
 'jest.deepUnmock()'.
@@ -38,11 +38,11 @@ test("example", () => {
 The following patterns are NOT considered problems:
 
 ```ts
-jest.mock('./file');
+jest.mock('./file'); // okay, because mock() is first
 import * as file from './file';
 
 test("example", () => {
-  jest.mock('./file2');
+  jest.mock('./file2'); // okay, because mock() is first within the test() code block
   const file2: typeof import('./file2') = require('./file2');
 });
 ```
@@ -216,4 +216,3 @@ enum E {
 }
 let e: E._PrivateMember = E._PrivateMember; // okay, because _PrivateMember is declared by E
 ```
-

--- a/stack/eslint-plugin/src/hoist-jest-mock.test.ts
+++ b/stack/eslint-plugin/src/hoist-jest-mock.test.ts
@@ -9,8 +9,8 @@ const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser'
 });
 
-// These are the same cases considered by ts-jest's hoist-jest.spec.ts
-const CODE_WITH_HOISTING = [
+// These are the CODE_WITH_HOISTING cases from ts-jest's hoist-jest.spec.ts
+const INVALID_EXAMPLE_CODE = [
   /* 001 */ "const foo = 'foo'",
   /* 002 */ 'console.log(foo)',
   /* 003 */ 'jest.enableAutomock()',
@@ -44,10 +44,44 @@ const CODE_WITH_HOISTING = [
   /* 031 */ '}'
 ].join('\n');
 
+const VALID_EXAMPLE_CODE = [
+  /* 001 */ 'jest.enableAutomock()',
+  /* 002 */ 'jest.disableAutomock()',
+  /* 003 */ "jest.mock('./foo')",
+  /* 004 */ "jest.mock('./foo/bar', () => 'bar')",
+  /* 005 */ "jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 006 */ "jest.deepUnmock('./foo')",
+  /* 007 */ "jest.mock('./foo').mock('./bar')",
+  /* 008 */ "const foo = 'foo'",
+  /* 009 */ 'console.log(foo)',
+  /* 010 */ 'const func = () => {',
+  /* 011 */ "  jest.unmock('./foo')",
+  /* 012 */ "  jest.mock('./bar')",
+  /* 013 */ "  jest.mock('./bar/foo', () => 'foo')",
+  /* 014 */ "  jest.unmock('./foo/bar')",
+  /* 015 */ "  jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 016 */ "  jest.deepUnmock('./bar')",
+  /* 017 */ "  jest.mock('./foo').mock('./bar')",
+  /* 018 */ "  const bar = 'bar'",
+  /* 019 */ '  console.log(bar)',
+  /* 020 */ '}',
+  /* 021 */ 'const func2 = () => {',
+  /* 022 */ "  jest.mock('./bar')",
+  /* 023 */ "  jest.unmock('./foo/bar')",
+  /* 024 */ "  jest.mock('./bar/foo', () => 'foo')",
+  /* 025 */ "  jest.unmock('./foo')",
+  /* 026 */ "  jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 027 */ "  jest.deepUnmock('./bar')",
+  /* 038 */ "  jest.mock('./foo').mock('./bar')",
+  /* 029 */ "  const bar = 'bar'",
+  /* 030 */ '  console.log(bar)',
+  /* 031 */ '}'
+].join('\n');
+
 ruleTester.run('hoist-jest-mock', hoistJestMock, {
   invalid: [
     {
-      code: CODE_WITH_HOISTING,
+      code: INVALID_EXAMPLE_CODE,
       errors: [
         { messageId: 'error-unhoisted-jest-mock', line: 3 },
         { messageId: 'error-unhoisted-jest-mock', line: 4 },
@@ -75,5 +109,5 @@ ruleTester.run('hoist-jest-mock', hoistJestMock, {
       ]
     }
   ],
-  valid: []
+  valid: [{ code: VALID_EXAMPLE_CODE }]
 });

--- a/stack/eslint-plugin/src/hoist-jest-mock.test.ts
+++ b/stack/eslint-plugin/src/hoist-jest-mock.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { hoistJestMock } from './hoist-jest-mock';
+
+const { RuleTester } = ESLintUtils;
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser'
+});
+
+// These are the same cases considered by ts-jest's hoist-jest.spec.ts
+const CODE_WITH_HOISTING = [
+  /* 001 */ "const foo = 'foo'",
+  /* 002 */ 'console.log(foo)',
+  /* 003 */ 'jest.enableAutomock()',
+  /* 004 */ 'jest.disableAutomock()',
+  /* 005 */ "jest.mock('./foo')",
+  /* 006 */ "jest.mock('./foo/bar', () => 'bar')",
+  /* 007 */ "jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 008 */ "jest.deepUnmock('./foo')",
+  /* 009 */ "jest.mock('./foo').mock('./bar')",
+  /* 010 */ 'const func = () => {',
+  /* 011 */ "  const bar = 'bar'",
+  /* 012 */ '  console.log(bar)',
+  /* 013 */ "  jest.unmock('./foo')",
+  /* 014 */ "  jest.mock('./bar')",
+  /* 015 */ "  jest.mock('./bar/foo', () => 'foo')",
+  /* 016 */ "  jest.unmock('./foo/bar')",
+  /* 017 */ "  jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 018 */ "  jest.deepUnmock('./bar')",
+  /* 019 */ "  jest.mock('./foo').mock('./bar')",
+  /* 020 */ '}',
+  /* 021 */ 'const func2 = () => {',
+  /* 022 */ "  const bar = 'bar'",
+  /* 023 */ '  console.log(bar)',
+  /* 024 */ "  jest.mock('./bar')",
+  /* 025 */ "  jest.unmock('./foo/bar')",
+  /* 026 */ "  jest.mock('./bar/foo', () => 'foo')",
+  /* 027 */ "  jest.unmock('./foo')",
+  /* 028 */ "  jest.unmock('./bar/foo').dontMock('./bar/bar')",
+  /* 029 */ "  jest.deepUnmock('./bar')",
+  /* 030 */ "  jest.mock('./foo').mock('./bar')",
+  /* 031 */ '}'
+].join('\n');
+
+ruleTester.run('hoist-jest-mock', hoistJestMock, {
+  invalid: [
+    {
+      code: CODE_WITH_HOISTING,
+      errors: [
+        { messageId: 'error-unhoisted-jest-mock', line: 3 },
+        { messageId: 'error-unhoisted-jest-mock', line: 4 },
+        { messageId: 'error-unhoisted-jest-mock', line: 5 },
+        { messageId: 'error-unhoisted-jest-mock', line: 6 },
+        { messageId: 'error-unhoisted-jest-mock', line: 7 },
+        { messageId: 'error-unhoisted-jest-mock', line: 8 },
+        { messageId: 'error-unhoisted-jest-mock', line: 9 },
+
+        { messageId: 'error-unhoisted-jest-mock', line: 13 },
+        { messageId: 'error-unhoisted-jest-mock', line: 14 },
+        { messageId: 'error-unhoisted-jest-mock', line: 15 },
+        { messageId: 'error-unhoisted-jest-mock', line: 16 },
+        { messageId: 'error-unhoisted-jest-mock', line: 17 },
+        { messageId: 'error-unhoisted-jest-mock', line: 18 },
+        { messageId: 'error-unhoisted-jest-mock', line: 19 },
+
+        { messageId: 'error-unhoisted-jest-mock', line: 24 },
+        { messageId: 'error-unhoisted-jest-mock', line: 25 },
+        { messageId: 'error-unhoisted-jest-mock', line: 26 },
+        { messageId: 'error-unhoisted-jest-mock', line: 27 },
+        { messageId: 'error-unhoisted-jest-mock', line: 28 },
+        { messageId: 'error-unhoisted-jest-mock', line: 29 },
+        { messageId: 'error-unhoisted-jest-mock', line: 30 }
+      ]
+    }
+  ],
+  valid: []
+});

--- a/stack/eslint-plugin/src/hoist-jest-mock.ts
+++ b/stack/eslint-plugin/src/hoist-jest-mock.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+
+import { matchTree } from './matchTree';
+import * as hoistJestMockPatterns from './hoistJestMockPatterns';
+
+type MessageIds = 'error-unhoisted-jest-mock';
+type Options = [];
+
+// Jest APIs that need to be hoisted
+// Based on HOIST_METHODS from ts-jest
+const HOIST_METHODS = ['mock', 'unmock', 'enableAutomock', 'disableAutomock', 'deepUnmock'];
+
+const hoistJestMock: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'problem',
+    messages: {
+      'error-unhoisted-jest-mock':
+        "Jest's mocks must be installed before the associated module is imported. Move this line to the top of its block."
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false
+      }
+    ],
+    docs: {
+      description: 'Require Jest mock calls to be manually hoisted to the top of their scope.',
+      category: 'Possible Errors',
+      recommended: 'error',
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'
+    }
+  },
+
+  create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
+    function isHoistableJestCall(node: TSESTree.Node | undefined): boolean {
+      if (node === undefined) {
+        return false;
+      }
+
+      const captures: hoistJestMockPatterns.IJestCallExpression = {};
+
+      if (matchTree(node, hoistJestMockPatterns.jestCallExpression, captures)) {
+        if (captures.methodName && HOIST_METHODS.indexOf(captures.methodName) >= 0) {
+          return true;
+        }
+      }
+
+      // Recurse into some common expression-combining syntaxes
+      switch (node.type) {
+        case AST_NODE_TYPES.CallExpression:
+          return isHoistableJestCall(node.callee);
+        case AST_NODE_TYPES.MemberExpression:
+          return isHoistableJestCall(node.object);
+        case AST_NODE_TYPES.LogicalExpression:
+          return isHoistableJestCall(node.left) || isHoistableJestCall(node.right);
+      }
+
+      return false;
+    }
+
+    function isHoistableJestStatement(node: TSESTree.Node): boolean {
+      switch (node.type) {
+        case AST_NODE_TYPES.ExpressionStatement:
+          return isHoistableJestCall(node.expression);
+      }
+      return false;
+    }
+
+    return {
+      'TSModuleBlock, BlockStatement, Program': (
+        node: TSESTree.TSModuleBlock | TSESTree.BlockStatement | TSESTree.Program
+      ): void => {
+        let encounteredRegularStatements: boolean = false;
+
+        for (const statement of node.body) {
+          if (isHoistableJestStatement(statement)) {
+            // Are we still at the start of the block?
+            if (encounteredRegularStatements) {
+              context.report({ node: statement, messageId: 'error-unhoisted-jest-mock' });
+            }
+          } else {
+            // We encountered a non-hoistable statement, so any further children that we visit
+            // must also be non-hoistable
+            encounteredRegularStatements = true;
+          }
+        }
+      }
+    };
+  }
+};
+
+export { hoistJestMock };

--- a/stack/eslint-plugin/src/hoist-jest-mock.ts
+++ b/stack/eslint-plugin/src/hoist-jest-mock.ts
@@ -19,7 +19,8 @@ const hoistJestMock: TSESLint.RuleModule<MessageIds, Options> = {
     type: 'problem',
     messages: {
       'error-unhoisted-jest-mock':
-        "Jest's mocks must be installed before the associated module is imported. Move this line to the top of its block."
+        "Jest's module mocking APIs must be called before their associated module is imported. " +
+        ' Move this statement to the top of its code block.'
     },
     schema: [
       {
@@ -28,7 +29,13 @@ const hoistJestMock: TSESLint.RuleModule<MessageIds, Options> = {
       }
     ],
     docs: {
-      description: 'Require Jest mock calls to be manually hoisted to the top of their scope.',
+      description:
+        'Require Jest module mocking APIs to be called before any other statements in their code block.' +
+        ' Jest module mocking APIs such as "jest.mock(\'./example\')" must be called before the associated module' +
+        ' is imported, otherwise they will have no effect. Transpilers such as ts-jest and babel-jest automatically' +
+        ' "hoist" these calls, however this can produce counterintuitive results. Instead, the hoist-jest-mocks' +
+        ' lint rule requires developers to manually hoist these calls. For technical background, please read the' +
+        ' Jest documentation here: https://jestjs.io/docs/en/es6-class-mocks',
       category: 'Possible Errors',
       recommended: 'error',
       url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'

--- a/stack/eslint-plugin/src/hoistJestMockPatterns.ts
+++ b/stack/eslint-plugin/src/hoistJestMockPatterns.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { matchTreeArg } from './matchTree';
+
+export interface IJestCallExpression {
+  // Example: "mock" from "jest.mock('./thing')"
+  methodName?: string;
+}
+
+// Matches a statement expression like this:
+//   jest.mock('./thing')
+//
+// Tree:
+//   {
+//     type: 'CallExpression',
+//     callee: {
+//       type: 'MemberExpression',
+//       object: {
+//         type: 'Identifier',
+//         name: 'jest'
+//       },
+//       property: {
+//         type: 'Identifier',
+//         name: 'mock'
+//       }
+//     },
+//     arguments: [
+//       {
+//         type: 'Literal',
+//         value: './thing'
+//       }
+//     ]
+//   };
+export const jestCallExpression = {
+  type: 'CallExpression',
+  callee: {
+    type: 'MemberExpression',
+    object: {
+      type: 'Identifier',
+      name: 'jest'
+    },
+    property: {
+      type: 'Identifier',
+      name: matchTreeArg('methodName')
+    }
+  }
+};

--- a/stack/eslint-plugin/src/index.ts
+++ b/stack/eslint-plugin/src/index.ts
@@ -3,8 +3,9 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
-import { noNullRule } from './no-null';
+import { hoistJestMock } from './hoist-jest-mock';
 import { noNewNullRule } from './no-new-null';
+import { noNullRule } from './no-null';
 import { noUntypedUnderscoreRule } from './no-untyped-underscore';
 
 interface IPlugin {
@@ -13,9 +14,16 @@ interface IPlugin {
 
 const plugin: IPlugin = {
   rules: {
-    // NOTE: The actual ESLint rule name will be "@rushstack/no-null".
-    'no-null': noNullRule,
+    // Full name: "@rushstack/hoist-jest-mock"
+    'hoist-jest-mock': hoistJestMock,
+
+    // Full name: "@rushstack/no-new-null"
     'no-new-null': noNewNullRule,
+
+    // Full name: "@rushstack/no-null"
+    'no-null': noNullRule,
+
+    // Full name: "@rushstack/no-untyped-underscore"
     'no-untyped-underscore': noUntypedUnderscoreRule
   }
 };

--- a/stack/eslint-plugin/src/matchTree.test.ts
+++ b/stack/eslint-plugin/src/matchTree.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { matchTree, matchTreeArg } from './matchTree';
+
+export interface IPattern {
+  branch?: string;
+}
+
+const pattern = {
+  a: [
+    1,
+    2,
+    matchTreeArg('branch', {
+      b: []
+    })
+  ]
+};
+
+describe('matchTree', () => {
+  test('matches using matchTreeArg', () => {
+    const tree = {
+      a: [
+        1,
+        2,
+        {
+          b: [],
+          extra: 'hi'
+        }
+      ],
+      b: 123
+    };
+
+    const captures: IPattern = {};
+    expect(matchTree(tree, pattern, captures)).toBe(true);
+    expect(captures.branch).toMatchObject({
+      b: [],
+      extra: 'hi'
+    });
+  });
+});

--- a/stack/eslint-plugin/src/matchTree.ts
+++ b/stack/eslint-plugin/src/matchTree.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export type IMatchTreeCaptureSet =
+  | {
+      [key: string]: any;
+    }
+  | { failPath: string };
+
+class MatchTreeArg {
+  public readonly keyName: string;
+  public readonly subtree: any | undefined;
+  public constructor(keyName: string, subtree?: any) {
+    this.keyName = keyName;
+    this.subtree = subtree;
+  }
+}
+
+class MatchTreeAlternatives {
+  public readonly possibleSubtrees: any[];
+  public constructor(possibleSubtrees: any[]) {
+    this.possibleSubtrees = possibleSubtrees;
+  }
+}
+
+function matchTreeRecursive(root: any, pattern: any, captures: IMatchTreeCaptureSet, path: string): boolean {
+  if (pattern === undefined) {
+    throw new Error('pattern has an undefined value at ' + path);
+  }
+
+  if (pattern instanceof MatchTreeArg) {
+    if (pattern.subtree !== undefined) {
+      if (!matchTreeRecursive(root, pattern.subtree, captures, path)) {
+        return false;
+      }
+    }
+
+    captures[pattern.keyName] = root;
+    return true;
+  }
+
+  if (pattern instanceof MatchTreeAlternatives) {
+    // Try each possible alternative until we find one that matches
+    for (const possibleSubtree of pattern.possibleSubtrees) {
+      // We shouldn't update "captures" unless the match is fully successful.
+      // So make a temporary copy of it.
+      const tempCaptures = { ...captures };
+      if (matchTreeRecursive(root, possibleSubtree, tempCaptures, path)) {
+        // The match was successful, so assign the tempCaptures results back into the
+        // original "captures" object.
+        for (const key of Object.getOwnPropertyNames(tempCaptures)) {
+          captures[key] = tempCaptures[key];
+        }
+        return true;
+      }
+    }
+
+    // None of the alternatives matched
+    return false;
+  }
+
+  if (Array.isArray(pattern)) {
+    if (!Array.isArray(root)) {
+      captures.failPath = path;
+      return false;
+    }
+
+    if (root.length !== pattern.length) {
+      captures.failPath = path;
+      return false;
+    }
+
+    for (let i = 0; i < pattern.length; ++i) {
+      const subPath: string = path + '[' + i + ']';
+
+      const rootElement = root[i];
+      const patternElement = pattern[i];
+      if (!matchTreeRecursive(rootElement, patternElement, captures, subPath)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // In JavaScript, typeof null === 'object'
+  if (typeof pattern === 'object' && pattern !== null) {
+    if (typeof root !== 'object' || root === null) {
+      captures.failPath = path;
+      return false;
+    }
+
+    for (const keyName of Object.getOwnPropertyNames(pattern)) {
+      let subPath: string;
+      if (/^[a-z_][a-z0-9_]*$/i.test(keyName)) {
+        subPath = path + '.' + keyName;
+      } else {
+        subPath = path + '[' + JSON.stringify(keyName) + ']';
+      }
+
+      if (!Object.hasOwnProperty.call(root, keyName)) {
+        captures.failPath = subPath;
+        return false;
+      }
+      if (!matchTreeRecursive(root[keyName], pattern[keyName], captures, subPath)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  if (root !== pattern) {
+    captures.failPath = path;
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Starting at `root`, search for the first subtree that matches `pattern`.
+ * If found, return true and assign the matching nodes to the `captures` object.
+ */
+export function matchTree(root: any, pattern: any, captures: IMatchTreeCaptureSet): boolean {
+  return matchTreeRecursive(root, pattern, captures, 'root');
+}
+
+/**
+ * Used to build the `pattern` tree for `matchTree()`.  For the given `subtree` of the pattern,
+ * if it is matched, that node will be assigned to the `captures` object using `keyName`.
+ */
+export function matchTreeArg(keyName: string, subtree?: any): any {
+  return new MatchTreeArg(keyName, subtree);
+}
+
+/**
+ * Used to build the `pattern` tree for `matchTree()`.  Allows several alternative patterns
+ * to be matched for a given subtree.
+ */
+export function matchTreeAlternatives(possibleSubtrees: any[]): any {
+  return new MatchTreeAlternatives(possibleSubtrees);
+}

--- a/stack/eslint-plugin/src/no-new-null.test.ts
+++ b/stack/eslint-plugin/src/no-new-null.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
+
 import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 import { noNewNullRule } from './no-new-null';
 


### PR DESCRIPTION
This ESLint rule catches a common mistake when using Heft's Jest transform.

See [README.md](https://github.com/microsoft/rushstack/blob/octogonz/jest-eslint/stack/eslint-plugin/README.md) for docs.