### PR TITLE
[eslint-config] 3 minor fixes for lint rules

### DIFF
--- a/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-51.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Remove the @typescript-eslint/array-type rule",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-52.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Relax @typescript-eslint/no-use-before-define slightly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-53.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-eslint-config-updates_2020-09-18-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Add *.spec.ts file extension for tests, since this is also a commonly used convention",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -67,20 +67,6 @@ module.exports = {
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         '@typescript-eslint/adjacent-overload-signatures': 'warn',
 
-        // RATIONALE:         We require "string[]" (instead of "Array<string>") because it is idiomatic TypeScript.
-        //                    We require "ReadonlyArray<string>" (instead of "readonly string[]") because, although
-        //                    the latter form is nicer, it is not supported by TypeScript version prior to 3.4.
-        //                    It can be expensive to upgrade a large code base to use the latest compiler, so our
-        //                    lint rules should not require usage of bleeding edge language features.  In the future
-        //                    when TypeScript 3 is obsolete, we'll change this rule to require "readonly string[]".
-        '@typescript-eslint/array-type': [
-          'warn',
-          {
-            default: 'array',
-            readonly: 'generic'
-          }
-        ],
-
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         //
         // CONFIGURATION:     By default, these are banned: String, Boolean, Number, Object, Symbol

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -399,7 +399,35 @@ module.exports = {
         ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        '@typescript-eslint/no-use-before-define': 'error',
+        '@typescript-eslint/no-use-before-define': [
+          'error',
+          {
+            // Base ESLint options
+
+            // We set functions=false so that functions can be ordered based on exported/local visibility
+            // similar to class methods.  Also the base lint rule incorrectly flags a legitimate case like:
+            //
+            //   function a(n: number): void {
+            //     if (n > 0) {
+            //       b(n-1); //   lint error
+            //     }
+            //   }
+            //   function b(n: number): void {
+            //     if (n > 0) {
+            //       a(n-1);
+            //     }
+            //   }
+            functions: false,
+            classes: true,
+            variables: true,
+
+            // TypeScript extensions
+
+            enums: true,
+            typedefs: true,
+            ignoreTypeReferences: true
+          }
+        ],
 
         // TODO: This is a good rule for web browser apps, but it is commonly needed API for Node.js tools.
         // '@typescript-eslint/no-var-requires': 'error',

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -756,6 +756,8 @@ module.exports = {
         // Test files
         '*.test.ts',
         '*.test.tsx',
+        '*.spec.ts',
+        '*.spec.tsx',
 
         // Facebook convention
         '**/__mocks__/*.ts',

--- a/stack/eslint-config/index.js
+++ b/stack/eslint-config/index.js
@@ -424,8 +424,8 @@ module.exports = {
             // TypeScript extensions
 
             enums: true,
-            typedefs: true,
-            ignoreTypeReferences: true
+            typedefs: true
+            // ignoreTypeReferences: true
           }
         ],
 


### PR DESCRIPTION
- `@typescript-eslint/array-type`:  This rule was awkward for certain expressions such as `Partial<Bar>[]` and `Array<[string, T[]]>`. We discussed fixing the rule implementation, but the consensus was that the benefits of this rule are dubious. It simply didn't seem worth the time investment to figure out how to handle those edge cases.

- `@typescript-eslint/no-use-before-define`:  A small option change (`functions: false`) which is explained in the comments.

- Add *.spec.ts file extension for tests, since this is also a commonly used convention