### PR TITLE
[heft] Delay build subsequent build stages until the current phase has notified that it is finished in --watch mode.

### DIFF
--- a/apps/heft/src/cli/actions/BuildAction.ts
+++ b/apps/heft/src/cli/actions/BuildAction.ts
@@ -73,4 +73,12 @@ export class BuildAction extends HeftActionBase {
     await buildStage.initializeAsync(buildStageOptions);
     await buildStage.executeAsync();
   }
+
+  protected async afterExecuteAsync(): Promise<void> {
+    if (this._watchFlag.value) {
+      await new Promise(() => {
+        /* never continue if in --watch mode */
+      });
+    }
+  }
 }

--- a/apps/heft/src/cli/actions/HeftActionBase.ts
+++ b/apps/heft/src/cli/actions/HeftActionBase.ts
@@ -123,6 +123,7 @@ export abstract class HeftActionBase extends CommandLineAction {
     let encounteredError: boolean = false;
     try {
       await this.actionExecuteAsync();
+      await this.afterExecuteAsync();
     } catch (e) {
       encounteredError = true;
       throw e;
@@ -171,10 +172,14 @@ export abstract class HeftActionBase extends CommandLineAction {
     }
   }
 
+  protected abstract actionExecuteAsync(): Promise<void>;
+
   /**
    * @virtual
    */
-  protected abstract actionExecuteAsync(): Promise<void>;
+  protected async afterExecuteAsync(): Promise<void> {
+    /* no-op by default */
+  }
 
   private _validateDefinedParameter(options: IBaseCommandLineDefinition): void {
     if (

--- a/apps/heft/src/cli/actions/StartAction.ts
+++ b/apps/heft/src/cli/actions/StartAction.ts
@@ -55,4 +55,10 @@ export class StartAction extends HeftActionBase {
     await buildStage.initializeAsync(buildStageOptions);
     await buildStage.executeAsync();
   }
+
+  protected async afterExecuteAsync(): Promise<void> {
+    await new Promise(() => {
+      /* start should never continue */
+    });
+  }
 }

--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -39,7 +39,6 @@ export {
   BuildStageHooks,
   BuildSubstageHooksBase,
   BundleSubstageHooks,
-  CompileSubstageHooks,
   CopyFromCacheMode,
   IBuildStageContext,
   IBuildStageProperties,

--- a/apps/heft/src/pluginFramework/PluginManager.ts
+++ b/apps/heft/src/pluginFramework/PluginManager.ts
@@ -115,7 +115,7 @@ export class PluginManager {
       const loadedPluginPackage: IHeftPlugin | { default: IHeftPlugin } = require(resolvedPluginPath);
       pluginPackage = (loadedPluginPackage as { default: IHeftPlugin }).default || loadedPluginPackage;
     } catch (e) {
-      throw new InternalError(`Error loading plugin package: ${e}`);
+      throw new InternalError(`Error loading plugin package from "${resolvedPluginPath}": ${e}`);
     }
 
     this._terminal.writeVerboseLine(`Loaded plugin package from "${resolvedPluginPath}"`);

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -130,8 +130,7 @@ export class CopyFilesPlugin implements IHeftPlugin {
 
     // Then enter watch mode if requested
     if (options.watchMode) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this._runWatchAsync(options);
+      Async.runWatcherWithErrorHandling(async () => await this._runWatchAsync(options), logger);
     }
   }
 

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -130,7 +130,8 @@ export class CopyFilesPlugin implements IHeftPlugin {
 
     // Then enter watch mode if requested
     if (options.watchMode) {
-      await this._runWatchAsync(options);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this._runWatchAsync(options);
     }
   }
 

--- a/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsPlugin.ts
+++ b/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsPlugin.ts
@@ -42,10 +42,18 @@ export class SassTypingsPlugin implements IHeftPlugin {
       buildFolder: heftConfiguration.buildFolder,
       sassConfiguration
     });
-    await sassTypingsGenerator.generateTypingsAsync();
-    if (isWatchMode) {
-      await sassTypingsGenerator.runWatcherAsync();
-    }
+    await new Promise((resolve: () => void, reject: (error: Error) => void) => {
+      sassTypingsGenerator
+        .generateTypingsAsync()
+        .then(() => {
+          resolve();
+          if (isWatchMode) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            sassTypingsGenerator.runWatcherAsync();
+          }
+        })
+        .catch(reject);
+    });
   }
 
   private async _loadSassConfigurationAsync(

--- a/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsPlugin.ts
+++ b/apps/heft/src/plugins/SassTypingsPlugin/SassTypingsPlugin.ts
@@ -8,6 +8,7 @@ import { IBuildStageContext, IPreCompileSubstage } from '../../stages/BuildStage
 import { ISassConfiguration, SassTypingsGenerator } from './SassTypingsGenerator';
 import { CoreConfigFiles } from '../../utilities/CoreConfigFiles';
 import { ScopedLogger } from '../../pluginFramework/logging/ScopedLogger';
+import { Async } from '../../utilities/Async';
 
 export interface ISassConfigurationJson extends ISassConfiguration {}
 
@@ -23,45 +24,42 @@ export class SassTypingsPlugin implements IHeftPlugin {
     heftSession.hooks.build.tap(PLUGIN_NAME, (build: IBuildStageContext) => {
       build.hooks.preCompile.tap(PLUGIN_NAME, (preCompile: IPreCompileSubstage) => {
         preCompile.hooks.run.tapPromise(PLUGIN_NAME, async () => {
-          await this._runSassTypingsGenerator(heftSession, heftConfiguration, build.properties.watchMode);
+          await this._runSassTypingsGeneratorAsync(
+            heftSession,
+            heftConfiguration,
+            build.properties.watchMode
+          );
         });
       });
     });
   }
 
-  private async _runSassTypingsGenerator(
+  private async _runSassTypingsGeneratorAsync(
     heftSession: HeftSession,
     heftConfiguration: HeftConfiguration,
     isWatchMode: boolean
   ): Promise<void> {
+    const logger: ScopedLogger = heftSession.requestScopedLogger('sass-typings-generator');
     const sassConfiguration: ISassConfiguration = await this._loadSassConfigurationAsync(
-      heftSession,
-      heftConfiguration
+      heftConfiguration,
+      logger
     );
     const sassTypingsGenerator: SassTypingsGenerator = new SassTypingsGenerator({
       buildFolder: heftConfiguration.buildFolder,
       sassConfiguration
     });
-    await new Promise((resolve: () => void, reject: (error: Error) => void) => {
-      sassTypingsGenerator
-        .generateTypingsAsync()
-        .then(() => {
-          resolve();
-          if (isWatchMode) {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            sassTypingsGenerator.runWatcherAsync();
-          }
-        })
-        .catch(reject);
-    });
+
+    await sassTypingsGenerator.generateTypingsAsync();
+    if (isWatchMode) {
+      Async.runWatcherWithErrorHandling(async () => await sassTypingsGenerator.runWatcherAsync(), logger);
+    }
   }
 
   private async _loadSassConfigurationAsync(
-    heftSession: HeftSession,
-    heftConfiguration: HeftConfiguration
+    heftConfiguration: HeftConfiguration,
+    logger: ScopedLogger
   ): Promise<ISassConfiguration> {
     const { buildFolder } = heftConfiguration;
-    const logger: ScopedLogger = heftSession.requestScopedLogger('sass-typings-plugin');
     const sassConfigurationJson:
       | ISassConfigurationJson
       | undefined = await CoreConfigFiles.sassConfigurationFileLoader.tryLoadConfigurationFileForProjectAsync(

--- a/apps/heft/src/plugins/Webpack/WebpackPlugin.ts
+++ b/apps/heft/src/plugins/Webpack/WebpackPlugin.ts
@@ -101,6 +101,8 @@ export class WebpackPlugin implements IHeftPlugin {
         devServer.listen(options.port!, options.host!, (error: Error | undefined) => {
           if (error) {
             reject(error);
+          } else {
+            resolve();
           }
         });
       });

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -302,12 +302,6 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
       buildStage: postBuildStage,
       watchMode: watchMode
     });
-
-    if (watchMode) {
-      await new Promise(() => {
-        /* never resolve */
-      });
-    }
   }
 
   private async _runSubstageWithLoggingAsync({

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -6,7 +6,7 @@ import * as webpack from 'webpack';
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
 import { StageBase, StageHooksBase, IStageContext } from './StageBase';
-import { Logging } from '../utilities/Logging';
+import { IFinishedWords, Logging } from '../utilities/Logging';
 import { HeftConfiguration } from '../configuration/HeftConfiguration';
 import {
   CommandLineAction,
@@ -38,16 +38,6 @@ export interface IBuildSubstage<
  * @public
  */
 export type CopyFromCacheMode = 'hardlink' | 'copy';
-
-/**
- * @public
- */
-export class CompileSubstageHooks extends BuildSubstageHooksBase {
-  /**
-   * @internal
-   */
-  public readonly afterTypescriptFirstEmit: AsyncParallelHook = new AsyncParallelHook();
-}
 
 /**
  * @public
@@ -102,7 +92,8 @@ export interface IPreCompileSubstage extends IBuildSubstage<BuildSubstageHooksBa
 /**
  * @public
  */
-export interface ICompileSubstage extends IBuildSubstage<CompileSubstageHooks, ICompileSubstageProperties> {}
+export interface ICompileSubstage
+  extends IBuildSubstage<BuildSubstageHooksBase, ICompileSubstageProperties> {}
 
 /**
  * @public
@@ -166,6 +157,17 @@ export interface IBuildStageStandardParameters {
   typescriptMaxWriteParallelismParameter: CommandLineIntegerParameter;
   maxOldSpaceSizeParameter: CommandLineStringParameter;
 }
+
+interface IRunSubstageWithLoggingOptions {
+  buildStageName: string;
+  buildStage: IBuildSubstage<BuildSubstageHooksBase, object>;
+  watchMode: boolean;
+}
+
+const WATCH_MODE_FINISHED_LOGGING_WORDS: IFinishedWords = {
+  success: 'ready to continue',
+  failure: 'continuing with errors'
+};
 
 export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties, IBuildStageOptions> {
   public constructor(heftConfiguration: HeftConfiguration, loggingManager: LoggingManager) {
@@ -240,7 +242,7 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
     this.stageHooks.preCompile.call(preCompileSubstage);
 
     const compileStage: ICompileSubstage = {
-      hooks: new CompileSubstageHooks(),
+      hooks: new BuildSubstageHooksBase(),
       properties: {
         typescriptMaxWriteParallelism: this.stageOptions.typescriptMaxWriteParallelism
       }
@@ -259,65 +261,66 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
     };
     this.stageHooks.postBuild.call(postBuildStage);
 
-    if (this.stageProperties.watchMode) {
-      // In --watch mode, run all configuration upfront and then kick off all stages
-      // concurrently with the expectation that the their promises will never resolve
-      // and that they will handle watching filesystem changes
+    const watchMode: boolean = this.stageProperties.watchMode;
 
-      await bundleStage.hooks.configureWebpack
-        .promise(undefined)
-        .then((webpackConfiguration) => (bundleStage.properties.webpackConfiguration = webpackConfiguration));
-      await bundleStage.hooks.afterConfigureWebpack.promise();
+    await this._runSubstageWithLoggingAsync({
+      buildStageName: 'Pre-compile',
+      buildStage: preCompileSubstage,
+      watchMode: watchMode
+    });
 
-      compileStage.hooks.afterTypescriptFirstEmit.tapPromise(
-        'build-stage',
-        async () =>
-          await Promise.all([
-            this._runSubstageWithLoggingAsync('Bundle', bundleStage),
-            this._runSubstageWithLoggingAsync('Post-build', postBuildStage)
-          ])
-      );
+    if (this.loggingManager.errorsHaveBeenEmitted && !watchMode) {
+      return;
+    }
 
-      await Promise.all([
-        this._runSubstageWithLoggingAsync('Pre-compile', preCompileSubstage),
-        this._runSubstageWithLoggingAsync('Compile', compileStage)
-      ]);
-    } else {
-      await this._runSubstageWithLoggingAsync('Pre-compile', preCompileSubstage);
+    await this._runSubstageWithLoggingAsync({
+      buildStageName: 'Compile',
+      buildStage: compileStage,
+      watchMode: watchMode
+    });
 
-      if (this.loggingManager.errorsHaveBeenEmitted) {
-        return;
-      }
+    if (this.loggingManager.errorsHaveBeenEmitted && !watchMode) {
+      return;
+    }
 
-      await this._runSubstageWithLoggingAsync('Compile', compileStage);
+    await bundleStage.hooks.configureWebpack
+      .promise(undefined)
+      .then((webpackConfiguration) => (bundleStage.properties.webpackConfiguration = webpackConfiguration));
+    await bundleStage.hooks.afterConfigureWebpack.promise();
+    await this._runSubstageWithLoggingAsync({
+      buildStageName: 'Bundle',
+      buildStage: bundleStage,
+      watchMode: watchMode
+    });
 
-      if (this.loggingManager.errorsHaveBeenEmitted) {
-        return;
-      }
+    if (this.loggingManager.errorsHaveBeenEmitted && !watchMode) {
+      return;
+    }
 
-      await bundleStage.hooks.configureWebpack
-        .promise(undefined)
-        .then((webpackConfiguration) => (bundleStage.properties.webpackConfiguration = webpackConfiguration));
-      await bundleStage.hooks.afterConfigureWebpack.promise();
-      await this._runSubstageWithLoggingAsync('Bundle', bundleStage);
+    await this._runSubstageWithLoggingAsync({
+      buildStageName: 'Post-build',
+      buildStage: postBuildStage,
+      watchMode: watchMode
+    });
 
-      if (this.loggingManager.errorsHaveBeenEmitted) {
-        return;
-      }
-
-      await this._runSubstageWithLoggingAsync('Post-build', postBuildStage);
+    if (watchMode) {
+      await new Promise(() => {
+        /* never resolve */
+      });
     }
   }
 
