### PR TITLE
[rush-lib] Added 'rush version' commit message to rush.json-> gitPolicy

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -263,7 +263,16 @@
      * you might configure your system's trigger to look for a special string such as "[skip-ci]"
      * in the commit message, and then customize Rush's message to contain that string.
      */
-    /*[LINE "DEMO"]*/ "versionBumpCommitMessage": "Applying package updates. [skip-ci]"
+    /*[LINE "DEMO"]*/ "versionBumpCommitMessage": "Applying package updates. [skip-ci]",
+
+    /**
+     * The commit message to use when committing changes during 'rush version'.
+     *
+     * For example, if you want to prevent these commits from triggering a CI build,
+     * you might configure your system's trigger to look for a special string such as "[skip-ci]"
+     * in the commit message, and then customize Rush's message to contain that string.
+     */
+    /*[LINE "DEMO"]*/ "changeLogUpdateCommitMessage": "Applying package updates. [skip-ci]"
   },
 
   "repository": {

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -70,6 +70,7 @@ export interface IRushGitPolicyJson {
   allowedEmailRegExps?: string[];
   sampleEmail?: string;
   versionBumpCommitMessage?: string;
+  changeLogUpdateCommitMessage?: string;
 }
 
 /**
@@ -466,6 +467,7 @@ export class RushConfiguration {
   private _gitAllowedEmailRegExps: string[];
   private _gitSampleEmail: string;
   private _gitVersionBumpCommitMessage: string | undefined;
+  private _gitChangeLogUpdateCommitMessage: string | undefined;
 
   // "hotfixChangeEnabled" feature
   private _hotfixChangeEnabled: boolean;
@@ -677,6 +679,10 @@ export class RushConfiguration {
 
       if (rushConfigurationJson.gitPolicy.versionBumpCommitMessage) {
         this._gitVersionBumpCommitMessage = rushConfigurationJson.gitPolicy.versionBumpCommitMessage;
+      }
+
+      if (rushConfigurationJson.gitPolicy.changeLogUpdateCommitMessage) {
+        this._gitChangeLogUpdateCommitMessage = rushConfigurationJson.gitPolicy.changeLogUpdateCommitMessage;
       }
     }
 
@@ -1289,6 +1295,14 @@ export class RushConfiguration {
    */
   public get gitVersionBumpCommitMessage(): string | undefined {
     return this._gitVersionBumpCommitMessage;
+  }
+
+  /**
+   * [Part of the "gitPolicy" feature.]
+   * The commit message to use when committing change log files 'rush version'
+   */
+  public get gitChangeLogUpdateCommitMessage(): string | undefined {
+    return this._gitChangeLogUpdateCommitMessage;
   }
 
   /**

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -20,6 +20,8 @@ import type * as VersionManagerTypes from '../../logic/VersionManager';
 const versionManagerModule: typeof VersionManagerTypes = Import.lazy('../../logic/VersionManager', require);
 
 export const DEFAULT_PACKAGE_UPDATE_MESSAGE: string = 'Applying package updates.';
+export const DEFAULT_CHANGELOG_UPDATE_MESSAGE: string =
+  'Deleting change files and updating change logs for package updates.';
 
 export class VersionAction extends BaseRushAction {
   private _ensureVersionPolicy!: CommandLineFlagParameter;
@@ -229,7 +231,7 @@ export class VersionAction extends BaseRushAction {
       git.addChanges('.', this.rushConfiguration.changesFolder);
       git.addChanges(':/**/CHANGELOG.json');
       git.addChanges(':/**/CHANGELOG.md');
-      git.commit('Deleting change files and updating change logs for package updates.');
+      git.commit(this.rushConfiguration.gitChangeLogUpdateCommitMessage || DEFAULT_CHANGELOG_UPDATE_MESSAGE);
     }
 
     // Commit the package.json and change files updates.

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -176,6 +176,10 @@
         "versionBumpCommitMessage": {
           "description": "The commit message to use when committing changes during \"rush publish\". Defaults to \"Applying package updates.\"",
           "type": "string"
+        },
+        "changeLogUpdateCommitMessage": {
+          "description": "The commit message to use when committing change log files \"rush version\". Defaults to \"Deleting change files and updating change logs for package updates.\"",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/common/changes/@microsoft/rush/issue-2360-add-rush-version-commit-message_2020-11-22-22-01.json
+++ b/common/changes/@microsoft/rush/issue-2360-add-rush-version-commit-message_2020-11-22-22-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add 'rush version' commit message to rush.json-> gitPolicy",
+      "comment": "Add the ability to customize the commit message used when \"rush version\" is run.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/issue-2360-add-rush-version-commit-message_2020-11-22-22-01.json
+++ b/common/changes/@microsoft/rush/issue-2360-add-rush-version-commit-message_2020-11-22-22-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add 'rush version' commit message to rush.json-> gitPolicy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "jaboko@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -351,6 +351,7 @@ export class RushConfiguration {
     getRepoState(variant?: string | undefined): RepoStateFile;
     getRepoStateFilePath(variant?: string | undefined): string;
     get gitAllowedEmailRegExps(): string[];
+    get gitChangeLogUpdateCommitMessage(): string | undefined;
     get gitSampleEmail(): string;
     get gitVersionBumpCommitMessage(): string | undefined;
     get hotfixChangeEnabled(): boolean;


### PR DESCRIPTION
## Summary
Issue #2360. Added variable commit message `changeLogUpdateCommitMessage` in rush.json -> gitPolicy for `rush version` like `versionBumpCommitMessage` 

## Details
At the moment, if I call the `rush version` in Azure Devops Pipeline, the message without [skip ci] will immediately commit and push to the Git. This causes re-build and may lead to build cycle if no additional check is done.

I have added the ability to edit this message by analogy with the `versionBumpCommitMessage`

**_Question_**
Do I need to add the parameter in `apps\rush-lib\assets\rush-init\rush.json`? Because when I add the parameter, I get a json validation error.