### PR TITLE
Upgrade to PNPM 5.15.2

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "5.14.3",
+  "pnpmVersion": "5.15.2",
 
   /*[LINE "HYPOTHETICAL"]*/ "npmVersion": "4.5.0",
   /*[LINE "HYPOTHETICAL"]*/ "yarnVersion": "1.9.4",

--- a/common/changes/@microsoft/rush/octogonz-upgrade-pnpm_2021-01-22-19-08.json
+++ b/common/changes/@microsoft/rush/octogonz-upgrade-pnpm_2021-01-22-19-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Updade the \"rush init\" template to specify PNPM 5.15.2, which fixes a performance regression introduced in PNPM 5.13.7",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,30 +3,30 @@ importers:
     specifiers: {}
   ../../apps/api-documenter:
     dependencies:
-      '@microsoft/api-extractor-model': 'link:../api-extractor-model'
+      '@microsoft/api-extractor-model': link:../api-extractor-model
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       colors: 1.2.5
       js-yaml: 3.13.1
       resolve: 1.17.0
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/js-yaml': 3.12.1
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
       jest: 25.4.0
     specifiers:
-      '@microsoft/api-extractor-model': 'workspace:*'
+      '@microsoft/api-extractor-model': workspace:*
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/ts-command-line': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/js-yaml': 3.12.1
       '@types/node': 10.17.13
@@ -37,11 +37,11 @@ importers:
       resolve: ~1.17.0
   ../../apps/api-extractor:
     dependencies:
-      '@microsoft/api-extractor-model': 'link:../api-extractor-model'
+      '@microsoft/api-extractor-model': link:../api-extractor-model
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/rig-package': 'link:../../libraries/rig-package'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/rig-package': link:../../libraries/rig-package
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       colors: 1.2.5
       lodash: 4.17.20
       resolve: 1.17.0
@@ -49,7 +49,7 @@ importers:
       source-map: 0.6.1
       typescript: 4.1.3
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/heft-jest': 1.0.1
@@ -58,14 +58,14 @@ importers:
       '@types/resolve': 1.17.1
       '@types/semver': 7.3.4
     specifiers:
-      '@microsoft/api-extractor-model': 'workspace:*'
+      '@microsoft/api-extractor-model': workspace:*
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/rig-package': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/rig-package': workspace:*
+      '@rushstack/ts-command-line': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
@@ -80,19 +80,19 @@ importers:
   ../../apps/api-extractor-model:
     dependencies:
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
   ../../apps/heft:
@@ -100,17 +100,17 @@ importers:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
       '@jest/transform': 25.4.0
-      '@rushstack/heft-config-file': 'link:../../libraries/heft-config-file'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/rig-package': 'link:../../libraries/rig-package'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
-      '@rushstack/typings-generator': 'link:../../libraries/typings-generator'
+      '@rushstack/heft-config-file': link:../../libraries/heft-config-file
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/rig-package': link:../../libraries/rig-package
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
+      '@rushstack/typings-generator': link:../../libraries/typings-generator
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.24
       '@types/webpack-dev-server': 3.11.0
       argparse: 1.0.10
       chokidar: 3.4.3
-      fast-glob: 3.2.4
+      fast-glob: 3.2.5
       glob: 7.0.6
       glob-escape: 0.0.2
       jest-snapshot: 25.4.0
@@ -121,12 +121,12 @@ importers:
       semver: 7.3.4
       tapable: 1.1.3
       true-case-path: 2.2.1
-      webpack: 4.44.2_webpack@4.44.2
-      webpack-dev-server: 3.11.1_webpack@4.44.2
+      webpack: 4.44.2
+      webpack-dev-server: 3.11.2_webpack@4.44.2
     devDependencies:
       '@jest/types': 25.4.0
-      '@microsoft/api-extractor': 'link:../api-extractor'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/api-extractor': link:../api-extractor
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/argparse': 1.0.38
@@ -144,15 +144,15 @@ importers:
       '@jest/reporters': ~25.4.0
       '@jest/transform': ~25.4.0
       '@jest/types': ~25.4.0
-      '@microsoft/api-extractor': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
-      '@rushstack/heft-config-file': 'workspace:*'
+      '@rushstack/heft-config-file': workspace:*
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/rig-package': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
-      '@rushstack/typings-generator': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/rig-package': workspace:*
+      '@rushstack/ts-command-line': workspace:*
+      '@rushstack/typings-generator': workspace:*
       '@types/argparse': 1.0.38
       '@types/eslint': 7.2.0
       '@types/glob': 7.1.1
@@ -183,43 +183,43 @@ importers:
       webpack-dev-server: ~3.11.0
   ../../apps/rundown:
     dependencies:
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       string-argv: 0.3.1
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/ts-command-line': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       string-argv: ~0.3.1
   ../../apps/rush:
     dependencies:
-      '@microsoft/rush-lib': 'link:../rush-lib'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/rush-lib': link:../rush-lib
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       colors: 1.2.5
       semver: 7.3.4
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/semver': 7.3.4
     specifiers:
-      '@microsoft/rush-lib': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@microsoft/rush-lib': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/semver': ~7.3.1
@@ -227,16 +227,16 @@ importers:
       semver: ~7.3.0
   ../../apps/rush-lib:
     dependencies:
-      '@azure/identity': 1.2.1
+      '@azure/identity': 1.2.2
       '@azure/storage-blob': 12.3.0
       '@pnpm/link-bins': 5.3.20
-      '@rushstack/heft-config-file': 'link:../../libraries/heft-config-file'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/package-deps-hash': 'link:../../libraries/package-deps-hash'
-      '@rushstack/rig-package': 'link:../../libraries/rig-package'
-      '@rushstack/stream-collator': 'link:../../libraries/stream-collator'
-      '@rushstack/terminal': 'link:../../libraries/terminal'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@rushstack/heft-config-file': link:../../libraries/heft-config-file
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/package-deps-hash': link:../../libraries/package-deps-hash
+      '@rushstack/rig-package': link:../../libraries/rig-package
+      '@rushstack/stream-collator': link:../../libraries/stream-collator
+      '@rushstack/terminal': link:../../libraries/terminal
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       '@yarnpkg/lockfile': 1.0.2
       builtin-modules: 3.1.0
       cli-table: 0.3.4
@@ -264,9 +264,9 @@ importers:
       wordwrap: 1.0.0
       z-schema: 3.18.4
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/cli-table': 0.3.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -291,16 +291,16 @@ importers:
       '@azure/identity': ~1.2.0
       '@azure/storage-blob': ~12.3.0
       '@pnpm/link-bins': ~5.3.7
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-config-file': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/package-deps-hash': 'workspace:*'
-      '@rushstack/rig-package': 'workspace:*'
-      '@rushstack/stream-collator': 'workspace:*'
-      '@rushstack/terminal': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-config-file': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/package-deps-hash': workspace:*
+      '@rushstack/rig-package': workspace:*
+      '@rushstack/stream-collator': workspace:*
+      '@rushstack/terminal': workspace:*
+      '@rushstack/ts-command-line': workspace:*
       '@types/cli-table': 0.3.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -349,81 +349,81 @@ importers:
       z-schema: ~3.18.3
   ../../build-tests/api-documenter-test:
     devDependencies:
-      '@microsoft/api-documenter': 'link:../../apps/api-documenter'
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-documenter': link:../../apps/api-documenter
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-documenter': 'workspace:*'
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-documenter': workspace:*
+      '@microsoft/api-extractor': workspace:*
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/api-extractor-lib1-test:
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 2.4.2
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
       typescript: ~2.4.2
   ../../build-tests/api-extractor-lib2-test:
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/api-extractor-lib3-test:
     dependencies:
-      api-extractor-lib1-test: 'link:../api-extractor-lib1-test'
+      api-extractor-lib1-test: link:../api-extractor-lib1-test
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      api-extractor-lib1-test: 'workspace:*'
+      api-extractor-lib1-test: workspace:*
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/api-extractor-scenarios:
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@microsoft/teams-js': 1.3.0-beta.4
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      api-extractor-lib1-test: 'link:../api-extractor-lib1-test'
-      api-extractor-lib2-test: 'link:../api-extractor-lib2-test'
-      api-extractor-lib3-test: 'link:../api-extractor-lib3-test'
+      api-extractor-lib1-test: link:../api-extractor-lib1-test
+      api-extractor-lib2-test: link:../api-extractor-lib2-test
+      api-extractor-lib3-test: link:../api-extractor-lib3-test
       colors: 1.2.5
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@microsoft/teams-js': 1.3.0-beta.4
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      api-extractor-lib1-test: 'workspace:*'
-      api-extractor-lib2-test: 'workspace:*'
-      api-extractor-lib3-test: 'workspace:*'
+      api-extractor-lib1-test: workspace:*
+      api-extractor-lib2-test: workspace:*
+      api-extractor-lib3-test: workspace:*
       colors: ~1.2.1
       fs-extra: ~7.0.1
       typescript: ~3.9.7
@@ -433,13 +433,13 @@ importers:
       '@types/long': 4.0.0
       long: 4.0.0
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/jest': 25.2.1
       '@types/long': 4.0.0
@@ -450,18 +450,18 @@ importers:
   ../../build-tests/api-extractor-test-02:
     dependencies:
       '@types/semver': 7.3.4
