### PR TITLE
[heft] Update jest-shared.config.json to specify "collectCoverageFrom"

### DIFF
--- a/apps/heft/includes/jest-shared.config.json
+++ b/apps/heft/includes/jest-shared.config.json
@@ -10,7 +10,24 @@
   "roots": ["<rootDir>", "<rootDir>/src"],
 
   "testURL": "http://localhost/",
+
   "testMatch": ["<rootDir>/src/**/*.test.{ts,tsx}"],
+  "testPathIgnorePatterns": ["/node_modules/"],
+
+  "//": "code coverage tracking is disabled by default; set this to true to enable it ",
+  "collectCoverage": false,
+
+  "collectCoverageFrom": [
+    "src/**/*.{ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/**/*.test.{ts,tsx}",
+    "!src/**/test/**",
+    "!src/**/__tests__/**",
+    "!src/**/__fixtures__/**",
+    "!src/**/__mocks__/**"
+  ],
+  "coveragePathIgnorePatterns": ["/node_modules/"],
+
   "transformIgnorePatterns": [],
 
   "//": "jest-identity-mock-transform returns a proxy for exported key/value pairs, where Webpack would return a module",
@@ -22,6 +39,7 @@
 
     "\\.(aac|eot|gif|jpeg|jpg|m4a|mp3|mp4|oga|otf|png|svg|ttf|wav|webm|webp|woff|woff2)$": "@rushstack/heft/lib/exports/jest-string-mock-transform.js"
   },
+
   "//": [
     "The modulePathIgnorePatterns below accepts these sorts of paths:",
     "  <rootDir>/src",
@@ -29,6 +47,7 @@
     "...and ignores anything else under <rootDir>"
   ],
   "modulePathIgnorePatterns": ["^<rootDir>/(?!(?:src/)|(?:src$))"],
+
   "setupFiles": ["@rushstack/heft/lib/exports/jest-global-setup.js"],
   "resolver": "@rushstack/heft/lib/exports/jest-improved-resolver.js",
   "passWithNoTests": true

--- a/apps/heft/includes/jest-shared.config.json
+++ b/apps/heft/includes/jest-shared.config.json
@@ -17,6 +17,8 @@
   "//": "code coverage tracking is disabled by default; set this to true to enable it ",
   "collectCoverage": false,
 
+  "coverageDirectory": "<rootDir>/temp/coverage",
+
   "collectCoverageFrom": [
     "src/**/*.{ts,tsx}",
     "!src/**/*.d.ts",

--- a/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-15-23-48.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-15-23-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "Update jest-shared.config.json to specify a default for \"collectCoverageFrom\" that excludes test files",
+      "comment": "Update jest-shared.config.json to specify a default \"collectCoverageFrom\" that includes all \"src\" files excluding test files",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-15-23-48.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-15-23-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Update jest-shared.config.json to specify a default for \"collectCoverageFrom\" that excludes test files",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-21-02-07.json
+++ b/common/changes/@rushstack/heft/octogonz-jest-coverage-globs_2021-01-21-02-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Update jest-shared.config.json to configure \"coverageDirectory\" to use \"./temp/coverage\" (instead of \"./coverage\")",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tutorials/heft-node-jest-tutorial/config/jest.config.json
+++ b/tutorials/heft-node-jest-tutorial/config/jest.config.json
@@ -1,3 +1,12 @@
 {
-  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json"
+  "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json",
+  "collectCoverage": true,
+  "coverageThreshold": {
+    "global": {
+      "branches": 50,
+      "functions": 50,
+      "lines": 50,
+      "statements": 50
+    }
+  }
 }


### PR DESCRIPTION
## Summary

We recently encountered two issues with Jest code coverage using Heft's **jest-shared.config.json**:

1. Code coverage was NOT being tracked for product code files (e.g. `src/Example.ts`) if they were not part of the transitive closure of files imported by `*.test.ts`.
2. Code coverage WAS being tracked for test helpers (e.g. `src/test/TestUtils.ts` or `src/__mocks__/ExampleClass.ts`)

## Details

Some people advocated that #<!-- -->2 may be a desirable behavior, because it identifies dead code in unit test files.  However in my opinion it also brings a couple downsides:

- It may skew the overall code coverage statistics (i.e. counting coverage of files that don't matter)
- Code coverage is notorious for annoying edge cases; it may be a nuisance to deal with this in non-shipping code
- Test helpers such as mock/assertion utilities often want to implement possible operation, even though many operations may not (yet) be used by any real test

For this reason I think Heft's default configuration should solve both #<!-- -->1 and #<!-- -->2.

Changes in this PR:

1. Specify `"collectCoverageFrom"` to include all TypeScript files under the `src` folder, but excluding any test files
2. For clarity, explicitly document Jest's defaults for `"testPathIgnorePatterns"` and `"coveragePathIgnorePatterns"` 
3. For clarity, document that `"collectCoverage"` is opt-in

Notes:
- I chose to represent file exclusions using negative globs so that `"coveragePathIgnorePatterns"` will have a simple value that is easy to override in inherited configs
- I did not include extensions such as `.js` or `.jsx` since Rush Stack currently assumes all normal product code written in TypeScript


## How it was tested

I'll test it against it against one of our production monorepos if people agree with this design change.

** UPDATE: **   I configured our monorepo to build using these tests and confirmed that the coverage reports were correct. I also updated the `tutorials/heft-node-jest-tutorial` example project to enable coverage.

@victor-wm @hbo-iecheruo @dharrie-hbo 