### PR TITLE
[rush] Enable support for Node.js 8.x again

### DIFF
--- a/apps/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/apps/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -53,7 +53,7 @@ export class NodeJsCompatibility {
       console.error(
         colors.red(
           `Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush. ` +
-            `Please upgrade to the latest Long-Term Support (LTS) version.`
+            `Please upgrade to the latest Long-Term Support (LTS) version.\n`
         )
       );
       return true;
@@ -90,7 +90,7 @@ export class NodeJsCompatibility {
             colors.yellow(
               `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
                 `of the Rush engine. Please consider upgrading the "rushVersion" setting in rush.json, ` +
-                `or downgrading Node.js.`
+                `or downgrading Node.js.\n`
             )
           );
         } else {
@@ -98,7 +98,7 @@ export class NodeJsCompatibility {
             colors.yellow(
               `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
                 `of Rush. Please consider installing a newer version of the "@microsoft/rush" ` +
-                `package, or downgrading Node.js.`
+                `package, or downgrading Node.js.\n`
             )
           );
         }
@@ -115,7 +115,7 @@ export class NodeJsCompatibility {
       console.warn(
         colors.yellow(
           `Your version of Node.js (${nodeVersion}) is not a Long-Term Support (LTS) release. ` +
-            'These versions frequently have bugs. Please consider installing a stable release.'
+            'These versions frequently have bugs. Please consider installing a stable release.\n'
         )
       );
 
@@ -131,7 +131,7 @@ export class NodeJsCompatibility {
         colors.yellow(
           `Your version of Node.js (${nodeVersion}) is an odd-numbered release. ` +
             `These releases frequently have bugs. Please consider installing a Long Term Support (LTS) ` +
-            `version instead.`
+            `version instead.\n`
         )
       );
 

--- a/apps/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/apps/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -4,7 +4,9 @@
 import colors from 'colors';
 import * as semver from 'semver';
 
-import { RushConfiguration } from '../api/RushConfiguration';
+// Minimize dependencies to avoid compatibility errors that might be encountered before
+// NodeJsCompatibility.terminateIfVersionIsTooOld() gets to run.
+import type { RushConfiguration } from '../api/RushConfiguration';
 
 /**
  * This constant is the major version of the next LTS node Node.js release. This constant should be updated when
@@ -19,6 +21,13 @@ const nodeMajorVersion: number = semver.major(nodeVersion);
 
 export interface IWarnAboutVersionTooNewOptions {
   isRushLib: boolean;
+
+  /**
+   * The CLI front-end does an early check for NodeJsCompatibility.warnAboutVersionTooNew(),
+   * so this flag is used to avoid reporting the same message twice.  Note that the definition
+   * of "too new" may differ between the globally installed "@microsoft/rush" front end
+   * versus the "@microsoft/rush-lib" loaded by the version selector.
+   */
   alreadyReportedNodeTooNewError: boolean;
 }
 
