### PR TITLE
[rush] Fix an issue where an empty (but not missing) script would always result in an error.

### DIFF
--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -47,7 +47,7 @@ export class TaskSelector {
   ): string | undefined {
     const script: string | undefined = TaskSelector._getScriptCommand(rushProject, commandToRun);
 
-    if (!script) {
+    if (script === undefined) {
       return undefined;
     }
 
@@ -201,7 +201,7 @@ export class TaskSelector {
       this._options.commandToRun,
       this._options.customParameterValues
     );
-    if (!commandToRun && !this._options.ignoreMissingScript) {
+    if (commandToRun === undefined && !this._options.ignoreMissingScript) {
       throw new Error(
         `The project [${project.packageName}] does not define a '${this._options.commandToRun}' command in the 'scripts' section of its package.json`
       );

--- a/common/changes/@microsoft/rush/ianc-fix-missing-command-error_2021-01-08-03-41.json
+++ b/common/changes/@microsoft/rush/ianc-fix-missing-command-error_2021-01-08-03-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This is a mistake I made here: https://github.com/microsoft/rushstack/pull/2421