### PR TITLE
[Rush] Refactor the TaskRunner

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -131,28 +131,29 @@ export class BulkScriptAction extends BaseScriptAction {
       allowWarningsInSuccessfulBuild: this._allowWarningsInSuccessfulBuild
     });
 
-    return taskRunner
-      .executeAsync()
-      .then(() => {
-        stopwatch.stop();
-        console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
-        this._doAfterTask(stopwatch, true);
-      })
-      .catch((error: Error) => {
-        stopwatch.stop();
-        if (error instanceof AlreadyReportedError) {
-          console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
-        } else {
-          if (error && error.message) {
-            console.log('Error: ' + error.message);
-          }
+    try {
+      await taskRunner.executeAsync();
 
-          console.log(colors.red(`rush ${this.actionName} - Errors! (${stopwatch.toString()})`));
+      stopwatch.stop();
+      console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
+
+      this._doAfterTask(stopwatch, true);
+    } catch (error) {
+      stopwatch.stop();
+
+      if (error instanceof AlreadyReportedError) {
+        console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
+      } else {
+        if (error && error.message) {
+          console.log('Error: ' + error.message);
         }
 
-        this._doAfterTask(stopwatch, false);
-        throw new AlreadyReportedError();
-      });
+        console.log(colors.red(`rush ${this.actionName} - Errors! (${stopwatch.toString()})`));
+      }
+
+      this._doAfterTask(stopwatch, false);
+      throw new AlreadyReportedError();
+    }
   }
 
   protected onDefineParameters(): void {

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -132,7 +132,7 @@ export class BulkScriptAction extends BaseScriptAction {
     });
 
     return taskRunner
