### PR TITLE
[module-minifier-plugin] Fix duplicate modules during render

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/dmichon-fix-duplicate-modules_2020-09-02-01-10.json
+++ b/common/changes/@rushstack/module-minifier-plugin/dmichon-fix-duplicate-modules_2020-09-02-01-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Fix duplicate module emit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -332,7 +332,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
             const externals: string[] = [];
             const externalNames: Map<string, string> = new Map();
 
-            const chunkModules: (string | number)[] = [];
+            const chunkModuleSet: Set<string | number> = new Set();
             const allChunkModules: Iterable<IExtendedModule> = chunk.modulesIterable;
             let hasNonNumber: boolean = false;
             for (const mod of allChunkModules) {
@@ -340,7 +340,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                 if (typeof mod.id !== 'number') {
                   hasNonNumber = true;
                 }
-                chunkModules.push(mod.id);
+                chunkModuleSet.add(mod.id);
 
                 if (mod.external) {
                   const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
@@ -355,6 +355,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
               }
             }
 
+            const chunkModules: (string | number)[] = Array.from(chunkModuleSet);
             // Sort by id before rehydration in case we rehydrate a given chunk multiple times
             chunkModules.sort(hasNonNumber ? stringifyIdSortPredicate : (x: number, y: number) => x - y);
 


### PR DESCRIPTION
Fixes a bug in which if a chunk somehow contained duplicate module ids they would render invalid code.