### PR TITLE
[heft] Fix an issue with the "--help" CLI parameter

### DIFF
--- a/apps/heft/src/cli/HeftToolsCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftToolsCommandLineParser.ts
@@ -190,7 +190,7 @@ export class HeftToolsCommandLineParser extends CommandLineParser {
 
   private _getPluginArgumentValues(args: string[] = process.argv): string[] {
     // This is a rough parsing of the --plugin parameters
-    const parser: ArgumentParser = new ArgumentParser();
+    const parser: ArgumentParser = new ArgumentParser({ addHelp: false });
     parser.addArgument(this._pluginsParameter.longName, { dest: 'plugins', action: 'append' });
 
     const [result]: { plugins: string[] }[] = parser.parseKnownArgs(args);

--- a/common/changes/@rushstack/heft/octogonz-heft-help_2020-09-26-05-09.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-help_2020-09-26-05-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where \"heft build --help\" printed incorrect help",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
This fixes a regression introduced by PR #2168.

Commands like `heft build --help` printed incorrect help because the `_getPluginArgumentValues()` parser was handling `--help`.