-      api-extractor-test-01: 'link:../api-extractor-test-01'
+      api-extractor-test-01: link:../api-extractor-test-01
       semver: 7.3.4
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@types/node': 10.17.13
       '@types/semver': ~7.3.1
-      api-extractor-test-01: 'workspace:*'
+      api-extractor-test-01: workspace:*
       fs-extra: ~7.0.1
       semver: ~7.3.0
       typescript: ~3.9.7
@@ -469,67 +469,67 @@ importers:
     devDependencies:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      api-extractor-test-02: 'link:../api-extractor-test-02'
+      api-extractor-test-02: link:../api-extractor-test-02
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      api-extractor-test-02: 'workspace:*'
+      api-extractor-test-02: workspace:*
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/api-extractor-test-04:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      api-extractor-lib1-test: 'link:../api-extractor-lib1-test'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      api-extractor-lib1-test: link:../api-extractor-lib1-test
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      api-extractor-lib1-test: 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      api-extractor-lib1-test: workspace:*
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/heft-action-plugin:
     dependencies:
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../build-tests/heft-action-plugin-test:
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
-      heft-action-plugin: 'link:../heft-action-plugin'
+      '@rushstack/heft': link:../../apps/heft
+      heft-action-plugin: link:../heft-action-plugin
     specifiers:
-      '@rushstack/heft': 'workspace:*'
-      heft-action-plugin: 'workspace:*'
+      '@rushstack/heft': workspace:*
+      heft-action-plugin: workspace:*
   ../../build-tests/heft-copy-files-test:
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/heft': link:../../apps/heft
     specifiers:
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/heft': workspace:*
   ../../build-tests/heft-example-plugin-01:
     dependencies:
       tapable: 1.1.3
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       '@types/tapable': 1.0.6
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/node': 10.17.13
       '@types/tapable': 1.0.6
       eslint: ~7.12.1
@@ -537,33 +537,33 @@ importers:
       typescript: ~3.9.7
   ../../build-tests/heft-example-plugin-02:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.12.1
-      heft-example-plugin-01: 'link:../heft-example-plugin-01'
+      heft-example-plugin-01: link:../heft-example-plugin-01
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
-      heft-example-plugin-01: 'workspace:*'
+      heft-example-plugin-01: workspace:*
       typescript: ~3.9.7
   ../../build-tests/heft-jest-reporters-test:
     devDependencies:
       '@jest/reporters': 25.4.0
       '@jest/types': 25.4.0
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
       '@jest/reporters': ~25.4.0
       '@jest/types': ~25.4.0
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       eslint: ~7.12.1
       typescript: ~3.9.7
@@ -571,72 +571,72 @@ importers:
     dependencies:
       typescript: 3.9.7
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       typescript: ~3.9.7
   ../../build-tests/heft-minimal-rig-usage-test:
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
-      heft-minimal-rig-test: 'link:../heft-minimal-rig-test'
+      heft-minimal-rig-test: link:../heft-minimal-rig-test
     specifiers:
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
-      heft-minimal-rig-test: 'workspace:*'
+      heft-minimal-rig-test: workspace:*
   ../../build-tests/heft-node-everything-test:
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.12.1
-      heft-example-plugin-01: 'link:../heft-example-plugin-01'
-      heft-example-plugin-02: 'link:../heft-example-plugin-02'
+      heft-example-plugin-01: link:../heft-example-plugin-01
+      heft-example-plugin-02: link:../heft-example-plugin-02
       tslint: 5.20.1_typescript@3.9.7
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.7
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: ~7.12.1
-      heft-example-plugin-01: 'workspace:*'
-      heft-example-plugin-02: 'workspace:*'
+      heft-example-plugin-01: workspace:*
+      heft-example-plugin-02: workspace:*
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
       typescript: ~3.9.7
   ../../build-tests/heft-oldest-compiler-test:
     devDependencies:
-      '@microsoft/rush-stack-compiler-2.9': 'link:../../stack/rush-stack-compiler-2.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@microsoft/rush-stack-compiler-2.9': link:../../stack/rush-stack-compiler-2.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
     specifiers:
-      '@microsoft/rush-stack-compiler-2.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@microsoft/rush-stack-compiler-2.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
   ../../build-tests/heft-rsc-test:
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
     specifiers:
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
   ../../build-tests/heft-sass-test:
     dependencies:
       buttono: 1.0.2
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/react': 16.9.45
       '@types/react-dom': 16.9.8
@@ -653,10 +653,10 @@ importers:
       sass-loader: 7.3.1_webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
       typescript: 3.9.7
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/react': 16.9.45
       '@types/react-dom': 16.9.8
@@ -677,17 +677,17 @@ importers:
       webpack: ~4.44.2
   ../../build-tests/heft-web-rig-library-test:
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-web-rig': 'link:../../rigs/heft-web-rig'
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-web-rig': link:../../rigs/heft-web-rig
       '@types/heft-jest': 1.0.1
     specifiers:
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-web-rig': 'workspace:*'
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-web-rig': workspace:*
       '@types/heft-jest': 1.0.1
   ../../build-tests/heft-webpack-everything-test:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
       eslint: 7.12.1
@@ -695,10 +695,10 @@ importers:
       tslint: 5.20.1_typescript@3.9.7
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
       eslint: ~7.12.1
@@ -709,25 +709,25 @@ importers:
       webpack: ~4.44.2
   ../../build-tests/localization-plugin-test-01:
     dependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/localization-plugin': 'link:../../webpack/localization-plugin'
-      '@rushstack/module-minifier-plugin': 'link:../../webpack/module-minifier-plugin'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/set-webpack-public-path-plugin': 'link:../../webpack/set-webpack-public-path-plugin'
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/localization-plugin': link:../../webpack/localization-plugin
+      '@rushstack/module-minifier-plugin': link:../../webpack/module-minifier-plugin
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.1_webpack@4.44.2
       ts-loader: 6.0.0_typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
+      webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 3.11.1_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 3.11.2_93ca2875a658e9d1552850624e6b91c7
     specifiers:
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/localization-plugin': 'workspace:*'
-      '@rushstack/module-minifier-plugin': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/set-webpack-public-path-plugin': 'workspace:*'
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/localization-plugin': workspace:*
+      '@rushstack/module-minifier-plugin': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/set-webpack-public-path-plugin': workspace:*
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: ~4.5.0
       ts-loader: 6.0.0
@@ -738,27 +738,27 @@ importers:
       webpack-dev-server: ~3.11.0
   ../../build-tests/localization-plugin-test-02:
     dependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/localization-plugin': 'link:../../webpack/localization-plugin'
-      '@rushstack/module-minifier-plugin': 'link:../../webpack/module-minifier-plugin'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/set-webpack-public-path-plugin': 'link:../../webpack/set-webpack-public-path-plugin'
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/localization-plugin': link:../../webpack/localization-plugin
+      '@rushstack/module-minifier-plugin': link:../../webpack/module-minifier-plugin
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/lodash': 4.14.116
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.1_webpack@4.44.2
       lodash: 4.17.20
       ts-loader: 6.0.0_typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
+      webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 3.11.1_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 3.11.2_93ca2875a658e9d1552850624e6b91c7
     specifiers:
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/localization-plugin': 'workspace:*'
-      '@rushstack/module-minifier-plugin': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/set-webpack-public-path-plugin': 'workspace:*'
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/localization-plugin': workspace:*
+      '@rushstack/module-minifier-plugin': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/set-webpack-public-path-plugin': workspace:*
       '@types/lodash': 4.14.116
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: ~4.5.0
@@ -771,23 +771,23 @@ importers:
       webpack-dev-server: ~3.11.0
   ../../build-tests/localization-plugin-test-03:
     dependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/localization-plugin': 'link:../../webpack/localization-plugin'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/set-webpack-public-path-plugin': 'link:../../webpack/set-webpack-public-path-plugin'
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/localization-plugin': link:../../webpack/localization-plugin
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.1_webpack@4.44.2
       ts-loader: 6.0.0_typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
+      webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 3.11.1_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 3.11.2_93ca2875a658e9d1552850624e6b91c7
     specifiers:
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/localization-plugin': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/set-webpack-public-path-plugin': 'workspace:*'
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/localization-plugin': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/set-webpack-public-path-plugin': workspace:*
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: ~4.5.0
       ts-loader: 6.0.0
