### PR TITLE
[eslint-config] Relax the "typedef" rule to allow inferred types for local variables

### DIFF
--- a/apps/api-documenter/.eslintrc.js
+++ b/apps/api-documenter/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/apps/api-extractor-model/.eslintrc.js
+++ b/apps/api-extractor-model/.eslintrc.js
@@ -2,7 +2,7 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@rushstack/eslint-config/profile/node', '@rushstack/eslint-config/mixins/friendly-locals'],
   parserOptions: { tsconfigRootDir: __dirname },
 
   rules: {

--- a/apps/api-extractor/.eslintrc.js
+++ b/apps/api-extractor/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/apps/heft/.eslintrc.js
+++ b/apps/heft/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/apps/rush-lib/.eslintrc.js
+++ b/apps/rush-lib/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/apps/rush/.eslintrc.js
+++ b/apps/rush/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/build-tests/heft-action-plugin/.eslintrc.js
+++ b/build-tests/heft-action-plugin/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/build-tests/heft-example-plugin-01/.eslintrc.js
+++ b/build-tests/heft-example-plugin-01/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/build-tests/heft-example-plugin-02/.eslintrc.js
+++ b/build-tests/heft-example-plugin-02/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/build-tests/node-library-build-eslint-test/.eslintrc.js
+++ b/build-tests/node-library-build-eslint-test/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@rushstack/eslint-config/profile/node', '@rushstack/eslint-config/mixins/friendly-locals'],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/common/changes/@microsoft/api-documenter/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor-model/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/gulp-core-build/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/load-themed-styles/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/node-library-build/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.4",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.7",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.8",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.9",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.0",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.1",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.2",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.4",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.5",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.6",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.7",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.8/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.8",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.8",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.9/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.9",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/rush/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@microsoft/web-library-build/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/debug-certificate-manager/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/debug-certificate-manager/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-config/octogonz-typedef-var_2020-09-20-21-05.json
+++ b/common/changes/@rushstack/eslint-config/octogonz-typedef-var_2020-09-20-21-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Relax the \"typedef\" rule so that type inference is now allowed for local variables, while still requiring explicit type declarations in other scopes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/octogonz-typedef-var_2020-09-20-21-05.json
+++ b/common/changes/@rushstack/eslint-plugin/octogonz-typedef-var_2020-09-20-21-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Add a new rule \"@rushstack/typedef-var\" which supplements \"@typescript-eslint/typedef\" by enabling a special policy for local variables",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-config-file/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/heft-config-file/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/heft/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/loader-raw-script/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/loader-raw-script/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/loader-raw-script",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/loader-raw-script",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/localization-plugin/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/localization-plugin/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/localization-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/module-minifier-plugin/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/module-minifier-plugin/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/package-deps-hash/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/package-deps-hash/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/set-webpack-public-path-plugin/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/set-webpack-public-path-plugin/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/set-webpack-public-path-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/set-webpack-public-path-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/stream-collator/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/stream-collator/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/stream-collator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/stream-collator",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/terminal/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/terminal/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/terminal",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/ts-command-line/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/typings-generator/octogonz-typedef-var_2020-09-22-01-06.json
+++ b/common/changes/@rushstack/typings-generator/octogonz-typedef-var_2020-09-22-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,5 +1,7 @@
 pool:
   vmImage: 'ubuntu-latest'
+variables:
+  FORCE_COLOR: 1
 jobs:
   - job: PRBuild
     condition: succeeded()

--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -3,5 +3,6 @@ pool:
 variables:
   NodeVersion: 12
   VersionPolicy: rush
+  FORCE_COLOR: 1
 steps:
   - template: templates/buildAndPublish.yaml

--- a/common/config/azure-pipelines/npm-publish.yaml
+++ b/common/config/azure-pipelines/npm-publish.yaml
@@ -3,5 +3,6 @@ pool:
 variables:
   NodeVersion: 12
   VersionPolicy: noRush
+  FORCE_COLOR: 1
 steps:
   - template: templates/buildAndPublish.yaml

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -1,7 +1,3 @@
-variables:
-  # Enable ANSI color escapes in CI logs
-  - name: FORCE_COLOR
-    value: 1
 steps:
   - task: NodeTool@0
     displayName: 'Use Node $(NodeVersion).x'

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -1,3 +1,7 @@
+variables:
+  # Enable ANSI color escapes in CI logs
+  - name: FORCE_COLOR
+    value: 1
 steps:
   - task: NodeTool@0
     displayName: 'Use Node $(NodeVersion).x'

--- a/core-build/gulp-core-build-mocha/.eslintrc.js
+++ b/core-build/gulp-core-build-mocha/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/gulp-core-build-sass/.eslintrc.js
+++ b/core-build/gulp-core-build-sass/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/gulp-core-build-serve/.eslintrc.js
+++ b/core-build/gulp-core-build-serve/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/gulp-core-build-typescript/.eslintrc.js
+++ b/core-build/gulp-core-build-typescript/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/gulp-core-build-webpack/.eslintrc.js
+++ b/core-build/gulp-core-build-webpack/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/gulp-core-build/.eslintrc.js
+++ b/core-build/gulp-core-build/.eslintrc.js
@@ -2,7 +2,10 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname },
   rules: {
     // This predates the new ESLint ruleset; not worth fixing

--- a/core-build/node-library-build/.eslintrc.js
+++ b/core-build/node-library-build/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/core-build/web-library-build/.eslintrc.js
+++ b/core-build/web-library-build/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/heft-plugins/pre-compile-hardlink-or-copy-plugin/.eslintrc.js
+++ b/heft-plugins/pre-compile-hardlink-or-copy-plugin/.eslintrc.js
@@ -2,6 +2,10 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool', '@rushstack/eslint-config/mixins/tsdoc'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals',
+    '@rushstack/eslint-config/mixins/tsdoc'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/debug-certificate-manager/.eslintrc.js
+++ b/libraries/debug-certificate-manager/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/heft-config-file/.eslintrc.js
+++ b/libraries/heft-config-file/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/load-themed-styles/.eslintrc.js
+++ b/libraries/load-themed-styles/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/web-app'],
+  extends: ['@rushstack/eslint-config/profile/web-app', '@rushstack/eslint-config/mixins/friendly-locals'],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/node-core-library/.eslintrc.js
+++ b/libraries/node-core-library/.eslintrc.js
@@ -2,6 +2,10 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node', '@rushstack/eslint-config/mixins/tsdoc'],
+  extends: [
+    '@rushstack/eslint-config/profile/node',
+    '@rushstack/eslint-config/mixins/friendly-locals',
+    '@rushstack/eslint-config/mixins/tsdoc'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/package-deps-hash/.eslintrc.js
+++ b/libraries/package-deps-hash/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/rushell/.eslintrc.js
+++ b/libraries/rushell/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/stream-collator/.eslintrc.js
+++ b/libraries/stream-collator/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@rushstack/eslint-config/profile/node', '@rushstack/eslint-config/mixins/friendly-locals'],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/terminal/.eslintrc.js
+++ b/libraries/terminal/.eslintrc.js
@@ -2,6 +2,10 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node', '@rushstack/eslint-config/mixins/tsdoc'],
+  extends: [
+    '@rushstack/eslint-config/profile/node',
+    '@rushstack/eslint-config/mixins/friendly-locals',
+    '@rushstack/eslint-config/mixins/tsdoc'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/ts-command-line/.eslintrc.js
+++ b/libraries/ts-command-line/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/libraries/typings-generator/.eslintrc.js
+++ b/libraries/typings-generator/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/repo-scripts/doc-plugin-rush-stack/.eslintrc.js
+++ b/repo-scripts/doc-plugin-rush-stack/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/repo-scripts/repo-toolbox/.eslintrc.js
+++ b/repo-scripts/repo-toolbox/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.34.0-pr2172.0",
+  "rushVersion": "5.34.2",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/stack/eslint-config/README.md
+++ b/stack/eslint-config/README.md
@@ -114,10 +114,13 @@ For Rush-specific settings, see the article
 
 Optionally, you can add some "mixins" to your `extends` array to opt-in to some extra behaviors.
 
+Important: Your **.eslintrc.js** `"extends"` field must load mixins after the profile entry.
+
+
 #### `@rushstack/eslint-config/mixins/react`
 
-For projects using React, the `"@rushstack/eslint-config/mixins/react"` mixin provides some recommended additional
-rules.  These rules are selected via a mixin because they require you to:
+For projects using the [React](https://reactjs.org/) library, the `"@rushstack/eslint-config/mixins/react"` mixin
+enables some recommended additional rules.  These rules are selected via a mixin because they require you to:
 
 - Add `"jsx": "react"` to your **tsconfig.json**
 - Configure your `settings.react.version` as shown below.  This determines which React APIs will be considered
@@ -125,7 +128,7 @@ rules.  These rules are selected via a mixin because they require you to:
   [loading the entire React library](https://github.com/yannickcr/eslint-plugin-react/blob/4da74518bd78f11c9c6875a159ffbae7d26be693/lib/util/version.js#L23)
   into the linter's process, which is costly.)
 
-Example:
+Add the mixin to your `"extends"` field like this:
 
 **.eslintrc.js**
 ```ts
@@ -135,17 +138,85 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/web-app",
-    "@rushstack/eslint-config/mixins/react"
+    "@rushstack/eslint-config/mixins/react" // <----
   ],
   parserOptions: { tsconfigRootDir: __dirname },
 
   settings: {
     react: {
-      "version": "16.9"
+      "version": "16.9" // <----
     }
   }
 };
 ```
+
+#### `@rushstack/eslint-config/mixins/friendly-locals`
+
+Requires explicit type declarations for local variables.
+
+For the first 5 years of Rush, our lint rules required explicit types for most declarations
+such as function parameters, function return values, and exported variables.  Although more verbose,
+declaring types (instead of relying on type inference) encourages engineers to create interfaces
+that inspire discussions about data structure design.  It also makes source files easier
+to understand for code reviewers who may be unfamiliar with a particular project.  Once developers get
+used to the extra work of declaring types, it turns out to be a surprisingly popular practice.
+
+However in 2020, to make adoption easier for existing projects, this rule was relaxed.  Explicit
+type declarations are now optional for local variables (although still required in other contexts).
+See [GitHub #2206](https://github.com/microsoft/rushstack/issues/2206) for background.
+
+If you are onboarding a large existing code base, this new default will make adoption easier:
+
+Example source file without `mixins/friendly-locals`:
+```ts
+export class MyDataService {
+  . . .
+  public queryResult(provider: IProvider): IResult {
+    // Type inference is concise, but what are "item", "index", and "data"?
+    const item = provider.getItem(provider.title);
+    const index = item.fetchIndex();
+    const data = index.get(provider.state);
+    return data.results.filter(x => x.title === provider.title);
+  }
+}
+```
+
+On the other hand, if your priority is make source files more friendly for other people to read, you can enable
+the `"@rushstack/eslint-config/mixins/friendly-locals"` mixin.  This restores the requirement that local variables
+should have explicit type declarations.
+
+Example source file with `mixins/friendly-locals`:
+```ts
+export class MyDataService {
+  . . .
+  public queryResult(provider: IProvider): IResult {
+    // This is more work for the person writing the code... but definitely easier to understand
+    // for a code reviewer if they are unfamiliar with your project
+    const item: ISalesReport = provider.getItem(provider.title);
+    const index: Map<string, IGeographicData> = item.fetchIndex();
+    const data: IGeographicData | undefined = index.get(provider.state);
+    return data.results.filter(x => x.title === provider.title);
+  }
+}
+```
+
+Add the mixin to your `"extends"` field like this:
+
+**.eslintrc.js**
+```ts
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: [
+    "@rushstack/eslint-config/profile/node",
+    "@rushstack/eslint-config/profile/mixins/friendly-locals" // <----
+  ],
+  parserOptions: { tsconfigRootDir: __dirname }
+};
+```
+
+
 
 #### `@rushstack/eslint-config/mixins/tsdoc`
 
@@ -154,8 +225,9 @@ the [TSDoc](https://github.com/Microsoft/tsdoc) standard for doc comments, it's 
 `"@rushstack/eslint-config/mixins/tsdoc"` mixin.  It will enable
 [eslint-plugin-tsdoc](https://www.npmjs.com/package/eslint-plugin-tsdoc) validation for TypeScript doc comments.
 
-Example:
+Add the mixin to your `"extends"` field like this:
 
+**.eslintrc.js**
 ```ts
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('@rushstack/eslint-config/patch/modern-module-resolution');
@@ -163,7 +235,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/tsdoc",
+    "@rushstack/eslint-config/profile/mixins/tsdoc" // <----
   ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/eslint-config/mixins/friendly-locals.js
+++ b/stack/eslint-config/mixins/friendly-locals.js
@@ -44,6 +44,42 @@ module.exports = {
           }
         ]
       }
+    },
+    // Note that the above block also applies to *.test.ts, so we need to
+    // reapply those overrides.
+    {
+      files: [
+        // Test files
+        '*.test.ts',
+        '*.test.tsx',
+        '*.spec.ts',
+        '*.spec.tsx',
+
+        // Facebook convention
+        '**/__mocks__/*.ts',
+        '**/__mocks__/*.tsx',
+        '**/__tests__/*.ts',
+        '**/__tests__/*.tsx',
+
+        // Microsoft convention
+        '**/test/*.ts',
+        '**/test/*.tsx'
+      ],
+      rules: {
+        '@typescript-eslint/typedef': [
+          'warn',
+          {
+            arrayDestructuring: false,
+            arrowParameter: false,
+            memberVariableDeclaration: true,
+            objectDestructuring: false,
+            parameter: true,
+            propertyDeclaration: true,
+            variableDeclaration: false, // <--- special case for test files
+            variableDeclarationIgnoreFunction: true
+          }
+        ]
+      }
     }
   ]
 };

--- a/stack/eslint-config/mixins/friendly-locals.js
+++ b/stack/eslint-config/mixins/friendly-locals.js
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// For the first 5 years of Rush, our lint rules required explicit types for most declarations
+// such as function parameters, function return values, and exported variables.  Although more verbose,
+// declaring types (instead of relying on type inference) encourages engineers to create interfaces
+// that inspire discussions about data structure design.  It also makes source files easier
+// to understand for code reviewers who may be unfamiliar with a particular project.  Once developers get
+// used to the extra work of declaring types, it turns out to be a surprisingly popular practice.
+//
+// However in 2020, to make adoption easier for existing projects, this rule was relaxed.  Explicit
+// type declarations are now optional for local variables (although still required in other contexts).
+// See this GitHub issue for background:
+//
+//  https://github.com/microsoft/rushstack/issues/2206
+//
+// If you are onboarding a large existing code base, this new default will make adoption easier.
+//
+// On the other hand, if your top priority is to make source files more friendly for other
+// people to read, enable the "@rushstack/eslint-config/mixins/friendly-locals" mixin.
+// It will restore the requirement that local variables should have explicit type declarations.
+//
+// IMPORTANT: Your .eslintrc.js "extends" field must load mixins AFTER the profile.
+module.exports = {
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        '@rushstack/typedef-var': 'off', // <--- disabled by the mixin
+
+        '@typescript-eslint/typedef': [
+          'warn',
+          {
+            arrayDestructuring: false,
+            arrowParameter: false,
+            memberVariableDeclaration: true,
+            objectDestructuring: false,
+            parameter: true,
+            propertyDeclaration: true,
+
+            variableDeclaration: true, // <--- reenabled by the mixin
+
+            variableDeclarationIgnoreFunction: true
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/stack/eslint-config/mixins/react.js
+++ b/stack/eslint-config/mixins/react.js
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+// This mixin applies some additional checks for projects using the React library.  For more information,
+// please see the README.md for "@rushstack/eslint-config".
 module.exports = {
+  // Plugin documentation: https://www.npmjs.com/package/eslint-plugin-react
   plugins: ['eslint-plugin-react'],
 
   settings: {
     react: {
+      // The default value is "detect".  Automatic detection works by loading the entire React library
+      // into the linter's process, which is inefficient.  It is recommended to specify the version
+      // explicity.  For details, see README.md for "@rushstack/eslint-config".
       version: 'detect'
     }
   },

--- a/stack/eslint-config/mixins/tsdoc.js
+++ b/stack/eslint-config/mixins/tsdoc.js
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+// This mixin validates code comments to ensure that they follow the TSDoc standard.  For more
+// information please see the README.md for @rushstack/eslint-config.
 module.exports = {
+  // The plugin documentation is here: https://www.npmjs.com/package/eslint-plugin-tsdoc
   plugins: ['eslint-plugin-tsdoc'],
 
   overrides: [

--- a/stack/eslint-config/profile/_common.js
+++ b/stack/eslint-config/profile/_common.js
@@ -64,6 +64,9 @@ function buildRules(profile) {
           '@rushstack/no-new-null': 'warn',
 
           // RATIONALE:         See the @rushstack/eslint-plugin documentation
+          '@rushstack/typedef-var': 'warn',
+
+          // RATIONALE:         See the @rushstack/eslint-plugin documentation
           //                    This is enabled and classified as an error because it is required when using Heft.
           //                    It's not required when using ts-jest, but still a good practice.
           '@rushstack/hoist-jest-mock': 'error',
@@ -490,26 +493,8 @@ function buildRules(profile) {
               propertyDeclaration: true,
               variableDeclaration: true,
 
-              // Normally we require type declarations for class members.  However, that rule is relaxed
-              // for situations where we need to bind the "this" pointer for a callback.  For example, consider
-              // this event handler for a React component:
-              //
-              //     class MyComponent {
-              //       public render(): React.ReactNode {
-              //          return (
-              //            <a href="#" onClick={this._onClick}> click me </a>
-              //          );
-              //        }
-              //
-              //        // The assignment here avoids the need for "this._onClick.bind(this)"
-              //        private _onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-              //          console.log("Clicked! " + this.props.title);
-              //        };
-              //      }
-              //
-              // This coding style has limitations and should be used sparingly.  For example, "_onClick"
-              // will not participate correctly in "virtual"/"override" inheritance.
-              variableDeclarationIgnoreFunction: true
+              // This case is handled by our "@rushstack/typedef-var" rule
+              variableDeclaration: false
             }
           ],
 

--- a/stack/eslint-config/profile/_common.js
+++ b/stack/eslint-config/profile/_common.js
@@ -796,8 +796,8 @@ function buildRules(profile) {
           // Jest's mocking API is designed in a way that produces compositional data types that often have
           // no concise description.  Since test code does not ship, and typically does not introduce new
           // concepts or algorithms, the usual arguments for prioritizing readability over writability can be
-          // relaxed in this case. We follow C#'s model of allowing type inference for local variable declarations,
-          // but still requiring strict types for function signatures.
+          // relaxed in this case.
+          '@rushstack/typedef-var': 'off',
           '@typescript-eslint/typedef': [
             'warn',
             {

--- a/stack/eslint-config/profile/_common.js
+++ b/stack/eslint-config/profile/_common.js
@@ -28,9 +28,13 @@ function buildRules(profile) {
     parser: '',
 
     plugins: [
+      // Plugin documentation: https://www.npmjs.com/package/@rushstack/eslint-plugin
       '@rushstack/eslint-plugin',
+      // Plugin documentation: https://www.npmjs.com/package/@rushstack/eslint-plugin-security
       '@rushstack/eslint-plugin-security',
+      // Plugin documentation: https://www.npmjs.com/package/@typescript-eslint/eslint-plugin
       '@typescript-eslint/eslint-plugin',
+      // Plugin documentation: https://www.npmjs.com/package/eslint-plugin-promise
       'eslint-plugin-promise'
     ],
 

--- a/stack/eslint-config/profile/_common.js
+++ b/stack/eslint-config/profile/_common.js
@@ -491,10 +491,32 @@ function buildRules(profile) {
               objectDestructuring: false,
               parameter: true,
               propertyDeclaration: true,
-              variableDeclaration: true,
 
               // This case is handled by our "@rushstack/typedef-var" rule
-              variableDeclaration: false
+              variableDeclaration: false,
+
+              // Normally we require type declarations for class members.  However, that rule is relaxed
+              // for situations where we need to bind the "this" pointer for a callback.  For example, consider
+              // this event handler for a React component:
+              //
+              //     class MyComponent {
+              //       public render(): React.ReactNode {
+              //          return (
+              //            <a href="#" onClick={this._onClick}> click me </a>
+              //          );
+              //        }
+              //
+              //        // The assignment here avoids the need for "this._onClick.bind(this)"
+              //        private _onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+              //          console.log("Clicked! " + this.props.title);
+              //        };
+              //      }
+              //
+              // This coding style has limitations and should be used sparingly.  For example, "_onClick"
+              // will not participate correctly in "virtual"/"override" inheritance.
+              //
+              // NOTE: This option affects both "memberVariableDeclaration" and "variableDeclaration" options.
+              variableDeclarationIgnoreFunction: true
             }
           ],
 

--- a/stack/eslint-plugin/src/index.ts
+++ b/stack/eslint-plugin/src/index.ts
@@ -7,6 +7,7 @@ import { hoistJestMock } from './hoist-jest-mock';
 import { noNewNullRule } from './no-new-null';
 import { noNullRule } from './no-null';
 import { noUntypedUnderscoreRule } from './no-untyped-underscore';
+import { typedefVar } from './typedef-var';
 
 interface IPlugin {
   rules: { [ruleName: string]: TSESLint.RuleModule<string, unknown[]> };
@@ -24,7 +25,10 @@ const plugin: IPlugin = {
     'no-null': noNullRule,
 
     // Full name: "@rushstack/no-untyped-underscore"
-    'no-untyped-underscore': noUntypedUnderscoreRule
+    'no-untyped-underscore': noUntypedUnderscoreRule,
+
+    // Full name: "@rushstack/typedef-var"
+    'typedef-var': typedefVar
   }
 };
 

--- a/stack/eslint-plugin/src/typedef-var.test.ts
+++ b/stack/eslint-plugin/src/typedef-var.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { typedefVar } from './typedef-var';
+
+const { RuleTester } = ESLintUtils;
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser'
+});
+
+ruleTester.run('typedef-var', typedefVar, {
+  invalid: [
+    {
+      code: 'const x = 123;',
+      errors: [{ messageId: 'expected-typedef-named' }]
+    },
+    {
+      code: 'let x = 123;',
+      errors: [{ messageId: 'expected-typedef-named' }]
+    },
+    {
+      code: 'var x = 123;',
+      errors: [{ messageId: 'expected-typedef-named' }]
+    },
+    {
+      code: '{ const x = 123; }',
+      errors: [{ messageId: 'expected-typedef-named' }]
+    }
+  ],
+  valid: [
+    {
+      code: 'function f() { const x = 123; }'
+    },
+    {
+      code: 'const f = () => { const x = 123; };'
+    },
+    {
+      code: 'const f = function() { const x = 123; }'
+    },
+    {
+      code: 'for (const x of []) { }'
+    },
+    {
+      // prettier-ignore
+      code: [
+        'let { a , b } = {',
+        '  a: 123,',
+        '  b: 234',
+        '}',
+      ].join('\n')
+    },
+    {
+      // prettier-ignore
+      code: [
+        'class C {',
+        '  public m(): void {',
+        '    const x = 123;',
+        '  }',
+        '}',
+      ].join('\n')
+    },
+    {
+      // prettier-ignore
+      code: [
+        'class C {',
+        '  public m = (): void => {',
+        '    const x = 123;',
+        '  }',
+        '}',
+      ].join('\n')
+    }
+  ]
+});

--- a/stack/eslint-plugin/src/typedef-var.ts
+++ b/stack/eslint-plugin/src/typedef-var.ts
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+
+type MessageIds = 'expected-typedef' | 'expected-typedef-named';
+type Options = [];
+
+const typedefVar: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'problem',
+    messages: {
+      'expected-typedef-named': 'Expected a type annotation.',
+      'expected-typedef': 'Expected {{name}} to have a type annotation.'
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false
+      }
+    ],
+    docs: {
+      description:
+        'Supplements the "@typescript-eslint/typedef" rule by relaxing the requirements for local variables',
+      category: 'Stylistic Issues',
+      recommended: 'error',
+      url: 'https://www.npmjs.com/package/@rushstack/eslint-plugin'
+    }
+  },
+
+  create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
+    // This rule implements the variableDeclarationIgnoreFunction=true behavior from
+    // @typescript-eslint/typedef
+    //
+    // Normally we require type declarations for class members.  However, that rule is relaxed
+    // for situations where we need to bind the "this" pointer for a callback.  For example, consider
+    // this event handler for a React component:
+    //
+    //     class MyComponent {
+    //       public render(): React.ReactNode {
+    //          return (
+    //            <a href="#" onClick={this._onClick}> click me </a>
+    //          );
+    //        }
+    //
+    //        // The assignment here avoids the need for "this._onClick.bind(this)"
+    //        private _onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+    //          console.log("Clicked! " + this.props.title);
+    //        };
+    //      }
+    //
+    // This coding style has limitations and should be used sparingly.  For example, "_onClick"
+    // will not participate correctly in "virtual"/"override" inheritance.
+    function isVariableDeclarationIgnoreFunction(node: TSESTree.Node): boolean {
+      return (
+        node.type === AST_NODE_TYPES.FunctionExpression ||
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression
+      );
+    }
+
+    function getNodeName(node: TSESTree.Parameter | TSESTree.PropertyName): string | undefined {
+      return node.type === AST_NODE_TYPES.Identifier ? node.name : undefined;
+    }
+
+    return {
+      VariableDeclarator(node): void {
+        if (node.id.typeAnnotation) {
+          // An explicit type declaration was provided
+          return;
+        }
+
+        // These are @typescript-eslint/typedef exemptions
+        if (
+          node.id.type === AST_NODE_TYPES.ArrayPattern /* ArrayDestructuring */ ||
+          node.id.type === AST_NODE_TYPES.ObjectPattern /* ObjectDestructuring */ ||
+          (node.init && isVariableDeclarationIgnoreFunction(node.init))
+        ) {
+          return;
+        }
+
+        // Ignore this case:
+        //
+        //   for (const NODE of thing) { }
+        let current: TSESTree.Node | undefined = node.parent;
+        while (current) {
+          switch (current.type) {
+            case AST_NODE_TYPES.VariableDeclaration:
+              // Keep looking upwards
+              current = current.parent;
+              break;
+            case AST_NODE_TYPES.ForOfStatement:
+            case AST_NODE_TYPES.ForInStatement:
+              // Stop traversing and don't report an error
+              return;
+            default:
+              // Stop traversing
+              current = undefined;
+              break;
+          }
+        }
+
+        // Is it a local variable?
+        current = node.parent;
+        while (current) {
+          switch (current.type) {
+            // function f() {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.FunctionDeclaration:
+
+            // class C {
+            //   public m(): void {
+            //     const NODE = 123;
+            //   }
+            // }
+            case AST_NODE_TYPES.MethodDefinition:
+
+            // let f = function() {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.FunctionExpression:
+
+            // let f = () => {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.ArrowFunctionExpression:
+              // Stop traversing and don't report an error
+              return;
+          }
+
+          current = current.parent;
+        }
+
+        const nodeName: string | undefined = getNodeName(node.id);
+        if (nodeName) {
+          context.report({
+            node,
+            messageId: 'expected-typedef-named',
+            data: { name: nodeName }
+          });
+        } else {
+          context.report({
+            node,
+            messageId: 'expected-typedef'
+          });
+        }
+      }
+    };
+  }
+};
+
+export { typedefVar };

--- a/stack/eslint-plugin/src/typedef-var.ts
+++ b/stack/eslint-plugin/src/typedef-var.ts
@@ -32,26 +32,6 @@ const typedefVar: TSESLint.RuleModule<MessageIds, Options> = {
   create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
     // This rule implements the variableDeclarationIgnoreFunction=true behavior from
     // @typescript-eslint/typedef
-    //
-    // Normally we require type declarations for class members.  However, that rule is relaxed
-    // for situations where we need to bind the "this" pointer for a callback.  For example, consider
-    // this event handler for a React component:
-    //
-    //     class MyComponent {
-    //       public render(): React.ReactNode {
-    //          return (
-    //            <a href="#" onClick={this._onClick}> click me </a>
-    //          );
-    //        }
-    //
-    //        // The assignment here avoids the need for "this._onClick.bind(this)"
-    //        private _onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-    //          console.log("Clicked! " + this.props.title);
-    //        };
-    //      }
-    //
-    // This coding style has limitations and should be used sparingly.  For example, "_onClick"
-    // will not participate correctly in "virtual"/"override" inheritance.
     function isVariableDeclarationIgnoreFunction(node: TSESTree.Node): boolean {
       return (
         node.type === AST_NODE_TYPES.FunctionExpression ||

--- a/stack/rush-stack-compiler-2.4/.eslintrc.js
+++ b/stack/rush-stack-compiler-2.4/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-2.7/.eslintrc.js
+++ b/stack/rush-stack-compiler-2.7/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-2.8/.eslintrc.js
+++ b/stack/rush-stack-compiler-2.8/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-2.9/.eslintrc.js
+++ b/stack/rush-stack-compiler-2.9/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.0/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.0/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.1/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.1/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.2/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.2/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.3/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.3/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.4/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.4/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.5/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.5/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.6/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.6/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.7/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.7/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.8/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.8/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/rush-stack-compiler-3.9/.eslintrc.js
+++ b/stack/rush-stack-compiler-3.9/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/webpack/loader-load-themed-styles/.eslintrc.js
+++ b/webpack/loader-load-themed-styles/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/webpack/loader-raw-script/.eslintrc.js
+++ b/webpack/loader-raw-script/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/webpack/localization-plugin/.eslintrc.js
+++ b/webpack/localization-plugin/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/webpack/module-minifier-plugin/.eslintrc.js
+++ b/webpack/module-minifier-plugin/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/webpack/set-webpack-public-path-plugin/.eslintrc.js
+++ b/webpack/set-webpack-public-path-plugin/.eslintrc.js
@@ -2,6 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node-trusted-tool'],
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
   parserOptions: { tsconfigRootDir: __dirname }
 };


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2206

See that issue for details.