### PR TITLE
[heft] fix plugin name error typo

### DIFF
--- a/apps/heft/src/pluginFramework/PluginManager.ts
+++ b/apps/heft/src/pluginFramework/PluginManager.ts
@@ -152,8 +152,8 @@ export class PluginManager {
 
     if (!pluginPackage.pluginName || typeof pluginPackage.pluginName !== 'string') {
       throw new InternalError(
-        `Plugin packages must define a "displayName" property. The plugin loaded from "${resolvedPluginPath}" ` +
-          'either doesn\'t define a "displayName" property, or its value isn\'t a string.'
+        `Plugin packages must define a "pluginName" property. The plugin loaded from "${resolvedPluginPath}" ` +
+          'either doesn\'t define a "pluginName" property, or its value isn\'t a string.'
       );
     }
 

--- a/common/changes/@rushstack/heft/benpapp-FixPluginNameErrorTypo_2020-09-08-23-39.json
+++ b/common/changes/@rushstack/heft/benpapp-FixPluginNameErrorTypo_2020-09-08-23-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "fix typo in an error message to read that plugins must define a \"pluginName\" property, rather than the former \"displayName\" property",
+      "comment": "Fix a typo in an error message to read that plugins must define a \"pluginName\" property, rather than the former \"displayName\" property",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft/benpapp-FixPluginNameErrorTypo_2020-09-08-23-39.json
+++ b/common/changes/@rushstack/heft/benpapp-FixPluginNameErrorTypo_2020-09-08-23-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "fix typo in an error message to read that plugins must define a \"pluginName\" property, rather than the former \"displayName\" property",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "BPapp-MS@users.noreply.github.com"
+}


### PR DESCRIPTION
fix typo in an error message to read that plugins must define a \"pluginName\" property, rather than the former \"displayName\" property