@@ -798,211 +798,211 @@ importers:
       webpack-dev-server: ~3.11.0
   ../../build-tests/node-library-build-eslint-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/node-library-build-tslint-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-2.4-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-2.4': 'link:../../stack/rush-stack-compiler-2.4'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-2.4': link:../../stack/rush-stack-compiler-2.4
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-2.4': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-2.4': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-2.7-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-2.7': 'link:../../stack/rush-stack-compiler-2.7'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-2.7': link:../../stack/rush-stack-compiler-2.7
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-2.7': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-2.7': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-2.8-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-2.8': 'link:../../stack/rush-stack-compiler-2.8'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-2.8': link:../../stack/rush-stack-compiler-2.8
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-2.8': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-2.8': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-2.9-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-2.9': 'link:../../stack/rush-stack-compiler-2.9'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-2.9': link:../../stack/rush-stack-compiler-2.9
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-2.9': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-2.9': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.0-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.0': 'link:../../stack/rush-stack-compiler-3.0'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.0': link:../../stack/rush-stack-compiler-3.0
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.0': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.0': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.1-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.1': 'link:../../stack/rush-stack-compiler-3.1'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.1': link:../../stack/rush-stack-compiler-3.1
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.1': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.1': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.2-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.2': 'link:../../stack/rush-stack-compiler-3.2'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.2': link:../../stack/rush-stack-compiler-3.2
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.2': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.2': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.3-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.3': 'link:../../stack/rush-stack-compiler-3.3'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.3': link:../../stack/rush-stack-compiler-3.3
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.3': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.3': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.4-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.4': 'link:../../stack/rush-stack-compiler-3.4'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.4': link:../../stack/rush-stack-compiler-3.4
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.4': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.4': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.5-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.5': 'link:../../stack/rush-stack-compiler-3.5'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.5': link:../../stack/rush-stack-compiler-3.5
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.5': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.5': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.6-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.6': 'link:../../stack/rush-stack-compiler-3.6'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.6': link:../../stack/rush-stack-compiler-3.6
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.6': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.6': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.7-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.7': 'link:../../stack/rush-stack-compiler-3.7'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.7': link:../../stack/rush-stack-compiler-3.7
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.7': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.7': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.8-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.8': 'link:../../stack/rush-stack-compiler-3.8'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.8': link:../../stack/rush-stack-compiler-3.8
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.8': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.8': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/rush-stack-compiler-3.9-library-test:
     devDependencies:
-      '@microsoft/node-library-build': 'link:../../core-build/node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
+      '@microsoft/node-library-build': link:../../core-build/node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
       '@types/node': 10.17.13
       gulp: 4.0.2
     specifiers:
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../build-tests/ts-command-line-test:
     devDependencies:
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       '@types/node': 10.17.13
       fs-extra: 7.0.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@rushstack/ts-command-line': workspace:*
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
       typescript: ~3.9.7
   ../../build-tests/web-library-build-test:
     devDependencies:
-      '@microsoft/load-themed-styles': 'link:../../libraries/load-themed-styles'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@microsoft/web-library-build': 'link:../../core-build/web-library-build'
+      '@microsoft/load-themed-styles': link:../../libraries/load-themed-styles
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@microsoft/web-library-build': link:../../core-build/web-library-build
       gulp: 4.0.2
       typescript: 3.9.7
     specifiers:
-      '@microsoft/load-themed-styles': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/web-library-build': 'workspace:*'
+      '@microsoft/load-themed-styles': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/web-library-build': workspace:*
       gulp: ~4.0.2
       typescript: ~3.9.7
   ../../core-build/gulp-core-build:
     dependencies:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/chalk': 0.4.31
       '@types/gulp': 4.0.6
       '@types/jest': 25.2.1
@@ -1042,7 +1042,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': 6.5.16
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/glob': 7.1.1
       '@types/z-schema': 3.16.31
     specifiers:
@@ -1050,8 +1050,8 @@ importers:
       '@jest/reporters': ~25.4.0
       '@microsoft/node-library-build': 6.5.16
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/chalk': 0.4.31
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
@@ -1092,7 +1092,7 @@ importers:
       z-schema: ~3.18.3
   ../../core-build/gulp-core-build-mocha:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
       '@types/node': 10.17.13
       glob: 7.0.6
       gulp: 4.0.2
@@ -1101,7 +1101,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': 6.5.16
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
       '@types/gulp-istanbul': 0.9.30
@@ -1109,10 +1109,10 @@ importers:
       '@types/mocha': 5.2.5
       '@types/orchestrator': 0.0.30
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
       '@microsoft/node-library-build': 6.5.16
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
       '@types/gulp-istanbul': 0.9.30
@@ -1126,9 +1126,9 @@ importers:
       gulp-mocha: ~6.0.0
   ../../core-build/gulp-core-build-sass:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
-      '@microsoft/load-themed-styles': 'link:../../libraries/load-themed-styles'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
+      '@microsoft/load-themed-styles': link:../../libraries/load-themed-styles
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       autoprefixer: 9.8.6
@@ -1138,9 +1138,9 @@ importers:
       postcss: 7.0.32
       postcss-modules: 1.5.0
     devDependencies:
-      '@microsoft/node-library-build': 'link:../node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/node-library-build': link:../node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/autoprefixer': 9.7.2
       '@types/clean-css': 4.2.1
       '@types/glob': 7.1.1
@@ -1149,12 +1149,12 @@ importers:
       gulp: 4.0.2
       jest: 25.4.0
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
-      '@microsoft/load-themed-styles': 'workspace:*'
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
+      '@microsoft/load-themed-styles': workspace:*
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/autoprefixer': 9.7.2
       '@types/clean-css': 4.2.1
       '@types/glob': 7.1.1
@@ -1172,9 +1172,9 @@ importers:
       postcss-modules: ~1.5.0
   ../../core-build/gulp-core-build-serve:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
-      '@rushstack/debug-certificate-manager': 'link:../../libraries/debug-certificate-manager'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
+      '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       colors: 1.2.5
       express: 4.16.4
@@ -1183,9 +1183,9 @@ importers:
       gulp-open: 3.0.1
       sudo: 1.0.3
     devDependencies:
-      '@microsoft/node-library-build': 'link:../node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/node-library-build': link:../node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/express': 4.11.0
       '@types/express-serve-static-core': 4.11.0
       '@types/gulp': 4.0.6
@@ -1195,12 +1195,12 @@ importers:
       '@types/through2': 2.0.32
       '@types/vinyl': 2.0.3
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/debug-certificate-manager': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/debug-certificate-manager': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/express': 4.11.0
       '@types/express-serve-static-core': 4.11.0
       '@types/gulp': 4.0.6
@@ -1218,31 +1218,31 @@ importers:
       sudo: ~1.0.3
   ../../core-build/gulp-core-build-typescript:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       decomment: 0.9.3
       glob: 7.0.6
       glob-escape: 0.0.2
       resolve: 1.17.0
     devDependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       '@microsoft/node-library-build': 6.5.16
-      '@microsoft/rush-stack-compiler-3.1': 'link:../../stack/rush-stack-compiler-3.1'
+      '@microsoft/rush-stack-compiler-3.1': link:../../stack/rush-stack-compiler-3.1
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/glob': 7.1.1
       '@types/resolve': 1.17.1
       gulp: 4.0.2
       typescript: 3.9.7
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/gulp-core-build': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/gulp-core-build': workspace:*
       '@microsoft/node-library-build': 6.5.16
-      '@microsoft/rush-stack-compiler-3.1': 'workspace:*'
+      '@microsoft/rush-stack-compiler-3.1': workspace:*
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/glob': 7.1.1
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
@@ -1254,26 +1254,26 @@ importers:
       typescript: ~3.9.7
   ../../core-build/gulp-core-build-webpack:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       colors: 1.2.5
       gulp: 4.0.2
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     devDependencies:
-      '@microsoft/node-library-build': 'link:../node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/node-library-build': link:../node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@types/orchestrator': 0.0.30
       '@types/source-map': 0.5.0
       '@types/uglify-js': 2.6.29
       '@types/webpack': 4.41.24
       '@types/webpack-dev-server': 3.11.0
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       '@types/orchestrator': 0.0.30
@@ -1286,70 +1286,70 @@ importers:
       webpack: ~4.44.2
   ../../core-build/node-library-build:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
-      '@microsoft/gulp-core-build-mocha': 'link:../gulp-core-build-mocha'
-      '@microsoft/gulp-core-build-typescript': 'link:../gulp-core-build-typescript'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
+      '@microsoft/gulp-core-build-mocha': link:../gulp-core-build-mocha
+      '@microsoft/gulp-core-build-typescript': link:../gulp-core-build-typescript
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       gulp: 4.0.2
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
-      '@microsoft/gulp-core-build-mocha': 'workspace:*'
-      '@microsoft/gulp-core-build-typescript': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
+      '@microsoft/gulp-core-build-mocha': workspace:*
+      '@microsoft/gulp-core-build-typescript': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       gulp: ~4.0.2
   ../../core-build/web-library-build:
     dependencies:
-      '@microsoft/gulp-core-build': 'link:../gulp-core-build'
-      '@microsoft/gulp-core-build-sass': 'link:../gulp-core-build-sass'
-      '@microsoft/gulp-core-build-serve': 'link:../gulp-core-build-serve'
-      '@microsoft/gulp-core-build-typescript': 'link:../gulp-core-build-typescript'
-      '@microsoft/gulp-core-build-webpack': 'link:../gulp-core-build-webpack'
+      '@microsoft/gulp-core-build': link:../gulp-core-build
+      '@microsoft/gulp-core-build-sass': link:../gulp-core-build-sass
+      '@microsoft/gulp-core-build-serve': link:../gulp-core-build-serve
+      '@microsoft/gulp-core-build-typescript': link:../gulp-core-build-typescript
+      '@microsoft/gulp-core-build-webpack': link:../gulp-core-build-webpack
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       gulp: 4.0.2
       gulp-replace: 0.5.4
     devDependencies:
-      '@microsoft/node-library-build': 'link:../node-library-build'
-      '@microsoft/rush-stack-compiler-3.9': 'link:../../stack/rush-stack-compiler-3.9'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@microsoft/node-library-build': link:../node-library-build
+      '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
+      '@rushstack/eslint-config': link:../../stack/eslint-config
     specifiers:
