### PR TITLE
Add additional property in sass schema to be compatible with sass.json in odsp-common

### DIFF
--- a/apps/heft/src/schemas/sass.schema.json
+++ b/apps/heft/src/schemas/sass.schema.json
@@ -39,6 +39,11 @@
         "type": "string",
         "pattern": "[^\\\\]"
       }
+    },
+
+    "useCSSModules": {
+      "type": "boolean",
+      "description": "Determines if CSS Modules are used, or not"
     }
   }
 }

--- a/common/changes/@rushstack/heft/zhas-add-property-in-sass-schema_2020-10-12-23-50.json
+++ b/common/changes/@rushstack/heft/zhas-add-property-in-sass-schema_2020-10-12-23-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add additional property in sass schema",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "claudiazhaoya@users.noreply.github.com"
+}


### PR DESCRIPTION
The current sass.json schema doesn't have the property called 'useCSSModule', which is declared and used in sass.json in odsp-common. To get it compatible with odsp-common, I add this property in heft sass schema.