### PR TITLE
[Gulp-core-build] Fail jest task when coverage fails

### DIFF
--- a/common/changes/@microsoft/gulp-core-build/master_2020-11-25-06-11.json
+++ b/common/changes/@microsoft/gulp-core-build/master_2020-11-25-06-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Fix bug: coverage will not fail jest task",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "mrexample@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build/src/tasks/JestTask.ts
+++ b/core-build/gulp-core-build/src/tasks/JestTask.ts
@@ -171,8 +171,8 @@ export class JestTask extends GulpTask<IJestConfig> {
     runCLI(jestConfig, [this.buildConfig.rootPath])
       .then((result: { results: AggregatedResult; globalConfig: Config.GlobalConfig }) => {
         process.stdout.isTTY = oldTTY;
-        if (result.results.numFailedTests || result.results.numFailedTestSuites) {
-          completeCallback(new Error('Jest tests failed'));
+        if (!result.results.success) {
+          completeCallback(new Error('Jest tests or coverage failed'));
         } else {
           if (!this.buildConfig.production) {
             this._copySnapshots(this.buildConfig.libFolder, this.buildConfig.srcFolder);


### PR DESCRIPTION
Related issue: https://github.com/microsoft/rushstack/issues/2367

About jest result data structure:
![image](https://user-images.githubusercontent.com/10512841/100188194-aa742a80-2f24-11eb-8a82-939402aec8d2.png)