-      '@microsoft/gulp-core-build': 'workspace:*'
-      '@microsoft/gulp-core-build-sass': 'workspace:*'
-      '@microsoft/gulp-core-build-serve': 'workspace:*'
-      '@microsoft/gulp-core-build-typescript': 'workspace:*'
-      '@microsoft/gulp-core-build-webpack': 'workspace:*'
-      '@microsoft/node-library-build': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/gulp-core-build': workspace:*
+      '@microsoft/gulp-core-build-sass': workspace:*
+      '@microsoft/gulp-core-build-serve': workspace:*
+      '@microsoft/gulp-core-build-typescript': workspace:*
+      '@microsoft/gulp-core-build-webpack': workspace:*
+      '@microsoft/node-library-build': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       gulp: ~4.0.2
       gulp-replace: ^0.5.4
   ../../libraries/debug-certificate-manager:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
+      '@rushstack/node-core-library': link:../node-core-library
       deasync: 0.1.21
       node-forge: 0.7.6
       sudo: 1.0.3
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/node-forge': 0.9.1
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/node-forge': 0.9.1
@@ -1358,35 +1358,35 @@ importers:
       sudo: ~1.0.3
   ../../libraries/heft-config-file:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
-      '@rushstack/rig-package': 'link:../rig-package'
+      '@rushstack/node-core-library': link:../node-core-library
+      '@rushstack/rig-package': link:../rig-package
       jsonpath-plus: 4.0.0
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/rig-package': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/rig-package': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       jsonpath-plus: ~4.0.0
   ../../libraries/load-themed-styles:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-web-rig': 'link:../../rigs/heft-web-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-web-rig': link:../../rigs/heft-web-rig
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-web-rig': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-web-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
   ../../libraries/node-core-library:
@@ -1401,7 +1401,7 @@ importers:
       timsort: 0.3.0
       z-schema: 3.18.4
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/fs-extra': 7.0.0
@@ -1412,7 +1412,7 @@ importers:
       '@types/timsort': 0.3.0
       '@types/z-schema': 3.16.31
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
       '@types/fs-extra': 7.0.0
@@ -1433,18 +1433,18 @@ importers:
       z-schema: ~3.18.3
   ../../libraries/package-deps-hash:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
+      '@rushstack/node-core-library': link:../node-core-library
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
   ../../libraries/rig-package:
@@ -1453,14 +1453,14 @@ importers:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/heft-jest': 1.0.1
       '@types/resolve': 1.17.1
       ajv: 6.12.6
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
       '@types/heft-jest': 1.0.1
@@ -1471,53 +1471,53 @@ importers:
       strip-json-comments: ~3.1.1
   ../../libraries/rushell:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
+      '@rushstack/node-core-library': link:../node-core-library
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
   ../../libraries/stream-collator:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
-      '@rushstack/terminal': 'link:../terminal'
+      '@rushstack/node-core-library': link:../node-core-library
+      '@rushstack/terminal': link:../terminal
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/terminal': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/terminal': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
   ../../libraries/terminal:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
+      '@rushstack/node-core-library': link:../node-core-library
       '@types/node': 10.17.13
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       colors: 1.2.5
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       colors: ~1.2.1
@@ -1543,13 +1543,13 @@ importers:
       colors: 1.2.5
       string-argv: 0.3.1
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
       '@types/argparse': 1.0.38
@@ -1560,120 +1560,120 @@ importers:
       string-argv: ~0.3.1
   ../../libraries/typings-generator:
     dependencies:
-      '@rushstack/node-core-library': 'link:../node-core-library'
+      '@rushstack/node-core-library': link:../node-core-library
       '@types/node': 10.17.13
       chokidar: 3.4.3
       glob: 7.0.6
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
       '@types/glob': 7.1.1
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/glob': 7.1.1
       '@types/node': 10.17.13
       chokidar: ~3.4.0
       glob: ~7.0.5
   ../../repo-scripts/doc-plugin-rush-stack:
     dependencies:
-      '@microsoft/api-documenter': 'link:../../apps/api-documenter'
-      '@microsoft/api-extractor-model': 'link:../../apps/api-extractor-model'
+      '@microsoft/api-documenter': link:../../apps/api-documenter
+      '@microsoft/api-extractor-model': link:../../apps/api-extractor-model
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       js-yaml: 3.13.1
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/js-yaml': 3.12.1
       '@types/node': 10.17.13
     specifiers:
-      '@microsoft/api-documenter': 'workspace:*'
-      '@microsoft/api-extractor-model': 'workspace:*'
+      '@microsoft/api-documenter': workspace:*
+      '@microsoft/api-extractor-model': workspace:*
       '@microsoft/tsdoc': 0.12.24
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/js-yaml': 3.12.1
       '@types/node': 10.17.13
       js-yaml: ~3.13.1
   ../../repo-scripts/generate-api-docs:
     devDependencies:
-      '@microsoft/api-documenter': 'link:../../apps/api-documenter'
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      doc-plugin-rush-stack: 'link:../doc-plugin-rush-stack'
+      '@microsoft/api-documenter': link:../../apps/api-documenter
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      doc-plugin-rush-stack: link:../doc-plugin-rush-stack
     specifiers:
-      '@microsoft/api-documenter': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      doc-plugin-rush-stack: 'workspace:*'
+      '@microsoft/api-documenter': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      doc-plugin-rush-stack: workspace:*
   ../../repo-scripts/repo-toolbox:
     dependencies:
-      '@microsoft/rush-lib': 'link:../../apps/rush-lib'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/ts-command-line': 'link:../../libraries/ts-command-line'
+      '@microsoft/rush-lib': link:../../apps/rush-lib
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/ts-command-line': link:../../libraries/ts-command-line
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/node': 10.17.13
     specifiers:
-      '@microsoft/rush-lib': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/ts-command-line': 'workspace:*'
+      '@microsoft/rush-lib': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/ts-command-line': workspace:*
       '@types/node': 10.17.13
   ../../rigs/heft-node-rig:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       eslint: 7.12.1
       typescript: 3.9.7
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/heft': link:../../apps/heft
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@rushstack/heft': workspace:*
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../rigs/heft-web-rig:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
       eslint: 7.12.1
       typescript: 3.9.7
     devDependencies:
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/heft': link:../../apps/heft
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@rushstack/heft': workspace:*
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../stack/eslint-config:
     dependencies:
-      '@rushstack/eslint-patch': 'link:../eslint-patch'
-      '@rushstack/eslint-plugin': 'link:../eslint-plugin'
-      '@rushstack/eslint-plugin-packlets': 'link:../eslint-plugin-packlets'
-      '@rushstack/eslint-plugin-security': 'link:../eslint-plugin-security'
+      '@rushstack/eslint-patch': link:../eslint-patch
+      '@rushstack/eslint-plugin': link:../eslint-plugin
+      '@rushstack/eslint-plugin-packlets': link:../eslint-plugin-packlets
+      '@rushstack/eslint-plugin-security': link:../eslint-plugin-security
       '@typescript-eslint/eslint-plugin': 3.4.0_6649435b64b6dbe6468bbdb6596c5748
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.12.1+typescript@3.9.7
       '@typescript-eslint/parser': 3.4.0_eslint@7.12.1+typescript@3.9.7
       '@typescript-eslint/typescript-estree': 3.4.0_typescript@3.9.7
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.20.6_eslint@7.12.1
-      eslint-plugin-tsdoc: 0.2.10
+      eslint-plugin-tsdoc: 0.2.11
     devDependencies:
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-patch': 'workspace:*'
-      '@rushstack/eslint-plugin': 'workspace:*'
-      '@rushstack/eslint-plugin-packlets': 'workspace:*'
-      '@rushstack/eslint-plugin-security': 'workspace:*'
+      '@rushstack/eslint-patch': workspace:*
+      '@rushstack/eslint-plugin': workspace:*
+      '@rushstack/eslint-plugin-packlets': workspace:*
+      '@rushstack/eslint-plugin-security': workspace:*
       '@typescript-eslint/eslint-plugin': 3.4.0
       '@typescript-eslint/experimental-utils': 3.4.0
       '@typescript-eslint/parser': 3.4.0
@@ -1694,7 +1694,7 @@ importers:
       '@types/node': 10.17.13
   ../../stack/eslint-plugin:
     dependencies:
-      '@rushstack/tree-pattern': 'link:../../libraries/tree-pattern'
+      '@rushstack/tree-pattern': link:../../libraries/tree-pattern
     devDependencies:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
@@ -1710,7 +1710,7 @@ importers:
     specifiers:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/tree-pattern': 'workspace:*'
+      '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -1722,7 +1722,7 @@ importers:
       typescript: ~3.9.7
   ../../stack/eslint-plugin-packlets:
     dependencies:
-      '@rushstack/tree-pattern': 'link:../../libraries/tree-pattern'
+      '@rushstack/tree-pattern': link:../../libraries/tree-pattern
     devDependencies:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
@@ -1738,7 +1738,7 @@ importers:
     specifiers:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/tree-pattern': 'workspace:*'
+      '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -1750,7 +1750,7 @@ importers:
       typescript: ~3.9.7
   ../../stack/eslint-plugin-security:
     dependencies:
-      '@rushstack/tree-pattern': 'link:../../libraries/tree-pattern'
+      '@rushstack/tree-pattern': link:../../libraries/tree-pattern
     devDependencies:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
