### PR TITLE
Gulp 4 compatibility: No longer pass empty string as glob argument for ServeTask and ReloadTask

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-serve/keco-gulp4-compat_2021-01-12-20-30.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/keco-gulp4-compat_2021-01-12-20-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Update source glob argument to be non-empty string for Gulp 4 compat",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-serve/src/ReloadTask.ts
+++ b/core-build/gulp-core-build-serve/src/ReloadTask.ts
@@ -13,7 +13,7 @@ export class ReloadTask extends GulpTask<void> {
     // eslint-disable-next-line
     const gulpConnect = require('gulp-connect');
 
-    gulp.src('').pipe(gulpConnect.reload());
+    gulp.src('.').pipe(gulpConnect.reload());
 
     completeCallback();
   }

--- a/core-build/gulp-core-build-serve/src/ServeTask.ts
+++ b/core-build/gulp-core-build-serve/src/ServeTask.ts
@@ -199,7 +199,7 @@ export class ServeTask<TExtendedConfig = {}> extends GulpTask<IServeTaskConfig &
         }:${port}${initialPage}`;
       }
 
-      gulp.src('').pipe(
+      gulp.src('.').pipe(
         open({
           uri: uri
         })


### PR DESCRIPTION
Gulp 4 throws an error at runtime for empty string as glob argument. This change resolves those errors.

```shell
[12:05:52] Starting 'serve-deprecated'...
[12:05:52] Starting gulp
[12:05:52] Starting subtask 'configure-sp-build-rig'...
[12:05:52] Finished subtask 'configure-sp-build-rig' after 11 ms    
[12:05:52] Starting subtask 'record-build-metadata'...
[12:05:52] Finished subtask 'record-build-metadata' after 290 μs    
[12:05:52] Starting subtask 'record-start-time-metadata'...
[12:05:52] Finished subtask 'record-start-time-metadata' after 273 μs
[12:05:52] Starting subtask 'spfx-serve'...
[12:05:52] [spfx-serve] To load your scripts, use this query string: ?debug=true&noredir=true&debugManifestsFile=https://localhost:4321/temp/manifests.js
[12:05:53] Starting server...
[12:05:53] Error - [spfx-serve] Error: Invalid glob argument: 
[12:05:53] Error - 'spfx-serve' sub task errored after 1.05 s 
 Invalid glob argument: 
[12:05:53] 'serve-deprecated' errored after 1.07 s
```