### PR TITLE
[rush] Change watch mode from the "--watch" CLI parameter to "watchForChanges": true in command-line.json

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -111,12 +111,12 @@
       "incremental": false,
 
       /**
-       * (EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush
+       * (EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to "true" Rush
        * will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a
        * change is detected, the command will be invoked again for the changed project and any selected projects that
        * directly or indirectly depend on it.
        *
-       * For details, refer to the website article \"Using watch mode\".
+       * For details, refer to the website article "Using watch mode".
        */
       "watchForChanges": false
     },

--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -104,11 +104,21 @@
        * Note: The default value is false. In Rush 5.7.x and earlier, the default value was true.
        */
       "allowWarningsInSuccessfulBuild": false,
-      
+
       /**
        * If true then this command will be incremental like the built-in "build" command
        */
-      "incremental": false
+      "incremental": false,
+
+      /**
+       * (EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush
+       * will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a
+       * change is detected, the command will be invoked again for the changed project and any selected projects that
+       * directly or indirectly depend on it.
+       *
+       * For details, refer to the website article \"Using watch mode\".
+       */
+      "watchForChanges": false
     },
 
     {

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -26,6 +26,7 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   ignoreMissingScript?: boolean;
   incremental?: boolean;
   allowWarningsInSuccessfulBuild?: boolean;
+  watchForChanges?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -269,7 +269,9 @@ export class RushCommandLineParser extends CommandLineParser {
             ignoreMissingScript: command.ignoreMissingScript || false,
             ignoreDependencyOrder: command.ignoreDependencyOrder || false,
             incremental: command.incremental || false,
-            allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild
+            allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild,
+
+            watchForChanges: command.watchForChanges || false
           })
         );
         break;

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -40,6 +40,7 @@ export interface IBulkScriptActionOptions extends IBaseScriptActionOptions {
   ignoreDependencyOrder: boolean;
   incremental: boolean;
   allowWarningsInSuccessfulBuild: boolean;
+  watchForChanges: boolean;
 
   /**
    * Optional command to run. Otherwise, use the `actionName` as the command to run.
@@ -69,6 +70,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _ignoreMissingScript: boolean;
   private _isIncrementalBuildAllowed: boolean;
   private _commandToRun: string;
+  private _watchForChanges: boolean;
 
   private _changedProjectsOnly!: CommandLineFlagParameter;
   private _fromProject!: CommandLineStringListParameter;
@@ -79,7 +81,6 @@ export class BulkScriptAction extends BaseScriptAction {
   private _impactedByExceptProject!: CommandLineStringListParameter;
   private _fromVersionPolicy!: CommandLineStringListParameter;
   private _toVersionPolicy!: CommandLineStringListParameter;
-  private _watchParameter!: CommandLineFlagParameter;
   private _verboseParameter!: CommandLineFlagParameter;
   private _parallelismParameter: CommandLineStringParameter | undefined;
   private _ignoreHooksParameter!: CommandLineFlagParameter;
@@ -94,6 +95,7 @@ export class BulkScriptAction extends BaseScriptAction {
     this._commandToRun = options.commandToRun || options.actionName;
     this._ignoreDependencyOrder = options.ignoreDependencyOrder;
     this._allowWarningsInSuccessfulBuild = options.allowWarningsInSuccessfulBuild;
+    this._watchForChanges = options.watchForChanges;
   }
 
   public async runAsync(): Promise<void> {
@@ -204,7 +206,7 @@ export class BulkScriptAction extends BaseScriptAction {
       terminal
     };
 
-    if (this._watchParameter.value) {
+    if (this._watchForChanges) {
       await this._runWatch(executeOptions);
     } else {
       await this._runOnce(executeOptions);
@@ -422,18 +424,6 @@ export class BulkScriptAction extends BaseScriptAction {
         ' The "--from-version-policy" parameter is equivalent to specifying "--from" for each of the projects' +
         ' belonging to VERSION_POLICY_NAME.' +
         ' For details, refer to the website article "Selecting subsets of projects".'
-    });
-
-    this._watchParameter = this.defineFlagParameter({
-      parameterLongName: '--watch',
-      parameterShortName: '-w',
-      description:
-        '(EXPERIMENTAL) Normally Rush terminates after the command finishes. The "--watch" parameter will instead cause Rush' +
-        ' to enter a loop where it watches the file system for changes to the selected projects.' +
-        ' Whenever a change is detected, the command will be invoked again for the changed project and' +
-        ' any selected projects that directly or indirectly depend on it.' +
-        ' This parameter may be combined with "--changed-projects-only" to ignore dependent projects.' +
-        ' For details, refer to the website article "Using watch mode".'
     });
 
     this._verboseParameter = this.defineFlagParameter({

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -113,7 +113,7 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
 "usage: rush build [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                   [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
-                  [--from-version-policy VERSION_POLICY_NAME] [-w] [-v] [-c]
+                  [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
                   [--ignore-hooks] [-s] [-m]
                   
 
@@ -217,17 +217,6 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  -w, --watch           (EXPERIMENTAL) Normally Rush terminates after the 
-                        command finishes. The \\"--watch\\" parameter will 
-                        instead cause Rush to enter a loop where it watches 
-                        the file system for changes to the selected projects. 
-                        Whenever a change is detected, the command will be 
-                        invoked again for the changed project and any 
-                        selected projects that directly or indirectly depend 
-                        on it. This parameter may be combined with 
-                        \\"--changed-projects-only\\" to ignore dependent 
-                        projects. For details, refer to the website article 
-                        \\"Using watch mode\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   -c, --changed-projects-only
@@ -365,8 +354,8 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
 "usage: rush import-strings [-h] [-p COUNT] [-t PROJECT] [-T PROJECT]
                            [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
-                           [--from-version-policy VERSION_POLICY_NAME] [-w]
-                           [-v] [--ignore-hooks]
+                           [--from-version-policy VERSION_POLICY_NAME] [-v]
+                           [--ignore-hooks]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -461,17 +450,6 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  -w, --watch           (EXPERIMENTAL) Normally Rush terminates after the 
-                        command finishes. The \\"--watch\\" parameter will 
-                        instead cause Rush to enter a loop where it watches 
-                        the file system for changes to the selected projects. 
-                        Whenever a change is detected, the command will be 
-                        invoked again for the changed project and any 
-                        selected projects that directly or indirectly depend 
-                        on it. This parameter may be combined with 
-                        \\"--changed-projects-only\\" to ignore dependent 
-                        projects. For details, refer to the website article 
-                        \\"Using watch mode\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
@@ -767,7 +745,7 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
 "usage: rush rebuild [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME] [-w] [-v]
+                    [--from-version-policy VERSION_POLICY_NAME] [-v]
                     [--ignore-hooks] [-s] [-m]
                     
 
@@ -868,17 +846,6 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  -w, --watch           (EXPERIMENTAL) Normally Rush terminates after the 
-                        command finishes. The \\"--watch\\" parameter will 
-                        instead cause Rush to enter a loop where it watches 
-                        the file system for changes to the selected projects. 
-                        Whenever a change is detected, the command will be 
-                        invoked again for the changed project and any 
-                        selected projects that directly or indirectly depend 
-                        on it. This parameter may be combined with 
-                        \\"--changed-projects-only\\" to ignore dependent 
-                        projects. For details, refer to the website article 
-                        \\"Using watch mode\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -83,7 +83,7 @@
             },
             "watchForChanges": {
               "title": "Watch For Changes",
-              "description": "Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a change is detected, the command will be invoked again for the changed project and any selected projects that directly or indirectly depend on it. For details, refer to the website article \"Using watch mode\".",
+              "description": "(EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a change is detected, the command will be invoked again for the changed project and any selected projects that directly or indirectly depend on it. For details, refer to the website article \"Using watch mode\".",
               "type": "boolean"
             }
           }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -80,6 +80,11 @@
               "title": "Allow Warnings in Successful Build",
               "description": "By default, Rush returns a nonzero exit code if errors or warnings occur during build. If this option is set to \"true\", Rush will return a zero exit code if warnings occur.",
               "type": "boolean"
+            },
+            "watchForChanges": {
+              "title": "Watch For Changes",
+              "description": "Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a change is detected, the command will be invoked again for the changed project and any selected projects that directly or indirectly depend on it. For details, refer to the website article \"Using watch mode\".",
+              "type": "boolean"
             }
           }
         },
@@ -93,6 +98,7 @@
             "description": { "$ref": "#/definitions/anything" },
             "safeForSimultaneousRushProcesses": { "$ref": "#/definitions/anything" },
             "allowWarningsInSuccessfulBuild": { "$ref": "#/definitions/anything" },
+            "watchForChanges": { "$ref": "#/definitions/anything" },
 
             "enableParallelism": { "$ref": "#/definitions/anything" },
             "ignoreDependencyOrder": { "$ref": "#/definitions/anything" },

--- a/common/changes/@microsoft/rush/reconfigure-watch_2021-02-13-00-01.json
+++ b/common/changes/@microsoft/rush/reconfigure-watch_2021-02-13-00-01.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Replace \"--watch\" with a \"watchForChanges: true\" setting in command-line.json, since running in watch mode is not automatically compatible with downstream file watchers, and use of such is the expected common scenario.",
-      "type": "none"
+      "comment": "Convert the experimental \"--watch\" parameter into a \"watchForChanges: true\" setting in command-line.json, based on user feedback",
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/rush",

--- a/common/changes/@microsoft/rush/reconfigure-watch_2021-02-13-00-01.json
+++ b/common/changes/@microsoft/rush/reconfigure-watch_2021-02-13-00-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Replace \"--watch\" with a \"watchForChanges: true\" setting in command-line.json, since running in watch mode is not automatically compatible with downstream file watchers, and use of such is the expected common scenario.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->
Since downstream file watchers (e.g. webpack, jest) have problems with watched files being deleted and recreated, and there is a common habit of having `npm run build` clean the output directories, requires that enabling "watch mode" is performed globally for a command, instead of being an addon to any existing command.

## Details

In `command-line.json`, specify `"watchForChanges": true` on a custom command of `"commandKind": "bulk"` to enable watch mode for the command.

Internal implementation of watch mode remains the same.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Modified `command-line.json` to temporarily declare "build" as a custom bulk command, with `"watchForChanges": true` and verified that this caused `rush build` to watch for changes.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
