### PR TITLE
[heft] Fix an issue where console.log() didn't get interceped by the Jest reporter

### DIFF
--- a/apps/heft/includes/jest-shared.config.json
+++ b/apps/heft/includes/jest-shared.config.json
@@ -1,5 +1,9 @@
 {
+  "//": "By default, don't hide console output",
   "silent": false,
+  "//": "In order for HeftJestReporter to receive console.log() events, we must set verbose=false",
+  "verbose": false,
+
   "rootDir": "../../../../",
 
   "//": ["Adding '<rootDir>/src' here enables src/__mocks__ to be used for mocking Node.js system modules."],

--- a/common/changes/@rushstack/heft/octogonz-heft-console-log_2020-09-16-01-05.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-console-log_2020-09-16-01-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where console.log() did not get formatted by HeftJestReporter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
This code:
```js
describe('Example Test', () => {
  it('Correctly tests stuff', () => {
    console.log('Hello,\nworld!');
    expect(true).toBeTruthy();
  });
```
Was supposed to show this output:
```
START src\test\ExampleTest.test.ts
|  console.log| Hello,
|  console.log| world!
PASS src\test\ExampleTest.test.ts (duration: 0.419s, 3 passed, 0 failed)
```
...but this feature weirdly gets disabled if `verbose=true` in the Jest options.