### PR TITLE
[rush] Provide override for package.json script executed by bulk commands

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -34,6 +34,7 @@ export class CommandLineConfiguration {
       ' build command is tracked by the "arguments" field in the "package-deps_build.json" file contained' +
       ' therein; a full rebuild is forced whenever the command has changed (e.g. "--production" or not).',
     enableParallelism: true,
+    script: RushConstants.buildScriptName,
     ignoreMissingScript: false,
     ignoreDependencyOrder: false,
     incremental: true,
@@ -44,6 +45,7 @@ export class CommandLineConfiguration {
   public static readonly defaultRebuildCommandJson: CommandJson = {
     commandKind: RushConstants.bulkCommandKind,
     name: RushConstants.rebuildCommandName,
+    script: [RushConstants.buildScriptName, RushConstants.buildCommandName],
     summary: 'Clean and rebuild the entire set of projects',
     description:
       'This command assumes that the package.json file for each project contains' +

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -23,6 +23,7 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   commandKind: 'bulk';
   enableParallelism: boolean;
   ignoreDependencyOrder?: boolean;
+  script?: string | string[];
   ignoreMissingScript?: boolean;
   incremental?: boolean;
   allowWarningsInSuccessfulBuild?: boolean;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -215,8 +215,7 @@ export class RushCommandLineParser extends CommandLineParser {
     if (!this.tryGetAction(RushConstants.rebuildCommandName)) {
       this._addCommandLineConfigAction(
         commandLineConfiguration,
-        CommandLineConfiguration.defaultRebuildCommandJson,
-        RushConstants.buildCommandName
+        CommandLineConfiguration.defaultRebuildCommandJson
       );
     }
   }
@@ -234,8 +233,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private _addCommandLineConfigAction(
     commandLineConfiguration: CommandLineConfiguration | undefined,
-    command: CommandJson,
-    commandToRun?: string
+    command: CommandJson
   ): void {
     if (this.tryGetAction(command.name)) {
       throw new Error(
@@ -251,10 +249,7 @@ export class RushCommandLineParser extends CommandLineParser {
         this.addAction(
           new BulkScriptAction({
             actionName: command.name,
-
-            // By default, the "rebuild" action runs the "build" script. However, if the command-line.json file
-            // overrides "rebuild," the "rebuild" script should be run.
-            commandToRun: commandToRun,
+            script: command.script,
 
             summary: command.summary,
             documentation: command.description || command.summary,

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -31,15 +31,14 @@ import { IRushConfigurationProjectJson } from '../../api/RushConfigurationProjec
  */
 export interface IBulkScriptActionOptions extends IBaseScriptActionOptions {
   enableParallelism: boolean;
+  /**
+   * Optional package.json script to run otherwise use `actionName` as the script to run..
+   */
+  script?: string | string[];
   ignoreMissingScript: boolean;
   ignoreDependencyOrder: boolean;
   incremental: boolean;
   allowWarningsInSuccessfulBuild: boolean;
-
-  /**
-   * Optional command to run. Otherwise, use the `actionName` as the command to run.
-   */
-  commandToRun?: string;
 }
 
 /**
@@ -55,7 +54,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _enableParallelism: boolean;
   private _ignoreMissingScript: boolean;
   private _isIncrementalBuildAllowed: boolean;
-  private _commandToRun: string;
+  private _commandToRun: string[];
 
   private _changedProjectsOnly!: CommandLineFlagParameter;
   private _fromFlag!: CommandLineStringListParameter;
@@ -72,9 +71,16 @@ export class BulkScriptAction extends BaseScriptAction {
     this._enableParallelism = options.enableParallelism;
     this._ignoreMissingScript = options.ignoreMissingScript;
     this._isIncrementalBuildAllowed = options.incremental;
-    this._commandToRun = options.commandToRun || options.actionName;
     this._ignoreDependencyOrder = options.ignoreDependencyOrder;
     this._allowWarningsInSuccessfulBuild = options.allowWarningsInSuccessfulBuild;
+
+    if (Array.isArray(options.script)) {
+      this._commandToRun = [...options.script, options.actionName];
+    } else if (typeof options.script === 'string') {
+      this._commandToRun = [options.script, options.actionName];
+    } else {
+      this._commandToRun = [options.actionName];
+    }
   }
 
   public async runAsync(): Promise<void> {
@@ -118,7 +124,7 @@ export class BulkScriptAction extends BaseScriptAction {
       isIncrementalBuildAllowed: this._isIncrementalBuildAllowed,
       ignoreMissingScript: this._ignoreMissingScript,
       ignoreDependencyOrder: this._ignoreDependencyOrder,
-      packageDepsFilename: Utilities.getPackageDepsFilenameForCommand(this._commandToRun)
+      packageDepsFilename: Utilities.getPackageDepsFilenameForCommand(this._commandToRun[0])
     });
 
     // Register all tasks with the task collection

--- a/apps/rush-lib/src/logic/RushConstants.ts
+++ b/apps/rush-lib/src/logic/RushConstants.ts
@@ -182,6 +182,11 @@ export class RushConstants {
   public static readonly buildCommandName: string = 'build';
 
   /**
+   * The name of the package.json script to execute when building via rush.
+   */
+  public static readonly buildScriptName: string = 'rush-build';
+
+  /**
    * The name of the non-incremental build command.
    */
   public static readonly rebuildCommandName: string = 'rebuild';

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -11,7 +11,7 @@ export interface ITaskSelectorConstructor {
   rushConfiguration: RushConfiguration;
   toProjects: ReadonlyArray<RushConfigurationProject>;
   fromProjects: ReadonlyArray<RushConfigurationProject>;
-  commandToRun: string;
+  commandToRun: string[];
   customParameterValues: string[];
   isQuietMode: boolean;
   isIncrementalBuildAllowed: boolean;
@@ -208,17 +208,19 @@ export class TaskSelector {
     return process.platform === 'win32' ? convertSlashesForWindows(taskCommand) : taskCommand;
   }
 
-  private _getScriptCommand(rushProject: RushConfigurationProject, script: string): string | undefined {
+  private _getScriptCommand(rushProject: RushConfigurationProject, script: string[]): string | undefined {
     if (!rushProject.packageJson.scripts) {
       return undefined;
     }
 
-    const rawCommand: string = rushProject.packageJson.scripts[script];
+    for (const candidate of script) {
+      const rawCommand: string = rushProject.packageJson.scripts[candidate];
 
-    if (rawCommand === undefined || rawCommand === null) {
-      return undefined;
+      if (typeof rawCommand === 'string') {
+        return rawCommand;
+      }
     }
 
-    return rawCommand;
+    return undefined;
   }
 }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -66,6 +66,20 @@
               "description": "Normally projects will be processed according to their dependency order: a given project will not start processing the command until all of its dependencies have completed.  This restriction doesn't apply for certain operations, for example, a \"clean\" task that deletes output files.  In this case you can set \"ignoreDependencyOrder\" to true to increase parallelism.",
               "type": "boolean"
             },
+            "script": {
+              "title": "script",
+              "oneOf": [
+                {
+                  "description": "\"scripts\" entry from project's package.json to execute, otherwise uses the command's name",
+                  "type": "string"
+                },
+                {
+                  "description": "Candidate \"scripts\" entries from project's package.json to execute, the first entry found is executed, otherwise uses the command's name",
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              ]
+            },
             "ignoreMissingScript": {
               "title": "Ignore Missing Script",
               "description": "Normally Rush requires that each project's package.json has a \"scripts\" entry matching the custom command name. To disable this check, set \"ignoreMissingScript\" to true.",
@@ -96,6 +110,7 @@
 
             "enableParallelism": { "$ref": "#/definitions/anything" },
             "ignoreDependencyOrder": { "$ref": "#/definitions/anything" },
+            "script": { "$ref": "#/definitions/anything" },
             "ignoreMissingScript": { "$ref": "#/definitions/anything" },
             "incremental": { "$ref": "#/definitions/anything" }
           }


### PR DESCRIPTION
Proof of concept solution for #2283 (Support customizing CI builds from Dev builds)

Adds a script configuration option for bulk commands that specifies
the package.json script to execute (falls-back to the bulk action name)

If an array of names is specified the first name that matches a scripts
entry in package.json will be executed (falls-back to the bulk action name).

This change also
- updates the default configuration for the builtin build command to have
  a script entry of "rush-build"
- updates the default configuration of the built in rebuild command to have
  a script entry of ["rush-build", "build"]

This enables a scenario where...
- a package can specify what happens for rush build
- a package can specify what happens rushx build (clean, build)
Without the two behaviors conflicting

```json
"script": {
  "build": "heft build --clean",
  "rush-build": "heft test --clean",
}
```