### PR TITLE
[node-core-library] Fix incorrect Terminal coloring on Linux

### DIFF
--- a/common/changes/@rushstack/node-core-library/octogonz-fix-linux-colors_2020-10-27-04-43.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-fix-linux-colors_2020-10-27-04-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix an issue where the TextAttribute.Bold ANSI escape was not rendered correctly by Linux",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/libraries/node-core-library/src/Terminal/AnsiEscape.ts
+++ b/libraries/node-core-library/src/Terminal/AnsiEscape.ts
@@ -124,8 +124,6 @@ export class AnsiEscape {
 
       case ConsoleColorCodes.Bold:
         return 'bold';
-      case ConsoleColorCodes.BoldOff:
-        return 'bold-off';
       case ConsoleColorCodes.Dim:
         return 'dim';
       case ConsoleColorCodes.NormalColorOrIntensity:

--- a/libraries/node-core-library/src/Terminal/Colors.ts
+++ b/libraries/node-core-library/src/Terminal/Colors.ts
@@ -69,7 +69,12 @@ export enum ConsoleColorCodes {
   DefaultBackground = 49,
 
   Bold = 1,
-  BoldOff = 21,
+
+  // On Linux, the "BoldOff" code instead causes the text to be double-underlined:
+  // https://en.wikipedia.org/wiki/Talk:ANSI_escape_code#SGR_21%E2%80%94%60Bold_off%60_not_widely_supported
+  // Use "NormalColorOrIntensity" instead
+  // BoldOff = 21,
+
   Dim = 2,
   NormalColorOrIntensity = 22,
   Underline = 4,

--- a/libraries/node-core-library/src/Terminal/Terminal.ts
+++ b/libraries/node-core-library/src/Terminal/Terminal.ts
@@ -318,7 +318,7 @@ export class Terminal {
               switch (textAttribute) {
                 case TextAttribute.Bold: {
                   startColorCodes.push(ConsoleColorCodes.Bold);
-                  endColorCodes.push(ConsoleColorCodes.BoldOff);
+                  endColorCodes.push(ConsoleColorCodes.NormalColorOrIntensity);
                   break;
                 }
 


### PR DESCRIPTION
Fix an issue where the TextAttribute.Bold ANSI escape was not rendered correctly by Linux.  It caused all subsequent text to be bold and underlined, even the shell prompt after the process had terminated.