### PR TITLE
[rush] Add `--from` to `rush install`

### DIFF
--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -9,7 +9,9 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 
 export class InstallAction extends BaseInstallAction {
   protected _toFlag!: CommandLineStringListParameter;
+  protected _fromFlag!: CommandLineStringListParameter;
   protected _toVersionPolicy!: CommandLineStringListParameter;
+  protected _fromVersionPolicy!: CommandLineStringListParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -44,12 +46,29 @@ export class InstallAction extends BaseInstallAction {
         'to specify the project in the current working directory. This argument is only valid in workspace ' +
         'environments.'
     });
+    this._fromFlag = this.defineStringListParameter({
+      parameterLongName: '--from',
+      parameterShortName: '-f',
+      argumentName: 'PROJECT2',
+      description:
+        'Run install in the specified project and all projects that directly or indirectly depend on the ' +
+        'specified project. "." can be used as shorthand to specify the project in the current working directory.' +
+        ' This argument is only valid in workspace environments.'
+    });
     this._toVersionPolicy = this.defineStringListParameter({
       parameterLongName: '--to-version-policy',
       argumentName: 'VERSION_POLICY_NAME',
       description:
         'Run install in all projects with the specified version policy and all of their dependencies. ' +
         'This argument is only valid in workspace environments.'
+    });
+    this._fromVersionPolicy = this.defineStringListParameter({
+      parameterLongName: '--from-version-policy',
+      argumentName: 'VERSION_POLICY_NAME',
+      description:
+        'Run command in all projects with the specified version policy ' +
+        'and all projects that directly or indirectly depend on projects with the specified version policy.' +
+        ' This argument is only valid in workspace environments.'
     });
   }
 
@@ -67,7 +86,8 @@ export class InstallAction extends BaseInstallAction {
       // Because the 'defaultValue' option on the _maxInstallAttempts parameter is set,
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
-      toProjects: this.mergeProjectsWithVersionPolicy(this._toFlag, this._toVersionPolicy)
+      toProjects: this.mergeProjectsWithVersionPolicy(this._toFlag, this._toVersionPolicy),
+      fromProjects: this.mergeProjectsWithVersionPolicy(this._fromFlag, this._fromVersionPolicy)
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -70,7 +70,8 @@ export class UpdateAction extends BaseInstallAction {
       // Because the 'defaultValue' option on the _maxInstallAttempts parameter is set,
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
-      toProjects: []
+      toProjects: [],
+      fromProjects: []
     };
   }
 }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -400,8 +400,9 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
 "usage: rush install [-h] [-p] [--bypass-policy] [--no-link]
                     [--network-concurrency COUNT] [--debug-package-manager]
                     [--max-install-attempts NUMBER] [--ignore-hooks]
-                    [--variant VARIANT] [-t PROJECT1]
+                    [--variant VARIANT] [-t PROJECT1] [-f PROJECT2]
                     [--to-version-policy VERSION_POLICY_NAME]
+                    [--from-version-policy VERSION_POLICY_NAME]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -450,10 +451,22 @@ Optional arguments:
                         dependencies. \\".\\" can be used as shorthand to specify 
                         the project in the current working directory. This 
                         argument is only valid in workspace environments.
+  -f PROJECT2, --from PROJECT2
+                        Run install in the specified project and all projects 
+                        that directly or indirectly depend on the specified 
+                        project. \\".\\" can be used as shorthand to specify the 
+                        project in the current working directory. This 
+                        argument is only valid in workspace environments.
   --to-version-policy VERSION_POLICY_NAME
                         Run install in all projects with the specified 
                         version policy and all of their dependencies. This 
                         argument is only valid in workspace environments.
