### PR TITLE
[rush] "Cannot get dependency key for temp project" error during "rush install"

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-rush-install-issue-2460_2021-01-29-23-28.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-install-issue-2460_2021-01-29-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an error \"Cannot get dependency key\" sometimes reported by \"rush install\" (GitHub #2460)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2460


## Details

See issue for details.

## How it was tested

I reproed this using the `rush-example` repo, then confirmed that my PR fixed the repro. 

I also confirmed that it fixes the real HBO repo where we originally encountered the problem.

I didn't test NPM/Yarn, but this code reuses the `shrinkwrapFile.getTempProjectNames()` collection that is already used by `_findOrphanedTempProjects()`, so it should be safe.