### PR TITLE
[rush] Use underscore for italic markdown text

### DIFF
--- a/apps/rush-lib/src/logic/ChangelogGenerator.ts
+++ b/apps/rush-lib/src/logic/ChangelogGenerator.ts
@@ -237,7 +237,7 @@ export class ChangelogGenerator {
 
       if (!comments) {
         markdown +=
-          (changelog.entries.length === index + 1 ? '*Initial release*' : '*Version update only*') +
+          (changelog.entries.length === index + 1 ? '_Initial release_' : '_Version update only_') +
           EOL +
           EOL;
       } else {

--- a/common/changes/@microsoft/rush/pr-2165_2020-09-09-03-10.json
+++ b/common/changes/@microsoft/rush/pr-2165_2020-09-09-03-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use underscores instead of asterisks for italic formatting in changelogs to match the way Prettier formats italics in markdown.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
Prettier formatter defaults to underscore instead of single-asterisk.

To avoid back and forth between generated markdown and formatted output,
default to prettier default in this small matter.