-  private async _runSubstageWithLoggingAsync(
-    buildStageName: string,
-    buildStage: IBuildSubstage<BuildSubstageHooksBase, object>
-  ): Promise<void> {
+  private async _runSubstageWithLoggingAsync({
+    buildStageName,
+    buildStage,
+    watchMode
+  }: IRunSubstageWithLoggingOptions): Promise<void> {
     if (buildStage.hooks.run.isUsed()) {
       await Logging.runFunctionWithLoggingBoundsAsync(
         this.globalTerminal,
         buildStageName,
-        async () => await buildStage.hooks.run.promise()
+        async () => await buildStage.hooks.run.promise(),
+        watchMode ? WATCH_MODE_FINISHED_LOGGING_WORDS : undefined
       );
     }
   }

--- a/apps/heft/src/utilities/Async.ts
+++ b/apps/heft/src/utilities/Async.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
+
 export class Async {
   public static async forEachLimitAsync<TEntry>(
     array: TEntry[],
@@ -35,5 +37,13 @@ export class Async {
 
       onOperationCompletion();
     });
+  }
+
+  public static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: ScopedLogger): void {
+    try {
+      fn().catch((e) => scopedLogger.emitError(e));
+    } catch (e) {
+      scopedLogger.emitError(e);
+    }
   }
 }

