### PR TITLE
[rush-lib] Run post-install step on every call to `rush install` or `rush update`

### DIFF
--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -243,16 +243,16 @@ export abstract class BaseInstallManager {
         }
       }
 
-      // Perform any post-install work the install manager requires
-      await this.postInstallAsync();
-
       // Create the marker file to indicate a successful install if it's not a filtered install
       if (!isFilteredInstall) {
         this._commonTempInstallFlag.create();
       }
-
-      console.log('');
     }
+
+    // Perform any post-install work the install manager requires
+    await this.postInstallAsync();
+
+    console.log('');
   }
 
   protected abstract prepareCommonTempAsync(

--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
@@ -179,7 +179,7 @@ export class PnpmProjectDependencyManifest {
     }
 
     for (const [peerDependencyName, peerDependencyVersion] of Object.entries(
-      shrinkwrapEntry.peerDependencies
+      shrinkwrapEntry.peerDependencies || {}
     )) {
       // Check to see if the peer dependency is satisfied with the current shrinkwrap
       // entry and if not, check the parent shrinkwrap entry

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -32,16 +32,16 @@ export interface IPnpmShrinkwrapDependencyYaml {
     tarball?: string;
   };
   /** The list of dependencies and the resolved version */
-  dependencies: { [dependency: string]: string };
+  dependencies?: { [dependency: string]: string };
   /** The list of optional dependencies and the resolved version */
-  optionalDependencies: { [dependency: string]: string };
+  optionalDependencies?: { [dependency: string]: string };
   /** The list of peer dependencies and the resolved version */
-  peerDependencies: { [dependency: string]: string };
+  peerDependencies?: { [dependency: string]: string };
   /**
    * Used to indicate optional peer dependencies, as described in this RFC:
    * https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md
    */
-  peerDependenciesMeta: { [dependency: string]: IPeerDependenciesMetaYaml };
+  peerDependenciesMeta?: { [dependency: string]: IPeerDependenciesMetaYaml };
 }
 
 export interface IPnpmShrinkwrapImporterYaml {
@@ -457,7 +457,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined = this._getPackageDescription(
       tempProjectDependencyKey
     );
-    if (!packageDescription) {
+    if (!packageDescription || !packageDescription.dependencies) {
       return undefined;
     }
 
@@ -577,7 +577,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined = this._getPackageDescription(
       tempProjectDependencyKey
     );
-    if (!packageDescription) {
+    if (!packageDescription || !packageDescription.dependencies) {
       return undefined;
     }
 

--- a/common/changes/@microsoft/rush/danade-FixUpdateBug_2020-10-16-20-41.json
+++ b/common/changes/@microsoft/rush/danade-FixUpdateBug_2020-10-16-20-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Prevent `rush unlink` from breaking installs for non-workspace projects",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes #2288 by moving the post-install `rush link` outside of the scope of the check for `last-install.flag`. We were skipping running linking if the install was still valid, causing `rush unlink` to break installs with no hope of recovery by calling `rush install` or `rush update`. Another option was to delete the `last-install.flag` when `rush unlink` is run, but this would unnecessarily force the package manager to be called. One more option would be to run post-install regardless of `last-install.flag` (as this change does) but conditionally run `rush link` only if the `last-link.flag` file is older than `last-install.flag`. However, linking is a lightweight operation so I decided against over-complicating the check.

Additionally, this PR fixes a bug introduced by #2286 wherein a dependency field in `pnpm-lock.yaml` is accessed when undefined.