-      .execute()
+      .executeAsync()
       .then(() => {
         stopwatch.stop();
         console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
@@ -223,7 +223,9 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const scopedNames: string[] = [];
 
-    const projectJsons: IRushConfigurationProjectJson[] = [...this.rushConfiguration.rushConfigurationJson.projects];
+    const projectJsons: IRushConfigurationProjectJson[] = [
+      ...this.rushConfiguration.rushConfigurationJson.projects
+    ];
 
     for (const projectJson of projectJsons) {
       scopedNames.push(projectJson.packageName);

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { ITaskWriter } from '@rushstack/stream-collator';
+
 import { TaskStatus } from './TaskStatus';
 
 /**
@@ -13,7 +14,7 @@ export abstract class BaseBuilder {
   /**
    * Name of the task definition.
    */
-  abstract name: string;
+  abstract readonly name: string;
 
   /**
    * This flag determines if an incremental build is allowed for the task.

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ITaskWriter } from '@rushstack/stream-collator';
+import { TaskStatus } from './TaskStatus';
+
+/**
+ * A definition for a task, an execute function returning a promise and a unique string name
+ */
+export abstract class BaseBuilder {
+  /**
+   * Name of the task definition.
+   */
+  abstract name: string;
+
+  /**
+   * This flag determines if an incremental build is allowed for the task.
+   */
+  abstract isIncrementalBuildAllowed: boolean;
+
+  /**
+   * Assigned by execute().  True if the build script was an empty string.  Operationally an empty string is
+   * like a shell command that succeeds instantly, but e.g. it would be odd to report build time statistics for it.
+   */
+  abstract hadEmptyScript: boolean;
+
+  /**
+   * Method to be executed for the task.
+   */
+  abstract async execute(writer: ITaskWriter): Promise<TaskStatus>;
+}

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -5,7 +5,9 @@ import { ITaskWriter } from '@rushstack/stream-collator';
 import { TaskStatus } from './TaskStatus';
 
 /**
- * A definition for a task, an execute function returning a promise and a unique string name
+ * The `Task` class is a node in the dependency graph of work that needs to be scheduled by the `TaskRunner`.
+ * Each `Task` has a `BaseBuilder` member, whose subclass manages the actual operations for building a single
+ * project.
  */
 export abstract class BaseBuilder {
   /**
@@ -27,5 +29,5 @@ export abstract class BaseBuilder {
   /**
    * Method to be executed for the task.
    */
-  abstract async execute(writer: ITaskWriter): Promise<TaskStatus>;
+  abstract async executeAsync(writer: ITaskWriter): Promise<TaskStatus>;
 }

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -12,14 +12,14 @@ import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { Utilities } from '../../utilities/Utilities';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
-import { ITaskDefinition } from '../taskRunner/ITask';
 import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
+import { BaseBuilder } from './BaseBuilder';
 
 interface IPackageDependencies extends IPackageDeps {
   arguments: string;
 }
 
-export interface IProjectTaskOptions {
+export interface IProjectBuilderOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   commandToRun: string;
@@ -47,9 +47,9 @@ function _areShallowEqual(object1: JsonObject, object2: JsonObject, writer: ITas
 /**
  * A TaskRunner task which cleans and builds a project
  */
-export class ProjectTask implements ITaskDefinition {
+export class ProjectBuilder extends BaseBuilder {
   public get name(): string {
-    return ProjectTask.getTaskName(this._rushProject);
+    return ProjectBuilder.getTaskName(this._rushProject);
   }
 
   public isIncrementalBuildAllowed: boolean;
@@ -62,7 +62,8 @@ export class ProjectTask implements ITaskDefinition {
   private _packageChangeAnalyzer: PackageChangeAnalyzer;
   private _packageDepsFilename: string;
 
-  public constructor(options: IProjectTaskOptions) {
+  public constructor(options: IProjectBuilderOptions) {
+    super();
     this._rushProject = options.rushProject;
     this._rushConfiguration = options.rushConfiguration;
     this._commandToRun = options.commandToRun;
@@ -72,7 +73,7 @@ export class ProjectTask implements ITaskDefinition {
   }
 
   /**
-   * A helper method to determine the task name of a ProjectTask. Used when the task
+   * A helper method to determine the task name of a ProjectBuilder. Used when the task
    * name is required before a task is created.
    */
   public static getTaskName(rushProject: RushConfigurationProject): string {

--- a/apps/rush-lib/src/logic/taskRunner/Task.ts
+++ b/apps/rush-lib/src/logic/taskRunner/Task.ts
@@ -6,55 +6,32 @@ import { ITaskWriter } from '@rushstack/stream-collator';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
-
-/**
- * A definition for a task, an execute function returning a promise and a unique string name
- */
-export interface ITaskDefinition {
-  /**
-   * Name of the task definition.
-   */
-  name: string;
-
-  /**
-   * This flag determines if an incremental build is allowed for the task.
-   */
-  isIncrementalBuildAllowed: boolean;
-
-  /**
-   * Assigned by execute().  True if the build script was an empty string.  Operationally an empty string is
-   * like a shell command that succeeds instantly, but e.g. it would be odd to report build time statistics for it.
-   */
-  hadEmptyScript: boolean;
-
-  /**
-   * Method to be executed for the task.
-   */
-  execute: (writer: ITaskWriter) => Promise<TaskStatus>;
-}
+import { BaseBuilder } from './BaseBuilder';
 
 /**
  * The interface used internally by TaskRunner, which tracks the dependencies and execution status
  */
-export interface ITask extends ITaskDefinition {
+export class Task {
+  public builder: BaseBuilder;
+
   /**
    * The current execution status of a task. Tasks start in the 'ready' state,
    * but can be 'blocked' if an upstream task failed. It is 'executing' when
    * the task is executing. Once execution is complete, it is either 'success' or
    * 'failure'.
    */
-  status: TaskStatus;
+  public status: TaskStatus;
 
   /**
    * A set of all dependencies which must be executed before this task is complete.
    * When dependencies finish execution, they are removed from this list.
    */
-  dependencies: Set<ITask>;
+  public dependencies: Set<Task>;
 
   /**
    * The inverse of dependencies, lists all projects which are directly dependent on this one.
    */
-  dependents: Set<ITask>;
+  public dependents: Set<Task>;
 
   /**
    * This number represents how far away this Task is from the furthest "root" project (i.e.
@@ -85,21 +62,25 @@ export interface ITask extends ITaskDefinition {
    *
    * The algorithm is implemented in TaskRunner as _calculateCriticalPaths()
    */
-  criticalPathLength: number | undefined;
+  public criticalPathLength: number | undefined;
 
   /**
    * The error which occurred while executing this task, this is stored in case we need
    * it later (for example to re-print errors at end of execution).
    */
-  error: TaskError | undefined;
+  public error: TaskError | undefined;
 
   /**
    * The task writer which contains information from the output streams of this task
    */
-  writer: ITaskWriter;
+  public writer: ITaskWriter;
 
   /**
    * The stopwatch which measures how long it takes the task to execute
    */
-  stopwatch: Stopwatch;
+  public stopwatch: Stopwatch;
+
+  public get name(): string {
+    return this.builder.name;
+  }
 }

--- a/apps/rush-lib/src/logic/taskRunner/Task.ts
+++ b/apps/rush-lib/src/logic/taskRunner/Task.ts
@@ -9,9 +9,15 @@ import { TaskError } from './TaskError';
 import { BaseBuilder } from './BaseBuilder';
 
 /**
- * The interface used internally by TaskRunner, which tracks the dependencies and execution status
+ * The `Task` class is a node in the dependency graph of work that needs to be scheduled by the `TaskRunner`.
+ * Each `Task` has a `BaseBuilder` member, whose subclass manages the actual operations for building a single
+ * project.
  */
 export class Task {
+  /**
+   * When the scheduler is ready to process this `Task`, the `builder` implements the actual work of
+   * building the project.
+   */
   public builder: BaseBuilder;
 
   /**

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -12,7 +12,7 @@ import {
 } from '@rushstack/node-core-library';
 
 import { Stopwatch } from '../../utilities/Stopwatch';
-import { ITask } from './ITask';
+import { Task } from './Task';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
 
@@ -31,10 +31,10 @@ export interface ITaskRunnerOptions {
  * tasks are complete, or prematurely fails if any of the tasks fail.
  */
 export class TaskRunner {
-  private _tasks: ITask[];
+  private _tasks: Task[];
   private _changedProjectsOnly: boolean;
   private _allowWarningsInSuccessfulBuild: boolean;
-  private _buildQueue: ITask[];
+  private _buildQueue: Task[];
   private _quietMode: boolean;
   private _hasAnyFailures: boolean;
   private _hasAnyWarnings: boolean;
@@ -44,7 +44,7 @@ export class TaskRunner {
   private _completedTasks: number;
   private _terminal: Terminal;
 
-  public constructor(orderedTasks: ITask[], options: ITaskRunnerOptions) {
+  public constructor(orderedTasks: Task[], options: ITaskRunnerOptions) {
     const {
       quietMode,
       parallelism,
@@ -121,9 +121,9 @@ export class TaskRunner {
    * Pulls the next task with no dependencies off the build queue
    * Removes any non-ready tasks from the build queue (this should only be blocked tasks)
    */
-  private _getNextTask(): ITask | undefined {
+  private _getNextTask(): Task | undefined {
     for (let i: number = 0; i < this._buildQueue.length; i++) {
-      const task: ITask = this._buildQueue[i];
+      const task: Task = this._buildQueue[i];
 
       if (task.status !== TaskStatus.Ready) {
         // It shouldn't be on the queue, remove it
@@ -145,10 +145,10 @@ export class TaskRunner {
    */
   private _startAvailableTasks(): Promise<void> {
     const taskPromises: Promise<void>[] = [];
-    let ctask: ITask | undefined;
+    let ctask: Task | undefined;
     while (this._currentActiveTasks < this._parallelism && (ctask = this._getNextTask())) {
       this._currentActiveTasks++;
-      const task: ITask = ctask;
+      const task: Task = ctask;
       task.status = TaskStatus.Executing;
       this._terminal.writeLine(Colors.white(`[${task.name}] started`));
 
@@ -156,7 +156,7 @@ export class TaskRunner {
       task.writer = Interleaver.registerTask(task.name, this._quietMode);
 
       taskPromises.push(
-        task
+        task.builder
           .execute(task.writer)
           .then((result: TaskStatus) => {
             task.stopwatch.stop();
@@ -202,10 +202,10 @@ export class TaskRunner {
   /**
    * Marks a task as having failed and marks each of its dependents as blocked
    */
-  private _markTaskAsFailed(task: ITask): void {
+  private _markTaskAsFailed(task: Task): void {
     this._terminal.writeErrorLine(`${os.EOL}${this._getCurrentCompletedTaskString()}[${task.name}] failed!`);
     task.status = TaskStatus.Failure;
-    task.dependents.forEach((dependent: ITask) => {
+    task.dependents.forEach((dependent: Task) => {
       this._markTaskAsBlocked(dependent, task);
     });
   }
@@ -213,14 +213,14 @@ export class TaskRunner {
   /**
    * Marks a task and all its dependents as blocked
    */
-  private _markTaskAsBlocked(task: ITask, failedTask: ITask): void {
+  private _markTaskAsBlocked(task: Task, failedTask: Task): void {
     if (task.status === TaskStatus.Ready) {
       this._completedTasks++;
       this._terminal.writeErrorLine(
         `${this._getCurrentCompletedTaskString()}[${task.name}] blocked by [${failedTask.name}]!`
       );
       task.status = TaskStatus.Blocked;
-      task.dependents.forEach((dependent: ITask) => {
+      task.dependents.forEach((dependent: Task) => {
         this._markTaskAsBlocked(dependent, failedTask);
       });
     }
@@ -229,8 +229,8 @@ export class TaskRunner {
   /**
    * Marks a task as being completed, and removes it from the dependencies list of all its dependents
    */
-  private _markTaskAsSuccess(task: ITask): void {
-    if (task.hadEmptyScript) {
+  private _markTaskAsSuccess(task: Task): void {
+    if (task.builder.hadEmptyScript) {
       this._terminal.writeLine(
         Colors.green(`${this._getCurrentCompletedTaskString()}[${task.name}] had an empty script`)
       );
@@ -244,9 +244,9 @@ export class TaskRunner {
     }
     task.status = TaskStatus.Success;
 
-    task.dependents.forEach((dependent: ITask) => {
+    task.dependents.forEach((dependent: Task) => {
       if (!this._changedProjectsOnly) {
-        dependent.isIncrementalBuildAllowed = false;
+        dependent.builder.isIncrementalBuildAllowed = false;
       }
       dependent.dependencies.delete(task);
     });
@@ -256,15 +256,15 @@ export class TaskRunner {
    * Marks a task as being completed, but with warnings written to stderr, and removes it from the dependencies
    * list of all its dependents
    */
-  private _markTaskAsSuccessWithWarning(task: ITask): void {
+  private _markTaskAsSuccessWithWarning(task: Task): void {
     this._terminal.writeWarningLine(
       `${this._getCurrentCompletedTaskString()}` +
         `[${task.name}] completed with warnings in ${task.stopwatch.toString()}`
     );
     task.status = TaskStatus.SuccessWithWarning;
-    task.dependents.forEach((dependent: ITask) => {
+    task.dependents.forEach((dependent: Task) => {
       if (!this._changedProjectsOnly) {
-        dependent.isIncrementalBuildAllowed = false;
+        dependent.builder.isIncrementalBuildAllowed = false;
       }
       dependent.dependencies.delete(task);
     });
@@ -273,10 +273,10 @@ export class TaskRunner {
   /**
    * Marks a task as skipped.
    */
-  private _markTaskAsSkipped(task: ITask): void {
+  private _markTaskAsSkipped(task: Task): void {
     this._terminal.writeLine(Colors.green(`${this._getCurrentCompletedTaskString()}[${task.name}] skipped`));
     task.status = TaskStatus.Skipped;
-    task.dependents.forEach((dependent: ITask) => {
+    task.dependents.forEach((dependent: Task) => {
       dependent.dependencies.delete(task);
     });
   }
@@ -289,8 +289,8 @@ export class TaskRunner {
    * Prints out a report of the status of each project
    */
   private _printTaskStatus(): void {
-    const tasksByStatus: { [status: number]: ITask[] } = {};
-    this._tasks.forEach((task: ITask) => {
+    const tasksByStatus: { [status: number]: Task[] } = {};
+    this._tasks.forEach((task: Task) => {
       if (tasksByStatus[task.status]) {
         tasksByStatus[task.status].push(task);
       } else {
@@ -313,9 +313,9 @@ export class TaskRunner {
     this._printStatus(TaskStatus.Blocked, tasksByStatus, Colors.red);
     this._printStatus(TaskStatus.Failure, tasksByStatus, Colors.red);
 
-    const tasksWithErrors: ITask[] = tasksByStatus[TaskStatus.Failure];
+    const tasksWithErrors: Task[] = tasksByStatus[TaskStatus.Failure];
     if (tasksWithErrors) {
-      tasksWithErrors.forEach((task: ITask) => {
+      tasksWithErrors.forEach((task: Task) => {
         if (task.error) {
           this._terminal.writeErrorLine(`[${task.name}] ${task.error.message}`);
         }
@@ -327,17 +327,17 @@ export class TaskRunner {
 
   private _printStatus(
     status: TaskStatus,
-    tasksByStatus: { [status: number]: ITask[] },
+    tasksByStatus: { [status: number]: Task[] },
     color: (text: string) => IColorableSequence,
     headingColor: (text: string) => IColorableSequence = color
   ): void {
-    const tasks: ITask[] = tasksByStatus[status];
+    const tasks: Task[] = tasksByStatus[status];
 
     if (tasks && tasks.length) {
       this._terminal.writeLine(headingColor(`${status} (${tasks.length})`));
       this._terminal.writeLine(color('================================'));
       for (let i: number = 0; i < tasks.length; i++) {
-        const task: ITask = tasks[i];
+        const task: Task = tasks[i];
 
         switch (status) {
           case TaskStatus.Executing:
@@ -350,7 +350,7 @@ export class TaskRunner {
           case TaskStatus.SuccessWithWarning:
           case TaskStatus.Blocked:
           case TaskStatus.Failure:
-            if (task.stopwatch && !task.hadEmptyScript) {
+            if (task.stopwatch && !task.builder.hadEmptyScript) {
               const time: string = task.stopwatch.toString();
               this._terminal.writeLine(headingColor(`${task.name} (${time})`));
             } else {

--- a/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ITaskWriter } from '@rushstack/stream-collator';
+
+import { TaskStatus } from '../TaskStatus';
+import { BaseBuilder } from '../BaseBuilder';
+
+export class MockBuilder extends BaseBuilder {
+  public readonly name: string;
+  private readonly _action: ((writer?: ITaskWriter) => Promise<TaskStatus>) | undefined;
+  public readonly hadEmptyScript: boolean = false;
+  public readonly isIncrementalBuildAllowed: boolean = false;
+
+  public constructor(name: string, action?: (writer: ITaskWriter) => Promise<TaskStatus>) {
+    super();
+
+    this.name = name;
+    this._action = action;
+  }
+
+  public async executeAsync(writer: ITaskWriter): Promise<TaskStatus> {
+    let result: TaskStatus | void;
+    if (this._action) {
+      result = await this._action(writer);
+    }
+    return result ? result : TaskStatus.Success;
+  }
+}

--- a/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
@@ -7,8 +7,8 @@ import { TaskStatus } from '../TaskStatus';
 import { BaseBuilder } from '../BaseBuilder';
 
 export class MockBuilder extends BaseBuilder {
-  public readonly name: string;
   private readonly _action: ((writer?: ITaskWriter) => Promise<TaskStatus>) | undefined;
+  public readonly name: string;
   public readonly hadEmptyScript: boolean = false;
   public readonly isIncrementalBuildAllowed: boolean = false;
 

--- a/apps/rush-lib/src/logic/taskRunner/test/ProjectTask.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/ProjectTask.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { convertSlashesForWindows } from '../ProjectTask';
+import { convertSlashesForWindows } from '../ProjectBuilder';
 
 describe('convertSlashesForWindows()', () => {
   it('converted inputs', () => {

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -8,9 +8,10 @@ import { EOL } from 'os';
 import { TaskRunner, ITaskRunnerOptions } from '../TaskRunner';
 import { ITaskWriter } from '@rushstack/stream-collator';
 import { TaskStatus } from '../TaskStatus';
-import { ITaskDefinition, ITask } from '../ITask';
+import { Task } from '../Task';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import { Utilities } from '../../../utilities/Utilities';
+import { BaseBuilder } from '../BaseBuilder';
 
 const mockGetTimeInMs: jest.Mock = jest.fn();
 Utilities.getTimeInMs = mockGetTimeInMs;
@@ -22,14 +23,12 @@ mockGetTimeInMs.mockImplementation(() => {
   return mockTimeInMs;
 });
 
-function createTaskRunner(
-  taskRunnerOptions: ITaskRunnerOptions,
-  taskDefinition: ITaskDefinition
-): TaskRunner {
-  const task: ITask = taskDefinition as ITask;
-  task.dependencies = new Set<ITask>();
-  task.dependents = new Set<ITask>();
+function createTaskRunner(taskRunnerOptions: ITaskRunnerOptions, builder: BaseBuilder): TaskRunner {
+  const task: Task = new Task();
+  task.dependencies = new Set<Task>();
+  task.dependents = new Set<Task>();
   task.status = TaskStatus.Ready;
+  task.builder = builder;
 
   return new TaskRunner([task], taskRunnerOptions);
 }

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -12,6 +12,7 @@ import { Task } from '../Task';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import { Utilities } from '../../../utilities/Utilities';
 import { BaseBuilder } from '../BaseBuilder';
+import { MockBuilder } from './MockBuilder';
 
 const mockGetTimeInMs: jest.Mock = jest.fn();
 Utilities.getTimeInMs = mockGetTimeInMs;
@@ -80,19 +81,17 @@ describe('TaskRunner', () => {
     const EXPECTED_FAIL: string = 'Promise returned by execute() resolved but was expected to fail';
 
     it('printedStderrAfterError', () => {
-      taskRunner = createTaskRunner(taskRunnerOptions, {
-        name: 'stdout+stderr',
-        isIncrementalBuildAllowed: false,
-        execute: (writer: ITaskWriter) => {
+      taskRunner = createTaskRunner(
+        taskRunnerOptions,
+        new MockBuilder('stdout+stderr', async (writer: ITaskWriter) => {
           writer.write('Build step 1' + EOL);
           writer.writeError('Error: step 1 failed' + EOL);
-          return Promise.resolve(TaskStatus.Failure);
-        },
-        hadEmptyScript: false
-      });
+          return TaskStatus.Failure;
+        })
+      );
 
       return taskRunner
-        .execute()
+        .executeAsync()
         .then(() => fail(EXPECTED_FAIL))
         .catch((err) => {
           expect(err.message).toMatchSnapshot();
@@ -104,19 +103,17 @@ describe('TaskRunner', () => {
     });
 
     it('printedStdoutAfterErrorWithEmptyStderr', () => {
-      taskRunner = createTaskRunner(taskRunnerOptions, {
-        name: 'stdout only',
-        isIncrementalBuildAllowed: false,
-        execute: (writer: ITaskWriter) => {
+      taskRunner = createTaskRunner(
+        taskRunnerOptions,
+        new MockBuilder('stdout only', async (writer: ITaskWriter) => {
           writer.write('Build step 1' + EOL);
           writer.write('Error: step 1 failed' + EOL);
-          return Promise.resolve(TaskStatus.Failure);
-        },
-        hadEmptyScript: false
-      });
+          return TaskStatus.Failure;
+        })
+      );
 
       return taskRunner
-        .execute()
+        .executeAsync()
         .then(() => fail(EXPECTED_FAIL))
         .catch((err) => {
           expect(err.message).toMatchSnapshot();
@@ -126,21 +123,19 @@ describe('TaskRunner', () => {
     });
 
     it('printedAbridgedStdoutAfterErrorWithEmptyStderr', () => {
-      taskRunner = createTaskRunner(taskRunnerOptions, {
-        name: 'large stdout only',
-        isIncrementalBuildAllowed: false,
-        execute: (writer: ITaskWriter) => {
+      taskRunner = createTaskRunner(
+        taskRunnerOptions,
+        new MockBuilder('large stdout only', async (writer: ITaskWriter) => {
           writer.write(`Building units...${EOL}`);
           for (let i: number = 1; i <= 50; i++) {
             writer.write(` - unit #${i};${EOL}`);
           }
-          return Promise.resolve(TaskStatus.Failure);
-        },
-        hadEmptyScript: false
-      });
+          return TaskStatus.Failure;
+        })
+      );
 
       return taskRunner
-        .execute()
+        .executeAsync()
         .then(() => fail(EXPECTED_FAIL))
         .catch((err) => {
           expect(err.message).toMatchSnapshot();
@@ -152,21 +147,19 @@ describe('TaskRunner', () => {
     });
 
     it('preservedLeadingBlanksButTrimmedTrailingBlanks', () => {
-      taskRunner = createTaskRunner(taskRunnerOptions, {
-        name: 'large stderr with leading and trailing blanks',
-        isIncrementalBuildAllowed: false,
-        execute: (writer: ITaskWriter) => {
+      taskRunner = createTaskRunner(
+        taskRunnerOptions,
+        new MockBuilder('large stderr with leading and trailing blanks', async (writer: ITaskWriter) => {
           writer.writeError(`List of errors:  ${EOL}`);
           for (let i: number = 1; i <= 50; i++) {
             writer.writeError(` - error #${i};  ${EOL}`);
           }
-          return Promise.resolve(TaskStatus.Failure);
-        },
-        hadEmptyScript: false
-      });
+          return TaskStatus.Failure;
+        })
+      );
 
       return taskRunner
-        .execute()
+        .executeAsync()
         .then(() => fail(EXPECTED_FAIL))
         .catch((err) => {
           expect(err.message).toMatchSnapshot();
@@ -191,19 +184,17 @@ describe('TaskRunner', () => {
       });
 
       it('Logs warnings correctly', () => {
-        taskRunner = createTaskRunner(taskRunnerOptions, {
-          name: 'success with warnings (failure)',
-          isIncrementalBuildAllowed: false,
-          execute: (writer: ITaskWriter) => {
+        taskRunner = createTaskRunner(
+          taskRunnerOptions,
+          new MockBuilder('success with warnings (failure)', async (writer: ITaskWriter) => {
             writer.write('Build step 1' + EOL);
             writer.write('Warning: step 1 succeeded with warnings' + EOL);
-            return Promise.resolve(TaskStatus.SuccessWithWarning);
-          },
-          hadEmptyScript: false
-        });
+            return TaskStatus.SuccessWithWarning;
+          })
+        );
 
         return taskRunner
-          .execute()
+          .executeAsync()
           .then(() => fail('Promise returned by execute() resolved but was expected to fail'))
           .catch((err) => {
             expect(err.message).toMatchSnapshot();
@@ -227,19 +218,17 @@ describe('TaskRunner', () => {
       });
 
       it('Logs warnings correctly', () => {
-        taskRunner = createTaskRunner(taskRunnerOptions, {
-          name: 'success with warnings (success)',
-          isIncrementalBuildAllowed: false,
-          execute: (writer: ITaskWriter) => {
+        taskRunner = createTaskRunner(
+          taskRunnerOptions,
+          new MockBuilder('success with warnings (success)', async (writer: ITaskWriter) => {
             writer.write('Build step 1' + EOL);
             writer.write('Warning: step 1 succeeded with warnings' + EOL);
-            return Promise.resolve(TaskStatus.SuccessWithWarning);
-          },
-          hadEmptyScript: false
-        });
+            return TaskStatus.SuccessWithWarning;
+          })
+        );
 
         return taskRunner
-          .execute()
+          .executeAsync()
           .then(() => {
             const allMessages: string = terminalProvider.getOutput();
             expect(allMessages).toContain('Build step 1');

--- a/common/changes/@microsoft/rush/octogonz-rush-task-runner-refactor_2020-09-04-00-53.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-task-runner-refactor_2020-09-04-00-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
This is some preliminary refactoring that gets things in better shape for my fix for https://github.com/microsoft/rushstack/issues/2135

The main changes:
- ITask becomes a class Task
- ITaskDefinition becomes a class BaseBuilder
- ProjectTask renames to ProjectBuilder

This eliminates the weirdness where ProjectTask implemented ITaskDefinition but got casted to ITask and then had undeclared properties added to its objects.

> This is a pure refactoring PR that should not affect the behavior of Rush at all.