### PR TITLE
[rush-lib] Fix bug on version process using version policy

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -494,6 +494,7 @@ export class RushConfiguration {
   private _projectsByName: Map<string, RushConfigurationProject> | undefined;
 
   private _versionPolicyConfiguration: VersionPolicyConfiguration;
+  private _versionPolicyConfigurationFilePath: string;
   private _experimentsConfiguration: ExperimentsConfiguration;
 
   private readonly _rushConfigurationJson: IRushConfigurationJson;
@@ -695,11 +696,13 @@ export class RushConfiguration {
     this._telemetryEnabled = !!rushConfigurationJson.telemetryEnabled;
     this._eventHooks = new EventHooks(rushConfigurationJson.eventHooks || {});
 
-    const versionPolicyConfigFile: string = path.join(
+    this._versionPolicyConfigurationFilePath = path.join(
       this._commonRushConfigFolder,
       RushConstants.versionPoliciesFilename
     );
-    this._versionPolicyConfiguration = new VersionPolicyConfiguration(versionPolicyConfigFile);
+    this._versionPolicyConfiguration = new VersionPolicyConfiguration(
+      this._versionPolicyConfigurationFilePath
+    );
 
     this._variants = new Set<string>();
 
@@ -1582,6 +1585,13 @@ export class RushConfiguration {
    */
   public get versionPolicyConfiguration(): VersionPolicyConfiguration {
     return this._versionPolicyConfiguration;
+  }
+
+  /**
+   * @beta
+   */
+  public get versionPolicyConfigurationFilePath(): string {
+    return this._versionPolicyConfigurationFilePath;
   }
 
   /**

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -239,6 +239,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (packageJsonUpdated) {
+      git.addChanges('.', this.rushConfiguration.versionPolicyConfigurationFilePath);
       git.addChanges(':/**/package.json');
       git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
     }

--- a/common/changes/@microsoft/rush/fix-missing-add-on-version_2020-10-26-20-57.json
+++ b/common/changes/@microsoft/rush/fix-missing-add-on-version_2020-10-26-20-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix bug where version process was not adding version-policy configuration file changes into the version commit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "manrueda@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -395,6 +395,8 @@ export class RushConfiguration {
     tryGetProjectForPath(currentFolderPath: string): RushConfigurationProject | undefined;
     // @beta (undocumented)
     get versionPolicyConfiguration(): VersionPolicyConfiguration;
+    // @beta (undocumented)
+    get versionPolicyConfigurationFilePath(): string;
     get yarnCacheFolder(): string;
     get yarnOptions(): YarnOptionsConfiguration;
     }


### PR DESCRIPTION
When version policy is used, during the version process the version-policy configuration file gets updated with the latest version of the versioned policy, but that change is not added to the stage during the commit process.

This changes add the file to the stage along the package.json changes.