### PR TITLE
[rush] Fix an issue where an array is incorrectly iterated over.

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -67,7 +67,7 @@ export class ProjectBuildCache {
     }
 
     const inputOutputFiles: string[] = [];
-    for (const file of Object.keys(trackedProjectFiles)) {
+    for (const file of trackedProjectFiles) {
       for (const outputFolder of outputFolders) {
         if (file.startsWith(outputFolder)) {
           inputOutputFiles.push(file);

--- a/common/changes/@microsoft/rush/ianc-fix-cache-check_2021-01-29-23-59.json
+++ b/common/changes/@microsoft/rush/ianc-fix-cache-check_2021-01-29-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the Rush cache feature did not correctly detect files that were both tracked by git and were expected to be cached build output.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

After a refactor, code that detects files that are both listed as cached build output and are tracked by git doesn't iterate over an array correctly.

## Details

This PR fixes the array iteration.

## How it was tested

Tested on this repo by adding a file under `rush-lib/lib` to be tracked by git and running a cached build.