@@ -32,51 +41,67 @@ export interface IWarnAboutCompatibilityIssuesOptions extends IWarnAboutVersionT
  * @internal
  */
 export class NodeJsCompatibility {
-  public static warnAboutCompatibilityIssues(options: IWarnAboutCompatibilityIssuesOptions): boolean {
-    // Only show the first warning
-    return (
-      NodeJsCompatibility.warnAboutVersionTooOld() ||
-      NodeJsCompatibility.warnAboutVersionTooNew(options) ||
-      NodeJsCompatibility.warnAboutOddNumberedVersion() ||
-      NodeJsCompatibility.warnAboutNonLtsVersion(options.rushConfiguration)
-    );
-  }
-
-  public static warnAboutVersionTooOld(): boolean {
-    if (semver.satisfies(nodeVersion, '< 10.13.0')) {
-      // We are on an ancient version of Node.js that is known not to work with Rush
+  /**
+   * This reports if the Node.js version is known to have serious incompatibilities.  In that situation, the user
+   * should downgrade Rush to an older release that supported their Node.js version.
+   */
+  public static reportAncientIncompatibleVersion(): boolean {
+    // IMPORTANT: If this test fails, the Rush CLI front-end process will terminate with an error.
+    // Only increment it when our code base is known to use newer features (e.g. "async"/"await") that
+    // have no hope of working with older Node.js.
+    if (semver.satisfies(nodeVersion, '< 8.9.0')) {
       console.error(
         colors.red(
           `Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush. ` +
             `Please upgrade to the latest Long-Term Support (LTS) version.`
         )
       );
-
       return true;
     } else {
       return false;
     }
   }
 
+  /**
+   * Detect whether the Node.js version is "supported" by the Rush maintainers.  We generally
+   * only support versions that were "Long Term Support" (LTS) at the time when Rush was published.
+   *
+   * This is a warning only -- the user is free to ignore it and use Rush anyway.
+   */
+  public static warnAboutCompatibilityIssues(options: IWarnAboutCompatibilityIssuesOptions): boolean {
+    // Only show the first warning
+    return (
+      NodeJsCompatibility.reportAncientIncompatibleVersion() ||
+      NodeJsCompatibility.warnAboutVersionTooNew(options) ||
+      NodeJsCompatibility._warnAboutOddNumberedVersion() ||
+      NodeJsCompatibility._warnAboutNonLtsVersion(options.rushConfiguration)
+    );
+  }
+
+  /**
+   * Warn about a Node.js version that has not been tested yet with Rush.
+   */
   public static warnAboutVersionTooNew(options: IWarnAboutVersionTooNewOptions): boolean {
-    if (!options.alreadyReportedNodeTooNewError && nodeMajorVersion >= UPCOMING_NODE_LTS_VERSION + 1) {
-      // We are on a much newer release than we have tested and support
-      if (options.isRushLib) {
-        console.warn(
-          colors.yellow(
-            `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
-              `of the Rush engine. Please consider upgrading the "rushVersion" setting in rush.json, ` +
-              `or downgrading Node.js.`
-          )
-        );
-      } else {
-        console.warn(
-          colors.yellow(
-            `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
-              `of Rush. Please consider installing a newer version of the "@microsoft/rush" ` +
-              `package, or downgrading Node.js.`
-          )
-        );
+    if (nodeMajorVersion >= UPCOMING_NODE_LTS_VERSION + 1) {
+      if (!options.alreadyReportedNodeTooNewError) {
+        // We are on a much newer release than we have tested and support
+        if (options.isRushLib) {
+          console.warn(
+            colors.yellow(
+              `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
+                `of the Rush engine. Please consider upgrading the "rushVersion" setting in rush.json, ` +
+                `or downgrading Node.js.`
+            )
+          );
+        } else {
+          console.warn(
+            colors.yellow(
+              `Your version of Node.js (${nodeVersion}) has not been tested with this release ` +
+                `of Rush. Please consider installing a newer version of the "@microsoft/rush" ` +
+                `package, or downgrading Node.js.`
+            )
+          );
+        }
       }
 
       return true;
@@ -85,7 +110,7 @@ export class NodeJsCompatibility {
     }
   }
 
-  public static warnAboutNonLtsVersion(rushConfiguration: RushConfiguration | undefined): boolean {
+  private static _warnAboutNonLtsVersion(rushConfiguration: RushConfiguration | undefined): boolean {
     if (rushConfiguration && !rushConfiguration.suppressNodeLtsWarning && !NodeJsCompatibility.isLtsVersion) {
       console.warn(
         colors.yellow(
@@ -100,7 +125,7 @@ export class NodeJsCompatibility {
     }
   }
 
-  public static warnAboutOddNumberedVersion(): boolean {
+  private static _warnAboutOddNumberedVersion(): boolean {
     if (NodeJsCompatibility.isOddNumberedVersion) {
       console.warn(
         colors.yellow(

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -7,8 +7,9 @@
 // shown a meaningful error message.
 import { NodeJsCompatibility } from '@microsoft/rush-lib/lib/logic/NodeJsCompatibility';
 
-if (NodeJsCompatibility.warnAboutVersionTooOld()) {
-  // We are on an ancient version of Node.js that is known not to work with Rush
+if (NodeJsCompatibility.reportAncientIncompatibleVersion()) {
+  // The Node.js version is known to have serious incompatibilities.  In that situation, the user
+  // should downgrade Rush to an older release that supported their Node.js version.
   process.exit(1);
 }
 

--- a/common/changes/@microsoft/rush/master_2021-02-13-03-35.json
+++ b/common/changes/@microsoft/rush/master_2021-02-13-03-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow usage of Node.js 8.x since we received feedback that some projects are still supporting it",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

We received feedback that some projects are still supporting Node.js 8.x, even though it officially reached end-of-life for support in December 2020.

## Details

PR #2406 changed Rush to reports a hard error and terminate for Node.js 8.x.  Some investigation shows that Node 10 didn't introduce any new APIs that are likely to cause compatibility issues for our code base.  So this PR reverts the version check to 8.9.0.   I also clarified the function names/comments to help us make this decision in the future.



## How it was tested

I can't easily test this because in order to run the PR branch under Node 8, I need to run `rush install` with Node 8 (because of native dependencies I assume -- simply running `node rush-lib/lib/start.js` weirdly terminates with no error message).  But Rush and PNPM both require Node 10 currently.  Downgrading is not easy.

A much cheaper test would be to publish a release with these changes, then roll back to a Node 8 era branch, and then upgrade it to use the latest Rush, and see if it builds.  Publishing this PR is relatively low risk, because the code changes are pretty safe.

CC @mikeharder