### PR TITLE
[rush] fix pnpm install "Unable to find dependency"

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -408,9 +408,10 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const packageId: string = version.indexOf('/') !== -1 ? version : `/${name}/${version}`;
     let ret: IPnpmShrinkwrapDependencyYaml | undefined = this._shrinkwrapJson.packages[packageId];
     if (!ret) {
-      // Try find the shrinkwrap dependency whose name starts with packageId
+      // Sometimes, the entry key could be /name/semver_peerDep@semver,
+      // So try to find the shrinkwrap dependency whose name starts with packageId_
       for (const [k, v] of Object.entries(this._shrinkwrapJson.packages)) {
-        if (k.startsWith(packageId)) {
+        if (k.startsWith(`${packageId}_`)) {
           ret = v;
           break;
         }

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -406,7 +406,17 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   public getShrinkwrapEntry(name: string, version: string): IPnpmShrinkwrapDependencyYaml | undefined {
     // Version can sometimes be in the form of a path that's already in the /name/version format.
     const packageId: string = version.indexOf('/') !== -1 ? version : `/${name}/${version}`;
-    return this._shrinkwrapJson.packages[packageId];
+    let ret: IPnpmShrinkwrapDependencyYaml | undefined = this._shrinkwrapJson.packages[packageId];
+    if (!ret) {
+      // Try find the shrinkwrap dependency whose name starts with packageId
+      for (const [k, v] of Object.entries(this._shrinkwrapJson.packages)) {
+        if (k.startsWith(packageId)) {
+          ret = v;
+          break;
+        }
+      }
+    }
+    return ret;
   }
 
   /**

--- a/common/changes/@microsoft/rush/fix-pnpm-get-shrinkwrap-with-peer-dep_2021-02-01-06-16.json
+++ b/common/changes/@microsoft/rush/fix-pnpm-get-shrinkwrap-with-peer-dep_2021-02-01-06-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix pnpm get shrinkwrap entry with peerDeps\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "liucheng.tech@outlook.com"
+}


### PR DESCRIPTION

## Summary

Fixes https://github.com/microsoft/rushstack/issues/2227

## Details

I run into the issue `ERROR: Internal Error: Unable to find dependency xxx with version /xxx/1.2.3 in shrinkwrap.`
After digging a little deeper, I found the cause comes from shrinkwrap entry name with peerDep.

Assuming we has the following pnpm-lock.yaml

```
# pnpm-lock.yaml

packages:
  /packageA/1.0.0_packageB@1.0.0:
    peerDependencies:
      packageB: '*'
```

It leads to packageA to getShrinkwrapEntry with `{ packageB: '/packageB/1.0.0' }`.

But if packageB has peerDependency, it could be

```
# pnpm-lock.yaml

packages:
  /packageB/1.0.0_packageC@1.0.0:
    peerDependencies:
      packageC: '*'
```

In this case, `shrinkWrapJson.package[packageId]` would never get the correct shirkwrap dependency info. because wanted key is `/packageB/1.0.0` but the actual key is `/packageB/1.0.0_somePeerDep@1.0.0`


Sorry for missing reproductive repo. I encounter this issue in a private monorepo, it contains certain private packages.


## How it was tested

