### PR TITLE
[heft] add --max-workers param to test action

### DIFF
--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -18,6 +18,7 @@ export class TestAction extends BuildAction {
   private _noTestFlag: CommandLineFlagParameter;
   private _noBuildFlag: CommandLineFlagParameter;
   private _updateSnapshotsFlag: CommandLineFlagParameter;
+  private _maxWorkersFlag: CommandLineIntegerParameter;
   private _findRelatedTests: CommandLineStringListParameter;
   private _silent: CommandLineFlagParameter;
   private _testNamePattern: CommandLineStringParameter;
@@ -53,6 +54,14 @@ export class TestAction extends BuildAction {
       description:
         'Update Jest snapshots while running the tests.' +
         ' This corresponds to the "--updateSnapshots" parameter in Jest'
+    });
+
+    this._maxWorkersFlag = this.defineIntegerParameter({
+      parameterLongName: '--max-workers',
+      argumentName: 'NUM_THREADS',
+      description:
+        'Sets the max number of worker threads to be used by the Jest process.' +
+        ' This corresponds to the "--maxWorkers" parameter in Jest'
     });
 
     this._findRelatedTests = this.defineStringListParameter({
@@ -141,6 +150,7 @@ export class TestAction extends BuildAction {
       const testStageOptions: ITestStageOptions = {
         watchMode: this._watchFlag.value,
         updateSnapshots: this._updateSnapshotsFlag.value,
+        maxWorkers: this._maxWorkersFlag.value,
 
         findRelatedTests: this._findRelatedTests.values,
         silent: this._silent.value,

--- a/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -92,9 +92,10 @@ exports[`CommandLineHelp prints the help for each action: test 1`] = `
 "usage: heft test [-h] [-v] [--production] [--locale LOCALE] [-l]
                  [--typescript-max-write-parallelism PARALLEILSM]
                  [--max-old-space-size SIZE] [--watch] [--clean] [--no-test]
-                 [--no-build] [-u] [--find-related-tests SOURCE_FILE]
-                 [--silent] [-t REGEXP] [--test-path-pattern REGEXP]
-                 [--test-timeout-ms INTEGER] [--debug-heft-reporter]
+                 [--no-build] [-u] [--max-workers NUM_THREADS]
+                 [--find-related-tests SOURCE_FILE] [--silent] [-t REGEXP]
+                 [--test-path-pattern REGEXP] [--test-timeout-ms INTEGER]
+                 [--debug-heft-reporter]
                  
 
 Optional arguments:
@@ -118,6 +119,10 @@ Optional arguments:
                         Update Jest snapshots while running the tests. This 
                         corresponds to the \\"--updateSnapshots\\" parameter in 
                         Jest
+  --max-workers NUM_THREADS
+                        Sets the max number of worker threads to be used by 
+                        the Jest process. This corresponds to the 
+                        \\"--maxWorkers\\" parameter in Jest
   --find-related-tests SOURCE_FILE
                         Find and run the tests that cover a space separated 
                         list of source files that were passed in as arguments.

--- a/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
@@ -54,11 +54,13 @@ export class JestPlugin implements IHeftPlugin {
 
       // In debug mode, avoid forking separate processes that are difficult to debug
       runInBand: heftSession.debugMode,
+      detectOpenHandles: heftSession.debugMode,
       debug: heftSession.debugMode,
 
       config: JEST_CONFIGURATION_LOCATION,
       cacheDirectory: this._getJestCacheFolder(heftConfiguration),
       updateSnapshot: test.properties.updateSnapshots,
+      maxWorkers: test.properties.maxWorkers,
 
       listTests: false,
       rootDir: buildFolder,

--- a/apps/heft/src/stages/TestStage.ts
+++ b/apps/heft/src/stages/TestStage.ts
@@ -20,6 +20,7 @@ export class TestStageHooks extends StageHooksBase<ITestStageProperties> {
 export interface ITestStageProperties {
   watchMode: boolean;
   updateSnapshots: boolean;
+  maxWorkers: number | undefined;
 
   findRelatedTests: ReadonlyArray<string> | undefined;
   silent: boolean | undefined;
@@ -37,6 +38,7 @@ export interface ITestStageContext extends IStageContext<TestStageHooks, ITestSt
 export interface ITestStageOptions {
   watchMode: boolean;
   updateSnapshots: boolean;
+  maxWorkers: number | undefined;
 
   findRelatedTests: ReadonlyArray<string> | undefined;
   silent: boolean | undefined;
@@ -55,7 +57,7 @@ export class TestStage extends StageBase<TestStageHooks, ITestStageProperties, I
     return {
       watchMode: options.watchMode,
       updateSnapshots: options.updateSnapshots,
-
+      maxWorkers: options.maxWorkers,
       findRelatedTests: options.findRelatedTests,
       silent: options.silent,
       testNamePattern: options.testNamePattern,

--- a/common/changes/@rushstack/heft/benpapp-AddMaxWorkersParamToTestAction_2020-09-08-19-47.json
+++ b/common/changes/@rushstack/heft/benpapp-AddMaxWorkersParamToTestAction_2020-09-08-19-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Adding \"--max-workers\" parameter to the command line interface of the heft test action, which passes the value along to the \"--maxWorkers\" parameter of the Jest subprocess",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "BPapp-MS@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/benpapp-AddMaxWorkersParamToTestAction_2020-09-08-19-50.json
+++ b/common/changes/@rushstack/heft/benpapp-AddMaxWorkersParamToTestAction_2020-09-08-19-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Adding flag \"--detectOpenHandles\" to the Jest subprocess when heft is in debug mode, in order to better debug leaks in tests",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "BPapp-MS@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -365,6 +365,8 @@ export interface ITestStageProperties {
     // (undocumented)
     findRelatedTests: ReadonlyArray<string> | undefined;
     // (undocumented)
+    maxWorkers: number | undefined;
+    // (undocumented)
     silent: boolean | undefined;
     // (undocumented)
     testNamePattern: string | undefined;


### PR DESCRIPTION
adds --max-workers parameter to test action which passes that value along to the --maxWorkers parameter of the Jest subprocess of the Jest plugin.  It would be nice to reimplement this someday with command line interfaces defined by plugins themselves, when support is added for that.

PR also includes one-line change which adds the --detectOpenHandles flag to the Jest subprocess when Heft is run in debug mode.