### PR TITLE
[rush] Fix an issue where local peer dependencies were not considered when determining build order

### DIFF
--- a/apps/rush-lib/src/api/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/api/RushConfigurationProject.ts
@@ -222,7 +222,8 @@ export class RushConfigurationProject {
       this._localDependencyProjects = [
         ...this._getLocalDependencyProjects(this.packageJson.dependencies),
         ...this._getLocalDependencyProjects(this.packageJson.devDependencies),
-        ...this._getLocalDependencyProjects(this.packageJson.optionalDependencies)
+        ...this._getLocalDependencyProjects(this.packageJson.optionalDependencies),
+        ...this._getLocalDependencyProjects(this.packageJson.peerDependencies)
       ];
     }
     return this._localDependencyProjects;

--- a/common/changes/@microsoft/rush/fix-local-peer-dep-build-order_2020-11-17-22-35.json
+++ b/common/changes/@microsoft/rush/fix-local-peer-dep-build-order_2020-11-17-22-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where local peer dependencies were not considered when determining build order",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "kiltyj@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
With Rush version 5.30.0 and later, we started seeing build failures in our repository, which includes packages that list other packages in our repository as peer dependencies. The build failures were related to packages building out of dependency order due to these local peer dependency relationships not being considered. This change adds peer dependencies to the list of local dependencies that are considered for determining package build order.

## Details
This change fixes our build, and seems like a safe and correct fix to me, but I acknowledge that I could be missing a valid reason for excluding local peer dependencies. However, given that our builds were working prior to 5.30.0 this seems like it might have been an inadvertent change.

## How it was tested
I manually invoked "rush rebuild" with a fresh version of our repository containing multiple local peer relationships to confirm that our build failures were no longer occurring.
