### PR TITLE
[rush] Fix "The EnvironmentConfiguration must be initialized" issue

### DIFF
--- a/apps/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/apps/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -1,3 +1,4 @@
+import { InternalError } from '@rushstack/node-core-library';
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
@@ -259,7 +260,9 @@ export class EnvironmentConfiguration {
 
   private static _ensureInitialized(): void {
     if (!EnvironmentConfiguration._hasBeenInitialized) {
-      throw new Error('The EnvironmentConfiguration must be initialized before values can be accessed.');
+      throw new InternalError(
+        'The EnvironmentConfiguration must be initialized before values can be accessed.'
+      );
     }
   }
 

--- a/apps/rush-lib/src/api/RushGlobalFolder.ts
+++ b/apps/rush-lib/src/api/RushGlobalFolder.ts
@@ -44,8 +44,13 @@ export class RushGlobalFolder {
   }
 
   public constructor() {
-    if (EnvironmentConfiguration.rushGlobalFolderOverride !== undefined) {
-      this._rushGlobalFolder = EnvironmentConfiguration.rushGlobalFolderOverride;
+    // Because RushGlobalFolder is used by the front-end VersionSelector before EnvironmentConfiguration
+    // is initialized, we need to read it using a special internal API.
+    const rushGlobalFolderOverride:
+      | string
+      | undefined = EnvironmentConfiguration._getRushGlobalFolderOverride(process.env);
+    if (rushGlobalFolderOverride !== undefined) {
+      this._rushGlobalFolder = rushGlobalFolderOverride;
     } else {
       this._rushGlobalFolder = path.join(Utilities.getHomeDirectory(), '.rush');
     }

--- a/common/changes/@microsoft/rush/octogonz-rush-env-var-regression_2020-09-17-06-54.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-env-var-regression_2020-09-17-06-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a regression that reported an error \"The EnvironmentConfiguration must be initialized before values can be accessed\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
This is a regression from https://github.com/microsoft/rushstack/pull/2188 that we missed during testing because it only affects the VersionSelector front-end.