### PR TITLE
[rush] Use forward slashes when creating deploy zip file for Unix compatibility

### DIFF
--- a/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
@@ -60,7 +60,8 @@ export class DeployArchiver {
 
     const zip: JSZip = new JSZip();
     for (const filePath of allPaths) {
-      const addPath: string = path.relative(dir, filePath);
+      // Get the relative path and replace backslashes for Unix compat
+      const addPath: string = path.relative(dir, filePath).replace(/\\/g, '/');
       const stat: FileSystemStats = FileSystem.getLinkStatistics(filePath);
       const permissions: number = stat.mode;
 

--- a/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
@@ -4,7 +4,7 @@
 import JSZip = require('jszip');
 
 import * as path from 'path';
-import { FileSystem, FileSystemStats } from '@rushstack/node-core-library';
+import { FileSystem, FileSystemStats, Path } from '@rushstack/node-core-library';
 
 import { IDeployState } from './DeployManager';
 
@@ -61,7 +61,7 @@ export class DeployArchiver {
     const zip: JSZip = new JSZip();
     for (const filePath of allPaths) {
       // Get the relative path and replace backslashes for Unix compat
-      const addPath: string = path.relative(dir, filePath).replace(/\\/g, '/');
+      const addPath: string = Path.convertToSlashes(path.relative(dir, filePath));
       const stat: FileSystemStats = FileSystem.getLinkStatistics(filePath);
       const permissions: number = stat.mode;
 

--- a/common/changes/@microsoft/rush/user-danade-FixZipPathing_2021-01-21-03-16.json
+++ b/common/changes/@microsoft/rush/user-danade-FixZipPathing_2021-01-21-03-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use forward slashes when creating deploy zip file for Unix compatibility",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
Zip files from `rush deploy` were created with the host machine's pathing format in mind. This fix converts backslashes to forward slashes prior to adding to the archive.