### PR TITLE
Add a missing changelog

### DIFF
--- a/common/changes/@microsoft/api-extractor-model/octogonz-fix-changelog_2020-11-18-06-09.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-fix-changelog_2020-11-18-06-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Update .api.json file format to store a new field \"isOptional\" for documenting optional properties",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-fix-changelog_2020-11-18-06-09.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-fix-changelog_2020-11-18-06-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Update .api.json file format to store a new field \"isOptional\" for documenting optional properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Add a missing change log so that `api-extractor` and `api-extractor-model` get new versions published to support the optional properties feature.