### PR TITLE
[rush] Convert remaining code in Rush to async/await

### DIFF
--- a/apps/rush-lib/src/cli/actions/CheckAction.ts
+++ b/apps/rush-lib/src/cli/actions/CheckAction.ts
@@ -35,7 +35,7 @@ export class CheckAction extends BaseRushAction {
     });
   }
 
-  protected runAsync(): Promise<void> {
+  protected async runAsync(): Promise<void> {
     const variant: string | undefined = this.rushConfiguration.currentInstalledVariant;
 
     if (!this._variant.value && variant) {
@@ -51,6 +51,5 @@ export class CheckAction extends BaseRushAction {
       variant: this._variant.value,
       printAsJson: this._jsonFlag.value
     });
-    return Promise.resolve();
   }
 }

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -79,19 +79,17 @@ export class InitAction extends BaseConfiglessRushAction {
     });
   }
 
-  protected runAsync(): Promise<void> {
+  protected async runAsync(): Promise<void> {
     const initFolder: string = process.cwd();
 
     if (!this._overwriteParameter.value) {
       if (!this._validateFolderIsEmpty(initFolder)) {
-        return Promise.reject(new AlreadyReportedError());
+        throw new AlreadyReportedError();
       }
     }
 
     this._defineMacroSections();
     this._copyTemplateFiles(initFolder);
-
-    return Promise.resolve();
   }
 
   private _defineMacroSections(): void {

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -208,41 +208,39 @@ export class PublishAction extends BaseRushAction {
   /**
    * Executes the publish action, which will read change request files, apply changes to package.jsons,
    */
-  protected runAsync(): Promise<void> {
-    return Promise.resolve().then(() => {
-      PolicyValidator.validatePolicy(this.rushConfiguration, { bypassPolicy: false });
+  protected async runAsync(): Promise<void> {
+    PolicyValidator.validatePolicy(this.rushConfiguration, { bypassPolicy: false });
 
-      // Example: "common\temp\publish-home"
-      this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');
+    // Example: "common\temp\publish-home"
+    this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');
 
-      // Example: "common\temp\publish-home\.npmrc"
-      this._targetNpmrcPublishPath = path.join(this._targetNpmrcPublishFolder, '.npmrc');
+    // Example: "common\temp\publish-home\.npmrc"
+    this._targetNpmrcPublishPath = path.join(this._targetNpmrcPublishFolder, '.npmrc');
 
-      const allPackages: Map<string, RushConfigurationProject> = this.rushConfiguration.projectsByName;
+    const allPackages: Map<string, RushConfigurationProject> = this.rushConfiguration.projectsByName;
 
-      if (this._regenerateChangelogs.value) {
-        console.log('Regenerating changelogs');
-        ChangelogGenerator.regenerateChangelogs(allPackages, this.rushConfiguration);
-        return Promise.resolve();
-      }
+    if (this._regenerateChangelogs.value) {
+      console.log('Regenerating changelogs');
+      ChangelogGenerator.regenerateChangelogs(allPackages, this.rushConfiguration);
+      return;
+    }
 
-      this._validate();
+    this._validate();
 
-      this._addNpmPublishHome();
+    this._addNpmPublishHome();
 
-      if (this._includeAll.value) {
-        this._publishAll(allPackages);
-      } else {
-        this._prereleaseToken = new PrereleaseToken(
-          this._prereleaseName.value,
-          this._suffix.value,
-          this._partialPrerelease.value
-        );
-        this._publishChanges(allPackages);
-      }
+    if (this._includeAll.value) {
+      this._publishAll(allPackages);
+    } else {
+      this._prereleaseToken = new PrereleaseToken(
+        this._prereleaseName.value,
+        this._suffix.value,
+        this._partialPrerelease.value
+      );
+      this._publishChanges(allPackages);
+    }
 
-      console.log(EOL + colors.green('Rush publish finished successfully.'));
-    });
+    console.log(EOL + colors.green('Rush publish finished successfully.'));
   }
 
   /**

--- a/apps/rush-lib/src/cli/actions/PurgeAction.ts
+++ b/apps/rush-lib/src/cli/actions/PurgeAction.ts
@@ -37,29 +37,27 @@ export class PurgeAction extends BaseRushAction {
     });
   }
 
-  protected runAsync(): Promise<void> {
-    return Promise.resolve().then(() => {
-      const stopwatch: Stopwatch = Stopwatch.start();
+  protected async runAsync(): Promise<void> {
+    const stopwatch: Stopwatch = Stopwatch.start();
 
-      const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
-      const purgeManager: PurgeManager = new PurgeManager(this.rushConfiguration, this.rushGlobalFolder);
+    const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
+    const purgeManager: PurgeManager = new PurgeManager(this.rushConfiguration, this.rushGlobalFolder);
 
-      unlinkManager.unlink(/*force:*/ true);
+    unlinkManager.unlink(/*force:*/ true);
 
-      if (this._unsafeParameter.value!) {
-        purgeManager.purgeUnsafe();
-      } else {
-        purgeManager.purgeNormal();
-      }
+    if (this._unsafeParameter.value!) {
+      purgeManager.purgeUnsafe();
+    } else {
+      purgeManager.purgeNormal();
+    }
 
-      purgeManager.deleteAll();
+    purgeManager.deleteAll();
 
-      console.log(
-        os.EOL +
-          colors.green(
-            `Rush purge started successfully and will complete asynchronously. (${stopwatch.toString()})`
-          )
-      );
-    });
+    console.log(
+      os.EOL +
+        colors.green(
+          `Rush purge started successfully and will complete asynchronously. (${stopwatch.toString()})`
+        )
+    );
   }
 }

