### PR TITLE
[heft] Include additionalModuleKindsToEmit in the copy-static-assets plugin

### DIFF
--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -104,10 +104,9 @@ export class CopyStaticAssetsPlugin implements IHeftPlugin {
     );
 
     const destinationFolderNames: string[] = ['lib'];
-    // eslint-disable-next-line no-unused-expressions
-    typescriptConfiguration?.additionalModuleKindsToEmit?.forEach((emitModule) =>
-      destinationFolderNames.push(emitModule.outFolderName)
-    );
+    for (const emitModule of typescriptConfiguration?.additionalModuleKindsToEmit || []) {
+      destinationFolderNames.push(emitModule.outFolderName);
+    }
 
     return {
       ...typescriptConfiguration?.staticAssetsToCopy,

--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -103,12 +103,18 @@ export class CopyStaticAssetsPlugin implements IHeftPlugin {
       heftConfiguration.rigConfig
     );
 
+    const destinationFolderNames: string[] = ['lib'];
+    // eslint-disable-next-line no-unused-expressions
+    typescriptConfiguration?.additionalModuleKindsToEmit?.forEach((emitModule) =>
+      destinationFolderNames.push(emitModule.outFolderName)
+    );
+
     return {
       ...typescriptConfiguration?.staticAssetsToCopy,
 
       // For now - these may need to be revised later
       sourceFolderName: 'src',
-      destinationFolderNames: ['lib']
+      destinationFolderNames
     };
   }
 

--- a/common/changes/@rushstack/heft/halfnibble-fix-copy-static_2020-10-10-00-57.json
+++ b/common/changes/@rushstack/heft/halfnibble-fix-copy-static_2020-10-10-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Include additionalModuleKindsToEmit in the copy-static-assets plugin destination folders.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "halfnibble@users.noreply.github.com"
+}


### PR DESCRIPTION
This will copy over static assets, like .scss files, into any additional folders specified by additionalModuleKindsToEmit.

For some reason, I had to add the eslint disable line. Not sure how the rule is being violated. 

Fixes #2251 