### PR TITLE
Add source and destination folder to `CopyStaticAssets`

### DIFF
--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -36,16 +36,19 @@ export interface ISharedCopyStaticAssetsConfiguration {
    * Globs that should be explicitly included.
    */
   includeGlobs?: string[];
+
+  /**
+   * The folder to which assets should be copied. For example "lib". This defaults to "lib"
+   */
+  destinationFolderName?: string;
+
+  /**
+   * The folder from which assets should be copied. For example, "src". This defaults to "src".
+   */
+  sourceFolderName?: string;
 }
 
 interface ICopyStaticAssetsConfiguration extends ISharedCopyStaticAssetsConfiguration {
-  /**
-   * The folder from which assets should be copied. For example, "src". This defaults to "src".
-   *
-   * This folder is directly under the folder containing the project's package.json file
-   */
-  sourceFolderName: string;
-
   /**
    * The folder(s) to which assets should be copied. For example ["lib", "lib-cjs"]. This defaults to ["lib"]
    *
@@ -103,16 +106,16 @@ export class CopyStaticAssetsPlugin implements IHeftPlugin {
       heftConfiguration.rigConfig
     );
 
-    const destinationFolderNames: string[] = ['lib'];
+    const destinationFolderNames: string[] = [
+      typescriptConfiguration?.staticAssetsToCopy?.destinationFolderName ?? 'lib'
+    ];
     for (const emitModule of typescriptConfiguration?.additionalModuleKindsToEmit || []) {
       destinationFolderNames.push(emitModule.outFolderName);
     }
 
     return {
       ...typescriptConfiguration?.staticAssetsToCopy,
-
-      // For now - these may need to be revised later
-      sourceFolderName: 'src',
+      sourceFolderName: typescriptConfiguration?.staticAssetsToCopy?.sourceFolderName ?? 'src',
       destinationFolderNames
     };
   }

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -90,6 +90,18 @@
             "type": "string",
             "pattern": "[^\\\\]"
           }
+        },
+
+        "destinationFolderName": {
+          "type": "string",
+          "description": "The folder to which assets should be copied. For example \"lib\". This defaults to \"lib\"",
+          "pattern": "[^\\\\\\/]"
+        },
+
+        "sourceFolderName": {
+          "type": "string",
+          "description": "The folder from which assets should be copied. For example, \"src\". This defaults to \"src\".",
+          "pattern": "[^\\\\\\/]"
         }
       }
     }

--- a/common/changes/@rushstack/heft/fix-icorrect-assets-output_2020-10-28-19-52.json
+++ b/common/changes/@rushstack/heft/fix-icorrect-assets-output_2020-10-28-19-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add source and destination configuration to `CopyStaticAssets`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "manrueda@users.noreply.github.com"
+}


### PR DESCRIPTION
Currently `CopyStaticAssets` has source and destination folder as fixed values (`src` and `lib`). 

This change allows to customize those two values using the `typescript.json` configuration file.

Related to issue #2307