### PR TITLE
Build transitive dependency projects when building from dependency

### DIFF
--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -147,6 +147,10 @@ export class TaskSelector {
       result.set(project.packageName, project);
 
       for (const dependent of dependentList.get(project.packageName) || []) {
+        // Collect all local dependency for these dependents to collect transitive dependency
+        // for e.g. B has D as dependent and D depends on both B and C
+        // project C is transitive dependency but needsto be collected to build D
+        this._collectAllDependencies(dependent, result);
         this._collectAllDependents(dependentList, dependent, result);
       }
     }

--- a/common/changes/@microsoft/rush/rush_lib_dependency_fix_2020-12-17-17-36.json
+++ b/common/changes/@microsoft/rush/rush_lib_dependency_fix_2020-12-17-17-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "praveenkuttappan@users.noreply.github.com"
+}


### PR DESCRIPTION
Change in this PR is to find and include any transitive dependency projects when --from is passed. For e.g. in below scenario, rush skips building some of the projects that are required by subsequent projects.

Let's say if project B requires project A and Project D requires project B. Project D also requires project C. 

When a developer changes project B and wants to ensure all it dependents are built properly, dev can pass --from B and expectation is that it builds all projects recursively that takes dependency on B. Rush currently attempts to build project D without building project C in this case which is a requirement for D. 

A <- B <- D
C<- D

Fix in this PR is to find and include projects required by any dependents.