### PR TITLE
[rush-lib] Fix bug where version process is using a wrong `git.addChanges` signature

### DIFF
--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -227,7 +227,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (changeLogUpdated) {
-      git.addChanges('.', this.rushConfiguration.changesFolder);
+      git.addChanges(this.rushConfiguration.changesFolder, '.');
       git.addChanges(':/**/CHANGELOG.json');
       git.addChanges(':/**/CHANGELOG.md');
       git.commit('Deleting change files and updating change logs for package updates.');
@@ -239,7 +239,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (packageJsonUpdated) {
-      git.addChanges('.', this.rushConfiguration.versionPolicyConfigurationFilePath);
+      git.addChanges(this.rushConfiguration.versionPolicyConfigurationFilePath, '.');
       git.addChanges(':/**/package.json');
       git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
     }

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -227,7 +227,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (changeLogUpdated) {
-      git.addChanges(this.rushConfiguration.changesFolder, '.');
+      git.addChanges('.', this.rushConfiguration.changesFolder);
       git.addChanges(':/**/CHANGELOG.json');
       git.addChanges(':/**/CHANGELOG.md');
       git.commit('Deleting change files and updating change logs for package updates.');
@@ -239,7 +239,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (packageJsonUpdated) {
-      git.addChanges(this.rushConfiguration.versionPolicyConfigurationFilePath, '.');
+      git.addChanges(this.rushConfiguration.versionPolicyConfigurationFilePath);
       git.addChanges(':/**/package.json');
       git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
     }

--- a/common/changes/@microsoft/rush/fix-add-changes-working-dir_2020-11-03-16-46.json
+++ b/common/changes/@microsoft/rush/fix-add-changes-working-dir_2020-11-03-16-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix bug where version process is using a wrong `git.addChanges` signature",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nikuph@users.noreply.github.com"
+}


### PR DESCRIPTION
When calling `rush version --bump` it fails with:
```
* EXECUTING: git add . (common/config/rush/version-policies.json)

ERROR: spawnSync /bin/sh ENOTDIR
```

This is caused by mixing up `workingDirectory` and `pathspec`.