### PR TITLE
[rush] Always prefer preferred versions for resolution in workspace install

### DIFF
--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -473,6 +473,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       allowedAlternativeVersions: MapExtensions.toObject(
         this.rushConfiguration.getCommonVersions(this.options.variant).allowedAlternativeVersions
       ),
+      coreLibraryPath: require.resolve('@rushstack/node-core-library'),
       semverPath: require.resolve('semver'),
       useClientPnpmfile: pnpmfileExists
     };

--- a/apps/rush-lib/src/logic/pnpm/IPnpmfileShimSettings.ts
+++ b/apps/rush-lib/src/logic/pnpm/IPnpmfileShimSettings.ts
@@ -4,6 +4,13 @@
 export interface IPnpmfileShimSettings {
   allPreferredVersions: { [dependencyName: string]: string };
   allowedAlternativeVersions: { [dependencyName: string]: ReadonlyArray<string> };
+  /**
+   * Path to `@rushstack/node-core-library`
+   */
+  coreLibraryPath: string;
+  /**
+   * Path to `semver`
+   */
   semverPath: string;
   useClientPnpmfile: boolean;
 }

--- a/apps/rush-lib/src/logic/pnpm/PnpmfileShim.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmfileShim.ts
@@ -26,18 +26,19 @@ const clientPnpmfile: IPnpmfile | undefined = pnpmfileSettings.useClientPnpmfile
   ? require('./clientPnpmfile')
   : undefined;
 
-const convertToSemverRange = ([dep, specifier]: [string, string]): [string, TSemver.Range] | undefined => {
-  try {
-    const range: TSemver.Range = new semver.Range(specifier);
-    return [dep, range];
-  } catch (err) {
-    return;
-  }
-};
+const preferredVersions: Map<string, TSemver.Range> = (() => {
+  const result: Map<string, TSemver.Range> = new Map();
 
-const preferredVersions: Map<string, TSemver.Range> = new Map(
-  Object.entries(pnpmfileSettings.allPreferredVersions).map(convertToSemverRange).filter(Boolean)
-);
+  for (const [dep, specifier] of Object.entries(pnpmfileSettings.allPreferredVersions)) {
+    try {
+      const range: TSemver.Range = new semver.Range(specifier);
+      result.set(dep, range);
+    } catch (err) {
+      continue;
+    }
+  }
+  return result;
+})();
 
 // Any time the preferred version is a subset of the dependency version, use it instead.
 // Allowed alternative versions are only for `rush check` validation

--- a/common/changes/@microsoft/rush/dmichon-preferred-versions_2020-10-07-23-23.json
+++ b/common/changes/@microsoft/rush/dmichon-preferred-versions_2020-10-07-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Always prefer preferred versions during resolution",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
Modifies the pnpmfile shim to always prefer versions from `preferredVersions` in `common-versions.json` if they satisfy the package's version specifier.

This ensures that if packages specify a wider range, e.g. to facilitate interoperability with peer dependencies by external consumers, that the repo still resolves them to the repository's preferred version during development.