### PR TITLE
Fix glob to only include package.json updates when commiting version bump changes

### DIFF
--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -239,7 +239,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (packageJsonUpdated) {
-      git.addChanges(':/*');
+      git.addChanges(':/**/package.json');
       git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
     }
 

--- a/common/changes/@microsoft/rush/danade-FixPackageJsonGlob_2020-10-09-21-22.json
+++ b/common/changes/@microsoft/rush/danade-FixPackageJsonGlob_2020-10-09-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "When running `rush version --bump`, only include package.json updates in the generated commit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes #2249 by only including package.json updates in the glob used to add files to the generated git commit