### PR TITLE
[rush] Fix incorrect "successful" exit status code

### DIFF
--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -369,7 +369,7 @@ export class RushCommandLineParser extends CommandLineParser {
     // performs nontrivial work that can throw an exception.  Either the Rush class would need
     // to handle reporting for those exceptions, or else _populateActions() should be moved
     // to a RushCommandLineParser lifecycle stage that can handle it.
-    if (process.exitCode > 0) {
+    if (typeof process.exitCode === 'number' && process.exitCode > 0) {
       process.exit(process.exitCode);
     } else {
       process.exit(1);

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -369,7 +369,7 @@ export class RushCommandLineParser extends CommandLineParser {
     // performs nontrivial work that can throw an exception.  Either the Rush class would need
     // to handle reporting for those exceptions, or else _populateActions() should be moved
     // to a RushCommandLineParser lifecycle stage that can handle it.
-    if (typeof process.exitCode === 'number' && process.exitCode > 0) {
+    if (process.exitCode !== undefined) {
       process.exit(process.exitCode);
     } else {
       process.exit(1);

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -369,7 +369,7 @@ export class RushCommandLineParser extends CommandLineParser {
     // performs nontrivial work that can throw an exception.  Either the Rush class would need
     // to handle reporting for those exceptions, or else _populateActions() should be moved
     // to a RushCommandLineParser lifecycle stage that can handle it.
-    if (!process.exitCode || process.exitCode > 0) {
+    if (process.exitCode > 0) {
       process.exit(process.exitCode);
     } else {
       process.exit(1);

--- a/common/changes/@microsoft/rush/patch-1_2020-09-18-15-01.json
+++ b/common/changes/@microsoft/rush/patch-1_2020-09-18-15-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix incorrect \"successful\" exit status code",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "mmkal@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2203

The check for `!process.exitCode` returned true when `process.exitCode` is `undefined`. This caused some commands to incorrectly exit with a success code when they should be failing.

Note: I created this PR from the GitHub UI after testing with a cloned copy, so I'm hoping tests will catch issues with it, if there are any. I've verified it manually by patching the code in a similar way by hand.