### PR TITLE
[eslint-plugin-packlets] Fix several miscellaneous issues

### DIFF
--- a/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-08.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Fix an exception that occured if a source file was added to the \"src/packlets\" folder, not belonging to any packlet",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-12.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Fix an issue where linting was sometimes not performed on MacOS, because Node.js \"path.relative()\" incorrectly assumes that every POSIX file system is case-sensitive",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-13.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/octogonz-fix-packlet-issues_2020-10-27-05-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Fix an issue where @rushstack/packlets/circular-deps did not detect certain types of circular dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/stack/eslint-plugin-packlets/src/DependencyAnalyzer.ts
+++ b/stack/eslint-plugin-packlets/src/DependencyAnalyzer.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import type * as ts from 'typescript';
-import * as path from 'path';
 
 import { Path } from './Path';
 import { PackletAnalyzer } from './PackletAnalyzer';
@@ -74,7 +73,7 @@ export class DependencyAnalyzer {
     visitedPacklets: Set<string>,
     previousNode: IImportListNode | undefined
   ): IImportListNode | undefined {
-    const packletEntryPoint: string = path.join(packletsFolderPath, packletName, 'index');
+    const packletEntryPoint: string = Path.join(packletsFolderPath, packletName, 'index');
 
     const tsSourceFile: ts.SourceFile | undefined =
       program.getSourceFile(packletEntryPoint + '.ts') || program.getSourceFile(packletEntryPoint + '.tsx');
@@ -93,7 +92,7 @@ export class DependencyAnalyzer {
 
         // Is it a reference to a packlet?
         if (Path.isUnder(referencingFilePath, packletsFolderPath)) {
-          const referencingRelativePath: string = path.relative(packletsFolderPath, referencingFilePath);
+          const referencingRelativePath: string = Path.relative(packletsFolderPath, referencingFilePath);
           const referencingPathParts: string[] = referencingRelativePath.split(/[\/\\]+/);
           const referencingPackletName: string = referencingPathParts[0];
 

--- a/stack/eslint-plugin-packlets/src/PackletAnalyzer.ts
+++ b/stack/eslint-plugin-packlets/src/PackletAnalyzer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import * as fs from 'fs';
 import { Path } from './Path';
 
@@ -82,7 +81,7 @@ export class PackletAnalyzer {
       return;
     }
 
-    srcFolderPath = path.join(path.dirname(tsconfigFilePath), 'src');
+    srcFolderPath = Path.join(Path.dirname(tsconfigFilePath), 'src');
 
     if (!fs.existsSync(srcFolderPath)) {
       this.error = { messageId: 'missing-src-folder', data: { srcFolderPath } };
@@ -96,21 +95,21 @@ export class PackletAnalyzer {
     }
 
     // Example: packlets/my-packlet/index.ts
-    const inputFilePathRelativeToSrc: string = path.relative(srcFolderPath, inputFilePath);
+    const inputFilePathRelativeToSrc: string = Path.relative(srcFolderPath, inputFilePath);
 
     // Example: [ 'packlets', 'my-packlet', 'index.ts' ]
     const pathParts: string[] = inputFilePathRelativeToSrc.split(/[\/\\]+/);
 
     let underPackletsFolder: boolean = false;
 
-    const expectedPackletsFolder: string = path.join(srcFolderPath, 'packlets');
+    const expectedPackletsFolder: string = Path.join(srcFolderPath, 'packlets');
 
     for (let i = 0; i < pathParts.length; ++i) {
       const pathPart: string = pathParts[i];
       if (pathPart.toUpperCase() === 'PACKLETS') {
         if (pathPart !== 'packlets') {
           // Example: /path/to/my-project/src/PACKLETS
-          const packletsFolderPath: string = path.join(srcFolderPath, ...pathParts.slice(0, i + 1));
+          const packletsFolderPath: string = Path.join(srcFolderPath, ...pathParts.slice(0, i + 1));
           this.error = { messageId: 'packlet-folder-case', data: { packletsFolderPath } };
           return;
         }
@@ -146,7 +145,7 @@ export class PackletAnalyzer {
           const thirdPart: string = pathParts[2];
 
           // Example: 'index'
-          const thirdPartWithoutExtension: string = path.parse(thirdPart).name;
+          const thirdPartWithoutExtension: string = Path.parse(thirdPart).name;
 
           if (thirdPartWithoutExtension.toUpperCase() === 'INDEX') {
             if (!PackletAnalyzer._validPackletName.test(packletName)) {
@@ -176,15 +175,15 @@ export class PackletAnalyzer {
     }
 
     // Example: /path/to/my-project/src/packlets/my-packlet
-    const inputFileFolder: string = path.dirname(this.inputFilePath);
+    const inputFileFolder: string = Path.dirname(this.inputFilePath);
 
     // Example: /path/to/my-project/src/other-packlet/index
-    const importedPath: string = path.resolve(inputFileFolder, modulePath);
+    const importedPath: string = Path.resolve(inputFileFolder, modulePath);
 
     // Is the imported path referring to a file under the src/packlets folder?
     if (Path.isUnder(importedPath, this.packletsFolderPath)) {
       // Example: other-packlet/index
-      const importedPathRelativeToPackletsFolder: string = path.relative(
+      const importedPathRelativeToPackletsFolder: string = Path.relative(
         this.packletsFolderPath,
         importedPath
       );
@@ -202,19 +201,19 @@ export class PackletAnalyzer {
           //
           // We discard the file extension to handle a degenerate case like:
           //   import { X } from "../index.js";
-          const lastPart: string = path.parse(importedPathParts[importedPathParts.length - 1]).name;
+          const lastPart: string = Path.parse(importedPathParts[importedPathParts.length - 1]).name;
           let pathToCompare: string;
           if (lastPart.toUpperCase() === 'INDEX') {
             // Example:
             //   importedPath = /path/to/my-project/src/other-packlet/index
             //   pathToCompare = /path/to/my-project/src/other-packlet
-            pathToCompare = path.dirname(importedPath);
+            pathToCompare = Path.dirname(importedPath);
           } else {
             pathToCompare = importedPath;
           }
 
           // Example: /path/to/my-project/src/other-packlet
-          const entryPointPath: string = path.join(this.packletsFolderPath, importedPackletName);
+          const entryPointPath: string = Path.join(this.packletsFolderPath, importedPackletName);
 
           if (Path.isEqual(pathToCompare, entryPointPath)) {
             return {
@@ -226,12 +225,12 @@ export class PackletAnalyzer {
           // to the index.ts entry point.
 
           // Example: /path/to/my-project/src/other-packlet
-          const entryPointPath: string = path.join(this.packletsFolderPath, importedPackletName);
+          const entryPointPath: string = Path.join(this.packletsFolderPath, importedPackletName);
 
           if (!Path.isEqual(importedPath, entryPointPath)) {
             // Example: "../packlets/other-packlet"
             const entryPointModulePath: string = Path.convertToSlashes(
-              path.relative(inputFileFolder, entryPointPath)
+              Path.relative(inputFileFolder, entryPointPath)
             );
 
             return {

--- a/stack/eslint-plugin-packlets/src/Path.ts
+++ b/stack/eslint-plugin-packlets/src/Path.ts
@@ -2,9 +2,113 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
+import * as fs from 'fs';
 
-// These helpers are borrowed from @rushstack/node-core-library
+export type ParsedPath = path.ParsedPath;
+
 export class Path {
+  /**
+   * Whether the filesystem is assumed to be case sensitive for Path operations.
+   *
+   * @remarks
+   * Regardless of operating system, a given file system's paths may be case-sensitive or case-insensitive.
+   * If a volume is mounted under a subfolder, then different parts of a path can even have different
+   * case-sensitivity.  The Node.js "path" API naively assumes that all Windows paths are case-insensitive,
+   * and that all other OS's are case-sensitive.  This is way off, for example a modern MacBook has a
+   * case-insensitive filesystem by default.  There isn't an easy workaround because Node.js does not expose
+   * the native OS APIs that would give accurate answers.
+   *
+   * The TypeScript compiler does somewhat better: it performs an empirical test of its own bundle path to see
+   * whether it can be read using different case.  If so, it normalizes all paths to lowercase (sometimes with
+   * no API for retrieving the real path).  This caused our Path.isUnder() to return incorrect answers because
+   * it relies on Node.js path.relative().
+   *
+   * To solve that problem, Path.ts performs an empirical test similar to what the TypeScript compiler does,
+   * and then we adjust path.relative() to be case insensitive if appropriate.
+   *
+   * @see {@link https://nodejs.org/en/docs/guides/working-with-different-filesystems/}
+   */
+  public static usingCaseSensitive: boolean = Path._detectCaseSensitive();
+
+  private static _detectCaseSensitive(): boolean {
+    // Can our own file be accessed using a path with different case?  If so, then the filesystem is case-insensitive.
+    return !fs.existsSync(__filename.toUpperCase());
+  }
+
+  // An implementation of path.relative() that is case-insensitive.
+  private static _relativeCaseInsensitive(from: string, to: string): string {
+    // Convert everything to uppercase and call path.relative()
+    const fromNormalized: string = from.toUpperCase();
+    const toNormalized: string = to.toUpperCase();
+    const result: string = path.relative(fromNormalized, toNormalized);
+
+    // Are there any cased characters in the result?
+    const lowerCasedResult = result.toLowerCase();
+    if (lowerCasedResult === result) {
+      // No cased characters
+      // Example: "../.."
+      return lowerCasedResult;
+    }
+
+    // Example:
+    //   from="/a/b/c"
+    //   to="/a/b/d/e"
+    //
+    //   fromNormalized="/A/B/C"
+    //   toNormalized="/A/B/D/E"
+    //
+    //   result="../D/E"
+    //
+    // Scan backwards through result and toNormalized, to find the first character where they differ
+    let resultIndex: number = result.length;
+    let toIndex: number = toNormalized.length;
+    for (;;) {
+      if (resultIndex === 0 || toIndex === 0) {
+        break;
+      }
+      --resultIndex;
+      --toIndex;
+      if (result.charCodeAt(resultIndex) !== toNormalized.charCodeAt(toIndex)) {
+        break;
+      }
+    }
+
+    // Replace the matching part with the casing from the "to" input
+    //
+    // Example:
+    //   ".." + "/d/e" = "../d/e"
+    return result.substring(0, resultIndex) + to.substring(toIndex);
+  }
+
+  public static relative(from: string, to: string): string {
+    if (!Path.usingCaseSensitive) {
+      return Path._relativeCaseInsensitive(from, to);
+    }
+    return path.relative(from, to);
+  }
+
+  // --------------------------------------------------------------------------------------------------------
+  // The operations below don't care about case sensitivity
+
+  public static dirname(p: string): string {
+    return path.dirname(p);
+  }
+
+  public static join(...paths: string[]): string {
+    return path.join(...paths);
+  }
+
+  public static resolve(...pathSegments: string[]): string {
+    return path.resolve(...pathSegments);
+  }
+
+  public static parse(pathString: string): ParsedPath {
+    return path.parse(pathString);
+  }
+
+  // --------------------------------------------------------------------------------------------------------
+  // The operations below are borrowed from @rushstack/node-core-library
+
   private static _relativePathRegex: RegExp = /^[.\/\\]+$/;
 
   /**
@@ -18,7 +122,7 @@ export class Path {
    * If the paths are relative, they will first be resolved using path.resolve().
    */
   public static isUnder(childPath: string, parentFolderPath: string): boolean {
-    const relativePath: string = path.relative(childPath, parentFolderPath);
+    const relativePath: string = Path.relative(childPath, parentFolderPath);
     return Path._relativePathRegex.test(relativePath);
   }
 
@@ -30,7 +134,7 @@ export class Path {
    * The comparison is performed using `path.relative()`.
    */
   public static isEqual(path1: string, path2: string): boolean {
-    return path.relative(path1, path2) === '';
+    return Path.relative(path1, path2) === '';
   }
 
   /**

--- a/stack/eslint-plugin-packlets/src/circular-deps.ts
+++ b/stack/eslint-plugin-packlets/src/circular-deps.ts
@@ -9,6 +9,7 @@ import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
 import { PackletAnalyzer } from './PackletAnalyzer';
 import { DependencyAnalyzer, IPackletImport } from './DependencyAnalyzer';
+import { Path } from './Path';
 
 export type MessageIds = 'circular-import';
 type Options = [];
@@ -62,7 +63,7 @@ const circularDeps: TSESLint.RuleModule<MessageIds, Options> = {
           );
 
           if (packletImports) {
-            const tsconfigFileFolder: string = path.dirname(tsconfigFilePath);
+            const tsconfigFileFolder: string = Path.dirname(tsconfigFilePath);
 
             const affectedPackletNames: string[] = packletImports.map((x) => x.packletName);
 
@@ -72,7 +73,7 @@ const circularDeps: TSESLint.RuleModule<MessageIds, Options> = {
             if (affectedPackletNames[0] === packletAnalyzer.inputFilePackletName) {
               let report: string = '';
               for (const packletImport of packletImports) {
-                const filePath: string = path.relative(tsconfigFileFolder, packletImport.fromFilePath);
+                const filePath: string = Path.relative(tsconfigFileFolder, packletImport.fromFilePath);
                 report += `"${packletImport.packletName}" is referenced by ${filePath}\n`;
               }
 

--- a/stack/eslint-plugin-packlets/src/mechanics.ts
+++ b/stack/eslint-plugin-packlets/src/mechanics.ts
@@ -13,15 +13,19 @@ const mechanics: TSESLint.RuleModule<MessageIds, Options> = {
   meta: {
     type: 'problem',
     messages: {
-      'missing-tsconfig':
-        'In order to use @rushstack/eslint-plugin-packlets, your ESLint config file' +
-        ' must configure the TypeScript parser',
-      'missing-src-folder': 'Expecting to find a "src" folder at: {{srcFolderPath}}',
-      'packlet-folder-case': 'The packlets folder must be all lower case: {{packletsFolderPath}}',
+      // InputFileMessageIds
+      'file-in-packets-folder': 'The "packlets" folder must not contain regular source files',
       'invalid-packlet-name':
         'Invalid packlet name "{{packletName}}".' +
         ' The name must be lowercase alphanumeric words separated by hyphens. Example: "my-packlet"',
       'misplaced-packlets-folder': 'The packlets folder must be located at "{{expectedPackletsFolder}}"',
+      'missing-src-folder': 'Expecting to find a "src" folder at: {{srcFolderPath}}',
+      'missing-tsconfig':
+        'In order to use @rushstack/eslint-plugin-packlets, your ESLint config file' +
+        ' must configure the TypeScript parser',
+      'packlet-folder-case': 'The packlets folder must be all lower case: {{packletsFolderPath}}',
+
+      // ImportMessageIds
       'bypassed-entry-point':
         'The import statement does not use the packlet\'s entry point "{{entryPointModulePath}}"',
       'circular-entry-point': 'Files under a packlet folder must not import from their own index.ts file',

--- a/stack/eslint-plugin-packlets/src/test/Path.test.ts
+++ b/stack/eslint-plugin-packlets/src/test/Path.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { Path } from '../Path';
+
+function toPosixPath(value: string): string {
+  return value.replace(/[\\\/]/g, '/');
+}
+function toNativePath(value: string): string {
+  return value.replace(/[\\\/]/g, path.sep);
+}
+
+function relativeCaseInsensitive(from: string, to: string) {
+  return toPosixPath(Path['_relativeCaseInsensitive'](toNativePath(from), toNativePath(to)));
+}
+
+describe('Path', () => {
+  test('_detectCaseSensitive()', () => {
+    // NOTE: To ensure these tests are deterministic, only use absolute paths
+    expect(relativeCaseInsensitive('/', '/')).toEqual('');
+    expect(relativeCaseInsensitive('/', '/a')).toEqual('a');
+    expect(relativeCaseInsensitive('/', '/a/')).toEqual('a');
+    expect(relativeCaseInsensitive('/', '/a//')).toEqual('a');
+    expect(relativeCaseInsensitive('/', '/a/b')).toEqual('a/b');
+    expect(relativeCaseInsensitive('/', '/a/b/c')).toEqual('a/b/c');
+    expect(relativeCaseInsensitive('/A', '/a/b/c')).toEqual('b/c');
+    expect(relativeCaseInsensitive('/A/', '/a/b/c')).toEqual('b/c');
+    expect(relativeCaseInsensitive('/A/B', '/a/b/c')).toEqual('c');
+    expect(relativeCaseInsensitive('/A/b/C', '/a/b/c')).toEqual('');
+    expect(relativeCaseInsensitive('/a/B/c', '/a/b/c')).toEqual('');
+    expect(relativeCaseInsensitive('/a/B/c/D', '/a/b/c')).toEqual('..');
+    expect(relativeCaseInsensitive('/a/B/c/D', '/a/b/c/e')).toEqual('../e');
+  });
+});


### PR DESCRIPTION
Fix a couple issues reported by @victor-wm:
- An exception occurred if a source file was added to the `src/packlets` folder, not belonging to any packlet
- linting was sometimes not performed on MacOS, because Node.js `path.relative()` incorrectly assumes that every POSIX file system is case-sensitive

While testing these fixes, I also noticed this problem and fixed it as well:
- `@rushstack/packlets/circular-deps` did not detect certain types of circular dependencies
