### PR TITLE
[api-extractor] Relax the requirements for "@packageDocumentation" tag

### DIFF
--- a/apps/api-extractor/src/aedoc/PackageDocComment.ts
+++ b/apps/api-extractor/src/aedoc/PackageDocComment.ts
@@ -2,8 +2,11 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { ParserContext, StandardTags, TSDocParser } from '@microsoft/tsdoc';
+
 import { Collector } from '../collector/Collector';
 import { ExtractorMessageId } from '../api/ExtractorMessageId';
+import { Sort } from '@rushstack/node-core-library';
 
 export class PackageDocComment {
   /**
@@ -13,56 +16,80 @@ export class PackageDocComment {
     sourceFile: ts.SourceFile,
     collector: Collector
   ): ts.TextRange | undefined {
-    // The @packageDocumentation comment is special because it is not attached to an AST
-    // definition.  Instead, it is part of the "trivia" tokens that the compiler treats
-    // as irrelevant white space.
-    //
-    // WARNING: If the comment doesn't precede an export statement, the compiler will omit
-    // it from the *.d.ts file, and API Extractor won't find it.  If this happens, you need
-    // to rearrange your statements to ensure it is passed through.
-    //
-    // This implementation assumes that the "@packageDocumentation" will be in the first TSDoc comment
-    // that appears in the entry point *.d.ts file.  We could possibly look in other places,
-    // but the above warning suggests enforcing a standardized layout.  This design choice is open
-    // to feedback.
     let packageCommentRange: ts.TextRange | undefined = undefined; // empty string
 
-    for (const commentRange of ts.getLeadingCommentRanges(sourceFile.text, sourceFile.getFullStart()) || []) {
-      if (commentRange.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
-        const commentBody: string = sourceFile.text.substring(commentRange.pos, commentRange.end);
+    const commentRanges: ts.CommentRange[] = [];
+    const commentRangesPosSet: Set<number> = new Set();
 
-        // Choose the first JSDoc-style comment
-        if (/^\s*\/\*\*/.test(commentBody)) {
-          // But only if it looks like it's trying to be @packageDocumentation
-          // (The TSDoc parser will validate this more rigorously)
-          if (/\@packageDocumentation/i.test(commentBody)) {
-            packageCommentRange = commentRange;
+    function collectCommentRanges(newCommentRanges: ts.CommentRange[] | undefined): void {
+      if (newCommentRanges !== undefined) {
+        for (const commentRange of newCommentRanges) {
+          // Have we already visited this comment before?
+          if (!commentRangesPosSet.has(commentRange.pos)) {
+            commentRangesPosSet.add(commentRange.pos);
+            commentRanges.push(commentRange);
           }
-          break;
         }
       }
     }
 
-    if (!packageCommentRange) {
-      // If we didn't find the @packageDocumentation tag in the expected place, is it in some
-      // wrong place?  This sanity check helps people to figure out why there comment isn't working.
-      for (const statement of sourceFile.statements) {
-        const ranges: ts.CommentRange[] = [];
-        ranges.push(...(ts.getLeadingCommentRanges(sourceFile.text, statement.getFullStart()) || []));
-        ranges.push(...(ts.getTrailingCommentRanges(sourceFile.text, statement.getEnd()) || []));
+    // Pick out the top-level comments only
+    collectCommentRanges(ts.getLeadingCommentRanges(sourceFile.text, sourceFile.getFullStart()));
+    for (const statement of sourceFile.statements) {
+      collectCommentRanges(ts.getLeadingCommentRanges(sourceFile.text, statement.getFullStart()));
+      collectCommentRanges(ts.getTrailingCommentRanges(sourceFile.text, statement.getEnd()));
+    }
 
-        for (const commentRange of ranges) {
-          const commentBody: string = sourceFile.text.substring(commentRange.pos, commentRange.end);
+    // Order them by the order they appear in the file
+    Sort.sortBy(commentRanges, (x) => x.pos);
 
+    let pastFirstComment: boolean = false;
+
+    for (const commentRange of commentRanges) {
+      if (commentRange.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+        const commentBody: string = sourceFile.text.substring(commentRange.pos, commentRange.end);
+
+        // Only consider TSDoc-style comments
+        if (/^\s*\/\*\*/.test(commentBody)) {
+          // Does it have the "@packageDocumentation" substring?  Note that the RegExp may incorrectly match
+          // something like:
+          //
+          //    /**
+          //     * This function tests whether the tag is the `@packageDocumentation` tag.
+          //     */
+          //
+          // We need the real TSDoc parser to determine for sure whether the tag is present.
           if (/\@packageDocumentation/i.test(commentBody)) {
-            collector.messageRouter.addAnalyzerIssueForPosition(
-              ExtractorMessageId.MisplacedPackageTag,
-              'The @packageDocumentation comment must appear at the top of entry point *.d.ts file',
-              sourceFile,
-              commentRange.pos
-            );
-            break;
+            const parser: TSDocParser = new TSDocParser();
+            const parserContext: ParserContext = parser.parseString(commentBody);
+            if (parserContext.docComment.modifierTagSet.hasTag(StandardTags.packageDocumentation)) {
+              if (pastFirstComment) {
+                // The @packageDocumentation comment is special because it is not attached to an AST
+                // definition.  Instead, it is part of the "trivia" tokens that the compiler treats
+                // as irrelevant white space.
+                //
+                // WARNING: If the comment doesn't precede an export statement, the compiler will omit
+                // it from the *.d.ts file, and API Extractor won't find it.  If this happens, you need
+                // to rearrange your statements to ensure it is passed through.  To minimize confusion,
+                // API Extractor normally requires that the "@packageDocumentation" will be in the first
+                // TSDoc comment that appears in the entry point *.d.ts file.
+                //
+                // If you need to locate the comment elsewhere in your file, use api-extractor.json to
+                // suppress the "ae-misplaced-package-tag" message.
+                collector.messageRouter.addAnalyzerIssueForPosition(
+                  ExtractorMessageId.MisplacedPackageTag,
+                  'The @packageDocumentation comment must appear at the top of entry point *.d.ts file',
+                  sourceFile,
+                  commentRange.pos
+                );
+              }
+
+              packageCommentRange = commentRange;
+              break;
+            }
           }
+
+          pastFirstComment = true;
         }
       }
     }


### PR DESCRIPTION
 

## Summary
This is a proof-of-concept fix for the issue that @wachunga reported in https://rushstack.zulipchat.com/#narrow/stream/262521-api-extractor/topic/packageDocumentation

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
