### PR TITLE
Support relative paths in @import and @use

### DIFF
--- a/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsGenerator.ts
+++ b/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsGenerator.ts
@@ -113,6 +113,7 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
   ): Promise<string> {
     const result: Result = await LegacyAdapters.convertCallbackToPromise(render, {
       data: fileContents,
+      file: filePath,
       importer: (url: string) => ({ file: this._patchSassUrl(url) }),
       includePaths: includePaths
         ? includePaths
@@ -125,7 +126,7 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
 
   private _patchSassUrl(url: string): string {
     if (url[0] === '~') {
-      url = 'node_modules/' + url.substr(1);
+      return 'node_modules/' + url.substr(1);
     }
 
     return url;

--- a/build-tests/heft-sass-test/src/utilities/relativeImport.sass
+++ b/build-tests/heft-sass-test/src/utilities/relativeImport.sass
@@ -1,0 +1,5 @@
+/**
+ * This file is not used by the example component. However, it verifies that relative Sass imports are successful.
+ */
+
+@import '../stylesImport'

--- a/common/changes/@rushstack/heft/halfnibble-fix-sass-typings_2020-10-09-01-25.json
+++ b/common/changes/@rushstack/heft/halfnibble-fix-sass-typings_2020-10-09-01-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Support relative imports in the Sass typings generator.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "halfnibble@users.noreply.github.com"
+}


### PR DESCRIPTION
We discovered relative paths were not resolved because Sass did not have the file path as context.

This fixes that issue and adds a test case. 