### PR TITLE
[rush-lib]: sort dependencies... with alphabetic order

### DIFF
--- a/apps/rush-lib/src/api/PackageJsonEditor.ts
+++ b/apps/rush-lib/src/api/PackageJsonEditor.ts
@@ -217,6 +217,7 @@ export class PackageJsonEditor {
 
   public saveIfModified(): boolean {
     if (this._modified) {
+      JsonFile.save(this._sanitize(), this._filePath, { updateExistingFile: true });
       JsonFile.save(this._normalize(), this._filePath, { updateExistingFile: true });
       this._modified = false;
       return true;
@@ -228,11 +229,16 @@ export class PackageJsonEditor {
     this._modified = true;
   }
 
-  private _normalize(): IPackageJson {
+  private _sanitize(): IPackageJson {
     delete this._data.dependencies;
     delete this._data.optionalDependencies;
     delete this._data.peerDependencies;
     delete this._data.devDependencies;
+    return this._data;
+  }
+
+  private _normalize(): IPackageJson {
+    this._sanitize();
 
     const keys: string[] = [...this._dependencies.keys()].sort();
 


### PR DESCRIPTION
## Summary

Keep alphabetic order for keys like dependencies, devDependencies when updating package.json

## Details

As per https://github.com/microsoft/rushstack/blob/master/apps/rush-lib/src/api/PackageJsonEditor.ts#L143, I think originally `PackageJsonEditor` tends to sort dependencies and devDependencies, but `jju` update function is trying to preserve the previous order. This PR is fixing the alphabetic order for `dependencies` `devDependencies` when updating package.json

## How it was tested

