### PR TITLE
[heft] Improve some warnings

### DIFF
--- a/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
+++ b/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
@@ -58,7 +58,7 @@ export class ApiExtractorRunner extends SubprocessRunnerBase<IApiExtractorRunner
 
     const apiExtractor: typeof TApiExtractor = require(this._configuration.apiExtractorPackagePath);
 
-    this._terminal.writeLine(`Using API Extractor version ${apiExtractor.Extractor.version}`);
+    this._scopedLogger.terminal.writeLine(`Using API Extractor version ${apiExtractor.Extractor.version}`);
 
     const apiExtractorVersion: semver.SemVer | null = semver.parse(apiExtractor.Extractor.version);
     if (

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -680,6 +680,15 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       return ts.DiagnosticCategory.Warning;
     }
 
+    // These pedantic checks also should not be treated as hard errors
+    switch (diagnostic.code) {
+      case ts.Diagnostics.Property_0_has_no_initializer_and_is_not_definitely_assigned_in_the_constructor
+        .code:
+      case ts.Diagnostics
+        .Element_implicitly_has_an_any_type_because_expression_of_type_0_can_t_be_used_to_index_type_1.code:
+        return ts.DiagnosticCategory.Warning;
+    }
+
     return diagnostic.category;
   }
 

--- a/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
@@ -146,6 +146,14 @@ export interface IExtendedTypeScript {
     // https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/diagnosticMessages.json#L4256-L4259
     // eslint-disable-next-line @typescript-eslint/naming-convention
     Found_0_errors_Watching_for_file_changes: TTypescript.DiagnosticMessage;
+
+    // https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/src/compiler/diagnosticMessages.json#L2252
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Property_0_has_no_initializer_and_is_not_definitely_assigned_in_the_constructor: TTypescript.DiagnosticMessage;
+
+    // https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/src/compiler/diagnosticMessages.json#L4920
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Element_implicitly_has_an_any_type_because_expression_of_type_0_can_t_be_used_to_index_type_1: TTypescript.DiagnosticMessage;
   };
 }
 

--- a/common/changes/@rushstack/heft/octogonz-heft-checks_2020-09-30-10-40.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-checks_2020-09-30-10-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Reclassify compiler messages TS2564 and TS7053 as warnings instead of errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-heft-checks_2020-09-30-10-50.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-checks_2020-09-30-10-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Print a warning if the API Extractor version is too old",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
- Reclassify TypeScript strict mode checks as warnings instead of errors
- Warn if API Extractor is too old