### PR TITLE
[heft] Fix an issue where an error isn't thrown if a config file's parent doesn't exist.

### DIFF
--- a/apps/heft/src/pluginFramework/PluginManager.ts
+++ b/apps/heft/src/pluginFramework/PluginManager.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { Terminal, InternalError, FileSystem, Import } from '@rushstack/node-core-library';
+import { Terminal, InternalError, Import } from '@rushstack/node-core-library';
 
 import { HeftConfiguration } from '../configuration/HeftConfiguration';
 import { IHeftPlugin } from './IHeftPlugin';
@@ -61,21 +61,20 @@ export class PluginManager {
   }
 
   public async initializePluginsFromConfigFileAsync(): Promise<void> {
-    try {
-      const pluginConfigFilePath: string = path.join(
-        this._heftConfiguration.projectHeftDataFolder,
-        'plugins.json'
-      );
-      const pluginConfigurationJson: IPluginConfigurationJson = await HeftConfigFiles.pluginConfigFileLoader.loadConfigurationFileAsync(
-        pluginConfigFilePath
-      );
+    const pluginConfigFilePath: string = path.join(
+      this._heftConfiguration.projectHeftDataFolder,
+      'plugins.json'
+    );
+    const pluginConfigurationJson:
+      | IPluginConfigurationJson
+      | undefined = await HeftConfigFiles.pluginConfigFileLoader.loadConfigurationFileAsync(
+      pluginConfigFilePath,
+      { ignoreIfNotExist: true }
+    );
 
+    if (pluginConfigurationJson?.plugins) {
       for (const pluginSpecifier of pluginConfigurationJson.plugins) {
         this._initializeResolvedPlugin(pluginSpecifier.plugin, pluginSpecifier.options);
-      }
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
       }
     }
   }

