### PR TITLE
Fix an issue with "clean" on Windows.

### DIFF
--- a/apps/heft/src/utilities/HeftConfigFiles.ts
+++ b/apps/heft/src/utilities/HeftConfigFiles.ts
@@ -81,12 +81,7 @@ export class HeftConfigFiles {
     if (!HeftConfigFiles._cleanConfigurationFileLoader) {
       const schemaPath: string = path.resolve(__dirname, '..', 'schemas', 'clean.schema.json');
       HeftConfigFiles._cleanConfigurationFileLoader = new ConfigurationFile<ICleanConfigurationJson>({
-        jsonSchemaPath: schemaPath,
-        jsonPathMetadata: {
-          '$.pathsToDelete.*': {
-            pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToProjectRoot
-          }
-        }
+        jsonSchemaPath: schemaPath
       });
     }
 

--- a/common/changes/@rushstack/heft/ianc-fix-clean_2020-09-18-22-33.json
+++ b/common/changes/@rushstack/heft/ianc-fix-clean_2020-09-18-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where folders listed in pathsToDelete in clean.json weren't deleted on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
There is an issue with the way we detect if a path contains a glob pattern on Windows. Right now, we tell `heft-config-file` to resolve all of the paths listed in `clean.json`, which results in paths that look like `C:\repo\my-project\lib` on Windows. We detect if that path contains a glob pattern by seeing if it is changed by `globEscape`. Escaping that path gives us `C:\\repo\\my-project\\lib`, so `C:\repo\my-project\lib` then gets expanded as a glob pattern (that matches nothing).