### PR TITLE
[rush] Update some console log messages

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -161,13 +161,13 @@ export class ProjectBuildCache {
     }
 
     if (restoreSuccess) {
-      terminal.writeLine('Successfully restored build output from cache.');
+      terminal.writeLine('Successfully restored output from the build cache.');
     } else {
-      terminal.writeWarningLine('Unable to restore build output from cache.');
+      terminal.writeWarningLine('Unable to restore output from the build cache.');
     }
 
     if (!updateLocalCacheSuccess) {
-      terminal.writeWarningLine('An error occurred updating the local cache with the cloud cache data.');
+      terminal.writeWarningLine('Unable to update the local build cache with data from the cloud cache.');
     }
 
     return restoreSuccess;

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -360,7 +360,9 @@ export class TaskRunner {
    * Marks a task as provided by cache.
    */
   private _markTaskAsFromCache(task: Task): void {
-    task.collatedWriter.terminal.writeStdoutLine(colors.green(`${task.name} was provided by cache.`));
+    task.collatedWriter.terminal.writeStdoutLine(
+      colors.green(`${task.name} was restored from the build cache.`)
+    );
     task.status = TaskStatus.FromCache;
     task.dependents.forEach((dependent: Task) => {
       dependent.dependencies.delete(task);

--- a/common/changes/@microsoft/rush/octogonz-rush-cache-messages_2021-02-05-02-25.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-cache-messages_2021-02-05-02-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve the wording of some log messages",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION


## Summary
Update some strings.

## Details

The wording of this console message was bugging me:
```
==[ @rushstack/eslint-plugin-security ]===========================[ 4 of 19 ]==
@rushstack/eslint-plugin-security was provided by cache.

==[ @rushstack/eslint-plugin-packlets ]===========================[ 5 of 19 ]==
@rushstack/eslint-plugin-packlets was provided by cache.

==[ @rushstack/eslint-config ]====================================[ 6 of 19 ]==
@rushstack/eslint-config was skipped.

==[ @rushstack/node-core-library ]================================[ 7 of 19 ]==
"@rushstack/node-core-library" completed successfully in 11.01 seconds.
```

Without an article, "was provided by cache" sounded cave manny.  :-)  

The revised message is:
```
==[ @rushstack/eslint-plugin-security ]===========================[ 4 of 19 ]==
@rushstack/eslint-plugin-security was restored from the build cache.
```

Generally the messages should try to refer to it consistently as the "build cache;" otherwise it's somewhat unclear which cache we are talking about.  Rush has lots of caches.

## How it was tested

None; these are just string updates.