### PR TITLE
[heft] Update README

### DIFF
--- a/apps/heft/README.md
+++ b/apps/heft/README.md
@@ -1,7 +1,5 @@
 # @rushstack/heft
 
-> 🚨 *This is an early preview release. Please report issues!* 🚨
-
 <div>
   <br />
   <a href="https://rushstack.io/pages/heft/overview/">
@@ -52,7 +50,7 @@ other similar systems, Heft has some unique design goals:
 <!-- Text above this line should stay in sync with the Rush Stack web site content -->
 <!-- ----------------------------------------------------------------------------- -->
 
-This is an early preview release, however the following tasks are already available:
+Heft has not yet reached its 1.0 milestone, however the following tasks are already available:
 
 - **Compiler**: [TypeScript](https://www.typescriptlang.org/) with incremental compilation, with "watch" mode
 - **Linter**: [TypeScript-ESLint](https://github.com/typescript-eslint/typescript-eslint), plus legacy support

--- a/common/changes/@rushstack/heft/octogonz-heft-readme_2020-11-02-21-39.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-readme_2020-11-02-21-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Update README.md",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR removes the conspicuous 🚨 alert from the Heft README.  Although Heft has not yet reached its "1.0" milestone, it is already being used for production projects, and at this point its contracts are reasonably stable. 