### PR TITLE
[heft] Fix a few issues related to "extends" fields in config files.

### DIFF
--- a/apps/heft/src/pluginFramework/PluginManager.ts
+++ b/apps/heft/src/pluginFramework/PluginManager.ts
@@ -61,21 +61,17 @@ export class PluginManager {
   }
 
   public async initializePluginsFromConfigFileAsync(): Promise<void> {
-    try {
-      const pluginConfigFilePath: string = path.join(
-        this._heftConfiguration.projectHeftDataFolder,
-        'plugins.json'
-      );
+    const pluginConfigFilePath: string = path.join(
+      this._heftConfiguration.projectHeftDataFolder,
+      'plugins.json'
+    );
+    if (await FileSystem.existsAsync(pluginConfigFilePath)) {
       const pluginConfigurationJson: IPluginConfigurationJson = await HeftConfigFiles.pluginConfigFileLoader.loadConfigurationFileAsync(
         pluginConfigFilePath
       );
 
       for (const pluginSpecifier of pluginConfigurationJson.plugins) {
         this._initializeResolvedPlugin(pluginSpecifier.plugin, pluginSpecifier.options);
-      }
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
       }
     }
   }

--- a/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorPlugin.ts
+++ b/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorPlugin.ts
@@ -64,15 +64,16 @@ export class ApiExtractorPlugin implements IHeftPlugin {
   ): Promise<void> {
     const { heftConfiguration, buildFolder, debugMode, watchMode, production } = options;
 
+    const apiExtractorTaskConfigurationPath: string = path.resolve(
+      heftConfiguration.buildFolder,
+      '.heft',
+      'api-extractor-task.json'
+    );
     let apiExtractorTaskConfiguration: IApiExtractorPluginConfiguration | undefined;
-    try {
+    if (await FileSystem.existsAsync(apiExtractorTaskConfigurationPath)) {
       apiExtractorTaskConfiguration = await HeftConfigFiles.apiExtractorTaskConfigurationLoader.loadConfigurationFileAsync(
-        path.resolve(heftConfiguration.buildFolder, '.heft', 'api-extractor-task.json')
+        apiExtractorTaskConfigurationPath
       );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
     }
 
     const terminal: Terminal = ApiExtractorRunner.getTerminal(heftConfiguration.terminalProvider);

--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -93,15 +93,16 @@ export class CopyStaticAssetsPlugin implements IHeftPlugin {
   private async _loadCopyStaticAssetsConfigurationAsync(
     buildFolder: string
   ): Promise<ICopyStaticAssetsConfiguration> {
+    const copyStaticAssetsConfigurationPath: string = path.resolve(
+      buildFolder,
+      '.heft',
+      'copy-static-assets.json'
+    );
     let copyStaticAssetsConfigurationJson: ICopyStaticAssetsConfigurationJson | undefined;
-    try {
+    if (await FileSystem.existsAsync(copyStaticAssetsConfigurationPath)) {
       copyStaticAssetsConfigurationJson = await HeftConfigFiles.copyStaticAssetsConfigurationLoader.loadConfigurationFileAsync(
-        path.resolve(buildFolder, '.heft', 'copy-static-assets.json')
+        copyStaticAssetsConfigurationPath
       );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
     }
 
     return {

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -131,18 +131,15 @@ export class TypeScriptPlugin implements IHeftPlugin {
       | undefined = this._typeScriptConfigurationFileCache.get(buildFolder);
 
     if (!typescriptConfigurationFileCacheEntry) {
-      try {
+      const typescriptConfigurationFilePath: string = path.resolve(buildFolder, '.heft', 'typescript.json');
+      if (await FileSystem.existsAsync(typescriptConfigurationFilePath)) {
         typescriptConfigurationFileCacheEntry = {
           configurationFile: await HeftConfigFiles.typeScriptConfigurationFileLoader.loadConfigurationFileAsync(
-            path.resolve(buildFolder, '.heft', 'typescript.json')
+            typescriptConfigurationFilePath
           )
         };
-      } catch (e) {
-        if (FileSystem.isNotExistError(e)) {
-          typescriptConfigurationFileCacheEntry = { configurationFile: undefined };
-        } else {
-          throw e;
-        }
+      } else {
+        typescriptConfigurationFileCacheEntry = { configurationFile: undefined };
       }
 
       this._typeScriptConfigurationFileCache.set(buildFolder, typescriptConfigurationFileCacheEntry);

--- a/apps/heft/src/stages/CleanStage.ts
+++ b/apps/heft/src/stages/CleanStage.ts
@@ -50,14 +50,15 @@ export class CleanStage extends StageBase<CleanStageHooks, ICleanStageProperties
     options: ICleanStageOptions
   ): Promise<ICleanStageProperties> {
     let cleanConfigurationFile: ICleanConfigurationJson | undefined = undefined;
-    try {
+    const cleanConfigurationFilePath: string = path.resolve(
+      this.heftConfiguration.buildFolder,
+      '.heft',
+      'clean.json'
+    );
+    if (await FileSystem.existsAsync(cleanConfigurationFilePath)) {
       cleanConfigurationFile = await HeftConfigFiles.cleanConfigurationFileLoader.loadConfigurationFileAsync(
-        path.resolve(this.heftConfiguration.buildFolder, '.heft', 'clean.json')
+        cleanConfigurationFilePath
       );
-    } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
-        throw e;
-      }
     }
 
     return {

--- a/apps/heft/src/utilities/fileSystem/CachedFileSystem.ts
+++ b/apps/heft/src/utilities/fileSystem/CachedFileSystem.ts
@@ -66,6 +66,19 @@ export class CachedFileSystem implements IExtendedFileSystem {
     }
   };
 
+  public existsAsync: (path: string) => Promise<boolean> = async (path: string) => {
+    try {
+      await this.getStatisticsAsync(path);
+      return true;
+    } catch (e) {
+      if (FileSystem.isNotExistError(e)) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  };
+
   public getStatistics: (path: string) => FileSystemStats = (path: string) => {
     return this._withCaching(path, FileSystem.getStatistics, this._statsCache);
   };

--- a/apps/heft/src/utilities/fileSystem/ExtendedFileSystem.ts
+++ b/apps/heft/src/utilities/fileSystem/ExtendedFileSystem.ts
@@ -29,6 +29,7 @@ export class ExtendedFileSystem implements IExtendedFileSystem {
    * This is a wrapper around the node-core-library FileSystem API, so just use those APIs for everything we can
    */
   public readonly exists: (path: string) => boolean = FileSystem.exists;
+  public readonly existsAsync: (path: string) => Promise<boolean> = FileSystem.existsAsync;
   public readonly getStatistics: (path: string) => FileSystemStats = FileSystem.getStatistics;
   public readonly getStatisticsAsync: (path: string) => Promise<FileSystemStats> =
     FileSystem.getStatisticsAsync;

--- a/common/changes/@rushstack/heft-config-file/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
+++ b/common/changes/@rushstack/heft-config-file/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Allow \"extends\" fields to refer to modules in addition to relative paths.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
+++ b/common/changes/@rushstack/heft/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where, if an \"extends\" field pointed to a module that didn't exist, the error was silently ignored.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
+++ b/common/changes/@rushstack/node-core-library/ianc-fix-issue-with-config-resolution_2020-09-18-20-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a missing \"existsAsync\" function to the FileSystem API.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -167,6 +167,7 @@ export class FileSystem {
     static ensureFolder(folderPath: string): void;
     static ensureFolderAsync(folderPath: string): Promise<void>;
     static exists(path: string): boolean;
+    static existsAsync(path: string): Promise<boolean>;
     static formatPosixModeBits(modeBits: PosixModeBits): string;
     static getLinkStatistics(path: string): FileSystemStats;
     static getLinkStatisticsAsync(path: string): Promise<FileSystemStats>;

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -262,10 +262,10 @@ export class ConfigurationFile<TConfigurationFile> {
 
         let parentConfiguration: Partial<TConfigurationFile> = {};
         if (configurationJson.extends) {
-          const resolvedParentConfigPath: string = nodeJsPath.resolve(
-            nodeJsPath.dirname(resolvedConfigurationFilePath),
-            configurationJson.extends
-          );
+          const resolvedParentConfigPath: string = Import.resolveModule({
+            modulePath: configurationJson.extends,
+            baseFolderPath: nodeJsPath.dirname(resolvedConfigurationFilePath)
+          });
           parentConfiguration = await this._loadConfigurationFileInnerAsync(
             resolvedParentConfigPath,
             visitedConfigurationFilePaths

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -337,6 +337,17 @@ export class FileSystem {
   }
 
   /**
+   * An async version of {@link FileSystem.exists}.
+   */
+  public static async existsAsync(path: string): Promise<boolean> {
+    return await FileSystem._wrapExceptionAsync(() => {
+      return new Promise<boolean>((resolve: (result: boolean) => void) => {
+        fsx.exists(path, resolve);
+      });
+    });
+  }
+
+  /**
    * Gets the statistics for a particular filesystem object.
    * If the path is a link, this function follows the link and returns statistics about the link target.
    * Behind the scenes it uses `fs.statSync()`.


### PR DESCRIPTION
This change fixes a few issues:

- "extends" fields can now use module reference syntax instead of only relative path syntax.
- If an "extends" field pointed to a module that didn't exist, the error was silently ignored.