### PR TITLE
[Rush] Fix an issue with generation of Azure Storage SAS.

### DIFF
--- a/common/changes/@microsoft/rush/ianc-fix-sas_2020-12-25-00-37.json
+++ b/common/changes/@microsoft/rush/ianc-fix-sas_2020-12-25-00-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR fixes a few issues with the way the Azure Storage SAS was generated. Namely:

- The parameter names must be the abbreviations listed [here](https://docs.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas)
- The container "write" permission is required for creating new blobs instead of the "create" permission
