### PR TITLE
[rush-init] update template pnpm to latest version

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "4.14.4",
+  "pnpmVersion": "5.14.3",
 
   /*[LINE "HYPOTHETICAL"]*/ "npmVersion": "4.5.0",
   /*[LINE "HYPOTHETICAL"]*/ "yarnVersion": "1.9.4",

--- a/common/changes/@microsoft/rush/update-init-template_2021-01-08-02-53.json
+++ b/common/changes/@microsoft/rush/update-init-template_2021-01-08-02-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "use pnpm 5 when rush init",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "liucheng.tech@outlook.com"
+}

--- a/common/changes/@microsoft/rush/update-init-template_2021-01-08-02-53.json
+++ b/common/changes/@microsoft/rush/update-init-template_2021-01-08-02-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "use pnpm 5 when rush init",
+      "comment": "Update rush.json produced by rush init to use PNPM 5.14.3",
       "type": "none"
     }
   ],


### PR DESCRIPTION

## Details

when `rush init` the default pnpm version is 4, this PR try to update to use the latest version of pnpm