### PR TITLE
Use source-map-loader to map back to .ts files in webpack tutorial

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -13,6 +13,10 @@
     {
       "name": "react-dom",
       "allowedCategories": [ "tests" ]
+    },
+    {
+      "name": "source-map-loader",
+      "allowedCategories": [ "tests" ]
     }
   ]
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1638,6 +1638,7 @@ importers:
     dependencies:
       '@rushstack/eslint-patch': 'link:../eslint-patch'
       '@rushstack/eslint-plugin': 'link:../eslint-plugin'
+      '@rushstack/eslint-plugin-packlets': 'link:../eslint-plugin-packlets'
       '@rushstack/eslint-plugin-security': 'link:../eslint-plugin-security'
       '@typescript-eslint/eslint-plugin': 3.4.0_def47c0014fd51b1497b94bf8e50ada2
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.2.0+typescript@3.9.7
@@ -1652,6 +1653,7 @@ importers:
     specifiers:
       '@rushstack/eslint-patch': 'workspace:*'
       '@rushstack/eslint-plugin': 'workspace:*'
+      '@rushstack/eslint-plugin-packlets': 'workspace:*'
       '@rushstack/eslint-plugin-security': 'workspace:*'
       '@typescript-eslint/eslint-plugin': 3.4.0
       '@typescript-eslint/experimental-utils': 3.4.0
@@ -2233,6 +2235,7 @@ importers:
       html-webpack-plugin: 3.2.0_webpack@4.31.0
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
+      source-map-loader: 1.1.2_webpack@4.31.0
       style-loader: 1.2.1_webpack@4.31.0
       typescript: 3.9.7
       webpack: 4.31.0_webpack@4.31.0
@@ -2248,6 +2251,7 @@ importers:
       html-webpack-plugin: ~3.2.0
       react: ~16.13.1
       react-dom: ~16.13.1
+      source-map-loader: ~1.1.2
       style-loader: ~1.2.1
       typescript: ~3.9.7
       webpack: ~4.31.0
@@ -7697,6 +7701,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  /iconv-lite/0.6.2:
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   /icss-replace-symbols/1.1.0:
     dev: false
     resolution:
@@ -11446,6 +11458,16 @@ packages:
       node: '>= 8.9.0'
     resolution:
       integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
+  /schema-utils/3.0.0:
+    dependencies:
+      '@types/json-schema': 7.0.6
+      ajv: 6.12.5
+      ajv-keywords: 3.5.2_ajv@6.12.5
+    dev: true
+    engines:
+      node: '>= 10.13.0'
+    resolution:
+      integrity: sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
   /scss-tokenizer/0.2.3:
     dependencies:
       js-base64: 2.6.4
@@ -11741,6 +11763,22 @@ packages:
   /source-list-map/2.0.1:
     resolution:
       integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+  /source-map-loader/1.1.2_webpack@4.31.0:
+    dependencies:
+      abab: 2.0.5
+      iconv-lite: 0.6.2
+      loader-utils: 2.0.0
+      schema-utils: 3.0.0
+      source-map: 0.6.1
+      webpack: 4.31.0_webpack@4.31.0
+      whatwg-mimetype: 2.3.0
+    dev: true
+    engines:
+      node: '>= 10.13.0'
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    resolution:
+      integrity: sha512-bjf6eSENOYBX4JZDfl9vVLNsGAQ6Uz90fLmOazcmMcyDYOBFsGxPNn83jXezWLY9bJsVAo1ObztxPcV8HAbjVA==
   /source-map-resolve/0.5.3:
     dependencies:
       atob: 2.1.2

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8a89f626be4d7746badda0720b4a1d771468e646",
+  "pnpmShrinkwrapHash": "3697df45728be4fd716345d9b92ce743fee57b35",
   "preferredVersionsHash": "0f2f367d951f4cd546b698d668533c1ff056e334"
 }

--- a/tutorials/heft-webpack-basic-tutorial/package.json
+++ b/tutorials/heft-webpack-basic-tutorial/package.json
@@ -21,6 +21,7 @@
     "react-dom": "~16.13.1",
     "style-loader": "~1.2.1",
     "typescript": "~3.9.7",
-    "webpack": "~4.31.0"
+    "webpack": "~4.31.0",
+    "source-map-loader": "~1.1.2"
   }
 }

--- a/tutorials/heft-webpack-basic-tutorial/webpack.config.js
+++ b/tutorials/heft-webpack-basic-tutorial/webpack.config.js
@@ -19,6 +19,11 @@ function createWebpackConfig({ production }) {
         {
           test: /\.css$/,
           use: [require.resolve('style-loader'), require.resolve('css-loader')]
+        },
+        {
+          test: /\.js$/,
+          enforce: 'pre',
+          use: ['source-map-loader']
         }
       ]
     },


### PR DESCRIPTION
One possible solution for issue #2316

Configures the heft-webpack-basic-tutorial project to use [source-map-loader](https://www.npmjs.com/package/source-map-loader) to resolve the transitive closure of mappings from the .js files in ./dist to the .ts files in ./src

Note this falls apart if the project has a dependency on another rush project.
source-map-loader has a strong assumption that its webpack config is in a common ancestor folder of all the traversed source maps leading to the wrong relative paths being generated for pretty much all source files discovered.

using `devtool: 'eval-source-map'` helps unblock the above issue by embedding the source map in generated bundles so that they can always be found but still leaves some odd quirks. e.g browsing source files in Chrome reveals the poorly generated paths

