### PR TITLE
[heft] Ensure rootDir is consistently specified in tsconfig. 

### DIFF
--- a/apps/api-extractor/src/api/test/test-data/config-lookup1/tsconfig.json
+++ b/apps/api-extractor/src/api/test/test-data/config-lookup1/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src/",
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/apps/api-extractor/src/api/test/test-data/config-lookup2/tsconfig.json
+++ b/apps/api-extractor/src/api/test/test-data/config-lookup2/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src/",
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/apps/api-extractor/src/api/test/test-data/config-lookup3/src/test/tsconfig.json
+++ b/apps/api-extractor/src/api/test/test-data/config-lookup3/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src/",
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/apps/api-extractor/src/api/test/test-data/config-lookup3/tsconfig.json
+++ b/apps/api-extractor/src/api/test/test-data/config-lookup3/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src/",
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-action-plugin/tsconfig.json
+++ b/build-tests/heft-action-plugin/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-example-plugin-01/tsconfig.json
+++ b/build-tests/heft-example-plugin-01/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-example-plugin-02/tsconfig.json
+++ b/build-tests/heft-example-plugin-02/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-jest-reporters-test/tsconfig.json
+++ b/build-tests/heft-jest-reporters-test/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "declaration": true,

--- a/build-tests/heft-minimal-rig-test/profiles/default/tsconfig-base.json
+++ b/build-tests/heft-minimal-rig-test/profiles/default/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-node-everything-test/tsconfig.json
+++ b/build-tests/heft-node-everything-test/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-sass-test/tsconfig.json
+++ b/build-tests/heft-sass-test/tsconfig.json
@@ -3,7 +3,8 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/", "temp/sass-ts/"],
+    "rootDir": "src",
+    "rootDirs": ["src", "temp/sass-ts"],
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/heft-webpack-everything-test/tsconfig.json
+++ b/build-tests/heft-webpack-everything-test/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/build-tests/localization-plugin-test-01/tsconfig.json
+++ b/build-tests/localization-plugin-test-01/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@microsoft/rush-stack-compiler-3.9/includes/tsconfig-web.json",
   "compilerOptions": {
-    "rootDirs": ["./src", "./temp/loc-json-ts/"],
+    "rootDir": "src",
+    "rootDirs": ["src", "temp/loc-json-ts"],
     "types": ["webpack-env"]
   }
 }

--- a/build-tests/localization-plugin-test-02/tsconfig.json
+++ b/build-tests/localization-plugin-test-02/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@microsoft/rush-stack-compiler-3.9/includes/tsconfig-web.json",
   "compilerOptions": {
-    "rootDirs": ["./src", "./temp/loc-json-ts/"],
+    "rootDir": "src",
+    "rootDirs": ["src", "temp/loc-json-ts"],
     "types": ["webpack-env"]
   }
 }

--- a/build-tests/localization-plugin-test-03/tsconfig.json
+++ b/build-tests/localization-plugin-test-03/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@microsoft/rush-stack-compiler-3.9/includes/tsconfig-web.json",
   "compilerOptions": {
-    "rootDirs": ["./src", "./temp/loc-json-ts/"],
+    "rootDir": "src",
+    "rootDirs": ["src", "temp/loc-json-ts"],
     "types": ["webpack-env"]
   }
 }

--- a/common/changes/@microsoft/api-extractor/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/api-extractor/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.4",
+      "comment": "Ensure rootDir is consistently specified. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush-stack-compiler-2.4",
-      "comment": "Ensure rootDir is consistently specified. ",
+      "comment": "Ensure rootDir is consistently specified.",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.7",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.8",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.9",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.0",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.1",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.2",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.3",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.4",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.5",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.6",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.7",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.8/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.8/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.8",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.8",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.9/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.9/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.9",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.9",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-node-rig/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@rushstack/heft-node-rig/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/halfnibble-ensure-rootdir_2020-12-04-23-00.json
+++ b/common/changes/@rushstack/heft-web-rig/halfnibble-ensure-rootdir_2020-12-04-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Ensure rootDir is consistently specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/rigs/heft-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/heft-node-rig/profiles/default/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../../lib",
-    "rootDirs": ["../../../../../src/"],
+    "rootDir": "../../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/rigs/heft-web-rig/profiles/library/tsconfig-base.json
+++ b/rigs/heft-web-rig/profiles/library/tsconfig-base.json
@@ -3,7 +3,8 @@
 
   "compilerOptions": {
     "outDir": "../../../../../lib",
-    "rootDirs": ["../../../../../src/", "../../../../../temp/sass-ts/"],
+    "rootDir": "../../../../../src",
+    "rootDirs": ["../../../../../src", "../../../../../temp/sass-ts"],
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-2.4/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-2.4/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-2.7/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-2.7/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-2.8/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-2.8/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-2.9/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-2.9/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.0/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.0/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.1/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.1/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.2/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.2/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.3/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.3/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.4/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.4/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.5/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.5/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.6/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.6/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.7/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.7/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.8/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.8/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/stack/rush-stack-compiler-3.9/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler-3.9/includes/tsconfig-base.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "../../../../lib",
-    "rootDirs": ["../../../../src/"],
+    "rootDir": "../../../../src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/tutorials/heft-node-basic-tutorial/tsconfig.json
+++ b/tutorials/heft-node-basic-tutorial/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/tutorials/heft-webpack-basic-tutorial/tsconfig.json
+++ b/tutorials/heft-webpack-basic-tutorial/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/tutorials/packlets-tutorial/tsconfig.json
+++ b/tutorials/packlets-tutorial/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "outDir": "lib",
-    "rootDirs": ["src/"],
+    "rootDir": "src",
 
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",


### PR DESCRIPTION
## Summary

Ensure the "rootDir" setting, which sets the root source directory and can impact output folder structure, is consistently specified in all tsconfig.json files, including build rig profiles. 

In places where "rootDirs" virtual directories are necessary for typings folders, ensure the source directory is specified both in "rootDirs" and "rootDir".



## Details

Basically, through trial and error, I determined that not setting the "rootDir" property can effect the output folder structure if the root source directory does not contain any TypeScript files. It appears that "rootDir" and "rootDirs" are actually not closely related and "src" needs to be in "rootDir" at a minimum. The "src" directory must also be in "rootDirs" if that setting is added to specify one or more virtual directories (e.g. for "loc-json-ts" and "sass-ts"). 

## How it was tested

On a work project. Plus it builds.