### PR TITLE
Use source-map-loader to map back to .ts files in webpack tutorial

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -3,19 +3,11 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
   "packages": [
     {
-      "name": "@rushstack/heft-web-rig",
-      "allowedCategories": [ "libraries", "tests" ]
-    },
-    {
       "name": "react",
       "allowedCategories": [ "tests" ]
     },
     {
       "name": "react-dom",
-      "allowedCategories": [ "tests" ]
-    },
-    {
-      "name": "source-map-loader",
       "allowedCategories": [ "tests" ]
     }
   ]

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -13,6 +13,10 @@
     {
       "name": "react-dom",
       "allowedCategories": [ "tests" ]
+    },
+    {
+      "name": "source-map-loader",
+      "allowedCategories": [ "tests" ]
     }
   ]
 }

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -195,6 +195,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "@rushstack/heft-web-rig",
+      "allowedCategories": [ "libraries", "tests" ]
+    },
+    {
       "name": "@rushstack/localization-plugin",
       "allowedCategories": [ "tests" ]
     },
@@ -677,6 +681,10 @@
     {
       "name": "source-map",
       "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "source-map-loader",
+      "allowedCategories": [ "tests" ]
     },
     {
       "name": "ssri",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2254,6 +2254,7 @@ importers:
       html-webpack-plugin: 4.5.0_webpack@4.44.2
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
+      source-map-loader: 1.1.2_webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
       typescript: 3.9.7
       webpack: 4.44.2_webpack@4.44.2
@@ -2269,6 +2270,7 @@ importers:
       html-webpack-plugin: ~4.5.0
       react: ~16.13.1
       react-dom: ~16.13.1
+      source-map-loader: ~1.1.2
       style-loader: ~1.2.1
       typescript: ~3.9.7
       webpack: ~4.44.2
@@ -8081,6 +8083,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  /iconv-lite/0.6.2:
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   /icss-replace-symbols/1.1.0:
     dev: false
     resolution:
@@ -12166,6 +12176,22 @@ packages:
   /source-list-map/2.0.1:
     resolution:
       integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+  /source-map-loader/1.1.2_webpack@4.44.2:
+    dependencies:
+      abab: 2.0.5
+      iconv-lite: 0.6.2
+      loader-utils: 2.0.0
+      schema-utils: 3.0.0
+      source-map: 0.6.1
+      webpack: 4.44.2_webpack@4.44.2
+      whatwg-mimetype: 2.3.0
+    dev: true
+    engines:
+      node: '>= 10.13.0'
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    resolution:
+      integrity: sha512-bjf6eSENOYBX4JZDfl9vVLNsGAQ6Uz90fLmOazcmMcyDYOBFsGxPNn83jXezWLY9bJsVAo1ObztxPcV8HAbjVA==
   /source-map-resolve/0.5.3:
     dependencies:
       atob: 2.1.2

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9c8e9cbebdb75bc619c581238ef33f2d8d3f73eb",
+  "pnpmShrinkwrapHash": "2a5a228009553e6527a411e2c32f2dc4b04c298c",
   "preferredVersionsHash": "2519e88d149a9cb84227de92c71a8d8063bdcfd4"
 }

--- a/tutorials/heft-webpack-basic-tutorial/package.json
+++ b/tutorials/heft-webpack-basic-tutorial/package.json
@@ -21,6 +21,7 @@
     "react-dom": "~16.13.1",
     "style-loader": "~1.2.1",
     "typescript": "~3.9.7",
-    "webpack": "~4.44.2"
+    "webpack": "~4.44.2",
+    "source-map-loader": "~1.1.2"
   }
 }

--- a/tutorials/heft-webpack-basic-tutorial/webpack.config.js
+++ b/tutorials/heft-webpack-basic-tutorial/webpack.config.js
@@ -19,6 +19,11 @@ function createWebpackConfig({ production }) {
         {
           test: /\.css$/,
           use: [require.resolve('style-loader'), require.resolve('css-loader')]
+        },
+        {
+          test: /\.js$/,
+          enforce: 'pre',
+          use: ['source-map-loader']
         }
       ]
     },


### PR DESCRIPTION
One possible solution for issue #2316

Configures the heft-webpack-basic-tutorial project to use [source-map-loader](https://www.npmjs.com/package/source-map-loader) to resolve the transitive closure of mappings from the .js files in ./dist to the .ts files in ./src

Note this falls apart if the project has a dependency on another rush project.
source-map-loader has a strong assumption that its webpack config is in a common ancestor folder of all the traversed source maps leading to the wrong relative paths being generated for pretty much all source files discovered.

using `devtool: 'eval-source-map'` helps unblock the above issue by embedding the source map in generated bundles so that they can always be found but still leaves some odd quirks. e.g browsing source files in Chrome reveals the poorly generated paths

