### PR TITLE
[rush] Normalize selection CLI parameters for "rush install"

### DIFF
--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -239,7 +239,7 @@ export class SelectionParameterSet {
     // --to-except
     // All projects that the project directly or indirectly declares as a dependency
     for (const project of this._evaluateProjectParameter(this._toExceptProject)) {
-      args.push('--filter', `^${project.packageName}...`);
+      args.push('--filter', `${project.packageName}^...`);
     }
 
     // --impacted-by

--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -1,0 +1,381 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as colors from 'colors/safe';
+
+import {
+  PackageName,
+  AlreadyReportedError,
+  PackageJsonLookup,
+  IPackageJson
+} from '@rushstack/node-core-library';
+import { CommandLineParameterProvider, CommandLineStringListParameter } from '@rushstack/ts-command-line';
+
+import { RushConfiguration } from '../api/RushConfiguration';
+import { RushConfigurationProject } from '../api/RushConfigurationProject';
+import { Selection } from '../logic/Selection';
+
+/**
+ * This class is provides the set of command line parameters used to select projects
+ * based on dependencies.
+ *
+ * It is a separate component such that unrelated actions can share the same parameters.
+ */
+export class SelectionParameterSet {
+  private readonly _rushConfiguration: RushConfiguration;
+
+  private readonly _fromProject: CommandLineStringListParameter;
+  private readonly _impactedByProject: CommandLineStringListParameter;
+  private readonly _impactedByExceptProject: CommandLineStringListParameter;
+  private readonly _onlyProject: CommandLineStringListParameter;
+  private readonly _toProject: CommandLineStringListParameter;
+  private readonly _toExceptProject: CommandLineStringListParameter;
+
+  private readonly _fromVersionPolicy: CommandLineStringListParameter;
+  private readonly _toVersionPolicy: CommandLineStringListParameter;
+
+  public constructor(rushConfiguration: RushConfiguration, action: CommandLineParameterProvider) {
+    this._rushConfiguration = rushConfiguration;
+
+    const getProjectNames: () => Promise<string[]> = this._getProjectNames.bind(this);
+
+    this._toProject = action.defineStringListParameter({
+      parameterLongName: '--to',
+      parameterShortName: '-t',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--to" parameter expands this selection to include PROJECT and all its dependencies.' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+    this._toExceptProject = action.defineStringListParameter({
+      parameterLongName: '--to-except',
+      parameterShortName: '-T',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--to-except" parameter expands this selection to include all dependencies of PROJECT,' +
+        ' but not PROJECT itself.' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+
+    this._fromProject = action.defineStringListParameter({
+      parameterLongName: '--from',
+      parameterShortName: '-f',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--from" parameter expands this selection to include PROJECT and all projects that depend on it,' +
+        ' plus all dependencies of this set.' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+    this._onlyProject = action.defineStringListParameter({
+      parameterLongName: '--only',
+      parameterShortName: '-o',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--only" parameter expands this selection to include PROJECT; its dependencies are not added.' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+
+    this._impactedByProject = action.defineStringListParameter({
+      parameterLongName: '--impacted-by',
+      parameterShortName: '-i',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--impacted-by" parameter expands this selection to include PROJECT and any projects that' +
+        ' depend on PROJECT (and thus might be broken by changes to PROJECT).' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+
+    this._impactedByExceptProject = action.defineStringListParameter({
+      parameterLongName: '--impacted-by-except',
+      parameterShortName: '-I',
+      argumentName: 'PROJECT',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' Each "--impacted-by-except" parameter works the same as "--impacted-by" except that PROJECT itself' +
+        ' is not added to the selection.' +
+        ' "." can be used as shorthand for the project in the current working directory.' +
+        ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
+        ' For details, refer to the website article "Selecting subsets of projects".',
+      completions: getProjectNames
+    });
+
+    this._toVersionPolicy = action.defineStringListParameter({
+      parameterLongName: '--to-version-policy',
+      argumentName: 'VERSION_POLICY_NAME',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' The "--to-version-policy" parameter is equivalent to specifying "--to" for each of the projects' +
+        ' belonging to VERSION_POLICY_NAME.' +
+        ' For details, refer to the website article "Selecting subsets of projects".'
+    });
+    this._fromVersionPolicy = action.defineStringListParameter({
+      parameterLongName: '--from-version-policy',
+      argumentName: 'VERSION_POLICY_NAME',
+      description:
+        'Normally all projects in the monorepo will be processed;' +
+        ' adding this parameter will instead select a subset of projects.' +
+        ' The "--from-version-policy" parameter is equivalent to specifying "--from" for each of the projects' +
+        ' belonging to VERSION_POLICY_NAME.' +
+        ' For details, refer to the website article "Selecting subsets of projects".'
+    });
+  }
+
+  /**
+   * Computes the set of selected projects based on all parameter values.
+   *
+   * If no parameters are specified, returns all projects in the Rush config file.
+   */
+  public getSelectedProjects(): Set<RushConfigurationProject> {
+    // Include exactly these projects (--only)
+    const onlyProjects: Iterable<RushConfigurationProject> = this._evaluateProjectParameter(
+      this._onlyProject
+    );
+
+    // Include all projects that depend on these projects, and all dependencies thereof
+    const fromProjects: Set<RushConfigurationProject> = Selection.union(
+      // --from
+      this._evaluateProjectParameter(this._fromProject),
+      // --from-version-policy
+      this._evaluateVersionPolicyProjects(this._fromVersionPolicy)
+    );
+
+    // Include dependencies of these projects
+    const toProjects: Set<RushConfigurationProject> = Selection.union(
+      // --to
+      this._evaluateProjectParameter(this._toProject),
+      // --to-version-policy
+      this._evaluateVersionPolicyProjects(this._toVersionPolicy),
+      // --to-except
+      Selection.directDependenciesOf(this._evaluateProjectParameter(this._toExceptProject)),
+      // --from / --from-version-policy
+      Selection.expandAllConsumers(fromProjects)
+    );
+
+    // These projects will not have their dependencies included
+    const impactedByProjects: Set<RushConfigurationProject> = Selection.union(
+      // --impacted-by
+      this._evaluateProjectParameter(this._impactedByProject),
+      // --impacted-by-except
+      Selection.directConsumersOf(this._evaluateProjectParameter(this._impactedByExceptProject))
+    );
+
+    const selection: Set<RushConfigurationProject> = Selection.union(
+      onlyProjects,
+      Selection.expandAllDependencies(toProjects),
+      // Only dependents of these projects, not dependencies
+      Selection.expandAllConsumers(impactedByProjects)
+    );
+
+    // If no projects selected, select everything.
+    if (selection.size === 0) {
+      for (const project of this._rushConfiguration.projects) {
+        selection.add(project);
+      }
+    }
+
+    return selection;
+  }
+
+  /**
+   * Represents the selection as `--filter` parameters to pnpm.
+   *
+   * @remarks
+   * This is a separate from the selection to allow the filters to be represented more concisely.
+   *
+   * @see https://pnpm.js.org/en/filtering
+   */
+  public getPnpmFilterArguments(): string[] {
+    const args: string[] = [];
+
+    // Include exactly these projects (--only)
+    for (const project of this._evaluateProjectParameter(this._onlyProject)) {
+      args.push('--filter', project.packageName);
+    }
+
+    // Include all projects that depend on these projects, and all dependencies thereof
+    const fromProjects: Set<RushConfigurationProject> = Selection.union(
+      // --from
+      this._evaluateProjectParameter(this._fromProject),
+      // --from-version-policy
+      this._evaluateVersionPolicyProjects(this._fromVersionPolicy)
+    );
+
+    // All specified projects and all projects that they depend on
+    for (const project of Selection.union(
+      // --to
+      this._evaluateProjectParameter(this._toProject),
+      // --to-version-policy
+      this._evaluateVersionPolicyProjects(this._toVersionPolicy),
+      // --from / --from-version-policy
+      Selection.expandAllConsumers(fromProjects)
+    )) {
+      args.push('--filter', `${project.packageName}...`);
+    }
+
+    // --to-except
+    // All projects that the project directly or indirectly declares as a dependency
+    for (const project of this._evaluateProjectParameter(this._toExceptProject)) {
+      args.push('--filter', `^${project.packageName}...`);
+    }
+
+    // --impacted-by
+    // The project and all projects directly or indirectly declare it as a dependency
+    for (const project of this._evaluateProjectParameter(this._impactedByProject)) {
+      args.push('--filter', `...${project.packageName}`);
+    }
+
+    // --impacted-by-except
+    // All projects that directly or indirectly declare the specified project as a dependency
+    for (const project of this._evaluateProjectParameter(this._impactedByExceptProject)) {
+      args.push('--filter', `...^${project.packageName}`);
+    }
+
+    return args;
+  }
+
+  /**
+   * Usage telemetry for selection parameters. Only saved locally, and if requested in the config.
+   */
+  public getTelemetry(): { [key: string]: string } {
+    return {
+      command_from: `${this._fromProject.values.length > 0}`,
+      command_impactedBy: `${this._impactedByProject.values.length > 0}`,
+      command_impactedByExcept: `${this._impactedByExceptProject.values.length > 0}`,
+      command_only: `${this._onlyProject.values.length > 0}`,
+      command_to: `${this._toProject.values.length > 0}`,
+      command_toExcept: `${this._toExceptProject.values.length > 0}`,
+
+      command_fromVersionPolicy: `${this._fromVersionPolicy.values.length > 0}`,
+      command_toVersionPolicy: `${this._toVersionPolicy.values.length > 0}`
+    };
+  }
+
+  /**
+   * Computes the referents of parameters that accept a project identifier.
+   * Handles '.', unscoped names, and scoped names.
+   */
+  private *_evaluateProjectParameter(
+    projectsParameters: CommandLineStringListParameter
+  ): Iterable<RushConfigurationProject> {
+    const packageJsonLookup: PackageJsonLookup = PackageJsonLookup.instance;
+
+    for (const projectParameter of projectsParameters.values) {
+      if (projectParameter === '.') {
+        const packageJson: IPackageJson | undefined = packageJsonLookup.tryLoadPackageJsonFor(process.cwd());
+        if (packageJson) {
+          const project: RushConfigurationProject | undefined = this._rushConfiguration.getProjectByName(
+            packageJson.name
+          );
+
+          if (project) {
+            yield project;
+          } else {
+            console.log(
+              colors.red(
+                'Rush is not currently running in a project directory specified in rush.json. ' +
+                  `The "." value for the ${projectsParameters.longName} parameter is not allowed.`
+              )
+            );
+            throw new AlreadyReportedError();
+          }
+        } else {
+          console.log(
+            colors.red(
+              'Rush is not currently running in a project directory. ' +
+                `The "." value for the ${projectsParameters.longName} parameter is not allowed.`
+            )
+          );
+          throw new AlreadyReportedError();
+        }
+      } else {
+        const project:
+          | RushConfigurationProject
+          | undefined = this._rushConfiguration.findProjectByShorthandName(projectParameter);
+        if (!project) {
+          console.log(colors.red(`The project '${projectParameter}' does not exist in rush.json.`));
+          throw new AlreadyReportedError();
+        }
+
+        yield project;
+      }
+    }
+  }
+
+  /**
+   * Computes the set of available project names, for use by tab completion.
+   */
+  private async _getProjectNames(): Promise<string[]> {
+    const unscopedNamesMap: Map<string, number> = new Map<string, number>();
+
+    const scopedNames: Set<string> = new Set();
+
+    for (const project of this._rushConfiguration.rushConfigurationJson.projects) {
+      scopedNames.add(project.packageName);
+      const unscopedName: string = PackageName.getUnscopedName(project.packageName);
+      const count: number = unscopedNamesMap.get(unscopedName) || 0;
+      unscopedNamesMap.set(unscopedName, count + 1);
+    }
+
+    const unscopedNames: string[] = [];
+
+    for (const [unscopedName, unscopedNameCount] of unscopedNamesMap) {
+      // don't suggest ambiguous unscoped names
+      if (unscopedNameCount === 1 && !scopedNames.has(unscopedName)) {
+        unscopedNames.push(unscopedName);
+      }
+    }
+
+    return unscopedNames.sort().concat([...scopedNames].sort());
+  }
+
+  /**
+   * Computes the set of projects that have the specified version policy
+   */
+  private *_evaluateVersionPolicyProjects(
+    versionPoliciesParameters: CommandLineStringListParameter
+  ): Iterable<RushConfigurationProject> {
+    if (versionPoliciesParameters.values && versionPoliciesParameters.values.length > 0) {
+      const policyNames: Set<string> = new Set(versionPoliciesParameters.values);
+
+      for (const policyName of policyNames) {
+        if (!this._rushConfiguration.versionPolicyConfiguration.versionPolicies.has(policyName)) {
+          console.log(
+            colors.red(`The version policy '${policyName}' does not exist in version-policies.json.`)
+          );
+          throw new AlreadyReportedError();
+        }
+      }
+
+      for (const project of this._rushConfiguration.projects) {
+        const matches: boolean = !!project.versionPolicyName && policyNames.has(project.versionPolicyName);
+        if (matches) {
+          yield project;
+        }
+      }
+    }
+  }
+}

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -5,20 +5,10 @@ import colors from 'colors';
 import * as os from 'os';
 import * as path from 'path';
 
-import {
-  CommandLineAction,
-  ICommandLineActionOptions,
-  CommandLineStringListParameter
-} from '@rushstack/ts-command-line';
-import {
-  LockFile,
-  PackageJsonLookup,
-  IPackageJson,
-  AlreadyReportedError
-} from '@rushstack/node-core-library';
+import { CommandLineAction, ICommandLineActionOptions } from '@rushstack/ts-command-line';
+import { LockFile } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
-import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { EventHooksManager } from '../../logic/EventHooksManager';
 import { RushCommandLineParser } from './../RushCommandLineParser';
 import { Utilities } from '../../utilities/Utilities';
@@ -129,66 +119,5 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
     }
 
     return super.onExecute();
-  }
-
-  protected *evaluateProjectParameter(
-    projectsParameters: CommandLineStringListParameter
-  ): Iterable<RushConfigurationProject> {
-    const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
-
-    for (const projectParameter of projectsParameters.values) {
-      if (projectParameter === '.') {
-        const packageJson: IPackageJson | undefined = packageJsonLookup.tryLoadPackageJsonFor(process.cwd());
-        if (packageJson) {
-          const project: RushConfigurationProject | undefined = this.rushConfiguration.getProjectByName(
-            packageJson.name
-          );
-          if (project) {
-            yield project;
-          } else {
-            console.log(
-              colors.red(
-                'Rush is not currently running in a project directory specified in rush.json. ' +
-                  `The "." value for the ${projectsParameters.longName} parameter is not allowed.`
-              )
-            );
-            throw new AlreadyReportedError();
-          }
-        } else {
-          console.log(
-            colors.red(
-              'Rush is not currently running in a project directory. ' +
-                `The "." value for the ${projectsParameters.longName} parameter is not allowed.`
-            )
-          );
-          throw new AlreadyReportedError();
-        }
-      } else {
-        const project:
-          | RushConfigurationProject
-          | undefined = this.rushConfiguration.findProjectByShorthandName(projectParameter);
-        if (!project) {
-          console.log(colors.red(`The project '${projectParameter}' does not exist in rush.json.`));
-          throw new AlreadyReportedError();
-        }
-
-        yield project;
-      }
-    }
-  }
-
-  protected *evaluateVersionPolicyProjects(
-    versionPoliciesParameters: CommandLineStringListParameter
-  ): Iterable<RushConfigurationProject> {
-    if (versionPoliciesParameters.values && versionPoliciesParameters.values.length > 0) {
-      for (const project of this.rushConfiguration.projects) {
-        const matches: boolean = versionPoliciesParameters.values.some((policyName) => {
-          return project.versionPolicyName === policyName;
-        });
-        if (matches) {
-          yield project;
-        }
-      }
-    }
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -70,8 +70,7 @@ export class UpdateAction extends BaseInstallAction {
       // Because the 'defaultValue' option on the _maxInstallAttempts parameter is set,
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
-      toProjects: new Set(),
-      fromProjects: new Set()
+      pnpmFilterArguments: []
     };
   }
 }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -527,7 +527,8 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
 "usage: rush install [-h] [-p] [--bypass-policy] [--no-link]
                     [--network-concurrency COUNT] [--debug-package-manager]
                     [--max-install-attempts NUMBER] [--ignore-hooks]
-                    [--variant VARIANT] [-t PROJECT] [-f PROJECT]
+                    [--variant VARIANT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
+                    [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
                     [--from-version-policy VERSION_POLICY_NAME]
                     
@@ -574,26 +575,82 @@ Optional arguments:
                         configuration. This parameter may alternatively be 
                         specified via the RUSH_VARIANT environment variable.
   -t PROJECT, --to PROJECT
-                        Run install in the specified project and all of its 
-                        dependencies. \\".\\" can be used as shorthand to specify 
-                        the project in the current working directory. This 
-                        argument is only valid in workspace environments.
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--to\\" parameter expands 
+                        this selection to include PROJECT and all its 
+                        dependencies. \\".\\" can be used as shorthand for the 
+                        project in the current working directory. For details,
+                         refer to the website article \\"Selecting subsets of 
+                        projects\\".
+  -T PROJECT, --to-except PROJECT
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--to-except\\" parameter 
+                        expands this selection to include all dependencies of 
+                        PROJECT, but not PROJECT itself. \\".\\" can be used as 
+                        shorthand for the project in the current working 
+                        directory. For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
   -f PROJECT, --from PROJECT
-                        Run install in the specified project and all projects 
-                        that directly or indirectly depend on the specified 
-                        project. \\".\\" can be used as shorthand to specify the 
-                        project in the current working directory. This 
-                        argument is only valid in workspace environments.
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--from\\" parameter expands 
+                        this selection to include PROJECT and all projects 
+                        that depend on it, plus all dependencies of this set. 
+                        \\".\\" can be used as shorthand for the project in the 
+                        current working directory. For details, refer to the 
+                        website article \\"Selecting subsets of projects\\".
+  -o PROJECT, --only PROJECT
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--only\\" parameter expands 
+                        this selection to include PROJECT; its dependencies 
+                        are not added. \\".\\" can be used as shorthand for the 
+                        project in the current working directory. Note that 
+                        this parameter is \\"unsafe\\" as it may produce a 
+                        selection that excludes some dependencies. For 
+                        details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
+  -i PROJECT, --impacted-by PROJECT
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--impacted-by\\" parameter 
+                        expands this selection to include PROJECT and any 
+                        projects that depend on PROJECT (and thus might be 
+                        broken by changes to PROJECT). \\".\\" can be used as 
+                        shorthand for the project in the current working 
+                        directory. Note that this parameter is \\"unsafe\\" as it 
+                        may produce a selection that excludes some 
+                        dependencies. For details, refer to the website 
+                        article \\"Selecting subsets of projects\\".
+  -I PROJECT, --impacted-by-except PROJECT
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Each \\"--impacted-by-except\\" 
+                        parameter works the same as \\"--impacted-by\\" except 
+                        that PROJECT itself is not added to the selection. \\".
+                        \\" can be used as shorthand for the project in the 
+                        current working directory. Note that this parameter 
+                        is \\"unsafe\\" as it may produce a selection that 
+                        excludes some dependencies. For details, refer to the 
+                        website article \\"Selecting subsets of projects\\".
   --to-version-policy VERSION_POLICY_NAME
-                        Run install in all projects with the specified 
-                        version policy and all of their dependencies. This 
-                        argument is only valid in workspace environments.
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. The \\"--to-version-policy\\" 
+                        parameter is equivalent to specifying \\"--to\\" for each 
+                        of the projects belonging to VERSION_POLICY_NAME. For 
+                        details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
   --from-version-policy VERSION_POLICY_NAME
-                        Run command in all projects with the specified 
-                        version policy and all projects that directly or 
-                        indirectly depend on projects with the specified 
-                        version policy. This argument is only valid in 
-                        workspace environments.
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. The \\"--from-version-policy\\" 
+                        parameter is equivalent to specifying \\"--from\\" for 
+                        each of the projects belonging to VERSION_POLICY_NAME.
+                         For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
 "
 `;
 

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -143,8 +143,7 @@ export class PackageJsonUpdater {
       collectLogFile: false,
       variant: variant,
       maxInstallAttempts: RushConstants.defaultMaxInstallAttempts,
-      toProjects: new Set(),
-      fromProjects: new Set()
+      pnpmFilterArguments: []
     };
     const installManager: BaseInstallManager = InstallManagerFactory.getInstallManager(
       this._rushConfiguration,

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -34,7 +34,6 @@ import { ShrinkwrapFileFactory } from '../ShrinkwrapFileFactory';
 import { Utilities } from '../../utilities/Utilities';
 import { InstallHelpers } from '../installManager/InstallHelpers';
 import { PolicyValidator } from '../policy/PolicyValidator';
-import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 
 const HttpsProxyAgent: typeof import('https-proxy-agent') = Import.lazy('https-proxy-agent', require);
 
@@ -99,14 +98,10 @@ export interface IInstallManagerOptions {
   maxInstallAttempts: number;
 
   /**
-   * The set of projects that should be installed, along with project dependencies.
+   * Filters to be passed to PNPM during installation, if applicable.
+   * These restrict the scope of a workspace installation.
    */
-  toProjects: ReadonlySet<RushConfigurationProject>;
-
-  /**
-   * The set of projects that should be installed, along with dependencies of the project.
-   */
-  fromProjects: ReadonlySet<RushConfigurationProject>;
+  pnpmFilterArguments: string[];
 }
 
 /**
@@ -153,7 +148,7 @@ export abstract class BaseInstallManager {
   }
 
   public async doInstall(): Promise<void> {
-    const isFilteredInstall: boolean = this.options.toProjects.size > 0 || this.options.fromProjects.size > 0;
+    const isFilteredInstall: boolean = this.options.pnpmFilterArguments.length > 0;
     const useWorkspaces: boolean =
       this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
 

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -522,7 +522,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (!workspaceImporter) {
       // Filtered installs will not contain all projects in the shrinkwrap, but if one is
       // missing during a full install, something has gone wrong
-      if (this.options.toProjects.size === 0 && this.options.fromProjects.size === 0) {
+      if (this.options.pnpmFilterArguments.length === 0) {
         throw new InternalError(
           `Cannot find shrinkwrap entry using importer key for workspace project: ${importerKey}`
         );
@@ -587,14 +587,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
-      // "<package>..." selects the specified package and all direct and indirect dependencies
-      for (const toProject of this.options.toProjects) {
-        args.push('--filter', `${toProject.packageName}...`);
-      }
-
-      // ..."<package>" selects the specified package and all direct and indirect dependents of that package
-      for (const fromProject of this.options.fromProjects) {
-        args.push('--filter', `...${fromProject.packageName}`);
+      for (const arg of this.options.pnpmFilterArguments) {
+        args.push(arg);
       }
     }
   }

--- a/common/changes/@microsoft/rush/install-only_2021-02-14-08-13.json
+++ b/common/changes/@microsoft/rush/install-only_2021-02-14-08-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Normalize selection CLI parameters for \"rush install\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Expands the set of selection parameters used by `rush install` to match those used by `rush build` and other bulk script actions.
See [selecting subsets of projects](https://rushjs.io/pages/developer/selecting_subsets/)

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Factors out the selection parameters and selection logic into a separate `SelectionParameterSet` component, so that it can be used in both `BulkScriptAction` and `InstallAction`, whose common ancestor is shared by actions for which selection parameters are not applicable.

Adds the following command line parameters to `rush install`:
`--only`: Install only the declared dependencies of the specified project
`--impacted-by`: Install the dependencies of the specified project and all projects that depend on it. Same as what `--from` previously did. Unsafe.
`--impacted-by-except`: Install the dependencies of all projects that depend on the specified project. Unsafe.
`--to-except`: Install the dependencies of all projects that the specified project directly or indirectly depends on.

Directly translates the selection parameters into the filter syntax used by `pnpm` to avoid bloating the command line and risking encountering "command too long" errors.

This is a behavior change for `--from` and `--from-version-policy` on `rush install` to also include the dependencies of the selected projects. To get the unsafe version, use `--impacted-by`.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Executed a variety of `rush build` and `rush install` commands against the rushstack repo, using `apps/rush-lib/lib/start.js` from compiled code. Unfortunately this has slightly odd effects on `install` commands since it breaks the command's own dependencies.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
