### PR TITLE
[heft] Improve reliability of jest-build-transform.js

### DIFF
--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -12,6 +12,14 @@ export interface IJestTypeScriptDataFileJson {
    * The "emitFolderNameForJest" from .heft/typescript.json
    */
   emitFolderNameForJest: string;
+
+  /**
+   * Normally the jest-build-transform compares the timestamps of the .js output file and .ts source file
+   * to determine whether the TypeScript compiler has completed.  However this heuristic is only necessary
+   * in the interactive "--watch" mode, since otherwise Heft doesn't invoke Jest until after the compiler
+   * has finished.  Heft improves reliability for a non-watch build by setting skipTimestampCheck=true.
+   */
+  skipTimestampCheck: boolean;
 }
 
 /**
@@ -23,12 +31,9 @@ export class JestTypeScriptDataFile {
   /**
    * Called by TypeScriptPlugin to write the file.
    */
-  public static saveForProject(projectFolder: string, emitFolderNameForJest: string = 'lib'): void {
+  public static saveForProject(projectFolder: string, json?: IJestTypeScriptDataFileJson): void {
     const jsonFilePath: string = JestTypeScriptDataFile.getConfigFilePath(projectFolder);
 
-    const json: IJestTypeScriptDataFileJson = {
-      emitFolderNameForJest
-    };
     JsonFile.save(json, jsonFilePath, {
       ensureFolderExists: true,
       onlyIfChanged: true,

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -229,10 +229,10 @@ export class TypeScriptPlugin implements IHeftPlugin {
       maxWriteParallelism: typeScriptConfiguration.maxWriteParallelism
     };
 
-    JestTypeScriptDataFile.saveForProject(
-      heftConfiguration.buildFolder,
-      typescriptConfigurationJson?.emitFolderNameForJest
-    );
+    JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, {
+      emitFolderNameForJest: typescriptConfigurationJson?.emitFolderNameForJest || 'lib',
+      skipTimestampCheck: !options.watchMode
+    });
 
     const callbacksForTsconfigs: Set<() => void> = new Set<() => void>();
     function getFirstEmitCallbackForTsconfig(): () => void {

--- a/common/changes/@rushstack/heft/octogonz-skip-timestamp-check_2020-09-15-00-58.json
+++ b/common/changes/@rushstack/heft/octogonz-skip-timestamp-check_2020-09-15-00-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Improve reliability of jest-build-transform.js by only comparing timestamps when in \"--watch\" mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
@D4N14L reported that jest-build-transform.js sometimes times out due to a timestamp issue. We can improve reliability of jest-build-transform.js by only comparing timestamps when `--watch` mode is enabled.