### PR TITLE
[heft] feat: add --max-workers CLI option for jest

### DIFF
--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -119,7 +119,8 @@ export class TestAction extends BuildAction {
         'Use this parameter to control maximum number of worker processes tests are allowed to use.' +
         ' This parameter is similar to the parameter noted in the Jest documentation, and can either be' +
         ' an integer representing the number of workers to spawn when running tests, or can be a string' +
-        ' representing a percentage of the available CPUs on the machine to utilize. Example values: "3", "25%"'
+        ' representing a percentage of the available CPUs on the machine to utilize. Example values: "3",' +
+        ' "25%%"' // The "%%" is required because argparse (used by ts-command-line) treats % as an escape character
     });
   }
 

--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -114,13 +114,12 @@ export class TestAction extends BuildAction {
 
     this._maxWorkers = this.defineStringParameter({
       parameterLongName: '--max-workers',
-      argumentName: 'STRING',
+      argumentName: 'COUNT_OR_PERCENTAGE',
       description:
-        'Change the default maximum workers for tests; this parameter conforms to the Jest' +
-        ' documentation, and can either be an integer representing the number of workers to spawn' +
-        ' when running tests, or can be a string representing a percentage of the available CPUs' +
-        ' on the machine to utilize.' +
-        ' This corresponds to the "--maxWorkers" parameter in Jest\'s documentation.'
+        'Use this parameter to control maximum number of worker processes tests are allowed to use.' +
+        ' This parameter is similar to the parameter noted in the Jest documentation, and can either be' +
+        ' an integer representing the number of workers to spawn when running tests, or can be a string' +
+        ' representing a percentage of the available CPUs on the machine to utilize. Example values: "3", "25%"'
     });
   }
 