@@ -1766,7 +1766,7 @@ importers:
     specifiers:
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/tree-pattern': 'workspace:*'
+      '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -1778,9 +1778,9 @@ importers:
       typescript: ~3.9.7
   ../../stack/rush-stack-compiler-2.4:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1788,18 +1788,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@2.4.2
       typescript: 2.4.2
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1808,9 +1808,9 @@ importers:
       typescript: ~2.4.2
   ../../stack/rush-stack-compiler-2.7:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1818,18 +1818,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@2.7.2
       typescript: 2.7.2
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1838,9 +1838,9 @@ importers:
       typescript: ~2.7.2
   ../../stack/rush-stack-compiler-2.8:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1848,18 +1848,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@2.8.4
       typescript: 2.8.4
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1868,9 +1868,9 @@ importers:
       typescript: ~2.8.4
   ../../stack/rush-stack-compiler-2.9:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1878,18 +1878,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@2.9.2
       typescript: 2.9.2
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1898,9 +1898,9 @@ importers:
       typescript: ~2.9.2
   ../../stack/rush-stack-compiler-3.0:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1908,18 +1908,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.0.3
       typescript: 3.0.3
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1928,9 +1928,9 @@ importers:
       typescript: ~3.0.3
   ../../stack/rush-stack-compiler-3.1:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1938,18 +1938,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.1.6
       typescript: 3.1.6
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1958,9 +1958,9 @@ importers:
       typescript: ~3.1.6
   ../../stack/rush-stack-compiler-3.2:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1968,18 +1968,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.2.4
       typescript: 3.2.4
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -1988,9 +1988,9 @@ importers:
       typescript: ~3.2.4
   ../../stack/rush-stack-compiler-3.3:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -1998,18 +1998,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_5de1f8fa14d12d0f8943ae8c5c9e10ce
       typescript: 3.3.4000
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2018,9 +2018,9 @@ importers:
       typescript: ~3.3.3
   ../../stack/rush-stack-compiler-3.4:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2028,18 +2028,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.4.5
       typescript: 3.4.5
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2048,9 +2048,9 @@ importers:
       typescript: ~3.4.3
   ../../stack/rush-stack-compiler-3.5:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2058,18 +2058,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.5.3
       typescript: 3.5.3
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2078,9 +2078,9 @@ importers:
       typescript: ~3.5.3
   ../../stack/rush-stack-compiler-3.6:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2088,18 +2088,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.6.5
       typescript: 3.6.5
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2108,9 +2108,9 @@ importers:
       typescript: ~3.6.4
   ../../stack/rush-stack-compiler-3.7:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2118,18 +2118,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.7.5
       typescript: 3.7.5
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2138,9 +2138,9 @@ importers:
       typescript: ~3.7.2
   ../../stack/rush-stack-compiler-3.8:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2148,18 +2148,18 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.8.3
       typescript: 3.8.3
     devDependencies:
-      '@microsoft/rush-stack-compiler-3.9': 'link:../rush-stack-compiler-3.9'
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-3.9': link:../rush-stack-compiler-3.9
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
-      '@microsoft/rush-stack-compiler-3.9': 'workspace:*'
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
+      '@microsoft/rush-stack-compiler-3.9': workspace:*
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2168,9 +2168,9 @@ importers:
       typescript: ~3.8.3
   ../../stack/rush-stack-compiler-3.9:
     dependencies:
-      '@microsoft/api-extractor': 'link:../../apps/api-extractor'
-      '@rushstack/eslint-config': 'link:../eslint-config'
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
+      '@microsoft/api-extractor': link:../../apps/api-extractor
+      '@rushstack/eslint-config': link:../eslint-config
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 10.17.13
       eslint: 7.12.1
       import-lazy: 4.0.0
@@ -2179,17 +2179,17 @@ importers:
       typescript: 3.9.7
     devDependencies:
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@microsoft/rush-stack-compiler-shared': 'link:../rush-stack-compiler-shared'
+      '@microsoft/rush-stack-compiler-shared': link:../rush-stack-compiler-shared
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0_@rushstack+heft@0.23.1
     specifiers:
-      '@microsoft/api-extractor': 'workspace:*'
+      '@microsoft/api-extractor': workspace:*
       '@microsoft/rush-stack-compiler-3.9': 0.4.37
-      '@microsoft/rush-stack-compiler-shared': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
+      '@microsoft/rush-stack-compiler-shared': workspace:*
+      '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': 0.23.1
       '@rushstack/heft-node-rig': 0.2.0
-      '@rushstack/node-core-library': 'workspace:*'
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       import-lazy: ~4.0.0
@@ -2200,51 +2200,51 @@ importers:
     specifiers: {}
   ../../tutorials/heft-node-basic-tutorial:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../tutorials/heft-node-jest-tutorial:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../tutorials/heft-node-rig-tutorial:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
   ../../tutorials/heft-webpack-basic-tutorial:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/react': 16.9.45
       '@types/react-dom': 16.9.8
@@ -2257,10 +2257,10 @@ importers:
       source-map-loader: 1.1.3_webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
       typescript: 3.9.7
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/react': 16.9.45
       '@types/react-dom': 16.9.8
@@ -2276,34 +2276,34 @@ importers:
       webpack: ~4.44.2
   ../../tutorials/packlets-tutorial:
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.12.1
       typescript: 3.9.7
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.12.1
       typescript: ~3.9.7
   ../../webpack/loader-load-themed-styles:
     dependencies:
-      '@microsoft/load-themed-styles': 'link:../../libraries/load-themed-styles'
+      '@microsoft/load-themed-styles': link:../../libraries/load-themed-styles
       loader-utils: 1.1.0
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/loader-utils': 1.1.3
       '@types/node': 10.17.13
       '@types/webpack': 4.41.24
     specifiers:
-      '@microsoft/load-themed-styles': 'workspace:*'
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
+      '@microsoft/load-themed-styles': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/loader-utils': 1.1.3
       '@types/node': 10.17.13
@@ -2313,22 +2313,22 @@ importers:
     dependencies:
       loader-utils: 1.1.0
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       loader-utils: ~1.1.0
   ../../webpack/localization-plugin:
     dependencies:
-      '@rushstack/node-core-library': 'link:../../libraries/node-core-library'
-      '@rushstack/typings-generator': 'link:../../libraries/typings-generator'
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/typings-generator': link:../../libraries/typings-generator
       '@types/node': 10.17.13
       '@types/tapable': 1.0.6
       decache: 4.5.1
@@ -2337,22 +2337,22 @@ importers:
       pseudolocale: 1.1.0
       xmldoc: 1.1.2
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
-      '@rushstack/set-webpack-public-path-plugin': 'link:../set-webpack-public-path-plugin'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@rushstack/set-webpack-public-path-plugin': link:../set-webpack-public-path-plugin
       '@types/loader-utils': 1.1.3
       '@types/lodash': 4.14.116
       '@types/webpack': 4.41.24
       '@types/xmldoc': 1.1.4
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
-      '@rushstack/node-core-library': 'workspace:*'
-      '@rushstack/set-webpack-public-path-plugin': 'workspace:*'
-      '@rushstack/typings-generator': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/set-webpack-public-path-plugin': workspace:*
+      '@rushstack/typings-generator': workspace:*
       '@types/loader-utils': 1.1.3
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
@@ -2373,18 +2373,18 @@ importers:
       tapable: 1.1.3
       terser: 4.7.0
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/webpack': 4.41.24
       '@types/webpack-sources': 1.4.2
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
       webpack-sources: 1.4.3
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/tapable': 1.0.6
@@ -2399,9 +2399,9 @@ importers:
     dependencies:
       lodash: 4.17.20
     devDependencies:
-      '@rushstack/eslint-config': 'link:../../stack/eslint-config'
-      '@rushstack/heft': 'link:../../apps/heft'
-      '@rushstack/heft-node-rig': 'link:../../rigs/heft-node-rig'
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
@@ -2409,9 +2409,9 @@ importers:
       '@types/uglify-js': 2.6.29
       '@types/webpack': 4.41.24
     specifiers:
-      '@rushstack/eslint-config': 'workspace:*'
-      '@rushstack/heft': 'workspace:*'
-      '@rushstack/heft-node-rig': 'workspace:*'
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
@@ -2419,7 +2419,7 @@ importers:
       '@types/uglify-js': 2.6.29
       '@types/webpack': 4.41.24
       lodash: ~4.17.15
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@azure/abort-controller/1.0.2:
     dependencies:
@@ -2449,7 +2449,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.1
       '@opentelemetry/api': 0.10.2
-      '@types/node-fetch': 2.5.7
+      '@types/node-fetch': 2.5.8
       '@types/tunnel': 0.0.1
       form-data: 3.0.0
       node-fetch: 2.6.1
@@ -2493,19 +2493,19 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==
-  /@azure/identity/1.2.1:
+  /@azure/identity/1.2.2:
     dependencies:
       '@azure/core-http': 1.2.2
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.1
-      '@azure/msal-node': 1.0.0-beta.1
+      '@azure/msal-node': 1.0.0-beta.3
       '@opentelemetry/api': 0.10.2
       axios: 0.21.1
       events: 3.2.0
       jws: 4.0.0
       msal: 1.4.4
       open: 7.3.1
