### PR TITLE
[eslint-plugin] Add missing dependency

### DIFF
--- a/common/changes/@rushstack/eslint-plugin-security/octogonz-fix-dep_2020-09-19-04-25.json
+++ b/common/changes/@rushstack/eslint-plugin-security/octogonz-fix-dep_2020-09-19-04-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "Add missing dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/octogonz-fix-dep_2020-09-19-04-25.json
+++ b/common/changes/@rushstack/eslint-plugin/octogonz-fix-dep_2020-09-19-04-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Add missing dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/eslint-plugin-security/package.json
+++ b/stack/eslint-plugin-security/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "build": "heft test --clean"
   },
+  "dependencies": {
+    "@rushstack/tree-pattern": "workspace:*"
+  },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"
   },
@@ -26,7 +29,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "@rushstack/heft": "0.8.0",
-    "@rushstack/tree-pattern": "workspace:*",
     "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",

--- a/stack/eslint-plugin/package.json
+++ b/stack/eslint-plugin/package.json
@@ -20,6 +20,9 @@
   "scripts": {
     "build": "heft test --clean"
   },
+  "dependencies": {
+    "@rushstack/tree-pattern": "workspace:*"
+  },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"
   },
@@ -30,7 +33,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "@rushstack/heft": "0.8.0",
-    "@rushstack/tree-pattern": "workspace:*",
     "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",


### PR DESCRIPTION
A dependency was accidentally added to `devDependencies` instead of `dependencies`