### PR TITLE
[terminal] Fix dependency on @rushstack/node-core-library

### DIFF
--- a/common/changes/@rushstack/terminal/dmichon-terminal-dep_2020-09-22-01-19.json
+++ b/common/changes/@rushstack/terminal/dmichon-terminal-dep_2020-09-22-01-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Fix @rushstack/node-core-library dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/terminal",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -12,13 +12,13 @@
     "build": "heft test --clean"
   },
   "dependencies": {
+    "@rushstack/node-core-library": "workspace:*",
     "@types/node": "10.17.13"
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/node-core-library": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "colors": "~1.2.1"
   }


### PR DESCRIPTION
Multiple files have a runtime, not just dev time dependency on @rushstack/node-core-library. Fixing the dependency to be a runtime dependency so that it can be successfully installed in pnpm/rush.