-      qs: 6.9.4
+      qs: 6.9.6
       tslib: 2.1.0
       uuid: 8.3.2
     dev: false
@@ -2514,7 +2514,7 @@ packages:
     optionalDependencies:
       keytar: 5.6.0
     resolution:
-      integrity: sha512-vCzV4Xg5hWJ2e4Et0waOmIEgYHsqtGF06kklnqblZg0hKDLKxTAX5FzKYuDMk1CctY2UdEmWFcA2li2uOXOLXQ==
+      integrity: sha512-aYkeNXl52aEHW1iOZQJb3SC7Vvbu87f01iNT+pSVHwj09LpN9+gP/Lb9uoWy36Fgv9WlukM55LbjLSbb1Renqw==
   /@azure/logger/1.0.1:
     dependencies:
       tslib: 2.1.0
@@ -2523,23 +2523,23 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-QYQeaJ+A5x6aMNu8BG5qdsVBnYBop9UMwgUvGihSjf1PdZZXB+c/oMdM2ajKwzobLBh9e9QuMQkN9iL+IxLBLA==
-  /@azure/msal-common/1.7.2:
+  /@azure/msal-common/2.1.0:
     dependencies:
       debug: 4.3.1
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha512-3/voCdFKONENX+5tMrNOBSrVJb6NbE7YB8vc4FZ/4ZbjpK7GVtq9Bu1MW+HZhrmsUzSF/joHx0ZIJDYIequ/jg==
-  /@azure/msal-node/1.0.0-beta.1:
+      integrity: sha512-Y1Id+jG59S3eY2ZQQtUA/lxwbRcgjcWaiib9YX+SwV3zeRauKfEiZT7l3z+lwV+T+Sst20F6l1mJsfQcfE7CEQ==
+  /@azure/msal-node/1.0.0-beta.3:
     dependencies:
-      '@azure/msal-common': 1.7.2
-      axios: 0.19.2
+      '@azure/msal-common': 2.1.0
+      axios: 0.21.1
       jsonwebtoken: 8.5.1
       uuid: 8.3.2
     dev: false
     resolution:
-      integrity: sha512-dO/bgVScpl5loZfsfhHXmFLTNoDxGvUiZIsJCe1+HpHyFWXwGsBZ71P5ixbxRhhf/bPpZS3X+/rm1Fq2uUucJw==
+      integrity: sha512-/KfYRfrsOIrZONvo/0Vi5umuqbPBtCWNtmRvkse64uI0C4CP/W4WXwRD42VMws/8LtKvr1I5rYlYgFzt5zDz/A==
   /@azure/storage-blob/12.3.0:
     dependencies:
       '@azure/abort-controller': 1.0.2
@@ -2857,7 +2857,7 @@ packages:
       jest-haste-map: 25.5.1
       jest-message-util: 25.5.0
       jest-regex-util: 25.2.6
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       jest-resolve-dependencies: 25.5.4
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
@@ -2921,7 +2921,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 25.5.1
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       jest-util: 25.5.0
       jest-worker: 25.5.0
       slash: 3.0.0
@@ -3150,17 +3150,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-AxDfMpiVqh3hsqTxMEYtQoz866WB/sw/Jl0pgTLh6sMHHmIBNMd+E0pVcP9WNk8zTkr9LCphJ5SziU1C8BgZMA==
-  /@microsoft/tsdoc-config/0.13.9:
+  /@microsoft/tsdoc-config/0.14.0:
     dependencies:
-      '@microsoft/tsdoc': 0.12.24
+      '@microsoft/tsdoc': 0.13.0
       ajv: 6.12.6
       jju: 1.4.0
       resolve: 1.19.0
     resolution:
-      integrity: sha512-VqqZn+rT9f6XujFPFR2aN9XKF/fuir/IzKVzoxI0vXIzxysp4ee6S2jCakmlGFHEasibifFTsJr7IYmRPxfzYw==
+      integrity: sha512-KSj15FwyaxMCGJkC320rvNXxuJNCOVO02pNqIEdf5cbLakvHK8afoHTmcjdBEWl0cfBFZlMu/1DhL4VCzZq0rQ==
   /@microsoft/tsdoc/0.12.24:
     resolution:
       integrity: sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==
+  /@microsoft/tsdoc/0.13.0:
+    resolution:
+      integrity: sha512-/8J+4DdvexBH1Qh1yR8VZ6bPay2DL/TDdmSIypAa3dAghJzsdaiZG8COvzpYIML6HV2UVN0g4qbuqzjG4YKgWg==
   /@nodelib/fs.scandir/2.1.4:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
@@ -3267,7 +3270,7 @@ packages:
       graceful-fs: 4.2.4
       is-windows: 1.0.2
       json5: 2.1.3
-      parse-json: 5.1.0
+      parse-json: 5.2.0
       read-yaml-file: 2.0.0
       sort-keys: 4.2.0
       strip-bom: 4.0.0
@@ -3307,7 +3310,7 @@ packages:
       eslint: 7.12.1
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.20.6_eslint@7.12.1
-      eslint-plugin-tsdoc: 0.2.10
+      eslint-plugin-tsdoc: 0.2.11
       typescript: 3.9.7
     dev: true
     peerDependencies:
@@ -3382,7 +3385,7 @@ packages:
       '@types/webpack-dev-server': 3.11.0
       argparse: 1.0.10
       chokidar: 3.4.3
-      fast-glob: 3.2.4
+      fast-glob: 3.2.5
       glob: 7.0.6
       glob-escape: 0.0.2
       jest-snapshot: 25.4.0
@@ -3393,8 +3396,8 @@ packages:
       semver: 7.3.4
       tapable: 1.1.3
       true-case-path: 2.2.1
-      webpack: 4.44.2_webpack@4.44.2
-      webpack-dev-server: 3.11.1_webpack@4.44.2
+      webpack: 4.44.2
+      webpack-dev-server: 3.11.2_webpack@4.44.2
     dev: true
     engines:
       node: '>=10.13.0'
@@ -3445,11 +3448,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3vBaTbrFJA299hCTfSiOpgNAyN+dvmilGLYFQXuxVaki9HKZtfLSVcpSGVBXl4mRWBb3Qyiw0kJP47XIJtSgOg==
-  /@sinonjs/commons/1.8.1:
+  /@sinonjs/commons/1.8.2:
     dependencies:
       type-detect: 4.0.8
     resolution:
-      integrity: sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+      integrity: sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
   /@types/anymatch/1.3.1:
     resolution:
       integrity: sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
@@ -3528,7 +3531,7 @@ packages:
   /@types/eslint/7.2.0:
     dependencies:
       '@types/estree': 0.0.44
-      '@types/json-schema': 7.0.6
+      '@types/json-schema': 7.0.7
     dev: true
     resolution:
       integrity: sha512-LpUXkr7fnmPXWGxB0ZuLEzNeTURuHPavkC5zuU4sg62/TgL5ZEjamr5Y8b6AftwHtx2bPJasI+CL0TT2JwQ7aA==
@@ -3607,15 +3610,15 @@ packages:
   /@types/http-proxy-middleware/0.19.3:
     dependencies:
       '@types/connect': 3.4.34
-      '@types/http-proxy': 1.17.4
+      '@types/http-proxy': 1.17.5
       '@types/node': 10.17.13
     resolution:
       integrity: sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
-  /@types/http-proxy/1.17.4:
+  /@types/http-proxy/1.17.5:
     dependencies:
       '@types/node': 10.17.13
     resolution:
-      integrity: sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+      integrity: sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==
   /@types/inquirer/0.0.43:
     dependencies:
       '@types/rx': 4.1.2
@@ -3651,9 +3654,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
-  /@types/json-schema/7.0.6:
+  /@types/json-schema/7.0.7:
     resolution:
-      integrity: sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+      integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
   /@types/loader-utils/1.1.3:
     dependencies:
       '@types/node': 10.17.13
@@ -3690,13 +3693,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==
-  /@types/node-fetch/2.5.7:
+  /@types/node-fetch/2.5.8:
     dependencies:
       '@types/node': 10.17.13
       form-data: 3.0.0
     dev: false
     resolution:
-      integrity: sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+      integrity: sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
   /@types/node-forge/0.9.1:
     dependencies:
       '@types/node': 10.17.13
@@ -4020,12 +4023,11 @@ packages:
       integrity: sha512-wfkpiqaEVhZIuQRmudDszc01jC/YR7gMSxa6ulhggAe/Hs0KVIuo9wzvFiDbG3JD5pRFQoqnf4m7REDsUvBnMQ==
   /@typescript-eslint/experimental-utils/3.4.0_eslint@7.12.1+typescript@3.9.7:
     dependencies:
-      '@types/json-schema': 7.0.6
+      '@types/json-schema': 7.0.7
       '@typescript-eslint/typescript-estree': 3.4.0_typescript@3.9.7
       eslint: 7.12.1
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
-      typescript: 3.9.7
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -4206,9 +4208,6 @@ packages:
   /abbrev/1.0.9:
     resolution:
       integrity: sha1-kbR5JYinc4wl813W9jdSovh3YTU=
-  /abbrev/1.1.1:
-    resolution:
-      integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.28
@@ -4481,7 +4480,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       get-intrinsic: 1.0.2
       is-string: 1.0.5
     engines:
@@ -4538,7 +4537,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       function-bind: 1.1.1
     engines:
       node: '>= 0.4'
