### PR TITLE
[heft] Fix issues with the --plugin and --max-old-space-size parameters.

### DIFF
--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -40,6 +40,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "@types/tapable": "1.0.5",
     "@types/webpack": "4.39.8",
+    "argparse": "~1.0.9",
     "chokidar": "~3.4.0",
     "glob-escape": "~0.0.2",
     "glob": "~7.0.5",
@@ -47,12 +48,12 @@
     "semver": "~7.3.0",
     "tapable": "1.1.3",
     "true-case-path": "~2.2.1",
-    "webpack": "~4.31.0",
-    "webpack-dev-server": "~3.11.0"
+    "webpack-dev-server": "~3.11.0",
+    "webpack": "~4.31.0"
   },
   "devDependencies": {
+    "@types/argparse": "1.0.38",
     "@jest/types": "~25.4.0",
-    "@types/heft-jest": "1.0.1",
     "@types/eslint": "7.2.0",
     "@types/glob": "7.1.1",
     "@types/heft-jest": "1.0.1",

--- a/apps/heft/src/cli/actions/HeftActionBase.ts
+++ b/apps/heft/src/cli/actions/HeftActionBase.ts
@@ -4,7 +4,17 @@
 import {
   CommandLineAction,
   CommandLineFlagParameter,
-  ICommandLineActionOptions
+  ICommandLineActionOptions,
+  ICommandLineFlagDefinition,
+  IBaseCommandLineDefinition,
+  ICommandLineChoiceDefinition,
+  CommandLineChoiceParameter,
+  CommandLineIntegerParameter,
+  ICommandLineIntegerDefinition,
+  CommandLineStringParameter,
+  ICommandLineStringDefinition,
+  CommandLineStringListParameter,
+  ICommandLineStringListDefinition
 } from '@rushstack/ts-command-line';
 import {
   Terminal,
@@ -22,6 +32,7 @@ import { BuildStage } from '../../stages/BuildStage';
 import { CleanStage } from '../../stages/CleanStage';
 import { TestStage } from '../../stages/TestStage';
 import { LoggingManager } from '../../pluginFramework/logging/LoggingManager';
+import { Constants } from '../../utilities/Constants';
 
 export interface IStages {
   buildStage: BuildStage;
@@ -65,6 +76,33 @@ export abstract class HeftActionBase extends CommandLineAction {
       parameterShortName: '-v',
       description: 'If specified, log information useful for debugging.'
     });
+  }
+
+  public defineChoiceParameter(options: ICommandLineChoiceDefinition): CommandLineChoiceParameter {
+    this._validateDefinedParameter(options);
+    return super.defineChoiceParameter(options);
+  }
+
+  public defineFlagParameter(options: ICommandLineFlagDefinition): CommandLineFlagParameter {
+    this._validateDefinedParameter(options);
+    return super.defineFlagParameter(options);
+  }
+
+  public defineIntegerParameter(options: ICommandLineIntegerDefinition): CommandLineIntegerParameter {
+    this._validateDefinedParameter(options);
+    return super.defineIntegerParameter(options);
+  }
+
+  public defineStringParameter(options: ICommandLineStringDefinition): CommandLineStringParameter {
+    this._validateDefinedParameter(options);
+    return super.defineStringParameter(options);
+  }
+
+  public defineStringListParameter(
+    options: ICommandLineStringListDefinition
+  ): CommandLineStringListParameter {
+    this._validateDefinedParameter(options);
+    return super.defineStringListParameter(options);
   }
 
   public setStartTime(): void {
@@ -139,4 +177,12 @@ export abstract class HeftActionBase extends CommandLineAction {
    * @virtual
    */
   protected abstract actionExecuteAsync(): Promise<void>;
+
+  private _validateDefinedParameter(options: IBaseCommandLineDefinition): void {
+    if (options.parameterLongName === Constants.pluginParameterLongName) {
+      throw new Error(
+        `Actions must not register a parameter with longName "${Constants.pluginParameterLongName}".`
+      );
+    }
+  }
 }

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -333,6 +333,7 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
       production: standardParameters.productionFlag.value,
       lite: standardParameters.liteFlag.value,
       locale: standardParameters.localeParameter.value,
+      maxOldSpaceSize: standardParameters.maxOldSpaceSizeParameter.value,
       typescriptMaxWriteParallelism: standardParameters.typescriptMaxWriteParallelismParameter.value
     };
   }

--- a/apps/heft/src/utilities/Constants.ts
+++ b/apps/heft/src/utilities/Constants.ts
@@ -5,4 +5,6 @@ export class Constants {
   public static projectHeftFolderName: string = '.heft';
 
   public static buildCacheFolderName: string = 'build-cache';
+
+  public static pluginParameterLongName: string = '--plugin';
 }

--- a/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-15.json
+++ b/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix parsing of the --plugin heft parameter.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-15.json
+++ b/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "Fix parsing of the --plugin heft parameter.",
+      "comment": "Fix parsing of the --max-old-space-size build parameter.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-16.json
+++ b/common/changes/@rushstack/heft/ianc-fix-some-parameter-issues_2020-09-04-23-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix parsing of the --plugin heft parameter.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -103,6 +103,7 @@ importers:
       '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
       '@types/tapable': 1.0.5
       '@types/webpack': 4.39.8
+      argparse: 1.0.10
       chokidar: 3.4.2
       glob: 7.0.6
       glob-escape: 0.0.2
@@ -117,6 +118,7 @@ importers:
       '@microsoft/rush-stack-compiler-3.7': 'link:../../stack/rush-stack-compiler-3.7'
       '@rushstack/eslint-config': 'link:../../stack/eslint-config'
       '@rushstack/heft': 0.8.0
+      '@types/argparse': 1.0.38
       '@types/eslint': 7.2.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -135,6 +137,7 @@ importers:
       '@rushstack/heft-config-file': 'workspace:*'
       '@rushstack/node-core-library': 'workspace:*'
       '@rushstack/ts-command-line': 'workspace:*'
+      '@types/argparse': 1.0.38
       '@types/eslint': 7.2.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -143,6 +146,7 @@ importers:
       '@types/tapable': 1.0.5
       '@types/webpack': 4.39.8
       '@types/webpack-dev-server': 3.11.0
+      argparse: ~1.0.9
       chokidar: ~3.4.0
       colors: ~1.2.1
       glob: ~7.0.5

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "7f6b8f7a7936ebbd1d205e52769556c6faed7492",
+  "pnpmShrinkwrapHash": "227ac867cf890094e4db65ae9ab699fee75daab6",
   "preferredVersionsHash": "334ea62b6a2798dcf80917b79555983377e7435e"
 }


### PR DESCRIPTION
The `--max-old-space-size` parameter's value was never read, and the `--plugin` parameter was parsed after plugins were initialized. This PR reads the former, and adds a special parser for the latter to get its value before the rest of the CLI is parsed.