### PR TITLE
[rush] Add `--ignore-hooks` command line flag to all rush actions

### DIFF
--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -102,11 +102,11 @@ export abstract class BaseInstallAction extends BaseRushAction {
       StandardScriptUpdater.validate(this.rushConfiguration);
     }
 
-    if (!this._ignoreHooksParameter.value) {
-      this.eventHooksManager.handle(Event.preRushInstall, this.parser.isDebug);
-    } else {
-      console.log(`The --ignore-hooks flag was specified, skipping preInstall hooks`);
-    }
+    this.eventHooksManager.handle(
+      Event.preRushInstall,
+      this.parser.isDebug,
+      this._ignoreHooksParameter.value
+    );
 
     const purgeManager: PurgeManager = new PurgeManager(this.rushConfiguration, this.rushGlobalFolder);
 
@@ -147,11 +147,11 @@ export abstract class BaseInstallAction extends BaseRushAction {
         stopwatch.stop();
 
         this._collectTelemetry(stopwatch, installManagerOptions, true);
-        if (!this._ignoreHooksParameter.value) {
-          this.eventHooksManager.handle(Event.postRushInstall, this.parser.isDebug);
-        } else {
-          console.log(`The --ignore-hooks flag was specified, skipping postInstall hooks`);
-        }
+        this.eventHooksManager.handle(
+          Event.postRushInstall,
+          this.parser.isDebug,
+          this._ignoreHooksParameter.value
+        );
 
         if (warnAboutScriptUpdate) {
           console.log(

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -80,7 +80,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     });
     this._ignoreHooksParameter = this.defineFlagParameter({
       parameterLongName: '--ignore-hooks',
-      description: `Overrides execution of event hooks. Make sure you know what you are skipping.`
+      description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -80,7 +80,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     });
     this._ignoreHooksParameter = this.defineFlagParameter({
       parameterLongName: '--ignore-hooks',
-      description: `Overrides execution of "preInstall" and "postInstall" event hooks. Meant for use on CI machines.`
+      description: `Overrides execution of event hooks. Make sure you know what you are skipping.`
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -222,7 +222,7 @@ export class BulkScriptAction extends BaseScriptAction {
     }
     this._ignoreHooksParameter = this.defineFlagParameter({
       parameterLongName: '--ignore-hooks',
-      description: `Overrides execution of event hooks. Meant for use on CI machines.`
+      description: `Overrides execution of event hooks. Make sure you know what you are skipping.`
     });
 
     this.defineScriptParameters();

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -222,7 +222,7 @@ export class BulkScriptAction extends BaseScriptAction {
     }
     this._ignoreHooksParameter = this.defineFlagParameter({
       parameterLongName: '--ignore-hooks',
-      description: `Overrides execution of event hooks. Make sure you know what you are skipping.`
+      description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
     });
 
     this.defineScriptParameters();

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -64,6 +64,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _toVersionPolicy!: CommandLineStringListParameter;
   private _verboseParameter!: CommandLineFlagParameter;
   private _parallelismParameter: CommandLineStringParameter | undefined;
+  private _ignoreHooksParameter!: CommandLineFlagParameter;
   private _ignoreDependencyOrder: boolean;
   private _allowWarningsInSuccessfulBuild: boolean;
 
@@ -219,6 +220,10 @@ export class BulkScriptAction extends BaseScriptAction {
           'but not any projects that directly or indirectly depend on the changed package.'
       });
     }
+    this._ignoreHooksParameter = this.defineFlagParameter({
+      parameterLongName: '--ignore-hooks',
+      description: `Overrides execution of event hooks. Meant for use on CI machines.`
+    });
 
     this.defineScriptParameters();
   }