@@ -4633,7 +4632,7 @@ packages:
   /autoprefixer/9.8.6:
     dependencies:
       browserslist: 4.16.1
-      caniuse-lite: 1.0.30001174
+      caniuse-lite: 1.0.30001179
       colorette: 1.2.1
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -4648,13 +4647,6 @@ packages:
   /aws4/1.11.0:
     resolution:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-  /axios/0.19.2:
-    dependencies:
-      follow-redirects: 1.5.10
-    deprecated: 'Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410'
-    dev: false
-    resolution:
-      integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   /axios/0.21.1:
     dependencies:
       follow-redirects: 1.13.1
@@ -5000,11 +4992,11 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/4.16.1:
     dependencies:
-      caniuse-lite: 1.0.30001174
+      caniuse-lite: 1.0.30001179
       colorette: 1.2.1
-      electron-to-chromium: 1.3.636
+      electron-to-chromium: 1.3.642
       escalade: 3.1.1
-      node-releases: 1.1.69
+      node-releases: 1.1.70
     engines:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
     hasBin: true
@@ -5172,9 +5164,9 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-  /caniuse-lite/1.0.30001174:
+  /caniuse-lite/1.0.30001179:
     resolution:
-      integrity: sha512-tqClL/4ThQq6cfFXH3oJL4rifFBeM6gTkphjao5kgwMaW9yn0tKgQLAEfKzDwj6HQWCB/aWo8kTFlSvIN8geEA==
+      integrity: sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -5262,22 +5254,6 @@ packages:
       fsevents: 2.1.3
     resolution:
       integrity: sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
-  /chokidar/3.5.0:
-    dependencies:
-      anymatch: 3.1.1
-      braces: 3.0.2
-      glob-parent: 5.1.1
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.5.0
-    engines:
-      node: '>= 8.10.0'
-    optional: true
-    optionalDependencies:
-      fsevents: 2.3.1
-    resolution:
-      integrity: sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
   /chownr/1.1.4:
     resolution:
       integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -5481,12 +5457,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-  /commander/6.2.1:
+  /commander/7.0.0:
     dev: false
     engines:
-      node: '>= 6'
+      node: '>= 10'
     resolution:
-      integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+      integrity: sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==
   /commondir/1.0.1:
     resolution:
       integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
@@ -5620,7 +5596,7 @@ packages:
     dependencies:
       '@types/parse-json': 4.0.0
       import-fresh: 3.3.0
-      parse-json: 5.1.0
+      parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.0
     dev: true
@@ -5708,7 +5684,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
       semver: 7.3.4
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -5919,7 +5895,7 @@ packages:
       is-regex: 1.1.1
       object-is: 1.1.4
       object-keys: 1.1.1
-      regexp.prototype.flags: 1.3.0
+      regexp.prototype.flags: 1.3.1
     resolution:
       integrity: sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
   /deep-extend/0.6.0:
@@ -6208,9 +6184,9 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-  /electron-to-chromium/1.3.636:
+  /electron-to-chromium/1.3.642:
     resolution:
-      integrity: sha512-Adcvng33sd3gTjNIDNXGD1G4H6qCImIy2euUJAQHtLNplEKU5WEz5KRJxupRNIIT8sD5oFZLTKBWAf12Bsz24A==
+      integrity: sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==
   /elliptic/6.5.3:
     dependencies:
       bn.js: 4.11.9
@@ -6310,10 +6286,12 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
-  /es-abstract/1.18.0-next.1:
+  /es-abstract/1.18.0-next.2:
     dependencies:
+      call-bind: 1.0.2
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
+      get-intrinsic: 1.0.2
       has: 1.0.3
       has-symbols: 1.0.1
       is-callable: 1.2.2
@@ -6327,7 +6305,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+      integrity: sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
   /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.2.2
@@ -6457,12 +6435,12 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==
-  /eslint-plugin-tsdoc/0.2.10:
+  /eslint-plugin-tsdoc/0.2.11:
     dependencies:
-      '@microsoft/tsdoc': 0.12.24
-      '@microsoft/tsdoc-config': 0.13.9
+      '@microsoft/tsdoc': 0.13.0
+      '@microsoft/tsdoc-config': 0.14.0
     resolution:
-      integrity: sha512-LDK6K0tQ7tIyVzyktwX7P9V/aZZOMSIGYRnDP3x6+obITkVyrCrkc5yUhBiUjTc/S9gEy5GpjwD02wgcMPBFbA==
+      integrity: sha512-vEjGANpmBfrvpKj9rwePGhA+gIe1mp+dhDZsrkxlHqPVOZvzVdFSV9fxu/o3eppmxhybI8brD88jOrLEAIB9Gw==
   /eslint-scope/4.0.3:
     dependencies:
       esrecurse: 4.3.0
@@ -6878,7 +6856,7 @@ packages:
   /fast-deep-equal/3.1.3:
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-  /fast-glob/3.2.4:
+  /fast-glob/3.2.5:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       '@nodelib/fs.walk': 1.2.6
@@ -6889,7 +6867,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+      integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   /fast-json-stable-stringify/2.1.0:
     resolution:
       integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -6952,7 +6930,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -7128,14 +7106,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
-  /follow-redirects/1.5.10:
-    dependencies:
-      debug: 3.1.0
-    dev: false
-    engines:
-      node: '>=4.0'
-    resolution:
-      integrity: sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   /for-in/1.0.2:
     engines:
       node: '>=0.10.0'
@@ -7699,7 +7669,7 @@ packages:
       replace-ext: 0.0.1
       through2: 2.0.5
       vinyl: 0.5.3
-    deprecated: 'gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5'
+    deprecated: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
     engines:
       node: '>=0.10'
     resolution:
@@ -7744,7 +7714,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.12.4
+      uglify-js: 3.12.5
     resolution:
       integrity: sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   /har-schema/2.0.0:
@@ -7934,7 +7904,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     engines:
       node: '>=6.9'
     peerDependencies:
@@ -8749,7 +8719,7 @@ packages:
       jest-get-type: 25.2.6
       jest-jasmine2: 25.5.4
       jest-regex-util: 25.2.6
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       jest-util: 25.5.0
       jest-validate: 25.5.0
       micromatch: 4.0.2
@@ -8919,7 +8889,7 @@ packages:
       integrity: sha1-2xmVprP68SkftT+wNyJJcKpLVJc=
   /jest-pnp-resolver/1.2.2_jest-resolve@25.5.1:
     dependencies:
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
     engines:
       node: '>=6'
     peerDependencies:
@@ -8943,7 +8913,7 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==
-  /jest-resolve/25.5.1_jest-resolve@25.5.1:
+  /jest-resolve/25.5.1:
     dependencies:
       '@jest/types': 25.5.0
       browser-resolve: 1.11.3
@@ -8956,8 +8926,6 @@ packages:
       slash: 3.0.0
     engines:
       node: '>= 8.3'
-    peerDependencies:
-      jest-resolve: '*'
     resolution:
       integrity: sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==
   /jest-runner/25.5.4:
@@ -8975,7 +8943,7 @@ packages:
       jest-jasmine2: 25.5.4
       jest-leak-detector: 25.5.0
       jest-message-util: 25.5.0
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       jest-runtime: 25.5.4
       jest-util: 25.5.0
       jest-worker: 25.5.0
@@ -9005,7 +8973,7 @@ packages:
       jest-message-util: 25.5.0
       jest-mock: 25.5.0
       jest-regex-util: 25.2.6
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       jest-snapshot: 25.5.1
       jest-util: 25.5.0
       jest-validate: 25.5.0
@@ -9036,7 +9004,7 @@ packages:
       jest-get-type: 25.2.6
       jest-matcher-utils: 25.5.0
       jest-message-util: 25.5.0
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       make-dir: 3.1.0
       natural-compare: 1.4.0
       pretty-format: 25.5.0
@@ -9057,7 +9025,7 @@ packages:
       jest-get-type: 25.2.6
       jest-matcher-utils: 25.5.0
       jest-message-util: 25.5.0
-      jest-resolve: 25.5.1_jest-resolve@25.5.1
+      jest-resolve: 25.5.1
       make-dir: 3.1.0
       natural-compare: 1.4.0
       pretty-format: 25.5.0
@@ -9677,7 +9645,7 @@ packages:
       integrity: sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
   /lolex/5.1.2:
     dependencies:
-      '@sinonjs/commons': 1.8.1
+      '@sinonjs/commons': 1.8.2
     resolution:
       integrity: sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   /long/4.0.0:
@@ -9909,12 +9877,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-  /mime/2.4.7:
+  /mime/2.5.0:
     engines:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==
+      integrity: sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
   /mimic-fn/1.2.0:
     dev: false
     engines:
@@ -10254,9 +10222,9 @@ packages:
     optional: true
     resolution:
       integrity: sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
-  /node-releases/1.1.69:
+  /node-releases/1.1.70:
     resolution:
-      integrity: sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
+      integrity: sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
   /node-sass/4.14.1:
     dependencies:
       async-foreach: 0.1.3
@@ -10289,7 +10257,7 @@ packages:
       integrity: sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
   /nopt/3.0.6:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 1.0.9
     hasBin: true
     resolution:
       integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -10474,7 +10442,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       has: 1.0.3
     engines:
       node: '>= 0.4'