--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -24,6 +24,7 @@ export class TestAction extends BuildAction {
   private _testPathPattern: CommandLineStringListParameter;
   private _testTimeout: CommandLineIntegerParameter;
   private _debugHeftReporter: CommandLineFlagParameter;
+  private _maxWorkers: CommandLineStringParameter;
 
   public constructor(heftActionOptions: IHeftActionBaseOptions) {
     super(heftActionOptions, {
@@ -110,6 +111,17 @@ export class TestAction extends BuildAction {
         ' default reporter would have presented it. Include this output in your bug report.' +
         ' Do not use "--debug-heft-reporter" in production.'
     });
+
+    this._maxWorkers = this.defineStringParameter({
+      parameterLongName: '--max-workers',
+      argumentName: 'STRING',
+      description:
+        'Change the default maximum workers for tests; this parameter conforms to the Jest' +
+        ' documentation, and can either be an integer representing the number of workers to spawn' +
+        ' when running tests, or can be a string representing a percentage of the available CPUs' +
+        ' on the machine to utilize.' +
+        ' This corresponds to the "--maxWorkers" parameter in Jest\'s documentation.'
+    });
   }
 
   protected async actionExecuteAsync(): Promise<void> {
@@ -147,7 +159,8 @@ export class TestAction extends BuildAction {
         testNamePattern: this._testNamePattern.value,
         testPathPattern: this._testPathPattern.values,
         testTimeout: this._testTimeout.value,
-        debugHeftReporter: this._debugHeftReporter.value
+        debugHeftReporter: this._debugHeftReporter.value,
+        maxWorkers: this._maxWorkers.value
       };
       await testStage.initializeAsync(testStageOptions);
 

--- a/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -95,6 +95,7 @@ exports[`CommandLineHelp prints the help for each action: test 1`] = `
                  [--no-build] [-u] [--find-related-tests SOURCE_FILE]
                  [--silent] [-t REGEXP] [--test-path-pattern REGEXP]
                  [--test-timeout-ms INTEGER] [--debug-heft-reporter]
+                 [--max-workers STRING]
                  
 
 Optional arguments:
@@ -154,5 +155,12 @@ Optional arguments:
                         how Jest's default reporter would have presented it. 
                         Include this output in your bug report. Do not use 
                         \\"--debug-heft-reporter\\" in production.
+  --max-workers STRING  Change the default maximum workers for tests; this 
+                        parameter conforms to the Jest documentation, and can 
+                        either be an integer representing the number of 
+                        workers to spawn when running tests, or can be a 
+                        string representing a percentage of the available 
+                        CPUs on the machine to utilize. This corresponds to 
+                        the \\"--maxWorkers\\" parameter in Jest's documentation.
 "
 `;

--- a/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -95,7 +95,7 @@ exports[`CommandLineHelp prints the help for each action: test 1`] = `
                  [--no-build] [-u] [--find-related-tests SOURCE_FILE]
                  [--silent] [-t REGEXP] [--test-path-pattern REGEXP]
                  [--test-timeout-ms INTEGER] [--debug-heft-reporter]
-                 [--max-workers STRING]
+                 [--max-workers COUNT_OR_PERCENTAGE]
                  
 
 Optional arguments:
@@ -155,12 +155,14 @@ Optional arguments:
                         how Jest's default reporter would have presented it. 
                         Include this output in your bug report. Do not use 
                         \\"--debug-heft-reporter\\" in production.
-  --max-workers STRING  Change the default maximum workers for tests; this 
-                        parameter conforms to the Jest documentation, and can 
-                        either be an integer representing the number of 
-                        workers to spawn when running tests, or can be a 
-                        string representing a percentage of the available 
-                        CPUs on the machine to utilize. This corresponds to 
-                        the \\"--maxWorkers\\" parameter in Jest's documentation.
+  --max-workers COUNT_OR_PERCENTAGE
+                        Use this parameter to control maximum number of 
+                        worker processes tests are allowed to use. This 
+                        parameter is similar to the parameter noted in the 
+                        Jest documentation, and can either be an integer 
+                        representing the number of workers to spawn when 
+                        running tests, or can be a string representing a 
+                        percentage of the available CPUs on the machine to 
+                        utilize. Example values: \\"3\\", \\"25%\\"
 "
 `;

--- a/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
@@ -67,6 +67,7 @@ export class JestPlugin implements IHeftPlugin {
       testNamePattern: test.properties.testNamePattern,
       testPathPattern: test.properties.testPathPattern ? [...test.properties.testPathPattern] : undefined,
       testTimeout: test.properties.testTimeout,
+      maxWorkers: test.properties.maxWorkers,
 
       $0: process.argv0,
       _: []

--- a/apps/heft/src/stages/TestStage.ts
+++ b/apps/heft/src/stages/TestStage.ts
@@ -27,6 +27,7 @@ export interface ITestStageProperties {
   testPathPattern: ReadonlyArray<string> | undefined;
   testTimeout: number | undefined;
   debugHeftReporter: boolean | undefined;
+  maxWorkers: string | undefined;
 }
 
 /**
@@ -44,6 +45,7 @@ export interface ITestStageOptions {
   testPathPattern: ReadonlyArray<string> | undefined;
   testTimeout: number | undefined;
   debugHeftReporter: boolean | undefined;
+  maxWorkers: string | undefined;
 }
 
 export class TestStage extends StageBase<TestStageHooks, ITestStageProperties, ITestStageOptions> {
@@ -61,7 +63,8 @@ export class TestStage extends StageBase<TestStageHooks, ITestStageProperties, I
       testNamePattern: options.testNamePattern,
       testPathPattern: options.testPathPattern,
       testTimeout: options.testTimeout,
-      debugHeftReporter: options.debugHeftReporter
+      debugHeftReporter: options.debugHeftReporter,
+      maxWorkers: options.maxWorkers
     };
   }
 

--- a/common/changes/@rushstack/heft/max-workers-cli_2020-09-07-17-39.json
+++ b/common/changes/@rushstack/heft/max-workers-cli_2020-09-07-17-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "add --maxWorkers option for running tests",
+      "comment": "Add --max-workers option to the \"test\" action to control the maximum number of worker processes the test process can use.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/max-workers-cli_2020-09-07-17-39.json
+++ b/common/changes/@rushstack/heft/max-workers-cli_2020-09-07-17-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "add --maxWorkers option for running tests",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "sammarks@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -365,6 +365,8 @@ export interface ITestStageProperties {
     // (undocumented)
     findRelatedTests: ReadonlyArray<string> | undefined;
     // (undocumented)
+    maxWorkers: string | undefined;
+    // (undocumented)
     silent: boolean | undefined;
     // (undocumented)
     testNamePattern: string | undefined;


### PR DESCRIPTION
For CI environments, I couldn't find a way to change the `maxWorkers` configuration value for Jest using an environment variable. The best I've come up with so far is to change the `maxWorkers` config option, but that requires the max workers config to be the same everywhere.

Since a CI environment might be more / less powerful than a local development machine, or one person's machine might be more / less powerful than the other, I think it makes sense to forward that Jest CLI option through the Heft CLI.

That way, I can just update my build script inside CI to pass `--maxWorkers` as something else, and have the default value inside the configuration something sensible for local development environments.

I noticed the CLI options for testing could potentially apply to more than just Jest in the future (whenever other plugins are developed), so tried to keep the verbiage as generic as possible.

I also am not sure what the preference is for something like this with regard to testing. So if I'm missing some tests, let me know and I'll write those up.

Let me know if you have any feedback or if there's anything else I need to do!