### PR TITLE
Fix an issue with webpack in "heft start" mode where "bundle" would continue too quickly.

### DIFF
--- a/apps/heft/src/plugins/Webpack/WebpackPlugin.ts
+++ b/apps/heft/src/plugins/Webpack/WebpackPlugin.ts
@@ -89,6 +89,23 @@ export class WebpackPlugin implements IHeftPlugin {
         options = { ...defaultDevServerOptions, ...webpackConfiguration.devServer };
       }
 
+      // Register a plugin to callback after webpack is done with the first compilation
+      // so we can move on to post-build
+      let firstCompilationDoneCallback: (() => void) | undefined;
+      const originalBeforeCallback: typeof options.before | undefined = options.before;
+      options.before = (app, devServer, compiler: webpack.Compiler) => {
+        compiler.hooks.done.tap('heft-webpack-plugin', () => {
+          if (firstCompilationDoneCallback) {
+            firstCompilationDoneCallback();
+            firstCompilationDoneCallback = undefined;
+          }
+        });
+
+        if (originalBeforeCallback) {
+          return originalBeforeCallback(app, devServer, compiler);
+        }
+      };
+
       // The webpack-dev-server package has a design flaw, where merely loading its package will set the
       // WEBPACK_DEV_SERVER environment variable -- even if no APIs are accessed. This environment variable
       // causes incorrect behavior if Heft is not running in serve mode. Thus, we need to be careful to call require()
@@ -96,13 +113,13 @@ export class WebpackPlugin implements IHeftPlugin {
       const WebpackDevServer: typeof TWebpackDevServer = require(WEBPACK_DEV_SERVER_PACKAGE_NAME);
       // TODO: the WebpackDevServer accepts a third parameter for a logger. We should make
       // use of that to make logging cleaner
-      const devServer: TWebpackDevServer = new WebpackDevServer(compiler, options);
-      await new Promise((resolve: () => void, reject: (error: Error) => void) => {
-        devServer.listen(options.port!, options.host!, (error: Error | undefined) => {
+      const webpackDevServer: TWebpackDevServer = new WebpackDevServer(compiler, options);
+      await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
+        firstCompilationDoneCallback = resolve;
+
+        webpackDevServer.listen(options.port!, options.host!, (error: Error | undefined) => {
           if (error) {
             reject(error);
-          } else {
-            resolve();
           }
         });
       });

--- a/common/changes/@rushstack/heft/ianc-fix-webpack-serve-issue_2021-01-22-05-14.json
+++ b/common/changes/@rushstack/heft/ianc-fix-webpack-serve-issue_2021-01-22-05-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue with webpack in \"heft start\" mode where \"bundle\" would continue too quickly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

There is an issue with the way `heft start` calls webpack. It causes the "bundle" step to resolve too quickly and move on to the post-build step before webpack has dropped files on disk.

## Details

We had been waiting for the first devserver request. This PR changes that behavior to wait until the webpack compilation's "done" hook fires.

## How it was tested

This was tested in a SPFx project compilation that has complex post-build steps that rely on files to exist in "dist."