@@ -10484,7 +10452,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       has: 1.0.3
     engines:
       node: '>= 0.4'
@@ -10494,7 +10462,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
     engines:
       node: '>= 0.8'
     resolution:
@@ -10526,7 +10494,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       has: 1.0.3
     engines:
       node: '>= 0.4'
@@ -10812,7 +10780,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-json/5.1.0:
+  /parse-json/5.2.0:
     dependencies:
       '@babel/code-frame': 7.12.11
       error-ex: 1.3.2
@@ -10821,7 +10789,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
+      integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   /parse-node-version/1.0.1:
     engines:
       node: '>= 0.10'
@@ -11072,7 +11040,7 @@ packages:
       postcss: 7.0.32
       schema-utils: 3.0.0
       semver: 7.3.4
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -11285,7 +11253,7 @@ packages:
       integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=
   /pseudolocale/1.1.0:
     dependencies:
-      commander: 6.2.1
+      commander: 7.0.0
     dev: false
     resolution:
       integrity: sha512-OZ8I/hwYEJ3beN3IEcNnt8EpcqblH0/x23hulKBXjs+WhTTEle+ijCHCkh2bd+cIIeCuCwSCbBe93IthGG6hLw==
@@ -11353,12 +11321,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-  /qs/6.9.4:
+  /qs/6.9.6:
     dev: false
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
+      integrity: sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
   /querystring-es3/0.2.1:
     engines:
       node: '>=0.4.x'
@@ -11534,7 +11502,7 @@ packages:
     dependencies:
       '@types/normalize-package-data': 2.4.0
       normalize-package-data: 2.5.0
-      parse-json: 5.1.0
+      parse-json: 5.2.0
       type-fest: 0.6.0
     engines:
       node: '>=8'
@@ -11640,14 +11608,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
-  /regexp.prototype.flags/1.3.0:
+  /regexp.prototype.flags/1.3.1:
     dependencies:
+      call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.17.7
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
+      integrity: sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
   /regexpp/3.1.0:
     engines:
       node: '>=8'
@@ -11747,7 +11715,7 @@ packages:
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
+    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     engines:
       node: '>=0.12.0'
     peerDependencies:
@@ -11776,7 +11744,7 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     engines:
       node: '>= 6'
     resolution:
@@ -11840,7 +11808,7 @@ packages:
     resolution:
       integrity: sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=
   /resolve-url/0.2.1:
-    deprecated: 'https://github.com/lydell/resolve-url#deprecated'
+    deprecated: https://github.com/lydell/resolve-url#deprecated
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
   /resolve/1.1.7:
@@ -11979,7 +11947,7 @@ packages:
       neo-async: 2.6.2
       pify: 4.0.1
       semver: 6.3.0
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     dev: true
     engines:
       node: '>= 6.9.0'
@@ -12015,7 +11983,7 @@ packages:
       integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==
   /schema-utils/2.7.1:
     dependencies:
-      '@types/json-schema': 7.0.6
+      '@types/json-schema': 7.0.7
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: true
@@ -12025,7 +11993,7 @@ packages:
       integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
   /schema-utils/3.0.0:
     dependencies:
-      '@types/json-schema': 7.0.6
+      '@types/json-schema': 7.0.7
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: true
@@ -12352,7 +12320,7 @@ packages:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
       source-map: 0.6.1
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
       whatwg-mimetype: 2.3.0
     dev: true
     engines:
@@ -12644,10 +12612,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0-next.2
       has-symbols: 1.0.1
       internal-slot: 1.0.2
-      regexp.prototype.flags: 1.3.0
+      regexp.prototype.flags: 1.3.1
       side-channel: 1.0.4
     resolution:
       integrity: sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==
@@ -12756,7 +12724,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -12919,7 +12887,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.7.0
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     engines:
@@ -14088,13 +14056,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-  /uglify-js/3.12.4:
+  /uglify-js/3.12.5:
     engines:
       node: '>=0.8.0'
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==
+      integrity: sha512-SgpgScL4T7Hj/w/GexjnBHi3Ien9WS1Rpfg5y91WXMj9SY997ZCQU76mH4TpLwwfmMvoOU8wiaRkIf6NaH3mtg==
   /unc-path-regex/0.1.2:
     engines:
       node: '>=0.10.0'
@@ -14180,7 +14148,7 @@ packages:
     resolution:
       integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   /urix/0.1.0:
-    deprecated: 'Please see https://github.com/lydell/urix#deprecated'
+    deprecated: Please see https://github.com/lydell/urix#deprecated
     resolution:
       integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
   /url-parse/1.4.7:
@@ -14379,7 +14347,7 @@ packages:
       graceful-fs: 4.2.4
       neo-async: 2.6.2
     optionalDependencies:
-      chokidar: 3.5.0
+      chokidar: 3.4.3
       watchpack-chokidar2: 2.0.1
     resolution:
       integrity: sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
@@ -14424,7 +14392,7 @@ packages:
       loader-utils: 1.4.0
       supports-color: 6.1.0
       v8-compile-cache: 2.2.0
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
+      webpack: 4.44.2_webpack-cli@3.3.12
       yargs: 13.3.2
     dev: false
     engines:
@@ -14437,10 +14405,10 @@ packages:
   /webpack-dev-middleware/3.7.3_webpack@4.44.2:
     dependencies:
       memory-fs: 0.4.1
-      mime: 2.4.7
+      mime: 2.5.0
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
       webpack-log: 2.0.0
     engines:
       node: '>= 6'
@@ -14448,7 +14416,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==
-  /webpack-dev-server/3.11.1_93ca2875a658e9d1552850624e6b91c7:
+  /webpack-dev-server/3.11.2_93ca2875a658e9d1552850624e6b91c7:
     dependencies:
       ansi-html: 0.0.7
       bonjour: 3.5.0
@@ -14479,7 +14447,7 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
+      webpack: 4.44.2_webpack-cli@3.3.12
       webpack-cli: 3.3.12_webpack@4.44.2
       webpack-dev-middleware: 3.7.3_webpack@4.44.2
       webpack-log: 2.0.0
@@ -14496,8 +14464,8 @@ packages:
       webpack-cli:
         optional: true
     resolution:
-      integrity: sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==
-  /webpack-dev-server/3.11.1_webpack@4.44.2:
+      integrity: sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==
+  /webpack-dev-server/3.11.2_webpack@4.44.2:
     dependencies:
       ansi-html: 0.0.7
       bonjour: 3.5.0
@@ -14528,7 +14496,7 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 4.44.2_webpack@4.44.2
+      webpack: 4.44.2
       webpack-dev-middleware: 3.7.3_webpack@4.44.2
       webpack-log: 2.0.0
       ws: 6.2.1
@@ -14543,7 +14511,7 @@ packages:
       webpack-cli:
         optional: true
     resolution:
-      integrity: sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==
+      integrity: sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==
   /webpack-log/2.0.0:
     dependencies:
       ansi-colors: 3.2.4
@@ -14558,7 +14526,7 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.44.2_93ca2875a658e9d1552850624e6b91c7:
+  /webpack/4.44.2:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -14582,15 +14550,11 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.44.2
       watchpack: 1.7.5
-      webpack: 4.44.2_93ca2875a658e9d1552850624e6b91c7
-      webpack-cli: 3.3.12_webpack@4.44.2
       webpack-sources: 1.4.3
-    dev: false
     engines:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
-      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:
@@ -14600,7 +14564,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==
-  /webpack/4.44.2_webpack@4.44.2:
+  /webpack/4.44.2_webpack-cli@3.3.12:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -14624,12 +14588,13 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.44.2
       watchpack: 1.7.5
+      webpack-cli: 3.3.12_webpack@4.44.2
       webpack-sources: 1.4.3
+    dev: false
     engines:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
-      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8057b8f0f6812516a5c975e6fd7b7c032e468579",
+  "pnpmShrinkwrapHash": "1c07e7829fae21de976b159e4428c457dcec16ac",
   "preferredVersionsHash": "2519e88d149a9cb84227de92c71a8d8063bdcfd4"
 }

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "4.14.4",
+  "pnpmVersion": "5.15.2",
 
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",


### PR DESCRIPTION
From the [PNPM changelog](https://github.com/pnpm/pnpm/blob/main/packages/pnpm/CHANGELOG.md):

> ## 5.15.0
> 
> ### Minor Changes
> 
> - Allow to specify the shell target when configuring autocompletion with `pnpm install-completion`. For instance: `pnpm install-completion zsh`.
> - New option added: `enable-modules-dir`. When `false`, pnpm will not write any files to the modules directory (node_modules). This is useful for when the modules directory is mounted with filesystem in userspace (FUSE). There is an experimental CLI that allows to mount a modules directory with FUSE: [@pnpm/mount-modules](https://www.npmjs.com/package/@pnpm/mount-modules).
> 
> ### Patch Changes
> 
> - Fixed a performance regression that was caused by [#3032](https://github.com/pnpm/pnpm/pull/3032) and shipped in pnpm v5.13.7
> 
>   The performance of repeat `pnpm install` execution was in some cases significantly slower.
> 
> - Don't create broken symlinks to skipped optional dependencies, when hoisting. This issue was already fixed in pnpm v5.13.7 for the case when the lockfile is up-to-date. This fixes the same issue for cases when the lockfile needs updates. For instance, when adding a new package.
