### PR TITLE
[rush-lib] Disable build cache feature in `--watch` after initial build

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -234,6 +234,9 @@ export class BulkScriptAction extends BaseScriptAction {
       projectsToWatch
     });
 
+    let buildCacheConfiguration: BuildCacheConfiguration | undefined =
+      options.taskSelectorOptions.buildCacheConfiguration;
+
     // Loop until Ctrl+C
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -270,6 +273,7 @@ export class BulkScriptAction extends BaseScriptAction {
       const executeOptions: IExecuteInternalOptions = {
         taskSelectorOptions: {
           ...options.taskSelectorOptions,
+          buildCacheConfiguration,
           // Revise down the set of projects to execute the command on
           selection,
           // Pass the PackageChangeAnalyzer from the state differ to save a bit of overhead
@@ -291,6 +295,10 @@ export class BulkScriptAction extends BaseScriptAction {
           throw err;
         }
       }
+      // Current implementation of the build cache deletes output folders before repopulating them;
+      // this tends to break `webpack --watch` and the like
+      // Also, skipping writes to the local cache improves inner loop performance
+      buildCacheConfiguration = undefined;
     }
   }
 

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -296,8 +296,8 @@ export class BulkScriptAction extends BaseScriptAction {
         }
       }
       // Current implementation of the build cache deletes output folders before repopulating them;
-      // this tends to break `webpack --watch` and the like
-      // Also, skipping writes to the local cache improves inner loop performance
+      // this tends to break `webpack --watch`, etc.
+      // Also, skipping writes to the local cache improves inner loop performance and saves disk usage.
       buildCacheConfiguration = undefined;
     }
   }

--- a/common/changes/@microsoft/rush/disable-cache-during-watch_2021-02-11-19-45.json
+++ b/common/changes/@microsoft/rush/disable-cache-during-watch_2021-02-11-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable build cache after initial build when \"--watch\" is specified. This saves disk space, reduces CPU usage, and improves compatibility with downstream file watcher processes (e.g. \"webpack --watch\").",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Disables the build cache feature during after the initial build with `--watch` finishes. This is for the following reasons:
- Prevent Rush from deleting and recreating files by rehydrating from cache, which tends to break downstream file watchers, such as `webpack --watch`
- Avoid the CPU overhead of writing to the local build cache
- Avoid the disk usage of creating new local build cache entries every time a change occurs

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
Works by removing awareness of the build cache from the build process after the first build finishes.
Will reduce performance if the developer reverts to a prior build state during a `--watch` process, since this will now require a build instead of a cache hit.

## How it was tested
`rush build --watch` on the `rushstack` repo, changing files in `package-deps-hash` and reverting said changes, observing that the rebuild no longer uses the cache, even when it reverts to a previously known build state. The initial build still uses the cache, however.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