+  --from-version-policy VERSION_POLICY_NAME
+                        Run command in all projects with the specified 
+                        version policy and all projects that directly or 
+                        indirectly depend on projects with the specified 
+                        version policy. This argument is only valid in 
+                        workspace environments.
 "
 `;
 

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -143,7 +143,8 @@ export class PackageJsonUpdater {
       collectLogFile: false,
       variant: variant,
       maxInstallAttempts: RushConstants.defaultMaxInstallAttempts,
-      toProjects: []
+      toProjects: [],
+      fromProjects: []
     };
     const installManager: BaseInstallManager = InstallManagerFactory.getInstallManager(
       this._rushConfiguration,

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -102,6 +102,11 @@ export interface IInstallManagerOptions {
    * The list of projects that should be installed, along with project dependencies.
    */
   toProjects: ReadonlyArray<RushConfigurationProject>;
+
+  /**
+   * The list of projects that should be installed, along with dependencies of the project.
+   */
+  fromProjects: ReadonlyArray<RushConfigurationProject>;
 }
 
 /**
@@ -148,7 +153,8 @@ export abstract class BaseInstallManager {
   }
 
   public async doInstall(): Promise<void> {
-    const isFilteredInstall: boolean = this.options.toProjects.length > 0;
+    const isFilteredInstall: boolean =
+      this.options.toProjects.length > 0 || this.options.fromProjects.length > 0;
     const useWorkspaces: boolean =
       this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
 

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -593,8 +593,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
 
       // ..."<package>" selects the specified package and all direct and indirect dependents of that package
-      for (const toProject of this.options.fromProjects) {
-        args.push('--filter', `...${toProject.packageName}`);
+      for (const fromProject of this.options.fromProjects) {
+        args.push('--filter', `...${fromProject.packageName}`);
       }
     }
   }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -522,7 +522,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (!workspaceImporter) {
       // Filtered installs will not contain all projects in the shrinkwrap, but if one is
       // missing during a full install, something has gone wrong
-      if (this.options.toProjects.length === 0) {
+      if (this.options.toProjects.length === 0 && this.options.fromProjects.length === 0) {
         throw new InternalError(
           `Cannot find shrinkwrap entry using importer key for workspace project: ${importerKey}`
         );
@@ -587,9 +587,14 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
-      // "<package>..." selects the specified package and all direct and indirect dependencies
-      for (const toProject of this.options.toProjects) {
-        args.push('--filter', `${toProject.packageName}...`);
+      const filteredProjects: string[] = this.options.toProjects
+        // "<package>..." selects the specified package and all direct and indirect dependencies
+        .map((p) => p.packageName + '...')
+        // ..."<package>" selects the specified package and all direct and indirect dependents of that package
+        .concat(this.options.fromProjects.map((p) => '...' + p.packageName));
+
+      for (const filteredProject of filteredProjects) {
+        args.push('--filter', filteredProject);
       }
     }
   }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -587,14 +587,14 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
-      const filteredProjects: string[] = this.options.toProjects
-        // "<package>..." selects the specified package and all direct and indirect dependencies
-        .map((p) => p.packageName + '...')
-        // ..."<package>" selects the specified package and all direct and indirect dependents of that package
-        .concat(this.options.fromProjects.map((p) => '...' + p.packageName));
+      // "<package>..." selects the specified package and all direct and indirect dependencies
+      for (const toProject of this.options.toProjects) {
+        args.push('--filter', `${toProject.packageName}...`);
+      }
 
-      for (const filteredProject of filteredProjects) {
-        args.push('--filter', filteredProject);
+      // ..."<package>" selects the specified package and all direct and indirect dependents of that package
+      for (const toProject of this.options.fromProjects) {
+        args.push('--filter', `...${toProject.packageName}`);
       }
     }
   }

--- a/common/changes/@microsoft/rush/from-flag_2021-01-13-20-47.json
+++ b/common/changes/@microsoft/rush/from-flag_2021-01-13-20-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for --from flag for filtered installs when using workspaces",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "wbern@users.noreply.github.com"
+}


### PR DESCRIPTION
My first real PR to rush, finally. ❤️ 
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
I added support for `--from`-based installs using `rush install`, currently there is only support for `--to`, and the change was trivial to make, following pnpm workspaces documentation here: https://pnpm.js.org/en/filtering#filter-lt-package_name-

Fixes #2434

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

In my org, we want to install/build/test only the changed projects in our CI, which we are accomplishing with the `--to` flag. However, we see that if we change a widely used package, we want to build and test all the dependents of that package when it gets changed, and publish those packages as well. Hence we have a need for the `--from` flag for `rush install`, a flag already present in the other rush commands we use around building things.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I created an alias called `testrush` locally on my machine and used in our biggest repo, I then did

`testrush install --to @org/my-lib`

I inspected the output being `Scope: 4 out of 124 workspace projects`,

then I ran `testrush install --to @org/my-lib --from @org/my-lib`

Which gave me the output of `Scope: 115 of 124 workspace projects`.

I also tested `testrush install --from @org/my-lib` which returned `Scope: 112 of 124 workspace projects`, so it adds up.

The output from the filtered install in this case is `pnpm install --filter ...@org/my-lib --filter @org/my-lib...`.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->
## Final notes

I know we're changing names of --from/--to to other things later, so open for suggestions how to merge this.
<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
