### PR TITLE
[localization-plugin] Handle webpack dev server hot update chunks.

### DIFF
--- a/common/changes/@rushstack/localization-plugin/halfnibble-fix-loc-webpack-devserver_2020-09-11-17-40.json
+++ b/common/changes/@rushstack/localization-plugin/halfnibble-fix-loc-webpack-devserver_2020-09-11-17-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-plugin",
+      "comment": "Handle webpack dev server hot updates.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/localization-plugin",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/webpack/localization-plugin/src/LocalizationPlugin.ts
+++ b/webpack/localization-plugin/src/LocalizationPlugin.ts
@@ -315,6 +315,7 @@ export class LocalizationPlugin implements Webpack.Plugin {
           };
 
           const alreadyProcessedAssets: Set<string> = new Set<string>();
+          const hotUpdateRegex: RegExp = /\.hot-update\.js$/;
 
           for (const untypedChunk of compilation.chunks) {
             const chunk: ILocalizedWebpackChunk = untypedChunk;
@@ -324,6 +325,7 @@ export class LocalizationPlugin implements Webpack.Plugin {
               for (const chunkFilename of chunk.files) {
                 if (
                   chunkFilename.endsWith('.js') && // Ensure this is a JS file
+                  !hotUpdateRegex.test(chunkFilename) && // Ensure this is not a webpack hot update
                   !alreadyProcessedAssets.has(chunkFilename) // Ensure this isn't a vendor chunk we've already processed
                 ) {
                   if (alreadyProcessedAFileInThisChunk) {


### PR DESCRIPTION
Webpack dev server will emit hot update chunks ending in 'hot-update.js', which conflict with the latest changes in the LocalizationPlugin. This attempts to address that.