### PR TITLE
[rush] Allow the cache entry name to be configured.

### DIFF
--- a/apps/rush-lib/src/cli/actions/UpdateCloudCredentials.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateCloudCredentials.ts
@@ -56,7 +56,7 @@ export class UpdateCloudCredentials extends BaseRushAction {
 
     const buildCacheConfiguration:
       | BuildCacheConfiguration
-      | undefined = await BuildCacheConfiguration.loadFromDefaultPathAsync(this.rushConfiguration);
+      | undefined = await BuildCacheConfiguration.loadFromDefaultPathAsync(terminal, this.rushConfiguration);
 
     if (!buildCacheConfiguration) {
       const buildCacheConfigurationFilePath: string = BuildCacheConfiguration.getBuildCacheConfigFilePath(
@@ -78,9 +78,7 @@ export class UpdateCloudCredentials extends BaseRushAction {
       } else if (buildCacheConfiguration.cloudCacheProvider) {
         await buildCacheConfiguration.cloudCacheProvider.deleteCachedCredentialsAsync(terminal);
       } else {
-        terminal.writeLine(
-          'A cloud build cache is not configured; there is nothing to delete.'
-        );
+        terminal.writeLine('A cloud build cache is not configured; there is nothing to delete.');
       }
     } else if (this._interactiveModeFlag.value && this._credentialParameter.value !== undefined) {
       terminal.writeErrorLine(

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -4,7 +4,7 @@
 import * as os from 'os';
 import colors from 'colors';
 
-import { AlreadyReportedError } from '@rushstack/node-core-library';
+import { AlreadyReportedError, ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import {
   CommandLineFlagParameter,
   CommandLineStringParameter,
@@ -110,9 +110,10 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const changedProjectsOnly: boolean = this._isIncrementalBuildAllowed && this._changedProjectsOnly.value;
 
+    const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const buildCacheConfiguration:
       | BuildCacheConfiguration
-      | undefined = await BuildCacheConfiguration.loadFromDefaultPathAsync(this.rushConfiguration);
+      | undefined = await BuildCacheConfiguration.loadFromDefaultPathAsync(terminal, this.rushConfiguration);
 
     const taskSelector: TaskSelector = new TaskSelector({
       rushConfiguration: this.rushConfiguration,

--- a/apps/rush-lib/src/logic/buildCache/CacheEntryId.ts
+++ b/apps/rush-lib/src/logic/buildCache/CacheEntryId.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const OPTIONS_ARGUMENT_NAME: string = 'options';
+
+export interface IGenerateCacheEntryIdOptions {
+  projectName: string;
+  projectStateHash: string;
+}
+
+export type GetCacheEntryIdFunction = (options: IGenerateCacheEntryIdOptions) => string;
+
+const HASH_TOKEN_NAME: string = 'hash';
+const PROJECT_NAME_TOKEN_NAME: string = 'projectName';
+
+export class CacheEntryId {
+  private constructor() {}
+
+  public static parsePattern(pattern?: string): GetCacheEntryIdFunction {
+    if (!pattern) {
+      return ({ projectStateHash }) => projectStateHash;
+    } else {
+      pattern = pattern.trim();
+
+      if (pattern.startsWith('/')) {
+        throw new Error('Cache entry name patterns may not start with a slash.');
+      }
+
+      const parts: string[] = [];
+
+      let lastCharacterWasEscape: boolean = false;
+      let inToken: boolean = false;
+      let buffer: string = '';
+      let foundHashToken: boolean = false;
+
+      function insertBufferAsStaticPart(): void {
+        if (buffer !== '') {
+          if (buffer.match(/^[A-z0-9-_\/]*$/)) {
+            parts.push(buffer);
+            buffer = '';
+          } else {
+            throw new Error(
+              'Cache entry name pattern contains an invalid character. ' +
+                'Only alphanumeric characters, slashes, underscores, and hyphens are allowed.'
+            );
+          }
+        }
+      }
+
+      for (let i: number = 0; i < pattern.length; i++) {
+        const char: string = pattern[i];
+
+        if (lastCharacterWasEscape) {
+          buffer += char;
+          lastCharacterWasEscape = false;
+        } else if (char === '\\') {
+          lastCharacterWasEscape = true;
+        } else if (char === '[' && !lastCharacterWasEscape) {
+          if (inToken) {
+            throw new Error(`Unexpected "[" character in cache entry name pattern at index ${i}.`);
+          } else {
+            insertBufferAsStaticPart();
+            inToken = true;
+          }
+        } else if (char === ']' && !lastCharacterWasEscape) {
+          if (!inToken) {
+            throw new Error(`Unexpected "]" character in cache entry name pattern at index ${i}.`);
+          } else {
+            let tokenName: string;
+            let tokenAttribute: string | undefined;
+            const tokenSplitIndex: number = buffer.indexOf(':');
+            if (tokenSplitIndex === -1) {
+              tokenName = buffer;
+            } else {
+              tokenName = buffer.substr(0, tokenSplitIndex);
+              tokenAttribute = buffer.substr(tokenSplitIndex + 1);
+            }
+
+            inToken = false;
+            buffer = '';
+
+            switch (tokenName) {
+              case HASH_TOKEN_NAME: {
+                if (tokenAttribute !== undefined) {
+                  throw new Error(`An attribute isn\'t supported for the "${tokenName}" token.`);
+                }
+
+                foundHashToken = true;
+                parts.push(`\${${OPTIONS_ARGUMENT_NAME}.projectStateHash}`);
+                break;
+              }
+
+              case PROJECT_NAME_TOKEN_NAME: {
+                switch (tokenAttribute) {
+                  case undefined: {
+                    parts.push(`\${${OPTIONS_ARGUMENT_NAME}.projectName}`);
+                    break;
+                  }
+
+                  case 'normalize': {
+                    parts.push(
+                      `\${${OPTIONS_ARGUMENT_NAME}.projectName.replace(/\\+/g, '++').replace(/\\/\/g, '+')}`
+                    );
+                    break;
+                  }
+
+                  default: {
+                    throw new Error(`Unexpected attribute "${tokenAttribute}" for the "${tokenName}" token.`);
+                  }
+                }
+
+                break;
+              }
+
+              default: {
+                throw new Error(`Unexpected token name "${tokenName}".`);
+              }
+            }
+          }
+        } else {
+          buffer += char;
+        }
+      }
+
+      if (inToken) {
+        throw new Error('Unclosed token in cache entry name pattern.');
+      } else if (lastCharacterWasEscape) {
+        throw new Error('Incomplete escape sequence in cache entry name pattern.');
+      } else {
+        insertBufferAsStaticPart();
+      }
+
+      if (!foundHashToken) {
+        throw new Error(`Cache entry name pattern is missing a [${HASH_TOKEN_NAME}] token.`);
+      }
+
+      // eslint-disable-next-line no-new-func
+      return new Function(
+        OPTIONS_ARGUMENT_NAME,
+        `"use strict"\nreturn \`${parts.join('')}\`;`
+      ) as GetCacheEntryIdFunction;
+    }
+  }
+}

--- a/apps/rush-lib/src/logic/buildCache/test/CacheEntryId.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/CacheEntryId.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { CacheEntryId, GetCacheEntryIdFunction } from '../CacheEntryId';
+
+describe(CacheEntryId.name, () => {
+  describe('Valid pattern names', () => {
+    function validatePatternMatchesSnapshot(projectName: string, pattern?: string): void {
+      const getCacheEntryId: GetCacheEntryIdFunction = CacheEntryId.parsePattern(pattern);
+      expect(
+        getCacheEntryId({
+          projectName,
+          projectStateHash: '09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3'
+        })
+      ).toMatchSnapshot();
+    }
+
+    it('Handles a cache entry name for a project name without a scope', () => {
+      const projectName: string = 'project+name';
+      validatePatternMatchesSnapshot(projectName);
+      validatePatternMatchesSnapshot(projectName, '[hash]');
+      validatePatternMatchesSnapshot(projectName, '[projectName]_[hash]');
+      validatePatternMatchesSnapshot(projectName, '[projectName:normalize]_[hash]');
+      validatePatternMatchesSnapshot(projectName, 'prefix/[projectName:normalize]_[hash]');
+    });
+
+    it('Handles a cache entry name for a project name with a scope', () => {
+      const projectName: string = '@scope/project+name';
+      validatePatternMatchesSnapshot(projectName);
+      validatePatternMatchesSnapshot(projectName, '[hash]');
+      validatePatternMatchesSnapshot(projectName, '[projectName]_[hash]');
+      validatePatternMatchesSnapshot(projectName, '[projectName:normalize]_[hash]');
+      validatePatternMatchesSnapshot(projectName, 'prefix/[projectName:normalize]_[hash]');
+    });
+  });
+
+  describe('Invalid pattern names', () => {
+    async function validateInvalidPatternErrorMatchesSnapshotAsync(pattern: string): Promise<void> {
+      await expect(() => CacheEntryId.parsePattern(pattern)).toThrowErrorMatchingSnapshot();
+    }
+
+    it('Throws an exception for an invalid pattern', async () => {
+      await validateInvalidPatternErrorMatchesSnapshotAsync('x');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[invalidTag]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('unstartedTag]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[incompleteTag');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[hash:badAttribute]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[hash:badAttribute:attr2]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[projectName:badAttribute]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[projectName:]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[:attr1]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('[projectName:attr1:attr2]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('/[hash]');
+      await validateInvalidPatternErrorMatchesSnapshotAsync('~');
+    });
+  });
+});

--- a/apps/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
+++ b/apps/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 1`] = `"Cache entry name pattern is missing a [hash] token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 2`] = `"Unexpected token name \\"invalidTag\\"."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 3`] = `"Unexpected \\"]\\" character in cache entry name pattern at index 12."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 4`] = `"Unclosed token in cache entry name pattern."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 5`] = `"An attribute isn't supported for the \\"hash\\" token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 6`] = `"An attribute isn't supported for the \\"hash\\" token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 7`] = `"Unexpected attribute \\"badAttribute\\" for the \\"projectName\\" token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 8`] = `"Unexpected attribute \\"\\" for the \\"projectName\\" token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 9`] = `"Unexpected token name \\"\\"."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 10`] = `"Unexpected attribute \\"attr1:attr2\\" for the \\"projectName\\" token."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 11`] = `"Cache entry name patterns may not start with a slash."`;
+
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 12`] = `"Cache entry name pattern contains an invalid character. Only alphanumeric characters, slashes, underscores, and hyphens are allowed."`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope 1`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope 2`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope 3`] = `"@scope/project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope 4`] = `"@scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope 5`] = `"prefix/@scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope 1`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope 2`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope 3`] = `"project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope 4`] = `"project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope 5`] = `"prefix/project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;

--- a/apps/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
+++ b/apps/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
@@ -4,7 +4,7 @@ exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid p
 
 exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 2`] = `"Unexpected token name \\"invalidTag\\"."`;
 
-exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 3`] = `"Unexpected \\"]\\" character in cache entry name pattern at index 12."`;
+exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 3`] = `"Unexpected \\"]\\" character in cache entry name pattern."`;
 
 exports[`CacheEntryId Invalid pattern names Throws an exception for an invalid pattern 4`] = `"Unclosed token in cache entry name pattern."`;
 

--- a/apps/rush-lib/src/schemas/build-cache.schema.json
+++ b/apps/rush-lib/src/schemas/build-cache.schema.json
@@ -3,6 +3,13 @@
   "title": "Configuration for Rush's build cache.",
   "description": "For use with the Rush tool, this file provides configuration options for cached project build output. See http://rushjs.io for details.",
 
+  "definitions": {
+    "anything": {
+      "type": ["array", "boolean", "integer", "number", "object", "string"],
+      "items": { "$ref": "#/definitions/anything" }
+    }
+  },
+
   "type": "object",
   "allOf": [
     {
@@ -16,6 +23,11 @@
         "cacheProvider": {
           "type": "string",
           "enum": ["local-only", "azure-blob-storage"]
+        },
+
+        "cacheEntryNamePattern": {
+          "type": "string",
+          "description": "Setting this property overrides the cache entry ID. If this property is set, it must contain a [hash] token. It may also contain a [projectName] or a [projectName:normalized] token."
         }
       }
     },
@@ -27,7 +39,9 @@
             "cacheProvider": {
               "type": "string",
               "enum": ["local-only"]
-            }
+            },
+
+            "cacheEntryNamePattern": { "$ref": "#/definitions/anything" }
           }
         },
 
@@ -39,6 +53,8 @@
               "type": "string",
               "enum": ["azure-blob-storage"]
             },
+
+            "cacheEntryNamePattern": { "$ref": "#/definitions/anything" },
 
             "azureBlobStorageConfiguration": {
               "type": "object",

--- a/common/changes/@microsoft/rush/ianc-customize-cache-entry-names_2021-01-06-07-56.json
+++ b/common/changes/@microsoft/rush/ianc-customize-cache-entry-names_2021-01-06-07-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR introduces a `cacheEntryNamePattern` to `common/config/rush/build-cache.json` to allow the cache entry IDs to be configured.

This field allows for patterns containing alphanumeric characters, slashes, underscores, and hyphens and tokens `[hash]` (which is replaced with the project state hash), `[projectName]` (which is replaced with the project's package name), and `[projectName:normalized]` (which is replaced with the project's package name, but with `/` characters replaced with `+` characters).