### PR TITLE
[api-extractor] Generalize "isOptional" to describe both methods and properties

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -40,7 +40,7 @@ import {
   IResolveDeclarationReferenceResult,
   ApiTypeAlias,
   ExcerptToken,
-  ApiPropertySignature
+  ApiOptionalMixin
 } from '@microsoft/api-extractor-model';
 
 import { CustomDocNodes } from '../nodes/CustomDocNodeKind';
@@ -919,7 +919,7 @@ export class MarkdownDocumenter {
     const configuration: TSDocConfiguration = this._tsdocConfiguration;
 
     let linkText: string = Utilities.getConciseSignature(apiItem);
-    if (apiItem instanceof ApiPropertySignature && apiItem.isOptional) {
+    if (ApiOptionalMixin.isBaseClassOf(apiItem) && apiItem.isOptional) {
       linkText += '?';
     }
 
@@ -958,7 +958,7 @@ export class MarkdownDocumenter {
       }
     }
 
-    if (apiItem instanceof ApiPropertySignature && apiItem.isOptional) {
+    if (ApiOptionalMixin.isBaseClassOf(apiItem) && apiItem.isOptional) {
       section.appendNodesInParagraph([
         new DocEmphasisSpan({ configuration, italic: true }, [
           new DocPlainText({ configuration, text: '(Optional)' })

--- a/apps/api-extractor-model/src/index.ts
+++ b/apps/api-extractor-model/src/index.ts
@@ -35,6 +35,8 @@ export { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from './mixins/ApiRele
 export { IApiReturnTypeMixinOptions, ApiReturnTypeMixin } from './mixins/ApiReturnTypeMixin';
 export { IApiStaticMixinOptions, ApiStaticMixin } from './mixins/ApiStaticMixin';
 export { IApiNameMixinOptions, ApiNameMixin } from './mixins/ApiNameMixin';
+export { IApiOptionalMixinOptions, ApiOptionalMixin } from './mixins/ApiOptionalMixin';
+
 export { ExcerptTokenKind, IExcerptTokenRange, IExcerptToken, ExcerptToken, Excerpt } from './mixins/Excerpt';
 export { Constructor, PropertiesOf } from './mixins/Mixin';
 

--- a/apps/api-extractor-model/src/items/ApiPropertyItem.ts
+++ b/apps/api-extractor-model/src/items/ApiPropertyItem.ts
@@ -6,6 +6,7 @@ import { IApiDeclaredItemOptions, ApiDeclaredItem, IApiDeclaredItemJson } from '
 import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiReleaseTagMixin';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
 import { DeserializerContext } from '../model/DeserializerContext';
+import { ApiOptionalMixin, IApiOptionalMixinOptions } from '../mixins/ApiOptionalMixin';
 
 /**
  * Constructor options for {@link ApiPropertyItem}.
@@ -14,14 +15,13 @@ import { DeserializerContext } from '../model/DeserializerContext';
 export interface IApiPropertyItemOptions
   extends IApiNameMixinOptions,
     IApiReleaseTagMixinOptions,
+    IApiOptionalMixinOptions,
     IApiDeclaredItemOptions {
   propertyTypeTokenRange: IExcerptTokenRange;
-  isOptional?: boolean;
 }
 
 export interface IApiPropertyItemJson extends IApiDeclaredItemJson {
   propertyTypeTokenRange: IExcerptTokenRange;
-  isOptional?: boolean;
 }
 
 /**
@@ -29,30 +29,16 @@ export interface IApiPropertyItemJson extends IApiDeclaredItemJson {
  *
  * @public
  */
-export class ApiPropertyItem extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem)) {
+export class ApiPropertyItem extends ApiNameMixin(ApiReleaseTagMixin(ApiOptionalMixin(ApiDeclaredItem))) {
   /**
    * An {@link Excerpt} that describes the type of the property.
    */
   public readonly propertyTypeExcerpt: Excerpt;
 
-  /**
-   * True if this is an optional property.
-   * @remarks
-   * For example:
-   * ```ts
-   * interface X {
-   *   y: string;   // not optional
-   *   z?: string;  // optional
-   * }
-   * ```
-   */
-  public readonly isOptional: boolean;
-
   public constructor(options: IApiPropertyItemOptions) {
     super(options);
 
     this.propertyTypeExcerpt = this.buildExcerpt(options.propertyTypeTokenRange);
-    this.isOptional = !!options.isOptional;
   }
 
   /** @override */
@@ -64,7 +50,6 @@ export class ApiPropertyItem extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclared
     super.onDeserializeInto(options, context, jsonObject);
 
     options.propertyTypeTokenRange = jsonObject.propertyTypeTokenRange;
-    options.isOptional = !!jsonObject.isOptional;
   }
 
   /**
@@ -89,8 +74,5 @@ export class ApiPropertyItem extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclared
     super.serializeInto(jsonObject);
 
     jsonObject.propertyTypeTokenRange = this.propertyTypeExcerpt.tokenRange;
-    if (this.isOptional) {
-      jsonObject.isOptional = true;
-    }
   }
 }

--- a/apps/api-extractor-model/src/mixins/ApiOptionalMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiOptionalMixin.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.s
+
+import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
+import { DeserializerContext } from '../model/DeserializerContext';
+
+/**
+ * Constructor options for {@link (IApiOptionalMixinOptions:interface)}.
+ * @public
+ */
+export interface IApiOptionalMixinOptions extends IApiItemOptions {
+  isOptional: boolean;
+}
+
+export interface IApiOptionalMixinJson extends IApiItemJson {
+  isOptional: boolean;
+}
+
+const _isOptional: unique symbol = Symbol('ApiOptionalMixin._isOptional');
+
+/**
+ * The mixin base class for API items that can be marked as optional by appending a `?` to them.
+ * For example, a property of an interface can be optional.
+ *
+ * @remarks
+ *
+ * This is part of the {@link ApiModel} hierarchy of classes, which are serializable representations of
+ * API declarations.  The non-abstract classes (e.g. `ApiClass`, `ApiEnum`, `ApiInterface`, etc.) use
+ * TypeScript "mixin" functions (e.g. `ApiDeclaredItem`, `ApiItemContainerMixin`, etc.) to add various
+ * features that cannot be represented as a normal inheritance chain (since TypeScript does not allow a child class
+ * to extend more than one base class).  The "mixin" is a TypeScript merged declaration with three components:
+ * the function that generates a subclass, an interface that describes the members of the subclass, and
+ * a namespace containing static members of the class.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ApiOptionalMixin extends ApiItem {
+  /**
+   * True if this is an optional property.
+   * @remarks
+   * For example:
+   * ```ts
+   * interface X {
+   *   y: string;   // not optional
+   *   z?: string;  // optional
+   * }
+   * ```
+   */
+  readonly isOptional: boolean;
+
+  /** @override */
+  serializeInto(jsonObject: Partial<IApiItemJson>): void;
+}
+
+/**
+ * Mixin function for {@link (ApiOptionalMixin:interface)}.
+ *
+ * @param baseClass - The base class to be extended
+ * @returns A child class that extends baseClass, adding the {@link (ApiOptionalMixin:interface)} functionality.
+ *
+ * @public
+ */
+export function ApiOptionalMixin<TBaseClass extends IApiItemConstructor>(
+  baseClass: TBaseClass
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): TBaseClass & (new (...args: any[]) => ApiOptionalMixin) {
+  abstract class MixedClass extends baseClass implements ApiOptionalMixin {
+    public [_isOptional]: boolean;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public constructor(...args: any[]) {
+      super(...args);
+
+      const options: IApiOptionalMixinOptions = args[0];
+      this[_isOptional] = !!options.isOptional;
+    }
+
+    /** @override */
+    public static onDeserializeInto(
+      options: Partial<IApiOptionalMixinOptions>,
+      context: DeserializerContext,
+      jsonObject: IApiOptionalMixinJson
+    ): void {
+      baseClass.onDeserializeInto(options, context, jsonObject);
+
+      options.isOptional = !!jsonObject.isOptional;
+    }
+
+    public get isOptional(): boolean {
+      return this[_isOptional];
+    }
+
+    /** @override */
+    public serializeInto(jsonObject: Partial<IApiOptionalMixinJson>): void {
+      super.serializeInto(jsonObject);
+
+      jsonObject.isOptional = this.isOptional;
+    }
+  }
+
+  return MixedClass;
+}
+
+/**
+ * Optional members for {@link (ApiOptionalMixin:interface)}.
+ * @public
+ */
+export namespace ApiOptionalMixin {
+  /**
+   * A type guard that tests whether the specified `ApiItem` subclass extends the `ApiOptionalMixin` mixin.
+   *
+   * @remarks
+   *
+   * The JavaScript `instanceof` operator cannot be used to test for mixin inheritance, because each invocation of
+   * the mixin function produces a different subclass.  (This could be mitigated by `Symbol.hasInstance`, however
+   * the TypeScript type system cannot invoke a runtime test.)
+   */
+  export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiOptionalMixin {
+    return apiItem.hasOwnProperty(_isOptional);
+  }
+}

--- a/apps/api-extractor-model/src/model/ApiMethod.ts
+++ b/apps/api-extractor-model/src/model/ApiMethod.ts
@@ -18,6 +18,7 @@ import {
   ApiTypeParameterListMixin,
   IApiTypeParameterListMixinOptions
 } from '../mixins/ApiTypeParameterListMixin';
+import { ApiOptionalMixin, IApiOptionalMixinOptions } from '../mixins/ApiOptionalMixin';
 
 /**
  * Constructor options for {@link ApiMethod}.
@@ -30,6 +31,7 @@ export interface IApiMethodOptions
     IApiReleaseTagMixinOptions,
     IApiReturnTypeMixinOptions,
     IApiStaticMixinOptions,
+    IApiOptionalMixinOptions,
     IApiDeclaredItemOptions {}
 
 /**
@@ -55,7 +57,9 @@ export interface IApiMethodOptions
  */
 export class ApiMethod extends ApiNameMixin(
   ApiTypeParameterListMixin(
-    ApiParameterListMixin(ApiReleaseTagMixin(ApiReturnTypeMixin(ApiStaticMixin(ApiDeclaredItem))))
+    ApiParameterListMixin(
+      ApiReleaseTagMixin(ApiReturnTypeMixin(ApiStaticMixin(ApiOptionalMixin(ApiDeclaredItem))))
+    )
   )
 ) {
   public constructor(options: IApiMethodOptions) {

--- a/apps/api-extractor-model/src/model/ApiMethodSignature.ts
+++ b/apps/api-extractor-model/src/model/ApiMethodSignature.ts
@@ -17,6 +17,7 @@ import {
   IApiTypeParameterListMixinOptions,
   ApiTypeParameterListMixin
 } from '../mixins/ApiTypeParameterListMixin';
+import { ApiOptionalMixin, IApiOptionalMixinOptions } from '../mixins/ApiOptionalMixin';
 
 /** @public */
 export interface IApiMethodSignatureOptions
@@ -25,6 +26,7 @@ export interface IApiMethodSignatureOptions
     IApiParameterListMixinOptions,
     IApiReleaseTagMixinOptions,
     IApiReturnTypeMixinOptions,
+    IApiOptionalMixinOptions,
     IApiDeclaredItemOptions {}
 
 /**
@@ -49,7 +51,9 @@ export interface IApiMethodSignatureOptions
  * @public
  */
 export class ApiMethodSignature extends ApiNameMixin(
-  ApiTypeParameterListMixin(ApiParameterListMixin(ApiReleaseTagMixin(ApiReturnTypeMixin(ApiDeclaredItem))))
+  ApiTypeParameterListMixin(
+    ApiParameterListMixin(ApiReleaseTagMixin(ApiReturnTypeMixin(ApiOptionalMixin(ApiDeclaredItem))))
+  )
 ) {
   public constructor(options: IApiMethodSignatureOptions) {
     super(options);

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -636,12 +636,15 @@ export class ApiModelGenerator {
       if (releaseTag === ReleaseTag.Internal || releaseTag === ReleaseTag.Alpha) {
         return; // trim out items marked as "@internal" or "@alpha"
       }
+      const isOptional: boolean =
+        (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 
       apiMethod = new ApiMethod({
         name,
         docComment,
         releaseTag,
         isStatic,
+        isOptional,
         typeParameters,
         parameters,
         overloadIndex,
@@ -689,11 +692,14 @@ export class ApiModelGenerator {
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
       const docComment: tsdoc.DocComment | undefined = apiItemMetadata.tsdocComment;
       const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
+      const isOptional: boolean =
+        (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 
       apiMethodSignature = new ApiMethodSignature({
         name,
         docComment,
         releaseTag,
+        isOptional,
         typeParameters,
         parameters,
         overloadIndex,
@@ -738,8 +744,6 @@ export class ApiModelGenerator {
     const name: string = exportedName ? exportedName : astDeclaration.astSymbol.localName;
 
     const isStatic: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0;
-    const isOptional: boolean =
-      (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 
     const containerKey: string = ApiProperty.getContainerKey(name, isStatic);
 
@@ -757,6 +761,8 @@ export class ApiModelGenerator {
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
       const docComment: tsdoc.DocComment | undefined = apiItemMetadata.tsdocComment;
       const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
+      const isOptional: boolean =
+        (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 
       apiProperty = new ApiProperty({
         name,
@@ -798,11 +804,14 @@ export class ApiModelGenerator {
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
       const docComment: tsdoc.DocComment | undefined = apiItemMetadata.tsdocComment;
       const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
+      const isOptional: boolean =
+        (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 
       apiPropertySignature = new ApiPropertySignature({
         name,
         docComment,
         releaseTag,
+        isOptional,
         excerptTokens,
         propertyTypeTokenRange
       });

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -158,6 +158,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -202,6 +203,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
@@ -253,6 +255,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
@@ -289,6 +292,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -318,6 +322,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "malformedEvent",
               "propertyTypeTokenRange": {
@@ -345,6 +350,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "modifiedEvent",
               "propertyTypeTokenRange": {
@@ -371,6 +377,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "readonlyProperty",
               "propertyTypeTokenRange": {
@@ -398,6 +405,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "regularProperty",
               "propertyTypeTokenRange": {
@@ -440,6 +448,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": true,
               "returnTypeTokenRange": {
                 "startIndex": 5,
@@ -483,6 +492,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -515,6 +525,7 @@
                   "text": "\n\nset writeableProperty(value: string);"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "writeableProperty",
               "propertyTypeTokenRange": {
@@ -1040,6 +1051,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "regularProperty",
               "propertyTypeTokenRange": {
@@ -1090,6 +1102,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -1138,6 +1151,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "\"[not.a.symbol]\"",
               "propertyTypeTokenRange": {
@@ -1172,6 +1186,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "[EcmaSmbols.example]",
               "propertyTypeTokenRange": {
@@ -1308,6 +1323,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "redundantQuotes",
               "propertyTypeTokenRange": {
@@ -1349,6 +1365,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "Context",
               "propertyTypeTokenRange": {
@@ -1379,6 +1396,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "generic",
               "propertyTypeTokenRange": {
@@ -1404,6 +1422,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "numberOrFunction",
               "propertyTypeTokenRange": {
@@ -1429,6 +1448,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "stringOrNumber",
               "propertyTypeTokenRange": {
@@ -1470,6 +1490,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "regularProperty",
               "propertyTypeTokenRange": {
@@ -1516,6 +1537,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "arrayProperty",
               "propertyTypeTokenRange": {
@@ -1549,6 +1571,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -1607,6 +1630,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "intersectionProperty",
               "propertyTypeTokenRange": {
@@ -1632,6 +1656,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "regularProperty",
               "propertyTypeTokenRange": {
@@ -1675,6 +1700,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "tupleProperty",
               "propertyTypeTokenRange": {
@@ -1714,6 +1740,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "typeReferenceProperty",
               "propertyTypeTokenRange": {
@@ -1749,6 +1776,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "unionProperty",
               "propertyTypeTokenRange": {
@@ -1790,6 +1818,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "optionalField",
               "propertyTypeTokenRange": {
@@ -1815,6 +1844,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -1842,6 +1872,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "optionalReadonlyField",
               "propertyTypeTokenRange": {
@@ -1867,6 +1898,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "optionalUndocumentedField",
               "propertyTypeTokenRange": {
@@ -2010,6 +2042,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.md
@@ -16,13 +16,13 @@ export interface IDocInterface7
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [optionalField](./api-documenter-test.idocinterface7.optionalfield.md) | boolean | Description of optionalField |
-|  [optionalReadonlyField](./api-documenter-test.idocinterface7.optionalreadonlyfield.md) | boolean | Description of optionalReadonlyField |
-|  [optionalUndocumentedField](./api-documenter-test.idocinterface7.optionalundocumentedfield.md) | boolean |  |
+|  [optionalField?](./api-documenter-test.idocinterface7.optionalfield.md) | boolean | <i>(Optional)</i> Description of optionalField |
+|  [optionalReadonlyField?](./api-documenter-test.idocinterface7.optionalreadonlyfield.md) | boolean | <i>(Optional)</i> Description of optionalReadonlyField |
+|  [optionalUndocumentedField?](./api-documenter-test.idocinterface7.optionalundocumentedfield.md) | boolean | <i>(Optional)</i> |
 
 ## Methods
 
 |  Method | Description |
 |  --- | --- |
-|  [optionalMember()](./api-documenter-test.idocinterface7.optionalmember.md) | Description of optionalMember |
+|  [optionalMember()?](./api-documenter-test.idocinterface7.optionalmember.md) | <i>(Optional)</i> Description of optionalMember |
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -46,6 +46,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -98,6 +99,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
@@ -143,6 +145,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -265,6 +268,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "member",
               "propertyTypeTokenRange": {
@@ -441,6 +445,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -469,6 +474,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "readonlyProperty",
               "propertyTypeTokenRange": {
@@ -499,6 +505,7 @@
                   "text": "\n\nset writeableProperty(value: string);"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "writeableProperty",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -115,6 +115,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "readonlyProperty",
               "propertyTypeTokenRange": {
@@ -141,6 +142,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "writeableProperty",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -47,6 +47,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "containingFolder",
               "propertyTypeTokenRange": {
@@ -94,6 +95,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "containingFolder",
               "propertyTypeTokenRange": {
@@ -125,6 +127,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "files",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -77,6 +77,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "containingFolder",
               "propertyTypeTokenRange": {
@@ -124,6 +125,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "containingFolder",
               "propertyTypeTokenRange": {
@@ -155,6 +157,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "files",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -121,6 +121,7 @@
                       "text": ";"
                     }
                   ],
+                  "isOptional": false,
                   "isStatic": false,
                   "returnTypeTokenRange": {
                     "startIndex": 3,

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -46,6 +46,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -74,6 +75,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -118,6 +120,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -146,6 +149,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -190,6 +194,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
@@ -218,6 +223,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -46,6 +46,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "myProperty",
               "propertyTypeTokenRange": {
@@ -100,6 +101,7 @@
                       "text": ";"
                     }
                   ],
+                  "isOptional": false,
                   "isStatic": false,
                   "returnTypeTokenRange": {
                     "startIndex": 1,

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -47,6 +47,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "context",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
@@ -236,6 +236,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
@@ -295,6 +296,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -46,6 +46,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Beta",
               "name": "x",
               "propertyTypeTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
@@ -55,6 +55,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
@@ -105,6 +106,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
@@ -141,6 +143,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -46,6 +46,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,

--- a/common/changes/@microsoft/api-documenter/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Both methods and properties can now be displayed as \"optional\" in the documentation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor-model/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Introduce an ApiOptionalMixin base class for representing optional properties and methods",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-more-optional-properties_2020-11-18-08-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "The \"isOptional\" .api.json field is now applied to both methods and properties",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -409,6 +409,21 @@ export class ApiNamespace extends ApiNamespace_base {
     get kind(): ApiItemKind;
 }
 
+// @public
+export function ApiOptionalMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiOptionalMixin);
+
+// @public
+export interface ApiOptionalMixin extends ApiItem {
+    readonly isOptional: boolean;
+    // @override (undocumented)
+    serializeInto(jsonObject: Partial<IApiItemJson>): void;
+}
+
+// @public
+export namespace ApiOptionalMixin {
+    export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiOptionalMixin;
+}
+
 // Warning: (ae-forgotten-export) The symbol "ApiPackage_base" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -469,7 +484,6 @@ export class ApiProperty extends ApiProperty_base {
 export class ApiPropertyItem extends ApiPropertyItem_base {
     constructor(options: IApiPropertyItemOptions);
     get isEventProperty(): boolean;
-    readonly isOptional: boolean;
     // Warning: (ae-forgotten-export) The symbol "IApiPropertyItemJson" needs to be exported by the entry point index.d.ts
     //
     // @override (undocumented)
@@ -706,11 +720,11 @@ export interface IApiItemOptions {
 }
 
 // @public
-export interface IApiMethodOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiStaticMixinOptions, IApiDeclaredItemOptions {
+export interface IApiMethodOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiStaticMixinOptions, IApiOptionalMixinOptions, IApiDeclaredItemOptions {
 }
 
 // @public (undocumented)
-export interface IApiMethodSignatureOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiDeclaredItemOptions {
+export interface IApiMethodSignatureOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiOptionalMixinOptions, IApiDeclaredItemOptions {
 }
 
 // @public
@@ -721,6 +735,12 @@ export interface IApiNameMixinOptions extends IApiItemOptions {
 
 // @public
 export interface IApiNamespaceOptions extends IApiItemContainerMixinOptions, IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
+}
+
+// @public
+export interface IApiOptionalMixinOptions extends IApiItemOptions {
+    // (undocumented)
+    isOptional: boolean;
 }
 
 // @public
@@ -751,9 +771,7 @@ export interface IApiParameterOptions {
 }
 
 // @public
-export interface IApiPropertyItemOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
-    // (undocumented)
-    isOptional?: boolean;
+export interface IApiPropertyItemOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiOptionalMixinOptions, IApiDeclaredItemOptions {
     // (undocumented)
     propertyTypeTokenRange: IExcerptTokenRange;
 }


### PR DESCRIPTION


## Summary

The recent PR https://github.com/microsoft/rushstack/pull/2280 introduced an `isOptional` field for tracking API items that should be displayed as "(Optional)" in the documentation.  But it only applied to properties.


## Details

This PR generalizes the model so that all of these things are now documented as optional:

- interface methods
- interface properties
- class methods
- class properties