### PR TITLE
Update RushInstallManager.ts

### DIFF
--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -605,7 +605,10 @@ export class RushInstallManager extends BaseInstallManager {
     }
 
     // Run "npm install" in the common folder
-    const installArgs: string[] = ['install'];
+    const installArgs: string[] = (
+      this.rushConfiguration.packageManager !== 'npm' ||
+      this.options.allowShrinkwrapUpdates
+    ) ? ['install'] : ['ci'];
     this.pushConfigurationArgs(installArgs, this.options);
 
     console.log(


### PR DESCRIPTION
When `npm install` is ran in a directory containing the npm-shrinkwrap file - devDependencies are still being installed - while they are not included in the shrinkwrap file. On further investigation it looks like this command can also lead to differing versions of dependencies being installed.

This does not align with the documented description for `rush install`:

> The "rush install" command installs package dependencies for all your projects, based on the shrinkwrap file that is created/updated using "rush update"

This is being observed when using npm@6.x. And potentially aligns with the comment in this forum post:

https://npm.community/t/npm-i-changed-my-npm-shrinkwrap-package-lock-why/190

That in npm@6 `install` can lead to updates in the shrinkwrap file.