### PR TITLE
[heft] Display message ID when reporting API Extractor issues

### DIFF
--- a/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
+++ b/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
@@ -117,7 +117,7 @@ export class ApiExtractorRunner extends SubprocessRunnerBase<IApiExtractorRunner
                 : message.sourceFilePath;
               logMessage =
                 `${filePathForLog}:${message.sourceFileLine}:${message.sourceFileColumn} - ` +
-                `(${message.category}) ${message.text}`;
+                `(${message.messageId}) ${message.text}`;
             } else {
               logMessage = message.text;
             }

--- a/common/changes/@rushstack/heft/octogonz-heft-ae-message_2020-11-14-19-45.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-ae-message_2020-11-14-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where API Extractor errors/warnings did not show the message ID",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

When invoked by Heft, API Extractor messages incorrectly printed the message category:
```
[api-extractor] Warning: src\Thing.ts:40:1 - (Extractor) "IThing" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

This Heft should print the message ID the same as the API Extractor CLI:
```
[api-extractor] Warning: src\Thing.ts:40:1 - (ae-missing-release-tag) "IThing" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

## Details

This makes it easy for people to search for an ID like `ae-missing-release-tag` in the documentation.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

Confirmed that it fixed the problem for my repro.