### PR TITLE
[heft] Improve a couple minor things.

### DIFF
--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -60,3 +60,6 @@ export {
   IHeftLifecycle as _IHeftLifecycle,
   HeftLifecycleHooks as _HeftLifecycleHooks
 } from './pluginFramework/HeftLifecycle';
+
+// Utilites
+export { Async } from './utilities/Async';

--- a/apps/heft/src/utilities/Async.ts
+++ b/apps/heft/src/utilities/Async.ts
@@ -3,7 +3,13 @@
 
 import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 
+/**
+ * Helpful async utility methods
+ */
 export class Async {
+  /**
+   * Utility method to limit the number of parallel async operations with a promise queue.
+   */
   public static async forEachLimitAsync<TEntry>(
     array: TEntry[],
     parallelismLimit: number,
@@ -39,6 +45,9 @@ export class Async {
     });
   }
 
+  /**
+   * Utility method to continuously run an async watcher in Heft's watchMode.
+   */
   public static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: ScopedLogger): void {
     try {
       fn().catch((e) => scopedLogger.emitError(e));

--- a/common/changes/@rushstack/heft-web-rig/halfnibble-fix-minor-things_2021-01-12-05-38.json
+++ b/common/changes/@rushstack/heft-web-rig/halfnibble-fix-minor-things_2021-01-12-05-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Update static assets to copy defaults",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/halfnibble-fix-minor-things_2021-01-12-05-38.json
+++ b/common/changes/@rushstack/heft/halfnibble-fix-minor-things_2021-01-12-05-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Export Async utility methods.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -20,6 +20,12 @@ import { SyncHook } from 'tapable';
 import { Terminal } from '@rushstack/node-core-library';
 import * as webpack from 'webpack';
 
+// @public
+export class Async {
+    static forEachLimitAsync<TEntry>(array: TEntry[], parallelismLimit: number, fn: (entry: TEntry) => Promise<void>): Promise<void>;
+    static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: ScopedLogger): void;
+}
+
 // @public (undocumented)
 export class BuildStageHooks extends StageHooksBase<IBuildStageProperties> {
     // (undocumented)

--- a/rigs/heft-web-rig/profiles/library/config/typescript.json
+++ b/rigs/heft-web-rig/profiles/library/config/typescript.json
@@ -56,7 +56,26 @@
     /**
      * File extensions that should be copied from the src folder to the destination folder(s).
      */
-    "fileExtensions": [".json"]
+    "fileExtensions": [
+      ".json",
+      // Fonts
+      ".eot",
+      ".ttf",
+      ".woff",
+      // Images
+      ".dds",
+      ".gif",
+      ".ico",
+      ".jpeg",
+      ".jpg",
+      ".png",
+      ".svg",
+      ".webp",
+      // Styles
+      ".css",
+      ".sass",
+      ".scss"
+    ]
 
     /**
      * Glob patterns that should be explicitly included.


### PR DESCRIPTION
## Summary

Two small changes to help Heft developers.

## Details

1. Export the Async utility methods so other Heft plugin developers can make use of them for plugins that support watchMode and multiple parallel async operations.

2. Update the default staticAssetsToCopy to this:
```
    "fileExtensions": [
      ".json",
      // Fonts
      ".eot",
      ".ttf",
      ".woff",
      // Images
      ".dds",
      ".gif",
      ".ico",
      ".jpeg",
      ".jpg",
      ".png",
      ".svg",
      ".webp",
      // Styles
      ".css",
      ".sass",
      ".scss"
    ]
```
## How it was tested

In our internal repo.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
