### PR TITLE
[rush] Improve logging for write-build-cache.

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/FileSystemBuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/FileSystemBuildCacheProvider.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { FileSystem } from '@rushstack/node-core-library';
+import { FileSystem, Terminal } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { RushUserConfiguration } from '../../api/RushUserConfiguration';
@@ -23,12 +23,16 @@ export class FileSystemBuildCacheProvider {
       path.join(options.rushConfiguration.commonTempFolder, BUILD_CACHE_FOLDER_NAME);
   }
 
-  public async tryGetCacheEntryBufferByIdAsync(cacheId: string): Promise<Buffer | undefined> {
+  public async tryGetCacheEntryBufferByIdAsync(
+    terminal: Terminal,
+    cacheId: string
+  ): Promise<Buffer | undefined> {
     const cacheEntryFilePath: string = path.join(this._cacheFolderPath, cacheId);
     try {
       return await FileSystem.readFileToBufferAsync(cacheEntryFilePath);
     } catch (e) {
       if (FileSystem.isNotExistError(e)) {
+        terminal.writeVerboseLine(`Cache entry at "${cacheEntryFilePath}" was not found.`);
         return undefined;
       } else {
         throw e;
@@ -36,9 +40,14 @@ export class FileSystemBuildCacheProvider {
     }
   }
 
-  public async trySetCacheEntryBufferAsync(cacheId: string, entryBuffer: Buffer): Promise<boolean> {
+  public async trySetCacheEntryBufferAsync(
+    terminal: Terminal,
+    cacheId: string,
+    entryBuffer: Buffer
+  ): Promise<boolean> {
     const cacheEntryFilePath: string = path.join(this._cacheFolderPath, cacheId);
     await FileSystem.writeFileAsync(cacheEntryFilePath, entryBuffer, { ensureFolderExists: true });
+    terminal.writeVerboseLine(`Wrote cache entry to "${cacheEntryFilePath}".`);
     return true;
   }
 }

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -95,7 +95,7 @@ export class ProjectBuildCache {
 
     let cacheEntryBuffer:
       | Buffer
-      | undefined = await this._localBuildCacheProvider.tryGetCacheEntryBufferByIdAsync(cacheId);
+      | undefined = await this._localBuildCacheProvider.tryGetCacheEntryBufferByIdAsync(terminal, cacheId);
     const foundInLocalCache: boolean = !!cacheEntryBuffer;
     if (!foundInLocalCache && this._cloudBuildCacheProvider) {
       terminal.writeVerboseLine(
@@ -116,6 +116,7 @@ export class ProjectBuildCache {
       return false;
     } else if (!foundInLocalCache) {
       setLocalCacheEntryPromise = this._localBuildCacheProvider.trySetCacheEntryBufferAsync(
+        terminal,
         cacheId,
         cacheEntryBuffer
       );
@@ -220,6 +221,7 @@ export class ProjectBuildCache {
     }
 
     const setLocalCacheEntryPromise: Promise<boolean> = this._localBuildCacheProvider.trySetCacheEntryBufferAsync(
+      terminal,
       cacheId,
       cacheEntryBuffer
     );

--- a/common/changes/@microsoft/rush/ianc-improve-write-build-cache-logging_2021-01-12-01-18.json
+++ b/common/changes/@microsoft/rush/ianc-improve-write-build-cache-logging_2021-01-12-01-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve logging for write-build-cache.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
Logging messages for write-build-cache are not clear, especially in the case when caching isn't supported for a project.

This PR adds a `--verbose` flag to `write-build-cache`, and includes a logging message in the case that the project doesn't support caching.