### PR TITLE
[stream-collator] Fix issue that caused lagged output for "rush build"

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-stream-collator-fix_2020-09-20-05-19.json
+++ b/common/changes/@microsoft/rush/octogonz-stream-collator-fix_2020-09-20-05-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush build\" output was lagged due to stream-collator not activating streams aggressively enough",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/stream-collator/octogonz-stream-collator-fix_2020-09-20-05-17.json
+++ b/common/changes/@rushstack/stream-collator/octogonz-stream-collator-fix_2020-09-20-05-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/stream-collator",
+      "comment": "Fix an issue where output was lagged because writers were not activated aggressively enough",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/stream-collator",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
I noticed that the `rush build` command sometimes stalled like this:
```
==[ @microsoft/rush-stack-compiler-3.5 ]=========================[ 20 of 97 ]==
"@microsoft/rush-stack-compiler-3.5" completed successfully in 18.52 seconds.

==[ @microsoft/rush-stack-compiler-3.0 ]=========================[ 21 of 97 ]==
"@microsoft/rush-stack-compiler-3.0" completed successfully in 18.31 seconds.

>>> PAUSE HERE <<<
==[ @microsoft/rush-stack-compiler-3.2 ]=========================[ 22 of 97 ]==
```
When we would expect the delay to happen like this:
```
==[ @microsoft/rush-stack-compiler-3.5 ]=========================[ 20 of 97 ]==
"@microsoft/rush-stack-compiler-3.5" completed successfully in 18.52 seconds.

==[ @microsoft/rush-stack-compiler-3.0 ]=========================[ 21 of 97 ]==
>>> PAUSE HERE <<<
"@microsoft/rush-stack-compiler-3.0" completed successfully in 18.31 seconds.
```

The reason was that in order to know the right number for `[ 21 of 97 ]`, we don't write the header to the stream until it becomes activated.  This interfered with `StreamCollator` logic that would lazily only activate streams that had some data written to them.

This PR fixes that by making `StreamCollator`  more aggressive about activating streams.