### PR TITLE
Replace Gitter link with Zulip

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><a href="https://rushstack.io/">https://rushstack.io/</a></p>
 </td></tr></table>
 
-[![Join the chat at https://gitter.im/rushstack](https://badges.gitter.im/rushstack.svg)](https://gitter.im/rushstack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) &nbsp; [![Build Status](https://dev.azure.com/RushStack/GitHubProjects/_apis/build/status/rushstack/rushstack%20CI%20Build?branchName=master)](https://dev.azure.com/RushStack/GitHubProjects/_build/latest?definitionId=3&branchName=master)
+[![Zulip chat room](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://rushstack.zulipchat.com/) &nbsp; [![Build Status](https://dev.azure.com/RushStack/GitHubProjects/_apis/build/status/rushstack/rushstack%20CI%20Build?branchName=master)](https://dev.azure.com/RushStack/GitHubProjects/_build/latest?definitionId=3&branchName=master)
 
 The home for various projects maintained by the Rush Stack community, whose mission is to develop reusable tooling
 for large scale TypeScript monorepos.
@@ -13,7 +13,7 @@ for large scale TypeScript monorepos.
 
 - [What is Rush Stack?](https://rushstack.io/) - learn about the mission behind these projects
 - [API reference](https://rushstack.io/pages/api/) - browse API documentation for NPM packages
-- [Gitter chat room](https://gitter.im/rushstack/rushstack) - chat with the Rush Stack developers
+- [Zulip chat room](https://rushstack.zulipchat.com/) - chat with the Rush Stack developers
 - [Rush](https://rushjs.io/) - a build orchestrator for large scale TypeScript monorepos
 - [API Extractor](https://api-extractor.com/) - create .d.ts rollups and track your TypeScript API signatures
 - [API Documenter](https://api-extractor.com/pages/setup/generating_docs/) - use TSDoc comments to publish an API documentation website


### PR DESCRIPTION
For many years Rush has used a Gitter chatter room to provide tech support, however we've been hearing a lot of frustration about the user experience. For example Gitter's mobile notifications [do not work reliably](https://gitlab.com/gitlab-org/gitter/webapp/blob/2d5abfce277534080fae45e86c3da27ae1d04d49/docs/notifications.md#mobile-notifications), with no solution after years of waiting.  They eventually stopped supporting the mobile apps, investing in a PWA mobile website as an alternative.  Recently GitLab [sold Gitter to Element](https://blog.gitter.im/2020/09/30/gitter-element-acquisition/) who makes the Riot chat client, and announced a new roadmap to eventually replace the mobile apps with Element's client.  That could be very positive. However in the meantime, we're going to try something different.

We looked at Discord, which is used by PNPM and ESLint.  Discord has very polished mobile clients, however it's lacking some important business features that Gitter had:

- Ability to login using GitHub without having to create a dedicated account
- Automatic linking to GitHub issues/PRs
- Rich user profiles
- Discussion threads
- Markdown in messages
- Message hyperlinks, so that chat conversations can be referenced from GitHub issues

Instead, we've decided to try [Zulip](https://zulip.com/), which is similar to Slack, but features and free hosting [specifically tailored for open source projects](https://zulip.com/for/open-source/).  Notably, Zulip's client and server are open source. They also provide a way to import our Gitter discussion history.  Zulip has pros and cons, but we're going to give it a try.  If it doesn't work out, Discord would probably be our next bet.

[CLICK HERE](https://rushstack.zulipchat.com/) to try the Zulip chat room! 🙂 