@@ -266,7 +271,7 @@ export class BulkScriptAction extends BaseScriptAction {
 
     SetupChecks.validate(this.rushConfiguration);
 
-    this.eventHooksManager.handle(Event.preRushBuild, this.parser.isDebug);
+    this.eventHooksManager.handle(Event.preRushBuild, this.parser.isDebug, this._ignoreHooksParameter.value);
   }
 
   private _doAfterTask(stopwatch: Stopwatch, success: boolean): void {
@@ -279,7 +284,7 @@ export class BulkScriptAction extends BaseScriptAction {
     }
     this._collectTelemetry(stopwatch, success);
     this.parser.flushTelemetry();
-    this.eventHooksManager.handle(Event.postRushBuild, this.parser.isDebug);
+    this.eventHooksManager.handle(Event.postRushBuild, this.parser.isDebug, this._ignoreHooksParameter.value);
   }
 
   private _collectTelemetry(stopwatch: Stopwatch, success: boolean): void {

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -390,8 +390,9 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for each action: install 1`] = `
 "usage: rush install [-h] [-p] [--bypass-policy] [--no-link]
                     [--network-concurrency COUNT] [--debug-package-manager]
-                    [--max-install-attempts NUMBER] [--variant VARIANT]
-                    [-t PROJECT1] [--to-version-policy VERSION_POLICY_NAME]
+                    [--max-install-attempts NUMBER] [--ignore-hooks]
+                    [--variant VARIANT] [-t PROJECT1]
+                    [--to-version-policy VERSION_POLICY_NAME]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -429,6 +430,8 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
+  --ignore-hooks        Overrides execution of \\"preInstall\\" and \\"postInstall\\" 
+                        event hooks. Meant for use on CI machines.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
@@ -686,8 +689,8 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for each action: update 1`] = `
 "usage: rush update [-h] [-p] [--bypass-policy] [--no-link]
                    [--network-concurrency COUNT] [--debug-package-manager]
-                   [--max-install-attempts NUMBER] [--variant VARIANT]
-                   [--full] [--recheck]
+                   [--max-install-attempts NUMBER] [--ignore-hooks]
+                   [--variant VARIANT] [--full] [--recheck]
                    
 
 The \\"rush update\\" command installs the dependencies described in your package.
@@ -724,6 +727,8 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
+  --ignore-hooks        Overrides execution of \\"preInstall\\" and \\"postInstall\\" 
+                        event hooks. Meant for use on CI machines.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -110,7 +110,7 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
 "usage: rush build [-h] [-p COUNT] [-t PROJECT1]
                   [--from-version-policy VERSION_POLICY_NAME]
                   [--to-version-policy VERSION_POLICY_NAME] [-f PROJECT2] [-v]
-                  [-o] [-s] [-m]
+                  [-o] [--ignore-hooks] [-s] [-m]
                   
 
 This command is similar to \\"rush rebuild\\", except that \\"rush build\\" performs 
@@ -159,6 +159,8 @@ Optional arguments:
                         If specified, the incremental build will only rebuild 
                         projects that have changed, but not any projects that 
                         directly or indirectly depend on the changed package.
+  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
+                        CI machines.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -282,7 +284,7 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
 "usage: rush import-strings [-h] [-p COUNT] [-t PROJECT1]
                            [--from-version-policy VERSION_POLICY_NAME]
                            [--to-version-policy VERSION_POLICY_NAME]
-                           [-f PROJECT2] [-v]
+                           [-f PROJECT2] [-v] [--ignore-hooks]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -319,6 +321,8 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
+  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
+                        CI machines.
   --locale {en-us,fr-fr,es-es,zh-cn}
                         Selects a single instead of the default locale 
                         (en-us) for non-ship builds or all locales for ship 
@@ -595,7 +599,7 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
 "usage: rush rebuild [-h] [-p COUNT] [-t PROJECT1]
                     [--from-version-policy VERSION_POLICY_NAME]
                     [--to-version-policy VERSION_POLICY_NAME] [-f PROJECT2]
-                    [-v] [-s] [-m]
+                    [-v] [--ignore-hooks] [-s] [-m]
                     
 
 This command assumes that the package.json file for each project contains a 
@@ -637,6 +641,8 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
+  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
+                        CI machines.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -159,8 +159,8 @@ Optional arguments:
                         If specified, the incremental build will only rebuild 
                         projects that have changed, but not any projects that 
                         directly or indirectly depend on the changed package.
-  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
-                        CI machines.
+  --ignore-hooks        Overrides execution of event hooks. Make sure you 
+                        know what you are skipping.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -321,8 +321,8 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
-  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
-                        CI machines.
+  --ignore-hooks        Overrides execution of event hooks. Make sure you 
+                        know what you are skipping.
   --locale {en-us,fr-fr,es-es,zh-cn}
                         Selects a single instead of the default locale 
                         (en-us) for non-ship builds or all locales for ship 
@@ -434,8 +434,8 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
-  --ignore-hooks        Overrides execution of \\"preInstall\\" and \\"postInstall\\" 
-                        event hooks. Meant for use on CI machines.
+  --ignore-hooks        Overrides execution of event hooks. Make sure you 
+                        know what you are skipping.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
@@ -641,8 +641,8 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
-  --ignore-hooks        Overrides execution of event hooks. Meant for use on 
-                        CI machines.
+  --ignore-hooks        Overrides execution of event hooks. Make sure you 
+                        know what you are skipping.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -733,8 +733,8 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
-  --ignore-hooks        Overrides execution of \\"preInstall\\" and \\"postInstall\\" 
-                        event hooks. Meant for use on CI machines.
+  --ignore-hooks        Overrides execution of event hooks. Make sure you 
+                        know what you are skipping.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -159,8 +159,9 @@ Optional arguments:
                         If specified, the incremental build will only rebuild 
                         projects that have changed, but not any projects that 
                         directly or indirectly depend on the changed package.
-  --ignore-hooks        Overrides execution of event hooks. Make sure you 
-                        know what you are skipping.
+  --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
+                        in rush.json. Make sure you know what you are 
+                        skipping.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -321,8 +322,9 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
-  --ignore-hooks        Overrides execution of event hooks. Make sure you 
-                        know what you are skipping.
+  --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
+                        in rush.json. Make sure you know what you are 
+                        skipping.
   --locale {en-us,fr-fr,es-es,zh-cn}
                         Selects a single instead of the default locale 
                         (en-us) for non-ship builds or all locales for ship 
@@ -434,8 +436,9 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
-  --ignore-hooks        Overrides execution of event hooks. Make sure you 
-                        know what you are skipping.
+  --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
+                        in rush.json. Make sure you know what you are 
+                        skipping.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
@@ -641,8 +644,9 @@ Optional arguments:
                         project in the current working directory.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
-  --ignore-hooks        Overrides execution of event hooks. Make sure you 
-                        know what you are skipping.
+  --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
+                        in rush.json. Make sure you know what you are 
+                        skipping.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -733,8 +737,9 @@ Optional arguments:
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
                         attempts. The default value is 3.
-  --ignore-hooks        Overrides execution of event hooks. Make sure you 
-                        know what you are skipping.
+  --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
+                        in rush.json. Make sure you know what you are 
+                        skipping.
   --variant VARIANT     Run command using a variant installation 
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -28,8 +28,8 @@ export class EventHooksManager {
 
     const scripts: string[] = this._eventHooks.get(event);
     if (scripts.length > 0) {
-      console.log(`Skipping event hooks for ${Event[event]} since --ignore-hooks was specified`);
       if (ignoreHooks) {
+        console.log(`Skipping event hooks for ${Event[event]} since --ignore-hooks was specified`);
         return;
       }
 

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -21,13 +21,18 @@ export class EventHooksManager {
     this._commonTempFolder = rushConfiguration.commonTempFolder;
   }
 
-  public handle(event: Event, isDebug: boolean): void {
+  public handle(event: Event, isDebug: boolean, ignoreHooks: boolean): void {
     if (!this._eventHooks) {
       return;
     }
 
     const scripts: string[] = this._eventHooks.get(event);
     if (scripts.length > 0) {
+      console.log(`Skipping event hooks for ${Event[event]} since --ignore-hooks was specified`);
+      if (ignoreHooks) {
+        return;
+      }
+
       const stopwatch: Stopwatch = Stopwatch.start();
       console.log(os.EOL + colors.green(`Executing event hooks for ${Event[event]}`));
       scripts.forEach((script) => {

--- a/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
+++ b/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add --ignore-hooks flag",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
+++ b/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Adds an --ignore-hooks flag to rush actions that skips event hooks during execution of the action",
+      "comment": "Adds an --ignore-hooks flag to every rush action that skips event hooks during execution of the action.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
+++ b/common/changes/@microsoft/rush/dmichon-add-ignore-hooks_2020-10-14-23-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add --ignore-hooks flag",
+      "comment": "Adds an --ignore-hooks flag to rush actions that skips event hooks during execution of the action",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Adds a new command line flag `--ignore-hooks` to all rush actions that does exactly what it says. Skips any configured `eventHooks` in `rush.json` during execution of the action. Example usage is when the actions are to perform telemetry for local dev installs and the commands are being invoked on a CI machine.

Edited: per feedback, switched from only `rush install` and `rush update` to all rush actions.