### PR TITLE
[rush-lib] Add AWS support for build cache feature

### DIFF
--- a/apps/rundown/src/Rundown.ts
+++ b/apps/rundown/src/Rundown.ts
@@ -132,7 +132,7 @@ export class Rundown {
       }
     });
 
-    await new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       childProcess.on('exit', (code: number | null, signal: string | null): void => {
         if (code !== 0 && !ignoreExitCode) {
           reject(new Error('Child process terminated with exit code ' + code));

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -55,7 +55,8 @@
     "tar": "~5.0.5",
     "true-case-path": "~2.2.1",
     "wordwrap": "~1.0.0",
-    "z-schema": "~3.18.3"
+    "z-schema": "~3.18.3",
+    "@aws-sdk/credential-provider-node": "~3.4.1"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-s3": "~3.3.0",
     "@azure/identity": "~1.2.0",
     "@azure/storage-blob": "~12.3.0",
     "@pnpm/link-bins": "~5.3.7",
@@ -67,8 +68,8 @@
     "@types/js-yaml": "3.12.1",
     "@types/lodash": "4.14.116",
     "@types/minimatch": "2.0.29",
-    "@types/node-fetch": "1.6.9",
     "@types/node": "10.17.13",
+    "@types/node-fetch": "1.6.9",
     "@types/npm-package-arg": "6.1.0",
     "@types/npm-packlist": "~1.1.1",
     "@types/read-package-tree": "5.1.0",

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -81,6 +81,7 @@
     "@types/tar": "4.0.3",
     "@types/wordwrap": "1.0.0",
     "@types/z-schema": "3.16.31",
-    "jest": "~25.4.0"
+    "jest": "~25.4.0",
+    "typescript": "~4.1.3"
   }
 }

--- a/apps/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/apps/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -7,14 +7,10 @@ import {
   JsonSchema,
   FileSystem,
   AlreadyReportedError,
-  Terminal
+  Terminal,
+  Import
 } from '@rushstack/node-core-library';
 
-import {
-  AzureEnvironmentNames,
-  AzureStorageBuildCacheProvider
-} from '../logic/buildCache/AzureStorageBuildCacheProvider';
-import { AmazonS3BuildCacheProvider } from '../logic/buildCache/AmazonS3BuildCacheProvider';
 import { RushConfiguration } from './RushConfiguration';
 import { FileSystemBuildCacheProvider } from '../logic/buildCache/FileSystemBuildCacheProvider';
 import { RushConstants } from '../logic/RushConstants';
@@ -22,25 +18,45 @@ import { CloudBuildCacheProviderBase } from '../logic/buildCache/CloudBuildCache
 import { RushUserConfiguration } from './RushUserConfiguration';
 import { CacheEntryId, GetCacheEntryIdFunction } from '../logic/buildCache/CacheEntryId';
 
+const AzureStorageBuildCacheProviderModule: typeof import('../logic/buildCache/AzureStorageBuildCacheProvider') = Import.lazy(
+  '../logic/buildCache/AzureStorageBuildCacheProvider',
+  require
+);
+import type {
+  AzureEnvironmentNames,
+  AzureStorageBuildCacheProvider
+} from '../logic/buildCache/AzureStorageBuildCacheProvider';
+const AmazonS3BuildCacheProviderModule: typeof import('../logic/buildCache/AmazonS3BuildCacheProvider') = Import.lazy(
+  '../logic/buildCache/AmazonS3BuildCacheProvider',
+  require
+);
+import type { AmazonS3BuildCacheProvider } from '../logic/buildCache/AmazonS3BuildCacheProvider';
+
 /**
  * Describes the file structure for the "common/config/rush/build-cache.json" config file.
  */
-interface IBuildCacheJson {
+interface IBaseBuildCacheJson {
   cacheProvider: 'azure-blob-storage' | 'amazon-s3' | 'local-only';
   cacheEntryNamePattern?: string;
 }
 
-interface IAzureBlobStorageBuildCacheJson extends IBuildCacheJson {
+interface IAzureBlobStorageBuildCacheJson extends IBaseBuildCacheJson {
   cacheProvider: 'azure-blob-storage';
 
   azureBlobStorageConfiguration: IAzureStorageConfigurationJson;
 }
 
-interface IAmazonS3BuildCacheJson extends IBuildCacheJson {
+interface IAmazonS3BuildCacheJson extends IBaseBuildCacheJson {
   cacheProvider: 'amazon-s3';
 
   amazonS3Configuration: IAmazonS3ConfigurationJson;
 }
+
+interface ILocalBuildCacheJson extends IBaseBuildCacheJson {
+  cacheProvider: 'local-only';
+}
+
+type IBuildCacheJson = IAzureBlobStorageBuildCacheJson | IAmazonS3BuildCacheJson | ILocalBuildCacheJson;
 
 interface IAzureStorageConfigurationJson {
   /**
@@ -127,34 +143,21 @@ export class BuildCacheConfiguration {
       }
 
       case 'azure-blob-storage': {
-        const azureStorageBuildCacheJson: IAzureBlobStorageBuildCacheJson = buildCacheJson as IAzureBlobStorageBuildCacheJson;
-        const azureStorageConfigurationJson: IAzureStorageConfigurationJson =
-          azureStorageBuildCacheJson.azureBlobStorageConfiguration;
-        this.cloudCacheProvider = new AzureStorageBuildCacheProvider({
-          storageAccountName: azureStorageConfigurationJson.storageAccountName,
-          storageContainerName: azureStorageConfigurationJson.storageContainerName,
-          azureEnvironment: azureStorageConfigurationJson.azureEnvironment,
-          blobPrefix: azureStorageConfigurationJson.blobPrefix,
-          isCacheWriteAllowed: !!azureStorageConfigurationJson.isCacheWriteAllowed
-        });
+        this.cloudCacheProvider = this._createAzureStorageBuildCacheProvider(
+          buildCacheJson.azureBlobStorageConfiguration
+        );
         break;
       }
 
       case 'amazon-s3': {
-        const amazonS3BuildCacheJson: IAmazonS3BuildCacheJson = buildCacheJson as IAmazonS3BuildCacheJson;
-        const amazonS3ConfigurationJson: IAmazonS3ConfigurationJson =
-          amazonS3BuildCacheJson.amazonS3Configuration;
-        this.cloudCacheProvider = new AmazonS3BuildCacheProvider({
-          s3Region: amazonS3ConfigurationJson.s3Region,
-          s3Bucket: amazonS3ConfigurationJson.s3Bucket,
-          s3Prefix: amazonS3ConfigurationJson.s3Prefix,
-          isCacheWriteAllowed: !!amazonS3ConfigurationJson.isCacheWriteAllowed
-        });
+        this.cloudCacheProvider = this._createAmazonS3BuildCacheProvider(
+          buildCacheJson.amazonS3Configuration
+        );
         break;
       }
 
       default: {
-        throw new Error(`Unexpected cache provider: ${buildCacheJson.cacheProvider}`);
+        throw new Error(`Unexpected cache provider: ${(buildCacheJson as IBuildCacheJson).cacheProvider}`);
       }
     }
   }
@@ -198,5 +201,28 @@ export class BuildCacheConfiguration {
 
   public static getBuildCacheConfigFilePath(rushConfiguration: RushConfiguration): string {
     return path.resolve(rushConfiguration.commonRushConfigFolder, RushConstants.buildCacheFilename);
+  }
+
+  private _createAzureStorageBuildCacheProvider(
+    azureStorageConfigurationJson: IAzureStorageConfigurationJson
+  ): AzureStorageBuildCacheProvider {
+    return new AzureStorageBuildCacheProviderModule.AzureStorageBuildCacheProvider({
+      storageAccountName: azureStorageConfigurationJson.storageAccountName,
+      storageContainerName: azureStorageConfigurationJson.storageContainerName,
+      azureEnvironment: azureStorageConfigurationJson.azureEnvironment,
+      blobPrefix: azureStorageConfigurationJson.blobPrefix,
+      isCacheWriteAllowed: !!azureStorageConfigurationJson.isCacheWriteAllowed
+    });
+  }
+
+  private _createAmazonS3BuildCacheProvider(
+    amazonS3ConfigurationJson: IAmazonS3ConfigurationJson
+  ): AmazonS3BuildCacheProvider {
+    return new AmazonS3BuildCacheProviderModule.AmazonS3BuildCacheProvider({
+      s3Region: amazonS3ConfigurationJson.s3Region,
+      s3Bucket: amazonS3ConfigurationJson.s3Bucket,
+      s3Prefix: amazonS3ConfigurationJson.s3Prefix,
+      isCacheWriteAllowed: !!amazonS3ConfigurationJson.isCacheWriteAllowed
+    });
   }
 }

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
@@ -51,7 +51,7 @@ export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
     }
     const splitIndex: number = credentialString.indexOf(':');
     if (splitIndex === -1) {
-      return undefined;
+      throw new Error('Amazon S3 credential is in an unexpected format.');
     }
     return {
       accessKeyId: credentialString.substring(0, splitIndex),

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Terminal } from '@rushstack/node-core-library';
+
+import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
+import { CloudBuildCacheProviderBase } from './CloudBuildCacheProviderBase';
+import { S3Client, GetObjectCommand, PutObjectCommand, GetObjectCommandOutput } from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+
+export interface IAmazonS3BuildCacheProviderOptions {
+  s3Bucket: string;
+  s3Region: string;
+  s3Prefix?: string;
+  isCacheWriteAllowed: boolean;
+}
+
+export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
+  private readonly _s3Bucket: string;
+  private readonly _s3Region: string;
+  private readonly _s3Prefix: string | undefined;
+  private readonly _environmentWriteCredential: string | undefined;
+  private readonly _isCacheWriteAllowedByConfiguration: boolean;
+
+  public get isCacheWriteAllowed(): boolean {
+    return this._isCacheWriteAllowedByConfiguration || !!this._environmentWriteCredential;
+  }
+
+  private _s3Client: S3Client | undefined;
+
+  public constructor(options: IAmazonS3BuildCacheProviderOptions) {
+    super();
+    //this._storageAccountName = options.storageAccountName;
+    this._s3Bucket = options.s3Bucket;
+    this._s3Region = options.s3Region;
+    this._s3Prefix = options.s3Prefix;
+    this._environmentWriteCredential = EnvironmentConfiguration.buildCacheWriteCredential;
+    this._isCacheWriteAllowedByConfiguration = options.isCacheWriteAllowed;
+
+    // TODO: Can we validate the region?
+    this._s3Client = new S3Client({ region: this._s3Region });
+  }
+
+  public async tryGetCacheEntryBufferByIdAsync(
+    terminal: Terminal,
+    cacheId: string
+  ): Promise<Buffer | undefined> {
+    try {
+      const fetchResult: GetObjectCommandOutput | undefined = await this._s3Client?.send(
+        new GetObjectCommand({
+          Bucket: this._s3Bucket,
+          Key: this._s3Prefix ? `${this._s3Prefix}/${cacheId}` : cacheId
+        })
+      );
+      if (fetchResult === undefined) {
+        return undefined;
+      }
+      return await this._streamToBuffer(fetchResult.Body as Readable);
+    } catch (e) {
+      if (e.name === 'NoSuchKey') {
+        // TODO Non-existent file is normal, can it be handled differently?
+        return undefined;
+      }
+      terminal.writeWarningLine(`Error getting cache entry from S3: ${e}`);
+      return undefined;
+    }
+  }
+
+  private _streamToBuffer(stream: Readable): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const parts: Array<Uint8Array> = [];
+      stream.on('data', (part) => parts.push(part));
+      stream.on('end', () => resolve(Buffer.concat(parts)));
+      stream.on('error', reject);
+    });
+  }
+
+  public async trySetCacheEntryBufferAsync(
+    terminal: Terminal,
+    cacheId: string,
+    entryStream: Buffer
+  ): Promise<boolean> {
+    if (!this.isCacheWriteAllowed) {
+      terminal.writeErrorLine('Writing to S3 cache is not allowed in the current configuration.');
+      return false;
+    }
+
+    try {
+      await this._s3Client?.send(
+        new PutObjectCommand({
+          Bucket: this._s3Bucket,
+          Key: this._s3Prefix ? `${this._s3Prefix}/${cacheId}` : cacheId,
+          Body: entryStream
+        })
+      );
+      return true;
+    } catch (e) {
+      terminal.writeWarningLine(`Error uploading cache entry to S3: ${e}`);
+      return false;
+    }
+  }
+
+  public updateCachedCredentialAsync(terminal: Terminal, credential: string): Promise<void> {
+    return Promise.reject('Unsupported');
+  }
+
+  public updateCachedCredentialInteractiveAsync(terminal: Terminal): Promise<void> {
+    return Promise.reject('Unsupported');
+  }
+
+  public deleteCachedCredentialsAsync(terminal: Terminal): Promise<void> {
+    return Promise.reject('Unsupported');
+  }
+}

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
@@ -59,10 +59,6 @@ export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
     };
   }
 
-  private _serializeCredentialString(credentials: IAmazonS3Credentials): string {
-    return `${credentials.accessKeyId}:${credentials.secretAccessKey}`;
-  }
-
   private get _credentialCacheId(): string {
     const cacheIdParts: string[] = ['aws-s3', this._s3Region, this._s3Bucket];
 

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
@@ -30,6 +30,7 @@ export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
   private readonly _s3Prefix: string | undefined;
   private readonly _environmentWriteCredential: string | undefined;
   private readonly _isCacheWriteAllowedByConfiguration: boolean;
+  private __credentialCacheId: string | undefined;
 
   public get isCacheWriteAllowed(): boolean {
     return this._isCacheWriteAllowedByConfiguration || !!this._environmentWriteCredential;
@@ -63,12 +64,17 @@ export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
   }
 
   private get _credentialCacheId(): string {
-    const cacheIdParts: string[] = ['aws-s3', this._s3Region, this._s3Bucket];
+    if (!this.__credentialCacheId) {
+      const cacheIdParts: string[] = ['aws-s3', this._s3Region, this._s3Bucket];
 
-    if (this._isCacheWriteAllowedByConfiguration) {
-      cacheIdParts.push('cacheWriteAllowed');
+      if (this._isCacheWriteAllowedByConfiguration) {
+        cacheIdParts.push('cacheWriteAllowed');
+      }
+
+      this.__credentialCacheId = cacheIdParts.join('|');
     }
-    return cacheIdParts.join('|');
+
+    return this.__credentialCacheId;
   }
 
   private async _getS3ClientAsync(): Promise<S3Client> {

--- a/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
@@ -77,7 +77,7 @@ export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase 
         cacheIdParts.push('cacheWriteAllowed');
       }
 
-      return cacheIdParts.join('|');
+      this.__credentialCacheId = cacheIdParts.join('|');
     }
 
     return this.__credentialCacheId;

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -16,6 +16,7 @@ import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { CloudBuildCacheProviderBase } from './CloudBuildCacheProviderBase';
 import { FileSystemBuildCacheProvider } from './FileSystemBuildCacheProvider';
 import { TarExecutable } from '../../utilities/TarExecutable';
+import { Utilities } from '../../utilities/Utilities';
 
 interface IProjectBuildCacheOptions {
   buildCacheConfiguration: BuildCacheConfiguration;
@@ -259,7 +260,7 @@ export class ProjectBuildCache {
         },
         filesToCache.outputFilePaths
       );
-      cacheEntryBuffer = await this._readStreamToBufferAsync(tarStream);
+      cacheEntryBuffer = await Utilities.readStreamToBufferAsync(tarStream);
       setLocalCacheEntryPromise = this._localBuildCacheProvider.trySetCacheEntryBufferAsync(
         terminal,
         cacheId,
@@ -384,18 +385,6 @@ export class ProjectBuildCache {
         yield entryPath;
       }
     }
-  }
-
-  private async _readStreamToBufferAsync(stream: stream.Readable): Promise<Buffer> {
-    return await new Promise((resolve: (result: Buffer) => void, reject: (error: Error) => void) => {
-      const parts: Uint8Array[] = [];
-      stream.on('data', (chunk) => parts.push(chunk));
-      stream.on('error', (error) => reject(error));
-      stream.on('end', () => {
-        const result: Buffer = Buffer.concat(parts);
-        resolve(result);
-      });
-    });
   }
 
   private static _getCacheId(options: Omit<IProjectBuildCacheOptions, 'terminal'>): string | undefined {

--- a/apps/rush-lib/src/logic/buildCache/test/AmazonS3BuildCacheProvider.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/AmazonS3BuildCacheProvider.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { EnvironmentConfiguration } from '../../../api/EnvironmentConfiguration';
+import { AmazonS3BuildCacheProvider } from '../AmazonS3BuildCacheProvider';
+
+describe('AmazonS3BuildCacheProvider', () => {
+  let buildCacheWriteCredentialEnvValue: string | undefined;
+
+  beforeEach(() => {
+    buildCacheWriteCredentialEnvValue = undefined;
+    jest
+      .spyOn(EnvironmentConfiguration, 'buildCacheWriteCredential', 'get')
+      .mockImplementation(() => buildCacheWriteCredentialEnvValue);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("Isn't writable if isCacheWriteAllowed is set to false and there is no env write credential", () => {
+    const cacheProvider: AmazonS3BuildCacheProvider = new AmazonS3BuildCacheProvider({
+      s3Region: 'region-name',
+      s3Bucket: 'container-name',
+      isCacheWriteAllowed: false
+    });
+
+    expect(cacheProvider.isCacheWriteAllowed).toBe(false);
+  });
+
+  it('Is writable if isCacheWriteAllowed is set to true and there is no env write credential', () => {
+    const cacheProvider: AmazonS3BuildCacheProvider = new AmazonS3BuildCacheProvider({
+      s3Region: 'region-name',
+      s3Bucket: 'container-name',
+      isCacheWriteAllowed: true
+    });
+
+    expect(cacheProvider.isCacheWriteAllowed).toBe(true);
+  });
+
+  it('Is writable if isCacheWriteAllowed is set to false and there is an env write credential', () => {
+    buildCacheWriteCredentialEnvValue = 'token';
+
+    const cacheProvider: AmazonS3BuildCacheProvider = new AmazonS3BuildCacheProvider({
+      s3Region: 'region-name',
+      s3Bucket: 'container-name',
+      isCacheWriteAllowed: false
+    });
+
+    expect(cacheProvider.isCacheWriteAllowed).toBe(true);
+  });
+});

--- a/apps/rush-lib/src/logic/buildCache/test/__snapshots__/AmazonS3BuildCacheProvider.test.ts.snap
+++ b/apps/rush-lib/src/logic/buildCache/test/__snapshots__/AmazonS3BuildCacheProvider.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AmazonS3BuildCacheProvider Has an expected cached credential name (write allowed) 1`] = `
+Array [
+  "aws-s3|region-name|bucket-name|cacheWriteAllowed",
+  "credential",
+]
+`;
+
+exports[`AmazonS3BuildCacheProvider Has an expected cached credential name (write not allowed) 1`] = `
+Array [
+  "aws-s3|region-name|bucket-name",
+  "credential",
+]
+`;

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -39,5 +39,5 @@ export abstract class BaseBuilder {
   /**
    * Method to be executed for the task.
    */
-  abstract async executeAsync(context: IBuilderContext): Promise<TaskStatus>;
+  abstract executeAsync(context: IBuilderContext): Promise<TaskStatus>;
 }

--- a/apps/rush-lib/src/schemas/build-cache.schema.json
+++ b/apps/rush-lib/src/schemas/build-cache.schema.json
@@ -22,7 +22,7 @@
 
         "cacheProvider": {
           "type": "string",
-          "enum": ["local-only", "azure-blob-storage"]
+          "enum": ["local-only", "azure-blob-storage", "amazon-s3"]
         },
 
         "cacheEntryNamePattern": {
@@ -82,6 +82,42 @@
                   "description": "An optional prefix for cache item blob names."
                 },
 
+                "isCacheWriteAllowed": {
+                  "type": "boolean",
+                  "description": "If set to true, allow writing to the cache. Defaults to false."
+                }
+              }
+            }
+          }
+        },
+
+        {
+          "additionalProperties": false,
+          "required": ["amazonS3Configuration"],
+          "properties": {
+            "cacheProvider": {
+              "type": "string",
+              "enum": ["amazon-s3"]
+            },
+
+            "cacheEntryNamePattern": { "$ref": "#/definitions/anything" },
+
+            "amazonS3Configuration": {
+              "type": "object",
+              "required": ["s3Region", "s3Bucket"],
+              "properties": {
+                "s3Region": {
+                  "type": "string",
+                  "description": "The Amazon S3 region of the bucket to use for build cache (e.g. \"us-east-1\")."
+                },
+                "s3Bucket": {
+                  "type": "string",
+                  "description": "The name of the bucket in Amazon S3 to use for build cache."
+                },
+                "s3Prefix": {
+                  "type": "string",
+                  "description": "An optional prefix (\"folder\") for cache items."
+                },
                 "isCacheWriteAllowed": {
                   "type": "boolean",
                   "description": "If set to true, allow writing to the cache. Defaults to false."

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -8,7 +8,7 @@ import * as tty from 'tty';
 import * as path from 'path';
 import wordwrap from 'wordwrap';
 import { JsonFile, IPackageJson, FileSystem, FileConstants, Terminal } from '@rushstack/node-core-library';
-import { Stream } from 'stream';
+import type * as stream from 'stream';
 import { CommandLineHelper } from '@rushstack/ts-command-line';
 
 import { RushConfiguration } from '../api/RushConfiguration';
@@ -658,6 +658,18 @@ export class Utilities {
     }
   }
 
+  public static async readStreamToBufferAsync(stream: stream.Readable): Promise<Buffer> {
+    return await new Promise((resolve: (result: Buffer) => void, reject: (error: Error) => void) => {
+      const parts: Uint8Array[] = [];
+      stream.on('data', (chunk) => parts.push(chunk));
+      stream.on('error', (error) => reject(error));
+      stream.on('end', () => {
+        const result: Buffer = Buffer.concat(parts);
+        resolve(result);
+      });
+    });
+  }
+
   private static _executeLifecycleCommandInternal<TCommandResult>(
     command: string,
     spawnFunction: (
@@ -798,7 +810,7 @@ export class Utilities {
       | 'pipe'
       | 'ignore'
       | 'inherit'
-      | (number | 'pipe' | 'ignore' | 'inherit' | 'ipc' | Stream | null | undefined)[]
+      | (number | 'pipe' | 'ignore' | 'inherit' | 'ipc' | stream.Stream | null | undefined)[]
       | undefined,
     environment?: IEnvironment,
     keepEnvironment: boolean = false

--- a/apps/rush-lib/tsconfig.json
+++ b/apps/rush-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "types": ["heft-jest", "node"]
+    "types": ["heft-jest", "node"],
+    "skipLibCheck": true
   }
 }

--- a/common/changes/@microsoft/rush/aws-build-cache_2021-02-09-16-23.json
+++ b/common/changes/@microsoft/rush/aws-build-cache_2021-02-09-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add AWS S3 support to the experimental build cache feature",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "raihle@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-node-rig/aws-build-cache_2021-02-09-16-23.json
+++ b/common/changes/@rushstack/heft-node-rig/aws-build-cache_2021-02-09-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Update to TypeScript 4",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "raihle@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/module-minifier-plugin/aws-build-cache_2021-02-09-16-23.json
+++ b/common/changes/@rushstack/module-minifier-plugin/aws-build-cache_2021-02-09-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "raihle@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rundown/aws-build-cache_2021-02-09-16-23.json
+++ b/common/changes/@rushstack/rundown/aws-build-cache_2021-02-09-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown",
+  "email": "raihle@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -3,6 +3,18 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
   "packages": [
     {
+      "name": "@aws-sdk/client-s3",
+      "allowedCategories": ["libraries"]
+    },
+    {
+      "name": "@aws-sdk/node-http-handler",
+      "allowedCategories": ["libraries"]
+    },
+    {
+      "name": "@aws-sdk/types",
+      "allowedCategories": ["libraries"]
+    },
+    {
       "name": "@azure/identity",
       "allowedCategories": ["libraries"]
     },

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -7,6 +7,10 @@
       "allowedCategories": ["libraries"]
     },
     {
+      "name": "@aws-sdk/credential-provider-node",
+      "allowedCategories": ["libraries"]
+    },
+    {
       "name": "@aws-sdk/node-http-handler",
       "allowedCategories": ["libraries"]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -228,6 +228,7 @@ importers:
   ../../apps/rush-lib:
     dependencies:
       '@aws-sdk/client-s3': 3.3.0
+      '@aws-sdk/credential-provider-node': 3.4.1
       '@azure/identity': 1.2.3
       '@azure/storage-blob': 12.3.0
       '@pnpm/link-bins': 5.3.22
@@ -291,6 +292,7 @@ importers:
       jest: 25.4.0
     specifiers:
       '@aws-sdk/client-s3': ~3.3.0
+      '@aws-sdk/credential-provider-node': ~3.4.1
       '@azure/identity': ~1.2.0
       '@azure/storage-blob': ~12.3.0
       '@pnpm/link-bins': ~5.3.7
@@ -2548,6 +2550,16 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-kyqZMlGdH/05IhuXLBUXtj5+hhRfYiHFcJLc3ts/uiwCixswVHPAYHgyWm9ajFkmWtpz6ih+0LoYryhPbYu01A==
+  /@aws-sdk/credential-provider-env/3.4.1:
+    dependencies:
+      '@aws-sdk/property-provider': 3.4.1
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-MwQRbsgq+skGinT/zP0fCxFrgOLXca64Z7H04gpDwLY1gCaqpWLR30r8zYkoNUZM/S72s3bec5DXxJd18BFpGA==
   /@aws-sdk/credential-provider-imds/3.3.0:
     dependencies:
       '@aws-sdk/property-provider': 3.3.0
@@ -2558,6 +2570,16 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-Cx0YMnO/ScGQVDns006bLbqOxNURGN2Xm21bCY0l0ZUJCdJ2va1/9q1rljDyw2KvdzZNQVRQII3uUgj/Oq/K+g==
+  /@aws-sdk/credential-provider-imds/3.4.1:
+    dependencies:
+      '@aws-sdk/property-provider': 3.4.1
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-UfwixtJCjMXodKoQW9NygdIPWrpginZQdjAyaDaRaLZ48ahcj3U0J+mrqs8qTilubO4cl+Oj0DORdfnyR2iIcA==
   /@aws-sdk/credential-provider-ini/3.3.0:
     dependencies:
       '@aws-sdk/property-provider': 3.3.0
@@ -2569,6 +2591,17 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-zawNFJoasXiaV5n0H3/KNOi7mAZ7mHpG1+nBEkoWhZ31lIUM9+heGPcxKCbf/pMQjiOebUqL1OpWe4uSWxIVMw==
+  /@aws-sdk/credential-provider-ini/3.4.1:
+    dependencies:
+      '@aws-sdk/property-provider': 3.4.1
+      '@aws-sdk/shared-ini-file-loader': 3.4.1
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-q/2cGi+F4/NnAqX6T9O2RPQLxgKTC05Fs2HT+xtg5BHNKmrl6YCkm5Xi3VBdoZ+gcyaTqyXEvnyotZvg7pXWnQ==
   /@aws-sdk/credential-provider-node/3.3.0:
     dependencies:
       '@aws-sdk/credential-provider-env': 3.3.0
@@ -2583,6 +2616,20 @@ packages:
       node: '>=10.0.0'
     resolution:
       integrity: sha512-PPBNzPq8fHk9dEQTTE4iJi6ZWtmo057Lc+I8Rlzmvz6NthK9iKiU819tfaxVBb6ZR7bLP0BuDiCi4G1lD+rQnQ==
+  /@aws-sdk/credential-provider-node/3.4.1:
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.4.1
+      '@aws-sdk/credential-provider-imds': 3.4.1
+      '@aws-sdk/credential-provider-ini': 3.4.1
+      '@aws-sdk/credential-provider-process': 3.4.1
+      '@aws-sdk/property-provider': 3.4.1
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-8qRIpyuKxAjH4LNcAt4hpMPCsaiIMFzlJHyq+xXo303KYWZ79lpkKL1jumKlhnoJreCdGy1X/hJAlgiZinPYag==
   /@aws-sdk/credential-provider-process/3.3.0:
     dependencies:
       '@aws-sdk/credential-provider-ini': 3.3.0
@@ -2595,6 +2642,18 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-7oOF1j6ydUq43P3SsasiIpbxMKCmT0C+XwggHTGiVxNtX+QZiH1vdMf8otA7puLEey0iY5wTAIEcZhC6HenojA==
+  /@aws-sdk/credential-provider-process/3.4.1:
+    dependencies:
+      '@aws-sdk/credential-provider-ini': 3.4.1
+      '@aws-sdk/property-provider': 3.4.1
+      '@aws-sdk/shared-ini-file-loader': 3.4.1
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-BfRjSUSkxSTcbyUV4+fNIjVnq+ht2tc9E7j8+q6q8f5Ny4RgsIIjA+wMPZQUsm3TL/hyJl9sPkzEyk1y58iwqA==
   /@aws-sdk/eventstream-marshaller/3.3.0:
     dependencies:
       '@aws-crypto/crc32': 1.0.0
@@ -2889,6 +2948,15 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-JTyjtXVNhFczL9IfgwXD55F6DqXL50PhfZxFW92t5dDj5VtWpOL74BbuxHQxHBgnQv1FKLr6N9cr7gfXWexDug==
+  /@aws-sdk/property-provider/3.4.1:
+    dependencies:
+      '@aws-sdk/types': 3.4.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-MAh+7ZmFKXWOrlhtvOnMOU9Xe/fHnLG5b7UduV/yduXQ2X+CqKJlBKX2ZuUNP7/7r46E89pasNzr80G0JWcv/A==
   /@aws-sdk/protocol-http/3.3.0:
     dependencies:
       '@aws-sdk/types': 3.1.0
@@ -2931,6 +2999,14 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-5MxZ/CnSaWvecwtLWmcskMe41zBnAkckQRl+xKygl8wLD/q0goWcmMkA4Sx9fyFnGQtGN/+nNvu0dlG2Arxmvw==
+  /@aws-sdk/shared-ini-file-loader/3.4.1:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-8FDYkJH0pQjfUWIugQz7fhWYmb5f5oo34jch6Wcsg4MrX2v0Ffw2/rpov/f+3l1U5g9d0T+rlFWxg1ZB6JM6hQ==
   /@aws-sdk/signature-v4/3.3.0:
     dependencies:
       '@aws-sdk/is-array-buffer': 3.1.0
@@ -2959,6 +3035,12 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-4Az7cemXCN4Qp8EheNkZTJJqIG0dvCT2KAreJLoclcVTcEFw2rzlATUnSeia1YTRsVd6aNxD001Ug7f3vYcQkw==
+  /@aws-sdk/types/3.4.1:
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg==
   /@aws-sdk/url-parser-native/3.3.0:
     dependencies:
       '@aws-sdk/querystring-parser': 3.3.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -227,6 +227,7 @@ importers:
       semver: ~7.3.0
   ../../apps/rush-lib:
     dependencies:
+      '@aws-sdk/client-s3': 3.3.0
       '@azure/identity': 1.2.3
       '@azure/storage-blob': 12.3.0
       '@pnpm/link-bins': 5.3.22
@@ -289,6 +290,7 @@ importers:
       '@types/z-schema': 3.16.31
       jest: 25.4.0
     specifiers:
+      '@aws-sdk/client-s3': ~3.3.0
       '@azure/identity': ~1.2.0
       '@azure/storage-blob': ~12.3.0
       '@pnpm/link-bins': ~5.3.7
@@ -1329,7 +1331,6 @@ importers:
   ../../libraries/debug-certificate-manager:
     dependencies:
       '@rushstack/node-core-library': link:../node-core-library
-      deasync: 0.1.21
       node-forge: 0.7.6
       sudo: 1.0.3
     devDependencies:
@@ -1347,7 +1348,6 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/node-forge': 0.9.1
-      deasync: ~0.1.19
       node-forge: ~0.7.1
       sudo: ~1.0.3
   ../../libraries/heft-config-file:
@@ -1627,14 +1627,14 @@ importers:
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       eslint: 7.12.1
-      typescript: 3.9.9
+      typescript: 4.1.5
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
     specifiers:
       '@microsoft/api-extractor': workspace:*
       '@rushstack/heft': workspace:*
       eslint: ~7.12.1
-      typescript: ~3.9.7
+      typescript: ~4.1.3
   ../../rigs/heft-web-rig:
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
@@ -2415,6 +2415,690 @@ importers:
       lodash: ~4.17.15
 lockfileVersion: 5.2
 packages:
+  /@aws-crypto/crc32/1.0.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==
+  /@aws-crypto/ie11-detection/1.0.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==
+  /@aws-crypto/sha256-browser/1.1.0:
+    dependencies:
+      '@aws-crypto/ie11-detection': 1.0.0
+      '@aws-crypto/sha256-js': 1.1.0
+      '@aws-crypto/supports-web-crypto': 1.0.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-locate-window': 3.6.1
+      '@aws-sdk/util-utf8-browser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==
+  /@aws-crypto/sha256-js/1.1.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-utf8-browser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==
+  /@aws-crypto/supports-web-crypto/1.0.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==
+  /@aws-sdk/abort-controller/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-hOsgg1fxdle9Fo4aqYCHBnrMoJEwk+sjEZUtl/dwcD4a6wW3Ono9bIC0R8QEJbOQoLqQ5X+JFiQIB2+dIIokNg==
+  /@aws-sdk/chunked-blob-reader-native/3.1.0:
+    dependencies:
+      '@aws-sdk/util-base64-browser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-ghBtZkhUWgy51/651l/GUR/qhdqjFR3GSCsz0B7qisrXc8ZNsd7OlXfnTfYNoySxD3XKpbcxsncytH4Hkxgi4A==
+  /@aws-sdk/chunked-blob-reader/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-/2fxbKwta8ZiSj59B8F3FyVRszo1/VOhpCeL16gmRRNV73rM3IqJD+xOaDdkc/sFYyBeWn/UhwgD98kxae9XsQ==
+  /@aws-sdk/client-s3/3.3.0:
+    dependencies:
+      '@aws-crypto/sha256-browser': 1.1.0
+      '@aws-crypto/sha256-js': 1.1.0
+      '@aws-sdk/config-resolver': 3.3.0
+      '@aws-sdk/credential-provider-node': 3.3.0
+      '@aws-sdk/eventstream-serde-browser': 3.3.0
+      '@aws-sdk/eventstream-serde-config-resolver': 3.3.0
+      '@aws-sdk/eventstream-serde-node': 3.3.0
+      '@aws-sdk/fetch-http-handler': 3.3.0
+      '@aws-sdk/hash-blob-browser': 3.3.0
+      '@aws-sdk/hash-node': 3.3.0
+      '@aws-sdk/hash-stream-node': 3.3.0
+      '@aws-sdk/invalid-dependency': 3.3.0
+      '@aws-sdk/md5-js': 3.3.0
+      '@aws-sdk/middleware-apply-body-checksum': 3.3.0
+      '@aws-sdk/middleware-bucket-endpoint': 3.3.0
+      '@aws-sdk/middleware-content-length': 3.3.0
+      '@aws-sdk/middleware-expect-continue': 3.3.0
+      '@aws-sdk/middleware-host-header': 3.3.0
+      '@aws-sdk/middleware-location-constraint': 3.3.0
+      '@aws-sdk/middleware-logger': 3.3.0
+      '@aws-sdk/middleware-retry': 3.3.0
+      '@aws-sdk/middleware-sdk-s3': 3.3.0
+      '@aws-sdk/middleware-serde': 3.3.0
+      '@aws-sdk/middleware-signing': 3.3.0
+      '@aws-sdk/middleware-ssec': 3.3.0
+      '@aws-sdk/middleware-stack': 3.1.0
+      '@aws-sdk/middleware-user-agent': 3.3.0
+      '@aws-sdk/node-config-provider': 3.3.0
+      '@aws-sdk/node-http-handler': 3.3.0
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/smithy-client': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/url-parser': 3.3.0
+      '@aws-sdk/url-parser-native': 3.3.0
+      '@aws-sdk/util-base64-browser': 3.1.0
+      '@aws-sdk/util-base64-node': 3.1.0
+      '@aws-sdk/util-body-length-browser': 3.1.0
+      '@aws-sdk/util-body-length-node': 3.1.0
+      '@aws-sdk/util-user-agent-browser': 3.3.0
+      '@aws-sdk/util-user-agent-node': 3.3.0
+      '@aws-sdk/util-utf8-browser': 3.1.0
+      '@aws-sdk/util-utf8-node': 3.1.0
+      '@aws-sdk/util-waiter': 3.3.0
+      '@aws-sdk/xml-builder': 3.1.0
+      fast-xml-parser: 3.18.0
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-beUL3kDEVY/aE8xPuXn5NFto9PaRO5oxLMKzcCj46P+L4wt9Tm8F6EEsr3XZT31r7YzBbu2TuhSqg4erUZQGEQ==
+  /@aws-sdk/config-resolver/3.3.0:
+    dependencies:
+      '@aws-sdk/signature-v4': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-d/1NjyzGl8/GyeTnhxTY1ewLBdOR9qGHcWIGukYsWllnyW/G5IwPuG0uGGCKZpBkvHcGZhZZMEfHuiEqdrLm9g==
+  /@aws-sdk/credential-provider-env/3.3.0:
+    dependencies:
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-kyqZMlGdH/05IhuXLBUXtj5+hhRfYiHFcJLc3ts/uiwCixswVHPAYHgyWm9ajFkmWtpz6ih+0LoYryhPbYu01A==
+  /@aws-sdk/credential-provider-imds/3.3.0:
+    dependencies:
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-Cx0YMnO/ScGQVDns006bLbqOxNURGN2Xm21bCY0l0ZUJCdJ2va1/9q1rljDyw2KvdzZNQVRQII3uUgj/Oq/K+g==
+  /@aws-sdk/credential-provider-ini/3.3.0:
+    dependencies:
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/shared-ini-file-loader': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-zawNFJoasXiaV5n0H3/KNOi7mAZ7mHpG1+nBEkoWhZ31lIUM9+heGPcxKCbf/pMQjiOebUqL1OpWe4uSWxIVMw==
+  /@aws-sdk/credential-provider-node/3.3.0:
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.3.0
+      '@aws-sdk/credential-provider-imds': 3.3.0
+      '@aws-sdk/credential-provider-ini': 3.3.0
+      '@aws-sdk/credential-provider-process': 3.3.0
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-PPBNzPq8fHk9dEQTTE4iJi6ZWtmo057Lc+I8Rlzmvz6NthK9iKiU819tfaxVBb6ZR7bLP0BuDiCi4G1lD+rQnQ==
+  /@aws-sdk/credential-provider-process/3.3.0:
+    dependencies:
+      '@aws-sdk/credential-provider-ini': 3.3.0
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/shared-ini-file-loader': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-7oOF1j6ydUq43P3SsasiIpbxMKCmT0C+XwggHTGiVxNtX+QZiH1vdMf8otA7puLEey0iY5wTAIEcZhC6HenojA==
+  /@aws-sdk/eventstream-marshaller/3.3.0:
+    dependencies:
+      '@aws-crypto/crc32': 1.0.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-hex-encoding': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-4xDaQP4EJXBsfmLA65NbgEBSVkqXVs6EkyWJ+hRWj7a/V6gYhlVShOBpleG62Yo4y064zropoDltRbr98cYBog==
+  /@aws-sdk/eventstream-serde-browser/3.3.0:
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.3.0
+      '@aws-sdk/eventstream-serde-universal': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-P7ropKNwAEaGhtjacFnHO2dnwZfnYqfe0nESQUwKCZ8BFZAEAIadh3i86QgBcAx9//Ib91x6h4biPsSiDV0poQ==
+  /@aws-sdk/eventstream-serde-config-resolver/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-C8DFaFRqA+cA4Jo8v75ZCZX5pCAwxL1DG7qINH40SZzEbDOUsFjEfFJnM0EWOcUx/apZ7/BVcEcyNLnSvC7NhQ==
+  /@aws-sdk/eventstream-serde-node/3.3.0:
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.3.0
+      '@aws-sdk/eventstream-serde-universal': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-OOTQRVuxP6RWmGLuGBs3jN4zfut5eJXu5Nobb1uyKDsUAzMBVQc4ZKz0KP/CJobP/23n/RTGTu7SC9FXALyusg==
+  /@aws-sdk/eventstream-serde-universal/3.3.0:
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-J6fqSM7g7Y2kzGrVAnpq4Zs47MNWVdaGeXuumfUaOILpqWR6h4sHp6EwS7L+QnFlUxyR8ZR7HWA/TKBr28iv4Q==
+  /@aws-sdk/fetch-http-handler/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/querystring-builder': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-base64-browser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-V1XwKOc2WzPuBwg70yEjr3P1bJPgD7yoRBdNn7cqte5LNWl3OVI5+DeLm+ztCvMsj4Y87klqhyrtQkxaxwdkGw==
+  /@aws-sdk/hash-blob-browser/3.3.0:
+    dependencies:
+      '@aws-sdk/chunked-blob-reader': 3.1.0
+      '@aws-sdk/chunked-blob-reader-native': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-LHgSuJNcIj9R4NCFOGcrMTMpkV3jNJw5psRAUeukr4cJkD7eKJ8odmvsbj+b7VmQuM0osDHWx8v+CzH/+FbJ3w==
+  /@aws-sdk/hash-node/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-buffer-from': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-sKrcmKoBqwhGmc7M0zae/YO06ueqh0uktZriQO+JpdIpG9MAiduqr9z3VR8IDhkCsznQqf6xRU5fdiaL6bcy9A==
+  /@aws-sdk/hash-stream-node/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-AQf76JY+UdS69zwjd3QKLdQDM1A1h3rmcvENjC8ar6zz7jH1XmuY5/T5Ii81u5xLaz0Ztswsu0cn9YCAkaueIg==
+  /@aws-sdk/invalid-dependency/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-gYPEnnMft3bT1/v4xLjvqU4Os+mVqAhg5FCQGmnk2keWuaTX3SVKDr5XEt4mg7WuP81/ldunvlgAF2RdULGn1Q==
+  /@aws-sdk/is-array-buffer/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-wE6Am+/FKuINc/aypXiBiLAatlSyxYQ9wGGQHf2iYOX5d5bHLOVKPoRwcqSCaiaR32aRcS7R+IhgxeBy+ajsMQ==
+  /@aws-sdk/md5-js/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-utf8-browser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-zfYUnkMPQnBZtJLKUE1YbEBM5a0Ra5KaPUhoA+ghcSVsxhuxBa+PHvMg5RxQtHz0kHKvzBu18DWkEhs76rg9gw==
+  /@aws-sdk/middleware-apply-body-checksum/3.3.0:
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.1.0
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-XHcyDZHZ19ZhR1VNiAyJk+xjngOP6oUtWsy/Gh42Zwrb9jIwG9R4wZ2E610yIh8pGiNmlPMtackUfrwszBHPjg==
+  /@aws-sdk/middleware-bucket-endpoint/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-arn-parser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-CIl0cZDNPVRSLcUtguW/edrTO+IAEX/8pu2W5CyWw/oT2h7oDUAWRi1ZuAoMGBCeK46JaWplEGtYVM2SvBBSOA==
+  /@aws-sdk/middleware-content-length/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-QSNTYBs8uGEtAxG9/97Jjfw1jI9Dyk8HUILX1pwDaZ9X+a0O/cdotqHbvwE1sylAlZl+clm2TDoKeLnaOHWRhg==
+  /@aws-sdk/middleware-expect-continue/3.3.0:
+    dependencies:
+      '@aws-sdk/middleware-header-default': 3.3.0
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-5kCIObFXSrmgzb97ClTLSiBXrX7iRNxlussU+SKHXvTY97KLQCEzriz8r9tJ470brs0wPWaE42bUxp0lOrzSfA==
+  /@aws-sdk/middleware-header-default/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-m7Fg4nJ2W+i1K5AQxCD0tJxaH3xRkqqoHTWP8lR9KIsN7j4cbUynRW5BYxS/OjcAKEQkoyIfHjZEEMVm/J45Ww==
+  /@aws-sdk/middleware-host-header/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-3rt5mfo0HFmKBcHQOsBLi0snVWnnbhqu0wuZmralffQLOZ7xl8p2213hwIGHt24aefjMFG+907cwoact1vEulg==
+  /@aws-sdk/middleware-location-constraint/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-sWtokFgtnI/IyQGTiivlSpkL8tN8aF7V5e01xhprq9yIt1Dvqv1Xwn79T1fqvF9EbOvkOKxiLTbFxgPY8VaaYg==
+  /@aws-sdk/middleware-logger/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-ySRUXK2UcGto73JDxeNjne/e7NvEoUtETS+U3+euD4DDUr+Bh9LRim7XxjkPciSE3VINVxZEP2C92XLYAQHcCA==
+  /@aws-sdk/middleware-retry/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/service-error-classification': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+      uuid: 3.4.0
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-62XOdoCS9+ZEUfccMkGVXHENsaMnIJ+IjQEwp6i79CVz8v387yVZRCb/cpATHILb2eLz+HsSiQvWiK3vZbTeDw==
+  /@aws-sdk/middleware-sdk-s3/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-arn-parser': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-Nt3ht9rk1rNRROKOQDtZQC9WgEllbGCnMe/CqKk3ZGAxl7Wqdx2/iePR5z5zzjL379u452GqmAfo7LVgLGXeLQ==
+  /@aws-sdk/middleware-serde/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-BLXJSj1erTlId6rj7I8YVGfJv82mDc2n52REYiR5Bnb7ob7ZBUlt5QFfLXC3HgCGIHT8ks7Kh7liTaIGXu1MVg==
+  /@aws-sdk/middleware-signing/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/signature-v4': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-6SdBgzibJLtOrBI8ANIVunsO2mPj2bNmaAGutLU5AOg313uaZWVZWhRkBvmk6KryH3B74EueOgI2+M2FWd6Ruw==
+  /@aws-sdk/middleware-ssec/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-o2r/Ewfa/Okv8p9cI7sVbtMSsP6hGy0xJ01Ezq60mw14Nz1igtfoTrq8LMEWtAXcpW3WoU7JXujb+Ler3c6S4A==
+  /@aws-sdk/middleware-stack/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-lin0C0xPspT/orPMWWHMYG/7Z128NsSj6Khs4G6TH+2rIixXxQtHLen8H2dSPNIYXnLaxvtUDl5VuqjRt+s2Ow==
+  /@aws-sdk/middleware-user-agent/3.3.0:
+    dependencies:
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-7kH0kpjcgtaxDnR5cdCHnOtsg35fMU8dnqcciTUUNIO619P4GFUROom0IpWMTDHeee4uGDTbJJ8j+dZL06/1bA==
+  /@aws-sdk/node-config-provider/3.3.0:
+    dependencies:
+      '@aws-sdk/property-provider': 3.3.0
+      '@aws-sdk/shared-ini-file-loader': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-5zxRyXu8oQuTOMFNPbeDsbR9Dm9XyZGAvK4WFmMm9XGfD04H9kllYVluGNo7fpV59DRsd+n8ft6g2kXm2PaMRg==
+  /@aws-sdk/node-http-handler/3.3.0:
+    dependencies:
+      '@aws-sdk/abort-controller': 3.3.0
+      '@aws-sdk/protocol-http': 3.3.0
+      '@aws-sdk/querystring-builder': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-24oLdrLfKPV8BtszIjxzc+SxBVrUDv7p8WmTHd9IdBWCU3BATcsJpAF6piRJ7o/VzJwvjHrk41Fum6iBNAXsLQ==
+  /@aws-sdk/property-provider/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-JTyjtXVNhFczL9IfgwXD55F6DqXL50PhfZxFW92t5dDj5VtWpOL74BbuxHQxHBgnQv1FKLr6N9cr7gfXWexDug==
+  /@aws-sdk/protocol-http/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-fAQ0iN489Sg3bHgVt1oRqPke3oEtWTPk/7LjVtx58+C5LdO4ynnERanB6YRG4NE+eeta92Ea/d+rmggfS/WQ2g==
+  /@aws-sdk/querystring-builder/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-uri-escape': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-2cTxRX3/p/GXNbyIPt3+Jn2TA4tI8dUpwLB5va1/W4YJ7baNoyKCZGFbGh9N3bsdl6x9MBk+wg8qemoXjNkr6g==
+  /@aws-sdk/querystring-parser/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-2tJ8Vj6mJNDrDx0tMXgE7GpwRhsrmXlUD4KI2m33BKzgB6vPl+iKappD/FSFheINpScVWP1oCV2+XgBLuZ25eQ==
+  /@aws-sdk/service-error-classification/3.3.0:
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-5sVE9AhvwTrlz3vm50oaVOFFjY5WGt2TOyqcV290l6TifHbJwxd5+sDq5e9wVowCiYaKB5KiRLHIn1F2pIhDTw==
+  /@aws-sdk/shared-ini-file-loader/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-5MxZ/CnSaWvecwtLWmcskMe41zBnAkckQRl+xKygl8wLD/q0goWcmMkA4Sx9fyFnGQtGN/+nNvu0dlG2Arxmvw==
+  /@aws-sdk/signature-v4/3.3.0:
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      '@aws-sdk/util-hex-encoding': 3.1.0
+      '@aws-sdk/util-uri-escape': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-l12hSwBam5Leghj4DsgJp28cDu4IFwCGSNJrNndt3CffN5RpCgayuVBnQpHtOnO01Eu728/zA3z4DKu9xXhn9Q==
+  /@aws-sdk/smithy-client/3.3.0:
+    dependencies:
+      '@aws-sdk/middleware-stack': 3.1.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-8cwSvHLlvPlQww1TnK9eu/vL7u4kWYM6C8N9mU+ug3SwvuqwIDTCYV8n6Gf+0gvu7m/J0PrIAKk32gnYPI1u6Q==
+  /@aws-sdk/types/3.1.0:
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-4Az7cemXCN4Qp8EheNkZTJJqIG0dvCT2KAreJLoclcVTcEFw2rzlATUnSeia1YTRsVd6aNxD001Ug7f3vYcQkw==
+  /@aws-sdk/url-parser-native/3.3.0:
+    dependencies:
+      '@aws-sdk/querystring-parser': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+      url: 0.11.0
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-vdAjz9NKpJkJyyFhAw0BtsZBGtWuPiorVKJver1DK5R7Ckk9zS4Wz+bY33KKqffFApyepFdu289TdMShSCOQPw==
+  /@aws-sdk/url-parser/3.3.0:
+    dependencies:
+      '@aws-sdk/querystring-parser': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-HkzZJHOlvpedNxt67NQMF1cbo53bvw9rAUuOaLyw6eBZKYD/qYsUwoUwCMnnpOw7AnRKx6N7oYyYR/sAkciTXw==
+  /@aws-sdk/util-arn-parser/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-xXL/nadq5mqEw6Mrv1ghoODuyWWsAxvr+rRNgDJOav6mypgEOiLb0ybkqinrH1ogTkAYbegs+uaWxgSPBe9ZSA==
+  /@aws-sdk/util-base64-browser/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-xkodj0VnkHl1gdYI9Nl4E2Ed+atM3xBTNaedoGnmqoyosMjPRJCpU8uFBmdiF4e+GGPsXlYe9oA/hLyJFxmeSQ==
+  /@aws-sdk/util-base64-node/3.1.0:
+    dependencies:
+      '@aws-sdk/util-buffer-from': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-FEtnINw2MeD3LAtyGcofah5D8j6OjpmwNKibr7mIgosRO++iVyXe2xa6iOoptZFn5pIU0C4fkJn5o+kjBhRafA==
+  /@aws-sdk/util-body-length-browser/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-vzKDD/p1gcA05jeLmn6+6HdOY4G6Axyp6dj1R1nVeFpPPx6KkFsNGL9/CoaRT2TGv1fHBoDXsve9JRaCxrER4Q==
+  /@aws-sdk/util-body-length-node/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-MfJoU2wFWkOmbjWDepq5bDGYZlpvtBi2Vs8ZeTcm/4+q+3L9tJ/Zb/Ofx5oeRg9VhCsAjvceQTdX+CAyP8byXA==
+  /@aws-sdk/util-buffer-from/3.1.0:
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-UeC4VKmWYgTXjNdLVHfurrdhznnoxWLUFx8xspyRd58BhSZ5vc5HiiKTPX/CGxzAP/qZG668PaoOJucwmEam4g==
+  /@aws-sdk/util-hex-encoding/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-MPOsUY3USCUBaqZ3ifgE9il/liVxEKsz6dYQ08pdtWRzZx2CT7kWslQeNAT565pMvktnvdLjfzBw2FwnSI6nqg==
+  /@aws-sdk/util-locate-window/3.6.1:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-xXJmtCNa1Sku2JkCx0RHRyXmTMBAraup6L14a5vgLrV2TNL89HRy2iybbe/6LqG8hg9QC3HFtr3QsXQXrsBI8Q==
+  /@aws-sdk/util-uri-escape/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-1ZcXVJpsA6uW3tDTQI+Rpawqh76fyHpFc55ST8VGyMgmCzlJzBpYG0ck1kqVRSUP7YyvkJQvHfcm+U6doL5Xkw==
+  /@aws-sdk/util-user-agent-browser/3.3.0:
+    dependencies:
+      '@aws-sdk/types': 3.1.0
+      bowser: 2.11.0
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-IXl5CStrW9gxZjENIkHHcnskeTKY1rFg0HVkNesjgdxX+Ly8RfpQ5VK1yXn84gz9mQbnDPXTyfh/NHt3uUpKfQ==
+  /@aws-sdk/util-user-agent-node/3.3.0:
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-EVGCqLWu4mmtqmdorW8aKA0Kc9pbAYgIMhmXN5vH277qQJGwx2TC5yuNeufoLWdk5rIb+MdXLi1CqmtyHd7mYw==
+  /@aws-sdk/util-utf8-browser/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    resolution:
+      integrity: sha512-vJP20me+Wc1RJHq+Y+gFD25aWhbQte+Qkyh3SOKQ+YvNaMcaeVwOV7b3Y3ItBuMdutHLJWmbJ2wF6dhhpy1kOA==
+  /@aws-sdk/util-utf8-node/3.1.0:
+    dependencies:
+      '@aws-sdk/util-buffer-from': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-lrBLkROMh9kTjHOguusqLvTX5+5O5CVpAGeISZlW6CCx2pMHtVRyE9cdNuRI8aJpyZsU12j8SoaKDUPGD+ixzw==
+  /@aws-sdk/util-waiter/3.3.0:
+    dependencies:
+      '@aws-sdk/abort-controller': 3.3.0
+      '@aws-sdk/types': 3.1.0
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-2oehLAHXws1tCFXQff7s/v0LExnFQVII4EXCJNyWDRWFA1uge4GtmyoJ6C8svyMI9y6vaACj997+le3z2uAgIA==
+  /@aws-sdk/xml-builder/3.1.0:
+    dependencies:
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>= 10.0.0'
+    resolution:
+      integrity: sha512-F6liCbWPMbnJq8d0qgzuXwG5O7jg1hhgiG71TTn83rnc6vFzyw2o0C+ztiqSZsbAq7r2PlEfBPWVD32gTFIXXw==
   /@azure/abort-controller/1.0.2:
     dependencies:
       tslib: 2.1.0
@@ -4709,6 +5393,7 @@ packages:
   /bindings/1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
     resolution:
       integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   /bl/4.1.0:
@@ -4799,6 +5484,10 @@ packages:
   /boolbase/1.0.0:
     resolution:
       integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+  /bowser/2.11.0:
+    dev: false
+    resolution:
+      integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
   /brace-expansion/1.1.11:
     dependencies:
       balanced-match: 1.0.0
@@ -5698,16 +6387,6 @@ packages:
   /dateformat/2.2.0:
     resolution:
       integrity: sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=
-  /deasync/0.1.21:
-    dependencies:
-      bindings: 1.5.0
-      node-addon-api: 1.7.2
-    dev: false
-    engines:
-      node: '>=0.11.0'
-    requiresBuild: true
-    resolution:
-      integrity: sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==
   /debug/2.2.0:
     dependencies:
       ms: 0.7.1
@@ -6756,6 +7435,11 @@ packages:
   /fast-levenshtein/2.0.6:
     resolution:
       integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  /fast-xml-parser/3.18.0:
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-tRrwShhppv0K5GKEtuVs92W0VGDaVltZAwtHbpjNF+JOT7cjIFySBGTEOmdBslXYyWYaZwEX/g4Su8ZeKg0LKQ==
   /fastparse/1.1.2:
     resolution:
       integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
@@ -6815,6 +7499,7 @@ packages:
     resolution:
       integrity: sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==
   /file-uri-to-path/1.0.0:
+    optional: true
     resolution:
       integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
   /fileset/0.2.1:
@@ -9996,10 +10681,6 @@ packages:
     optional: true
     resolution:
       integrity: sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
-  /node-addon-api/1.7.2:
-    dev: false
-    resolution:
-      integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
   /node-addon-api/3.1.0:
     dev: false
     optional: true

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -290,6 +290,7 @@ importers:
       '@types/wordwrap': 1.0.0
       '@types/z-schema': 3.16.31
       jest: 25.4.0
+      typescript: 4.1.5
     specifiers:
       '@aws-sdk/client-s3': ~3.3.0
       '@aws-sdk/credential-provider-node': ~3.4.1
@@ -351,6 +352,7 @@ importers:
       strict-uri-encode: ~2.0.0
       tar: ~5.0.5
       true-case-path: ~2.2.1
+      typescript: ~4.1.3
       wordwrap: ~1.0.0
       z-schema: ~3.18.3
   ../../build-tests/api-documenter-test:
@@ -1629,14 +1631,14 @@ importers:
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       eslint: 7.12.1
-      typescript: 4.1.5
+      typescript: 3.9.9
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
     specifiers:
       '@microsoft/api-extractor': workspace:*
       '@rushstack/heft': workspace:*
       eslint: ~7.12.1
-      typescript: ~4.1.3
+      typescript: ~3.9.7
   ../../rigs/heft-web-rig:
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
@@ -14651,7 +14653,6 @@ packages:
     resolution:
       integrity: sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==
   /typescript/4.1.5:
-    dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true

--- a/common/config/rush/pnpmfile.js
+++ b/common/config/rush/pnpmfile.js
@@ -36,5 +36,9 @@ function readPackage(packageJson, context) {
     packageJson.dependencies['ajv'] = '~6.12.5';
   }
 
+  if (packageJson.name === '@aws-sdk/middleware-retry') {
+    delete packageJson.dependencies['react-native-get-random-values'];
+  }
+
   return packageJson;
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "301a8baeefe35700301ad0a6e70d2886ed01091d",
+  "pnpmShrinkwrapHash": "4982b225acd9a375a976bde4e4d3801a08b2beba",
   "preferredVersionsHash": "2519e88d149a9cb84227de92c71a8d8063bdcfd4"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "fca2476277589a0c583197210d69f82b0e52c825",
+  "pnpmShrinkwrapHash": "301a8baeefe35700301ad0a6e70d2886ed01091d",
   "preferredVersionsHash": "2519e88d149a9cb84227de92c71a8d8063bdcfd4"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "4982b225acd9a375a976bde4e4d3801a08b2beba",
+  "pnpmShrinkwrapHash": "417db4f1cab0e0f324da0e00118820a2c0ee96f5",
   "preferredVersionsHash": "2519e88d149a9cb84227de92c71a8d8063bdcfd4"
 }

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "eslint": "~7.12.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.1.3"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "eslint": "~7.12.1",
-    "typescript": "~4.1.3"
+    "typescript": "~3.9.7"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -445,7 +445,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
           allRequestsIssued = true;
 
           if (pendingMinificationRequests) {
-            await new Promise((resolve) => {
+            await new Promise<void>((resolve) => {
               resolveMinifyPromise = resolve;
             });
           }

--- a/webpack/module-minifier-plugin/src/workerPool/WebpackWorker.ts
+++ b/webpack/module-minifier-plugin/src/workerPool/WebpackWorker.ts
@@ -50,7 +50,7 @@ async function processTaskAsync(index: number): Promise<void> {
     ];
   }
 
-  await new Promise((resolve: () => void, reject: (err: Error) => void) => {
+  await new Promise<void>((resolve: () => void, reject: (err: Error) => void) => {
     const compiler: webpack.Compiler = webpack(config);
     compiler.run(async (err: Error | undefined, stats: webpack.Stats) => {
       if (err) {

--- a/webpack/module-minifier-plugin/src/workerPool/WorkerPool.ts
+++ b/webpack/module-minifier-plugin/src/workerPool/WorkerPool.ts
@@ -122,7 +122,7 @@ export class WorkerPool {
     }
 
     // There are still active workers, wait for them to clean up.
-    await new Promise((resolve, reject) => this._onComplete.push([resolve, reject]));
+    await new Promise<void>((resolve, reject) => this._onComplete.push([resolve, reject]));
   }
 
   /**


### PR DESCRIPTION
## Summary

AWS adapter for #2393. Build output can be cached in and fetched from an S3 bucket.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Uses aws-sdk-js-v3, which has some unfortunate characteristics:
* It's not as big as v2, but still adds ~15 MB
* Supports browsers and React Native, bringing in some otherwise unnecessary dependencies in order to do so.
* * I've overridden the worst offenders in pnpmfile.js.
* * I've set `skipLibCheck` in tsconfig.json, to work around the fact that AWS SDK types are often a union of Node, DOM, and React Native types, while we only want to know about Node types.
* Relies on some TypeScript 4 features.
* * I've upgraded and made some minor fixes across the repo.

I haven't implemented the `--interactive` flag, except for providing a somewhat useful error message. I don't know of any flows (similar to the Azure implementation) a developer could use in order to authenticate rush with AWS.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Added the same basic set of unit tests as the Azure integration (no check for region names, as valid options are not exposed by AWS SDK).

Enabled the experiment and configured one of our in-house projects to use AWS S3 for build cache.
* Ran `rush build`
* Made changes
* Ran `rush build` again
* Deleted the local `temp/build-cache` folder
* Changed back to the original code
* Ran `rush build` and confirmed that it was using the uploaded cache-files

Repeated the same experiment, but deleted the uploaded cache-files before the final step to confirm that it wasn't magically finding the files somewhere else.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