--- a/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorPlugin.ts
+++ b/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorPlugin.ts
@@ -64,16 +64,12 @@ export class ApiExtractorPlugin implements IHeftPlugin {
   ): Promise<void> {
     const { heftConfiguration, buildFolder, debugMode, watchMode, production } = options;
 
-    let apiExtractorTaskConfiguration: IApiExtractorPluginConfiguration | undefined;
-    try {
-      apiExtractorTaskConfiguration = await HeftConfigFiles.apiExtractorTaskConfigurationLoader.loadConfigurationFileAsync(
-        path.resolve(heftConfiguration.buildFolder, '.heft', 'api-extractor-task.json')
-      );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
-    }
+    const apiExtractorTaskConfiguration:
+      | IApiExtractorPluginConfiguration
+      | undefined = await HeftConfigFiles.apiExtractorTaskConfigurationLoader.loadConfigurationFileAsync(
+      path.resolve(heftConfiguration.buildFolder, '.heft', 'api-extractor-task.json'),
+      { ignoreIfNotExist: true }
+    );
 
     const terminal: Terminal = ApiExtractorRunner.getTerminal(heftConfiguration.terminalProvider);
 

--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -93,16 +93,12 @@ export class CopyStaticAssetsPlugin implements IHeftPlugin {
   private async _loadCopyStaticAssetsConfigurationAsync(
     buildFolder: string
   ): Promise<ICopyStaticAssetsConfiguration> {
-    let copyStaticAssetsConfigurationJson: ICopyStaticAssetsConfigurationJson | undefined;
-    try {
-      copyStaticAssetsConfigurationJson = await HeftConfigFiles.copyStaticAssetsConfigurationLoader.loadConfigurationFileAsync(
-        path.resolve(buildFolder, '.heft', 'copy-static-assets.json')
-      );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
-    }
+    const copyStaticAssetsConfigurationJson:
+      | ICopyStaticAssetsConfigurationJson
+      | undefined = await HeftConfigFiles.copyStaticAssetsConfigurationLoader.loadConfigurationFileAsync(
+      path.resolve(buildFolder, '.heft', 'copy-static-assets.json'),
+      { ignoreIfNotExist: true }
+    );
 
     return {
       ...copyStaticAssetsConfigurationJson,

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import * as glob from 'glob';
-import { LegacyAdapters, ITerminalProvider, FileSystem } from '@rushstack/node-core-library';
+import { LegacyAdapters, ITerminalProvider } from '@rushstack/node-core-library';
 
 import { TypeScriptBuilder, ITypeScriptBuilderConfiguration } from './TypeScriptBuilder';
 import { HeftSession } from '../../pluginFramework/HeftSession';
@@ -131,19 +131,12 @@ export class TypeScriptPlugin implements IHeftPlugin {
       | undefined = this._typeScriptConfigurationFileCache.get(buildFolder);
 
     if (!typescriptConfigurationFileCacheEntry) {
-      try {
-        typescriptConfigurationFileCacheEntry = {
-          configurationFile: await HeftConfigFiles.typeScriptConfigurationFileLoader.loadConfigurationFileAsync(
-            path.resolve(buildFolder, '.heft', 'typescript.json')
-          )
-        };
-      } catch (e) {
-        if (FileSystem.isNotExistError(e)) {
-          typescriptConfigurationFileCacheEntry = { configurationFile: undefined };
-        } else {
-          throw e;
-        }
-      }
+      typescriptConfigurationFileCacheEntry = {
+        configurationFile: await HeftConfigFiles.typeScriptConfigurationFileLoader.loadConfigurationFileAsync(
+          path.resolve(buildFolder, '.heft', 'typescript.json'),
+          { ignoreIfNotExist: true }
+        )
+      };
 
       this._typeScriptConfigurationFileCache.set(buildFolder, typescriptConfigurationFileCacheEntry);
     }

--- a/apps/heft/src/stages/CleanStage.ts
+++ b/apps/heft/src/stages/CleanStage.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as glob from 'glob';
 import * as globEscape from 'glob-escape';
 import { AsyncSeriesBailHook } from 'tapable';
-import { FileSystem, LegacyAdapters } from '@rushstack/node-core-library';
+import { LegacyAdapters } from '@rushstack/node-core-library';
 
 import { StageBase, StageHooksBase, IStageContext } from './StageBase';
 import { Async } from '../utilities/Async';
@@ -49,16 +49,12 @@ export class CleanStage extends StageBase<CleanStageHooks, ICleanStageProperties
   protected async getDefaultStagePropertiesAsync(
     options: ICleanStageOptions
   ): Promise<ICleanStageProperties> {
-    let cleanConfigurationFile: ICleanConfigurationJson | undefined = undefined;
-    try {
-      cleanConfigurationFile = await HeftConfigFiles.cleanConfigurationFileLoader.loadConfigurationFileAsync(
-        path.resolve(this.heftConfiguration.buildFolder, '.heft', 'clean.json')
-      );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
-    }
+    const cleanConfigurationFile:
+      | ICleanConfigurationJson
+      | undefined = await HeftConfigFiles.cleanConfigurationFileLoader.loadConfigurationFileAsync(
+      path.resolve(this.heftConfiguration.buildFolder, '.heft', 'clean.json'),
+      { ignoreIfNotExist: true }
+    );
 
     return {
       deleteCache: false,

--- a/apps/rundown/.heft/clean.json
+++ b/apps/rundown/.heft/clean.json
@@ -1,0 +1,11 @@
+/**
+ * Configures the "clean" stage for Heft.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/clean.schema.json",
+
+  /**
+   * Glob patterns to be deleted by the "heft clean" action.  The paths are resolved relative to the project folder.
+   */
+  "pathsToDelete": ["dist", "lib", "temp"]
+}

--- a/common/changes/@rushstack/heft-config-file/ianc-fix-config-file-issue_2020-09-16-06-44.json
+++ b/common/changes/@rushstack/heft-config-file/ianc-fix-config-file-issue_2020-09-16-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Add an option to prevent throwing of an exception if a config file doesn't eixst.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-config-file/ianc-fix-config-file-issue_2020-09-16-06-45.json
+++ b/common/changes/@rushstack/heft-config-file/ianc-fix-config-file-issue_2020-09-16-06-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Fix an issue where the \"extends\" property wouldn't resolve a package.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ianc-fix-config-file-issue_2020-09-16-06-44.json
+++ b/common/changes/@rushstack/heft/ianc-fix-config-file-issue_2020-09-16-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where an error would not be thrown if a config file's \"extends\" property didn't resolve correctly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/loader-raw-script/ianc-fix-config-file-issue_2020-09-16-16-41.json
+++ b/common/changes/@rushstack/loader-raw-script/ianc-fix-config-file-issue_2020-09-16-16-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/loader-raw-script",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/loader-raw-script",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rundown/ianc-fix-config-file-issue_2020-09-16-16-41.json
+++ b/common/changes/@rushstack/rundown/ianc-fix-config-file-issue_2020-09-16-16-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -12,7 +12,9 @@ export class ConfigurationFile<TConfigurationFile> {
     getObjectSourceFilePath<TObject extends object>(obj: TObject): string | undefined;
     getPropertyOriginalValue<TParentProperty extends object, TValue>(options: IOriginalValueOptions<TParentProperty>): TValue;
     // (undocumented)
-    loadConfigurationFileAsync(configurationFilePath: string): Promise<TConfigurationFile>;
+    loadConfigurationFileAsync(configurationFilePath: string, options?: ILoadConfigurationFileOptions): Promise<TConfigurationFile>;
+    // (undocumented)
+    loadConfigurationFileAsync(configurationFilePath: string, options: ILoadConfigurationFileOptionsIgnoreNotExist): Promise<TConfigurationFile | undefined>;
     }
 
 // @beta (undocumented)
@@ -31,6 +33,17 @@ export interface IJsonPathMetadata {
 export interface IJsonPathsMetadata {
     // (undocumented)
     [jsonPath: string]: IJsonPathMetadata;
+}
+
+// @beta (undocumented)
+export interface ILoadConfigurationFileOptions {
+    ignoreIfNotExist?: boolean;
+}
+
+// @beta (undocumented)
+export interface ILoadConfigurationFileOptionsIgnoreNotExist extends ILoadConfigurationFileOptions {
+    // (undocumented)
+    ignoreIfNotExist: true;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -12,9 +12,15 @@ export class ConfigurationFile<TConfigurationFile> {
     getObjectSourceFilePath<TObject extends object>(obj: TObject): string | undefined;
     getPropertyOriginalValue<TParentProperty extends object, TValue>(options: IOriginalValueOptions<TParentProperty>): TValue;
     // (undocumented)
-    loadConfigurationFileAsync(configurationFilePath: string, options?: ILoadConfigurationFileOptions): Promise<TConfigurationFile>;
+    loadConfigurationFileAsync(configurationFilePath: string, options?: {}): Promise<TConfigurationFile>;
     // (undocumented)
-    loadConfigurationFileAsync(configurationFilePath: string, options: ILoadConfigurationFileOptionsIgnoreNotExist): Promise<TConfigurationFile | undefined>;
+    loadConfigurationFileAsync(configurationFilePath: string, options?: {
+        ignoreIfNotExist: false;
+    }): Promise<TConfigurationFile>;
+    // (undocumented)
+    loadConfigurationFileAsync(configurationFilePath: string, options: {
+        ignoreIfNotExist: true;
+    }): Promise<TConfigurationFile | undefined>;
     }
 
 // @beta (undocumented)
@@ -38,12 +44,6 @@ export interface IJsonPathsMetadata {
 // @beta (undocumented)
 export interface ILoadConfigurationFileOptions {
     ignoreIfNotExist?: boolean;
-}
-
-// @beta (undocumented)
-export interface ILoadConfigurationFileOptionsIgnoreNotExist extends ILoadConfigurationFileOptions {
-    // (undocumented)
-    ignoreIfNotExist: true;
 }
 
 // @beta (undocumented)

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -142,13 +142,6 @@ export interface ILoadConfigurationFileOptions {
 /**
  * @beta
  */
-export interface ILoadConfigurationFileOptionsIgnoreNotExist extends ILoadConfigurationFileOptions {
-  ignoreIfNotExist: true;
-}
-
-/**
- * @beta
- */
 export class ConfigurationFile<TConfigurationFile> {
   private readonly _schemaPath: string;
   private readonly _jsonPathMetadata: IJsonPathsMetadata;
@@ -176,11 +169,15 @@ export class ConfigurationFile<TConfigurationFile> {
 
   public async loadConfigurationFileAsync(
     configurationFilePath: string,
-    options?: ILoadConfigurationFileOptions
+    options?: {}
   ): Promise<TConfigurationFile>;
   public async loadConfigurationFileAsync(
     configurationFilePath: string,
-    options: ILoadConfigurationFileOptionsIgnoreNotExist
+    options?: { ignoreIfNotExist: false }
+  ): Promise<TConfigurationFile>;
+  public async loadConfigurationFileAsync(
+    configurationFilePath: string,
+    options: { ignoreIfNotExist: true }
   ): Promise<TConfigurationFile | undefined>;
   public async loadConfigurationFileAsync(
     configurationFilePath: string,

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -255,8 +255,6 @@ export class ConfigurationFile<TConfigurationFile> {
       } else {
         return undefined;
       }
-    } else if (cacheEntry.error) {
-      throw cacheEntry.error;
     } else {
       return cacheEntry.configurationFile;
     }

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -10,6 +10,5 @@ export {
   IOriginalValueOptions,
   IPropertyInheritanceTypes,
   PathResolutionMethod,
-  ILoadConfigurationFileOptions,
-  ILoadConfigurationFileOptionsIgnoreNotExist
+  ILoadConfigurationFileOptions
 } from './ConfigurationFile';

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -9,5 +9,7 @@ export {
   InheritanceType,
   IOriginalValueOptions,
   IPropertyInheritanceTypes,
-  PathResolutionMethod
+  PathResolutionMethod,
+  ILoadConfigurationFileOptions,
+  ILoadConfigurationFileOptionsIgnoreNotExist
 } from './ConfigurationFile';

--- a/webpack/loader-raw-script/.heft/clean.json
+++ b/webpack/loader-raw-script/.heft/clean.json
@@ -1,0 +1,11 @@
+/**
+ * Configures the "clean" stage for Heft.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/clean.schema.json",
+
+  /**
+   * Glob patterns to be deleted by the "heft clean" action.  The paths are resolved relative to the project folder.
+   */
+  "pathsToDelete": ["dist", "lib", "temp"]
+}


### PR DESCRIPTION
This PR also allows the "extends" property to refer to a module path.