### PR TITLE
[rush-lib] Add publishFolder settings to project configuration

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -437,6 +437,15 @@
       /*[LINE "HYPOTHETICAL"]*/ "shouldPublish": false,
 
       /**
+       * Facilitates postprocessing of a project's files prior to publishing.
+       *
+       * If specified, the "publishFolder" is the relative path to a subfolder of the project folder.
+       * The "rush publish" command will publish the subfolder instead of the project folder.  The subfolder
+       * must contain its own package.json file, which is typically a build output.
+       */
+      /*[LINE "HYPOTHETICAL"]*/ "publishFolder": "temp/publish",
+
+      /**
        * An optional version policy associated with the project.  Version policies are defined
        * in "version-policies.json" file.  See the "rush publish" documentation for more info.
        * NOTE: "versionPolicyName" and "shouldPublish" are alternatives; you cannot specify them both.

--- a/apps/rush-lib/src/api/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/api/RushConfigurationProject.ts
@@ -29,6 +29,7 @@ export interface IRushConfigurationProjectJson {
   versionPolicyName?: string;
   shouldPublish?: boolean;
   skipRushCheck?: boolean;
+  publishFolder?: string;
 }
 
 /**
@@ -52,6 +53,8 @@ export class RushConfigurationProject {
   private _versionPolicy: VersionPolicy | undefined;
   private _shouldPublish: boolean;
   private _skipRushCheck: boolean;
+  private _publishFolder: string;
+  private _publishRelativeFolder: string;
   private _downstreamDependencyProjects: string[];
   private _localDependencyProjects: ReadonlyArray<RushConfigurationProject> | undefined;
   private readonly _rushConfiguration: RushConfiguration;
@@ -144,6 +147,13 @@ export class RushConfigurationProject {
     this._skipRushCheck = !!projectJson.skipRushCheck;
     this._downstreamDependencyProjects = [];
     this._versionPolicyName = projectJson.versionPolicyName;
+
+    this._publishRelativeFolder = this._projectRelativeFolder;
+    this._publishFolder = this._projectFolder;
+    if (projectJson.publishFolder) {
+      this._publishRelativeFolder = path.join(this._publishRelativeFolder, projectJson.publishFolder);
+      this._publishFolder = path.join(this._publishFolder, projectJson.publishFolder);
+    }
   }
 
   /**
@@ -298,6 +308,24 @@ export class RushConfigurationProject {
    */
   public get versionPolicyName(): string | undefined {
     return this._versionPolicyName;
+  }
+
+  /**
+   * The full path of the folder that will get published by Rush.
+   *
+   * Example: `C:\MyRepo\libraries\my-project`
+   */
+  public get publishFolder(): string {
+    return this._publishFolder;
+  }
+
+  /**
+   * The relative path of the folder that will get published by Rush.
+   *
+   * Example: `libraries\my-project`
+   */
+  public get publishRelativeFolder(): string {
+    return this._publishRelativeFolder;
   }
 
   /**

--- a/apps/rush-lib/src/api/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/api/RushConfigurationProject.ts
@@ -54,7 +54,6 @@ export class RushConfigurationProject {
   private _shouldPublish: boolean;
   private _skipRushCheck: boolean;
   private _publishFolder: string;
-  private _publishRelativeFolder: string;
   private _downstreamDependencyProjects: string[];
   private _localDependencyProjects: ReadonlyArray<RushConfigurationProject> | undefined;
   private readonly _rushConfiguration: RushConfiguration;
@@ -148,10 +147,8 @@ export class RushConfigurationProject {
     this._downstreamDependencyProjects = [];
     this._versionPolicyName = projectJson.versionPolicyName;
 
-    this._publishRelativeFolder = this._projectRelativeFolder;
     this._publishFolder = this._projectFolder;
     if (projectJson.publishFolder) {
-      this._publishRelativeFolder = path.join(this._publishRelativeFolder, projectJson.publishFolder);
       this._publishFolder = path.join(this._publishFolder, projectJson.publishFolder);
     }
   }
@@ -313,19 +310,14 @@ export class RushConfigurationProject {
   /**
    * The full path of the folder that will get published by Rush.
    *
-   * Example: `C:\MyRepo\libraries\my-project`
+   * @remarks
+   * By default this is the same as the project folder, but a custom folder can be specified
+   * using the the "publishFolder" setting in rush.json.
+   *
+   * Example: `C:\MyRepo\libraries\my-project\temp\publish`
    */
   public get publishFolder(): string {
     return this._publishFolder;
-  }
-
-  /**
-   * The relative path of the folder that will get published by Rush.
-   *
-   * Example: `libraries\my-project`
-   */
-  public get publishRelativeFolder(): string {
-    return this._publishRelativeFolder;
   }
 
   /**

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -311,7 +311,7 @@ export class PublishAction extends BaseRushAction {
             const project: RushConfigurationProject | undefined = allPackages.get(change.packageName);
             if (project) {
               if (!this._packageExists(project)) {
-                this._npmPublish(change.packageName, project.projectFolder);
+                this._npmPublish(change.packageName, project.publishFolder);
               } else {
                 console.log(`Skip ${change.packageName}. Package exists.`);
               }
@@ -344,6 +344,7 @@ export class PublishAction extends BaseRushAction {
     console.log(`Rush publish starts with includeAll and version policy ${this._versionPolicy.value}`);
 
     let updated: boolean = false;
+
     allPackages.forEach((packageConfig, packageName) => {
       if (
         packageConfig.shouldPublish &&
@@ -374,13 +375,14 @@ export class PublishAction extends BaseRushAction {
           applyTag(this._applyGitTagsOnPack.value);
         } else if (this._force.value || !this._packageExists(packageConfig)) {
           // Publish to npm repository
-          this._npmPublish(packageName, packageConfig.projectFolder);
+          this._npmPublish(packageName, packageConfig.publishFolder);
           applyTag(true);
         } else {
           console.log(`Skip ${packageName}. Not updated.`);
         }
       }
     });
+
     if (updated) {
       git.push(this._targetBranch.value!);
     }
@@ -462,7 +464,7 @@ export class PublishAction extends BaseRushAction {
 
     const publishedVersions: string[] = Npm.publishedVersions(
       packageConfig.packageName,
-      packageConfig.projectFolder,
+      packageConfig.publishFolder,
       env,
       args
     );
@@ -477,14 +479,14 @@ export class PublishAction extends BaseRushAction {
       !!this._publish.value,
       this.rushConfiguration.packageManagerToolFilename,
       args,
-      project.projectFolder,
+      project.publishFolder,
       env
     );
 
     if (this._publish.value) {
       // Copy the tarball the release folder
       const tarballName: string = this._calculateTarballName(project);
-      const tarballPath: string = path.join(project.projectFolder, tarballName);
+      const tarballPath: string = path.join(project.publishFolder, tarballName);
       const destFolder: string = this._releaseFolder.value
         ? this._releaseFolder.value
         : path.join(this.rushConfiguration.commonTempFolder, 'artifacts', 'packages');

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -261,6 +261,10 @@
           "versionPolicyName": {
             "description": "An optional version policy associated with the project. Version policies are defined in \"version-policies.json\" file.",
             "type": "string"
+          },
+          "publishFolder": {
+            "description": "An optional path relative to the project folder that will be used by the \"rush publish\" command.",
+            "type": "string"
           }
         },
         "additionalProperties": false,

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -263,7 +263,7 @@
             "type": "string"
           },
           "publishFolder": {
-            "description": "An optional path relative to the project folder that will be used by the \"rush publish\" command.",
+            "description": "Facilitates postprocessing of a project's files prior to publishing. If specified, the \"publishFolder\" is the relative path to a subfolder of the project folder. The \"rush publish\" command will publish the subfolder instead of the project folder. The subfolder must contain its own package.json file, which is typically a build output.",
             "type": "string"
           }
         },

--- a/common/changes/@microsoft/rush/feat-publish-folder_2020-12-16-21-26.json
+++ b/common/changes/@microsoft/rush/feat-publish-folder_2020-12-16-21-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add `publishFolder` property to the project configuration to allow publishing a sub-folder of the project",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "manrueda@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -426,7 +426,6 @@ export class RushConfigurationProject {
     get projectRushConfigFolder(): string;
     get projectRushTempFolder(): string;
     get publishFolder(): string;
-    get publishRelativeFolder(): string;
     get reviewCategory(): string | undefined;
     get rushConfiguration(): RushConfiguration;
     get shouldPublish(): boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -425,6 +425,8 @@ export class RushConfigurationProject {
     get projectRelativeFolder(): string;
     get projectRushConfigFolder(): string;
     get projectRushTempFolder(): string;
+    get publishFolder(): string;
+    get publishRelativeFolder(): string;
     get reviewCategory(): string | undefined;
     get rushConfiguration(): RushConfiguration;
     get shouldPublish(): boolean;


### PR DESCRIPTION
## Summary

Add a new project configuration that allows to customize the folder that will be used during the `rush publish` process.

By default that configuration will be equal to the `projectFolder` value.

~~This implementation only works with pnpm workspace, the trick is to create a temporal project in the workspace for each project that will get published and uses the new `publishFolder` setting, run the publish command on the subfolder and then remove the temporal project.~~

~~This temporal projects are required because the packages being published must be part of the workspace and have the dependencies installed. Thanks to pnpm cache and linking, the process is really fast.~~

## How it was tested

- Changed the settings for `@microsoft/api-documenter` to use the new `publishFolder` setting as `dist`
- Copy the `@microsoft/api-documenter` into the `dist` folder manually
- Replace all usage of `workspace:*` with fixed versions
- Run the following command to pack all project
   ```bash
      node .\apps\rush-lib\lib\start.js publish -p --include-all --pack --release-folder .
   ```
- Confirm that the generated `microsoft-api-documenter-N.N.N.tgz` file has the content of the `dist` folder and not the content of the root folder of that project.


Related to #728