--- a/apps/rush-lib/src/cli/actions/ScanAction.ts
+++ b/apps/rush-lib/src/cli/actions/ScanAction.ts
@@ -36,7 +36,7 @@ export class ScanAction extends BaseConfiglessRushAction {
     // abstract
   }
 
-  protected runAsync(): Promise<void> {
+  protected async runAsync(): Promise<void> {
     const packageJsonFilename: string = path.resolve('./package.json');
 
     if (!FileSystem.exists(packageJsonFilename)) {
@@ -124,6 +124,5 @@ export class ScanAction extends BaseConfiglessRushAction {
         console.log('  ' + packageName);
       }
     }
-    return Promise.resolve();
   }
 }

--- a/apps/rush-lib/src/cli/actions/UnlinkAction.ts
+++ b/apps/rush-lib/src/cli/actions/UnlinkAction.ts
@@ -24,15 +24,13 @@ export class UnlinkAction extends BaseRushAction {
     // No parameters
   }
 
-  protected runAsync(): Promise<void> {
-    return Promise.resolve().then(() => {
-      const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
+  protected async runAsync(): Promise<void> {
+    const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
 
-      if (!unlinkManager.unlink()) {
-        console.log('Nothing to do.');
-      } else {
-        console.log(os.EOL + 'Done.');
-      }
-    });
+    if (!unlinkManager.unlink()) {
+      console.log('Nothing to do.');
+    } else {
+      console.log(os.EOL + 'Done.');
+    }
   }
 }

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -206,7 +206,7 @@ export class TaskRunner {
    * Helper function which finds any tasks which are available to run and begins executing them.
    * It calls the complete callback when all tasks are completed, or rejects if any task fails.
    */
-  private _startAvailableTasksAsync(): Promise<void> {
+  private async _startAvailableTasksAsync(): Promise<void> {
     const taskPromises: Promise<void>[] = [];
     let ctask: Task | undefined;
     while (this._currentActiveTasks < this._parallelism && (ctask = this._getNextTask())) {
@@ -221,9 +221,7 @@ export class TaskRunner {
       taskPromises.push(this._executeTaskAndChainAsync(task));
     }
 
-    return Promise.all(taskPromises).then(() => {
-      // collapse void[] to void
-    });
+    await Promise.all(taskPromises);
   }
 
   private async _executeTaskAndChainAsync(task: Task): Promise<void> {

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -503,26 +503,6 @@ export class Utilities {
     );
   }
 
-  public static withFinally<T>(options: { promise: Promise<T>; finally: () => void }): Promise<T> {
-    return options.promise
-      .then<T>((result: T) => {
-        try {
-          options.finally();
-        } catch (error) {
-          return Promise.reject(error);
-        }
-        return result;
-      })
-      .catch<T>((error: Error) => {
-        try {
-          options.finally();
-        } catch (innerError) {
-          return Promise.reject(innerError);
-        }
-        return Promise.reject(error);
-      });
-  }
-
   /**
    * As a workaround, copyAndTrimNpmrcFile() copies the .npmrc file to the target folder, and also trims
    * unusable lines from the .npmrc file.

--- a/apps/rush/src/RushVersionSelector.ts
+++ b/apps/rush/src/RushVersionSelector.ts
@@ -22,7 +22,7 @@ export class RushVersionSelector {
     this._currentPackageVersion = currentPackageVersion;
   }
 
-  public ensureRushVersionInstalled(
+  public async ensureRushVersionInstalledAsync(
     version: string,
     configuration: MinimalRushConfiguration | undefined,
     executeOptions: ILaunchOptions
@@ -34,71 +34,64 @@ export class RushVersionSelector {
       node: process.versions.node
     });
 
-    let installPromise: Promise<void> = Promise.resolve();
-
     if (!installMarker.isValid()) {
-      installPromise = installPromise.then(() => {
-        // Need to install Rush
-        console.log(`Rush version ${version} is not currently installed. Installing...`);
+      // Need to install Rush
+      console.log(`Rush version ${version} is not currently installed. Installing...`);
 
-        const resourceName: string = `rush-${version}`;
+      const resourceName: string = `rush-${version}`;
 
-        console.log(`Trying to acquire lock for ${resourceName}`);
+      console.log(`Trying to acquire lock for ${resourceName}`);
 
-        return LockFile.acquire(expectedRushPath, resourceName).then((lock: LockFile) => {
-          if (installMarker.isValid()) {
-            console.log('Another process performed the installation.');
-          } else {
-            Utilities.installPackageInDirectory({
-              directory: expectedRushPath,
-              packageName: isLegacyRushVersion ? '@microsoft/rush' : '@microsoft/rush-lib',
-              version: version,
-              tempPackageTitle: 'rush-local-install',
-              maxInstallAttempts: MAX_INSTALL_ATTEMPTS,
-              // This is using a local configuration to install a package in a shared global location.
-              // Generally that's a bad practice, but in this case if we can successfully install
-              // the package at all, we can reasonably assume it's good for all the repositories.
-              // In particular, we'll assume that two different NPM registries cannot have two
-              // different implementations of the same version of the same package.
-              // This was needed for: https://github.com/microsoft/rushstack/issues/691
-              commonRushConfigFolder: configuration ? configuration.commonRushConfigFolder : undefined,
-              suppressOutput: true
-            });
-
-            console.log(`Successfully installed Rush version ${version} in ${expectedRushPath}.`);
-
-            // If we've made it here without exception, write the flag file
-            installMarker.create();
-
-            lock.release();
-          }
+      const lock: LockFile = await LockFile.acquire(expectedRushPath, resourceName);
+      if (installMarker.isValid()) {
+        console.log('Another process performed the installation.');
+      } else {
+        Utilities.installPackageInDirectory({
+          directory: expectedRushPath,
+          packageName: isLegacyRushVersion ? '@microsoft/rush' : '@microsoft/rush-lib',
+          version: version,
+          tempPackageTitle: 'rush-local-install',
+          maxInstallAttempts: MAX_INSTALL_ATTEMPTS,
+          // This is using a local configuration to install a package in a shared global location.
+          // Generally that's a bad practice, but in this case if we can successfully install
+          // the package at all, we can reasonably assume it's good for all the repositories.
+          // In particular, we'll assume that two different NPM registries cannot have two
+          // different implementations of the same version of the same package.
+          // This was needed for: https://github.com/microsoft/rushstack/issues/691
+          commonRushConfigFolder: configuration ? configuration.commonRushConfigFolder : undefined,
+          suppressOutput: true
         });
-      });
+
+        console.log(`Successfully installed Rush version ${version} in ${expectedRushPath}.`);
+
+        // If we've made it here without exception, write the flag file
+        installMarker.create();
+
+        lock.release();
+      }
     }
 
-    return installPromise.then(() => {
-      if (semver.lt(version, '3.0.20')) {
-        // In old versions, requiring the entry point invoked the command-line parser immediately,
-        // so fail if "rushx" was used
-        RushCommandSelector.failIfNotInvokedAsRush(version);
-        require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'rush'));
-      } else if (semver.lt(version, '4.0.0')) {
-        // In old versions, requiring the entry point invoked the command-line parser immediately,
-        // so fail if "rushx" was used
-        RushCommandSelector.failIfNotInvokedAsRush(version);
-        require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'start'));
-      } else {
-        // For newer rush-lib, RushCommandSelector can test whether "rushx" is supported or not
-        const rushCliEntrypoint: {} = require(path.join(
-          expectedRushPath,
-          'node_modules',
-          '@microsoft',
-          'rush-lib',
-          'lib',
-          'index'
-        ));
-        RushCommandSelector.execute(this._currentPackageVersion, rushCliEntrypoint, executeOptions);
-      }
-    });
+    if (semver.lt(version, '3.0.20')) {
+      // In old versions, requiring the entry point invoked the command-line parser immediately,
+      // so fail if "rushx" was used
+      RushCommandSelector.failIfNotInvokedAsRush(version);
+      require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'rush'));
+    } else if (semver.lt(version, '4.0.0')) {
+      // In old versions, requiring the entry point invoked the command-line parser immediately,
+      // so fail if "rushx" was used
+      RushCommandSelector.failIfNotInvokedAsRush(version);
+      require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'start'));
+    } else {
+      // For newer rush-lib, RushCommandSelector can test whether "rushx" is supported or not
+      const rushCliEntrypoint: {} = require(path.join(
+        expectedRushPath,
+        'node_modules',
+        '@microsoft',
+        'rush-lib',
+        'lib',
+        'index'
+      ));
+      RushCommandSelector.execute(this._currentPackageVersion, rushCliEntrypoint, executeOptions);
+    }
   }
 }

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -89,7 +89,7 @@ const launchOptions: rushLib.ILaunchOptions = { isManaged, alreadyReportedNodeTo
 if (rushVersionToLoad && rushVersionToLoad !== currentPackageVersion) {
   const versionSelector: RushVersionSelector = new RushVersionSelector(currentPackageVersion);
   versionSelector
-    .ensureRushVersionInstalled(rushVersionToLoad, configuration, launchOptions)
+    .ensureRushVersionInstalledAsync(rushVersionToLoad, configuration, launchOptions)
     .catch((error: Error) => {
       console.log(colors.red('Error: ' + error.message));
     });

--- a/common/changes/@microsoft/rush/ianc-asyncify_2020-12-13-00-07.json
+++ b/common/changes/@microsoft/rush/ianc-asyncify_2020-12-13-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

This simple PR converts the remaining old-style async code (`.then` and `.catch`) to `async`/`await`.

## How it was tested

- Ran `rush update` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master`
- Ran `rush build` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 
- Ran `rush purge` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master`
- Ran `rush install` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master`
- Ran `rush rebuild` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 
- Ran `rush unlink` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 
  - Error message, but that's expected.
- Ran `rush unlink` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 
  - Error message, but that's expected.
- Ran `rush build` with this build of `rush` in a https://github.com/microsoft/rushstack/ repo on `master` 
- Ran `rush version` with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 
- Ran `rush publish` (to Verdaccio) with this build of `rush-lib` in a https://github.com/microsoft/rushstack/ repo on `master` 