--- a/apps/heft/src/utilities/Logging.ts
+++ b/apps/heft/src/utilities/Logging.ts
@@ -4,19 +4,30 @@
 import { Terminal } from '@rushstack/node-core-library';
 import { performance } from 'perf_hooks';
 
+export interface IFinishedWords {
+  success: string;
+  failure: string;
+}
+
+const DEFAULT_FINISHED_WORDS: IFinishedWords = {
+  success: 'finished',
+  failure: 'encountered an error'
+};
+
 export class Logging {
   public static async runFunctionWithLoggingBoundsAsync(
     terminal: Terminal,
     name: string,
-    fn: () => Promise<void>
+    fn: () => Promise<void>,
+    finishedWords: IFinishedWords = DEFAULT_FINISHED_WORDS
   ): Promise<void> {
     terminal.writeLine(` ---- ${name} started ---- `);
     const startTime: number = performance.now();
-    let finishedLoggingWord: string = 'finished';
+    let finishedLoggingWord: string = finishedWords.success;
     try {
       await fn();
     } catch (e) {
-      finishedLoggingWord = 'encountered an error';
+      finishedLoggingWord = finishedWords.failure;
       throw e;
     } finally {
       const executionTime: number = Math.round(performance.now() - startTime);

--- a/common/changes/@rushstack/heft/ianc-heft-watch_2020-12-09-01-33.json
+++ b/common/changes/@rushstack/heft/ianc-heft-watch_2020-12-09-01-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Delay build stages in --watch mode until the previous stage reports an initial completion.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -53,12 +53,6 @@ export class CleanStageHooks extends StageHooksBase<ICleanStageProperties> {
 }
 
 // @public (undocumented)
-export class CompileSubstageHooks extends BuildSubstageHooksBase {
-    // @internal (undocumented)
-    readonly afterTypescriptFirstEmit: AsyncParallelHook;
-}
-
-// @public (undocumented)
 export type CopyFromCacheMode = 'hardlink' | 'copy';
 
 // @beta (undocumented)
@@ -171,7 +165,7 @@ export interface ICompilerPackage {
 }
 
 // @public (undocumented)
-export interface ICompileSubstage extends IBuildSubstage<CompileSubstageHooks, ICompileSubstageProperties> {
+export interface ICompileSubstage extends IBuildSubstage<BuildSubstageHooksBase, ICompileSubstageProperties> {
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Right now, when `heft build --watch` is run, all build stages are kicked off simultaneously. This causes problems when downstream stages have dependencies on a "first emit" of upstream stages. For example, if the TypeScript compiler requires generated typings.

This change doesn't kick off the next stage until all of the plugins in the current stage resolve. In `--watch` mode, plugins are expected to stay active after resolving.

In the future, I'd like to formalize this better by having watch operations register themselves and potentially receive a cancellation token.

## Test Notes

This change was tested by running `heft start`, `heft build --watch`, and `heft test --watch` in all of the tutorials projects. Everything behaved as expected.