### PR TITLE
[rush] Add the ability to disable cache in certain scenarios.

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -121,9 +121,10 @@
       "watchForChanges": false,
 
       /**
-       * Disable cache for this action. This may be useful if this command affects state outside of projects' own folders.
+       * (EXPERIMENTAL) Disable cache for this action. This may be useful if this command affects state outside of
+       * projects' own folders.
        */
-      "disableCache": false
+      "disableBuildCache ": false
     },
 
     {

--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -118,7 +118,12 @@
        *
        * For details, refer to the website article "Using watch mode".
        */
-      "watchForChanges": false
+      "watchForChanges": false,
+
+      /**
+       * Disable cache for this action.
+       */
+      "disableCache": false
     },
 
     {

--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -121,7 +121,7 @@
       "watchForChanges": false,
 
       /**
-       * Disable cache for this action.
+       * Disable cache for this action. This may be useful if this command affects state outside of projects' own folders.
        */
       "disableCache": false
     },

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -27,6 +27,7 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   incremental?: boolean;
   allowWarningsInSuccessfulBuild?: boolean;
   watchForChanges?: boolean;
+  disableCache?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -27,7 +27,7 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   incremental?: boolean;
   allowWarningsInSuccessfulBuild?: boolean;
   watchForChanges?: boolean;
-  disableCache?: boolean;
+  disableBuildCache?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -21,27 +21,27 @@ interface IRushProjectJson {
    */
   projectOutputFolderNames?: string[];
 
-  cacheOptions?: ICacheOptionsJson;
+  buildCacheOptions?: IBuildCacheOptionsJson;
 }
 
-interface ICacheOptionsJson extends ICacheOptionsBase {
+interface IBuildCacheOptionsJson extends IBuildCacheOptionsBase {
   /**
    * Allows for fine-grained control of cache for individual commands.
    */
   optionsForCommands?: ICacheOptionsForCommand[];
 }
 
-export interface ICacheOptionsBase {
+export interface IBuildCacheOptionsBase {
   /**
    * NOT RECOMMENDED.
    *
    * Disable caching for this project. The project will never be restored from cache.
    * This may be useful if this project affects state outside of its folder.
    */
-  disableCache?: boolean;
+  disableBuildCache?: boolean;
 }
 
-export interface ICacheOptions extends ICacheOptionsBase {
+export interface IBuildCacheOptions extends IBuildCacheOptionsBase {
   /**
    * Allows for fine-grained control of cache for individual commands.
    */
@@ -60,7 +60,7 @@ export interface ICacheOptionsForCommand {
    * Disable caching for this command.
    * This may be useful if this command for this project affects state outside of this project folder.
    */
-  disableCache?: boolean;
+  disableBuildCache?: boolean;
 }
 
 /**
@@ -78,12 +78,12 @@ export class RushProjectConfiguration {
         projectOutputFolderNames: {
           inheritanceType: InheritanceType.append
         },
-        cacheOptions: {
+        buildCacheOptions: {
           inheritanceType: InheritanceType.custom,
           inheritanceFunction: (
-            current: ICacheOptionsJson | undefined,
-            parent: ICacheOptionsJson | undefined
-          ): ICacheOptionsJson | undefined => {
+            current: IBuildCacheOptionsJson | undefined,
+            parent: IBuildCacheOptionsJson | undefined
+          ): IBuildCacheOptionsJson | undefined => {
             if (!current) {
               return parent;
             } else if (!parent) {
@@ -116,7 +116,7 @@ export class RushProjectConfiguration {
   /**
    * Project-specific cache options.
    */
-  public readonly cacheOptions: ICacheOptions;
+  public readonly cacheOptions: IBuildCacheOptions;
 
   private constructor(project: RushConfigurationProject, rushProjectJson: IRushProjectJson) {
     this.project = project;
@@ -127,13 +127,13 @@ export class RushProjectConfiguration {
       string,
       ICacheOptionsForCommand
     >();
-    if (rushProjectJson.cacheOptions?.optionsForCommands) {
-      for (const cacheOptionsForCommand of rushProjectJson.cacheOptions.optionsForCommands) {
+    if (rushProjectJson.buildCacheOptions?.optionsForCommands) {
+      for (const cacheOptionsForCommand of rushProjectJson.buildCacheOptions.optionsForCommands) {
         optionsForCommandsByName.set(cacheOptionsForCommand.name, cacheOptionsForCommand);
       }
     }
     this.cacheOptions = {
-      disableCache: rushProjectJson.cacheOptions?.disableCache,
+      disableBuildCache: rushProjectJson.buildCacheOptions?.disableBuildCache,
       optionsForCommandsByName
     };
   }
@@ -194,7 +194,7 @@ export class RushProjectConfiguration {
 
     const duplicateCommandNames: Set<string> = new Set<string>();
     const invalidCommandNames: string[] = [];
-    if (rushProjectJson.cacheOptions?.optionsForCommands) {
+    if (rushProjectJson.buildCacheOptions?.optionsForCommands) {
       const commandNames: Set<string> = new Set<string>([
         RushConstants.buildCommandName,
         RushConstants.rebuildCommandName
@@ -208,7 +208,7 @@ export class RushProjectConfiguration {
       }
 
       const alreadyEncounteredCommandNames: Set<string> = new Set<string>();
-      for (const cacheOptionsForCommand of rushProjectJson.cacheOptions.optionsForCommands) {
+      for (const cacheOptionsForCommand of rushProjectJson.buildCacheOptions.optionsForCommands) {
         const commandName: string = cacheOptionsForCommand.name;
         if (!commandNames.has(commandName)) {
           invalidCommandNames.push(commandName);

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -33,10 +33,14 @@ interface IBuildCacheOptionsJson extends IBuildCacheOptionsBase {
 
 export interface IBuildCacheOptionsBase {
   /**
-   * NOT RECOMMENDED.
-   *
    * Disable caching for this project. The project will never be restored from cache.
    * This may be useful if this project affects state outside of its folder.
+   *
+   * This option is only used when the cloud build cache is enabled for the repo. You can set
+   * disableBuildCache=true to disable caching for a specific project. This is a useful workaround
+   * if that project's build scripts violate the assumptions of the cache, for example by writing
+   * files outside the project folder. Where possible, a better solution is to improve the build scripts
+   * to be compatible with caching.
    */
   disableBuildCache?: boolean;
 }
@@ -55,10 +59,14 @@ export interface ICacheOptionsForCommand {
   name: string;
 
   /**
-   * NOT RECOMMENDED.
-   *
    * Disable caching for this command.
    * This may be useful if this command for this project affects state outside of this project folder.
+   *
+   * This option is only used when the cloud build cache is enabled for the repo. You can set
+   * disableBuildCache=true to disable caching for a command in a specific project. This is a useful workaround
+   * if that project's build scripts violate the assumptions of the cache, for example by writing
+   * files outside the project folder. Where possible, a better solution is to improve the build scripts
+   * to be compatible with caching.
    */
   disableBuildCache?: boolean;
 }

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -29,6 +29,7 @@ export interface ICacheOptions {
    * NOT RECOMMENDED.
    *
    * Disable caching for this project. The project will never be restored from cache.
+   * This may be useful if this project affects state outside of its folder.
    */
   disableCache?: boolean;
 
@@ -45,6 +46,7 @@ export interface ICacheOptionsForCommand {
    * NOT RECOMMENDED.
    *
    * Disable caching for this command.
+   * This may be useful if this command for this project affects state outside of this project folder.
    */
   disableCache?: boolean;
 }

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -272,7 +272,7 @@ export class RushCommandLineParser extends CommandLineParser {
             allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild,
 
             watchForChanges: command.watchForChanges || false,
-            repoCommandLineConfiguration: commandLineConfiguration
+            disableCache: command.disableCache || false
           })
         );
         break;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -53,7 +53,7 @@ export interface IRushCommandLineParserOptions {
 export class RushCommandLineParser extends CommandLineParser {
   public telemetry: Telemetry | undefined;
   public rushGlobalFolder!: RushGlobalFolder;
-  public rushConfiguration!: RushConfiguration;
+  public readonly rushConfiguration!: RushConfiguration;
 
   private _debugParameter!: CommandLineFlagParameter;
   private _rushOptions: IRushCommandLineParserOptions;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -272,7 +272,7 @@ export class RushCommandLineParser extends CommandLineParser {
             allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild,
 
             watchForChanges: command.watchForChanges || false,
-            disableCache: command.disableCache || false
+            disableBuildCache: command.disableBuildCache || false
           })
         );
         break;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -192,12 +192,12 @@ export class RushCommandLineParser extends CommandLineParser {
     // If there is not a rush.json file, we still want "build" and "rebuild" to appear in the
     // command-line help
     if (this.rushConfiguration) {
-      const commandLineConfigFile: string = path.join(
+      const commandLineConfigFilePath: string = path.join(
         this.rushConfiguration.commonRushConfigFolder,
         RushConstants.commandLineFilename
       );
 
-      commandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(commandLineConfigFile);
+      commandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(commandLineConfigFilePath);
     }
 
     // Build actions from the command line configuration supersede default build actions.
@@ -271,7 +271,8 @@ export class RushCommandLineParser extends CommandLineParser {
             incremental: command.incremental || false,
             allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild,
 
-            watchForChanges: command.watchForChanges || false
+            watchForChanges: command.watchForChanges || false,
+            repoCommandLineConfiguration: commandLineConfiguration
           })
         );
         break;

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -63,13 +63,15 @@ interface IExecuteInternalOptions {
  * execute scripts from package.json in the same as any custom command.
  */
 export class BulkScriptAction extends BaseScriptAction {
-  private _enableParallelism: boolean;
-  private _ignoreMissingScript: boolean;
-  private _isIncrementalBuildAllowed: boolean;
-  private _commandToRun: string;
-  private _watchForChanges: boolean;
-  private _disableCache: boolean;
-  private _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
+  private readonly _enableParallelism: boolean;
+  private readonly _ignoreMissingScript: boolean;
+  private readonly _isIncrementalBuildAllowed: boolean;
+  private readonly _commandToRun: string;
+  private readonly _watchForChanges: boolean;
+  private readonly _disableCache: boolean;
+  private readonly _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
+  private readonly _ignoreDependencyOrder: boolean;
+  private readonly _allowWarningsInSuccessfulBuild: boolean;
 
   private _changedProjectsOnly!: CommandLineFlagParameter;
   private _selectionParameters!: SelectionParameterSet;
@@ -77,8 +79,6 @@ export class BulkScriptAction extends BaseScriptAction {
   private _parallelismParameter: CommandLineStringParameter | undefined;
   private _ignoreHooksParameter!: CommandLineFlagParameter;
   private _disableCacheFlag!: CommandLineFlagParameter;
-  private _ignoreDependencyOrder: boolean;
-  private _allowWarningsInSuccessfulBuild: boolean;
 
   public constructor(options: IBulkScriptActionOptions) {
     super(options);

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -37,7 +37,7 @@ export interface IBulkScriptActionOptions extends IBaseScriptActionOptions {
   incremental: boolean;
   allowWarningsInSuccessfulBuild: boolean;
   watchForChanges: boolean;
-  disableCache: boolean;
+  disableBuildCache: boolean;
 
   /**
    * Optional command to run. Otherwise, use the `actionName` as the command to run.
@@ -68,7 +68,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private readonly _isIncrementalBuildAllowed: boolean;
   private readonly _commandToRun: string;
   private readonly _watchForChanges: boolean;
-  private readonly _disableCache: boolean;
+  private readonly _disableBuildCache: boolean;
   private readonly _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
   private readonly _ignoreDependencyOrder: boolean;
   private readonly _allowWarningsInSuccessfulBuild: boolean;
@@ -78,7 +78,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _verboseParameter!: CommandLineFlagParameter;
   private _parallelismParameter: CommandLineStringParameter | undefined;
   private _ignoreHooksParameter!: CommandLineFlagParameter;
-  private _disableCacheFlag: CommandLineFlagParameter | undefined;
+  private _disableBuildCacheFlag: CommandLineFlagParameter | undefined;
 
   public constructor(options: IBulkScriptActionOptions) {
     super(options);
@@ -89,7 +89,7 @@ export class BulkScriptAction extends BaseScriptAction {
     this._ignoreDependencyOrder = options.ignoreDependencyOrder;
     this._allowWarningsInSuccessfulBuild = options.allowWarningsInSuccessfulBuild;
     this._watchForChanges = options.watchForChanges;
-    this._disableCache = options.disableCache;
+    this._disableBuildCache = options.disableBuildCache;
     this._repoCommandLineConfiguration = options.commandLineConfiguration;
   }
 
@@ -126,7 +126,7 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
-    if (!this._disableCacheFlag?.value && !this._disableCache) {
+    if (!this._disableBuildCacheFlag?.value && !this._disableBuildCache) {
       buildCacheConfiguration = await BuildCacheConfiguration.loadFromDefaultPathAsync(
         terminal,
         this.rushConfiguration
@@ -306,10 +306,13 @@ export class BulkScriptAction extends BaseScriptAction {
       description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
     });
 
-    if (!this._disableCache && this.rushConfiguration?.experimentsConfiguration.configuration.buildCache) {
-      this._disableCacheFlag = this.defineFlagParameter({
-        parameterLongName: '--disable-cache',
-        description: `Disables the build cache for this command invocation.`
+    if (
+      !this._disableBuildCache &&
+      this.rushConfiguration?.experimentsConfiguration.configuration.buildCache
+    ) {
+      this._disableBuildCacheFlag = this.defineFlagParameter({
+        parameterLongName: '--disable-build-cache',
+        description: '(EXPERIMENTAL) Disables the build cache for this command invocation.'
       });
     }
 

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -25,11 +25,13 @@ import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { Selection } from '../../logic/Selection';
 import { SelectionParameterSet } from '../SelectionParameterSet';
+import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 
 /**
  * Constructor parameters for BulkScriptAction.
  */
 export interface IBulkScriptActionOptions extends IBaseScriptActionOptions {
+  repoCommandLineConfiguration: CommandLineConfiguration | undefined;
   enableParallelism: boolean;
   ignoreMissingScript: boolean;
   ignoreDependencyOrder: boolean;
@@ -66,6 +68,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _isIncrementalBuildAllowed: boolean;
   private _commandToRun: string;
   private _watchForChanges: boolean;
+  private _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
 
   private _changedProjectsOnly!: CommandLineFlagParameter;
   private _selectionParameters!: SelectionParameterSet;
@@ -84,6 +87,7 @@ export class BulkScriptAction extends BaseScriptAction {
     this._ignoreDependencyOrder = options.ignoreDependencyOrder;
     this._allowWarningsInSuccessfulBuild = options.allowWarningsInSuccessfulBuild;
     this._watchForChanges = options.watchForChanges;
+    this._repoCommandLineConfiguration = options.repoCommandLineConfiguration;
   }
 
   public async runAsync(): Promise<void> {
@@ -128,6 +132,7 @@ export class BulkScriptAction extends BaseScriptAction {
       rushConfiguration: this.rushConfiguration,
       buildCacheConfiguration,
       selection,
+      commandName: this.actionName,
       commandToRun: this._commandToRun,
       customParameterValues,
       isQuietMode: isQuietMode,
@@ -141,7 +146,8 @@ export class BulkScriptAction extends BaseScriptAction {
       quietMode: isQuietMode,
       parallelism: parallelism,
       changedProjectsOnly: changedProjectsOnly,
-      allowWarningsInSuccessfulBuild: this._allowWarningsInSuccessfulBuild
+      allowWarningsInSuccessfulBuild: this._allowWarningsInSuccessfulBuild,
+      repoCommandLineConfiguration: this._repoCommandLineConfiguration
     };
 
     const executeOptions: IExecuteInternalOptions = {

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -78,7 +78,7 @@ export class BulkScriptAction extends BaseScriptAction {
   private _verboseParameter!: CommandLineFlagParameter;
   private _parallelismParameter: CommandLineStringParameter | undefined;
   private _ignoreHooksParameter!: CommandLineFlagParameter;
-  private _disableCacheFlag!: CommandLineFlagParameter;
+  private _disableCacheFlag: CommandLineFlagParameter | undefined;
 
   public constructor(options: IBulkScriptActionOptions) {
     super(options);
@@ -126,7 +126,7 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
-    if (!this._disableCacheFlag.value && !this._disableCache) {
+    if (!this._disableCacheFlag?.value && !this._disableCache) {
       buildCacheConfiguration = await BuildCacheConfiguration.loadFromDefaultPathAsync(
         terminal,
         this.rushConfiguration
@@ -306,10 +306,12 @@ export class BulkScriptAction extends BaseScriptAction {
       description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
     });
 
-    this._disableCacheFlag = this.defineFlagParameter({
-      parameterLongName: '--disable-cache',
-      description: `Disables the build cache for this command invocation.`
-    });
+    if (!this._disableCache && this.rushConfiguration?.experimentsConfiguration.configuration.buildCache) {
+      this._disableCacheFlag = this.defineFlagParameter({
+        parameterLongName: '--disable-cache',
+        description: `Disables the build cache for this command invocation.`
+      });
+    }
 
     this.defineScriptParameters();
   }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -116,7 +116,7 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
                   [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
                   [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
-                  [--ignore-hooks] [--disable-cache] [-s] [-m]
+                  [--ignore-hooks] [--disable-build-cache] [-s] [-m]
                   
 
 This command is similar to \\"rush rebuild\\", except that \\"rush build\\" performs 
@@ -233,7 +233,9 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
-  --disable-cache       Disables the build cache for this command invocation.
+  --disable-build-cache
+                        (EXPERIMENTAL) Disables the build cache for this 
+                        command invocation.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -358,7 +360,7 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
                            [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
                            [--from-version-policy VERSION_POLICY_NAME] [-v]
-                           [--ignore-hooks] [--disable-cache]
+                           [--ignore-hooks] [--disable-build-cache]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -458,7 +460,9 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
-  --disable-cache       Disables the build cache for this command invocation.
+  --disable-build-cache
+                        (EXPERIMENTAL) Disables the build cache for this 
+                        command invocation.
   --locale {en-us,fr-fr,es-es,zh-cn}
                         Selects a single instead of the default locale 
                         (en-us) for non-ship builds or all locales for ship 
@@ -807,7 +811,7 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
                     [--from-version-policy VERSION_POLICY_NAME] [-v]
-                    [--ignore-hooks] [--disable-cache] [-s] [-m]
+                    [--ignore-hooks] [--disable-build-cache] [-s] [-m]
                     
 
 This command assumes that the package.json file for each project contains a 
@@ -912,7 +916,9 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
-  --disable-cache       Disables the build cache for this command invocation.
+  --disable-build-cache
+                        (EXPERIMENTAL) Disables the build cache for this 
+                        command invocation.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -114,7 +114,7 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
                   [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
                   [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
-                  [--ignore-hooks] [-s] [-m]
+                  [--ignore-hooks] [--disable-cache] [-s] [-m]
                   
 
 This command is similar to \\"rush rebuild\\", except that \\"rush build\\" performs 
@@ -231,6 +231,7 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
+  --disable-cache       Disables the build cache for this command invocation.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 
@@ -355,7 +356,7 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
                            [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
                            [--from-version-policy VERSION_POLICY_NAME] [-v]
-                           [--ignore-hooks]
+                           [--ignore-hooks] [--disable-cache]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -455,6 +456,7 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
+  --disable-cache       Disables the build cache for this command invocation.
   --locale {en-us,fr-fr,es-es,zh-cn}
                         Selects a single instead of the default locale 
                         (en-us) for non-ship builds or all locales for ship 
@@ -803,7 +805,7 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
                     [--from-version-policy VERSION_POLICY_NAME] [-v]
-                    [--ignore-hooks] [-s] [-m]
+                    [--ignore-hooks] [--disable-cache] [-s] [-m]
                     
 
 This command assumes that the package.json file for each project contains a 
@@ -908,6 +910,7 @@ Optional arguments:
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
+  --disable-cache       Disables the build cache for this command invocation.
   -s, --ship            Perform a production build, including minification 
                         and localization steps
   -m, --minimal         Perform a fast build, which disables certain tasks 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -51,6 +51,8 @@ Positional arguments:
     update-cloud-credentials
                         (EXPERIMENTAL) Update the credentials used by the 
                         build cache provider.
+    write-build-cache   Writes the current state of the current project to 
+                        the cache.
     import-strings      Imports translated strings into each project.
     upload              Uploads the built files to the server
     build               Build all projects that haven't been built, or have 
@@ -1117,5 +1119,20 @@ Optional arguments:
                         prerelease id when \\"--bump\\" is provided but only 
                         replaces the prerelease name when 
                         \\"--ensure-version-policy\\" is provided.
+"
+`;
+
+exports[`CommandLineHelp prints the help for each action: write-build-cache 1`] = `
+"usage: rush write-build-cache [-h] -c COMMAND [-v]
+
+(EXPERIMENTAL) If the build cache is configured, when this command is run in 
+the folder of a project, write the current state of the project to the cache.
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  -c COMMAND, --command COMMAND
+                        (Required) The command run in the current project 
+                        that produced the current project state.
+  -v, --verbose         Display verbose log information.
 "
 `;

--- a/apps/rush-lib/src/cli/test/repo/common/config/rush/experiments.json
+++ b/apps/rush-lib/src/cli/test/repo/common/config/rush/experiments.json
@@ -1,0 +1,3 @@
+{
+  "buildCache": true
+}

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -12,6 +12,7 @@ export interface ITaskSelectorConstructor {
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration: BuildCacheConfiguration | undefined;
   selection: ReadonlySet<RushConfigurationProject>;
+  commandName: string;
   commandToRun: string;
   customParameterValues: string[];
   isQuietMode: boolean;
@@ -125,6 +126,7 @@ export class TaskSelector {
         rushConfiguration: this._options.rushConfiguration,
         buildCacheConfiguration: this._options.buildCacheConfiguration,
         commandToRun: commandToRun || '',
+        commandName: this._options.commandName,
         isIncrementalBuildAllowed: this._options.isIncrementalBuildAllowed,
         packageChangeAnalyzer: this._packageChangeAnalyzer,
         packageDepsFilename: this._options.packageDepsFilename

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -36,7 +36,7 @@ export class ProjectBuildCache {
     this._project = options.projectConfiguration.project;
     this._localBuildCacheProvider = options.buildCacheConfiguration.localCacheProvider;
     this._cloudBuildCacheProvider = options.buildCacheConfiguration.cloudCacheProvider;
-    this._projectOutputFolderNames = options.projectConfiguration.projectOutputFolderNames;
+    this._projectOutputFolderNames = options.projectConfiguration.projectOutputFolderNames || [];
     this._cacheId = ProjectBuildCache._getCacheId(options);
   }
 
@@ -62,8 +62,10 @@ export class ProjectBuildCache {
       projectConfiguration.project.projectRelativeFolder
     );
     const outputFolders: string[] = [];
-    for (const outputFolderName of projectConfiguration.projectOutputFolderNames) {
-      outputFolders.push(`${path.posix.join(normalizedProjectRelativeFolder, outputFolderName)}/`);
+    if (projectConfiguration.projectOutputFolderNames) {
+      for (const outputFolderName of projectConfiguration.projectOutputFolderNames) {
+        outputFolders.push(`${path.posix.join(normalizedProjectRelativeFolder, outputFolderName)}/`);
+      }
     }
 
     const inputOutputFiles: string[] = [];

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -5,8 +5,10 @@ import { StdioSummarizer } from '@rushstack/terminal';
 import { CollatedWriter } from '@rushstack/stream-collator';
 
 import { TaskStatus } from './TaskStatus';
+import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 
 export interface IBuilderContext {
+  repoCommandLineConfiguration: CommandLineConfiguration | undefined;
   collatedWriter: CollatedWriter;
   stdioSummarizer: StdioSummarizer;
   quietMode: boolean;

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -367,10 +367,9 @@ export class ProjectBuilder extends BaseBuilder {
           if (projectConfiguration.cacheOptions?.disableCache) {
             terminal.writeVerboseLine('Caching has been disabled for this project.');
           } else {
-            const commandOptions: ICacheOptionsForCommand | undefined = projectConfiguration.cacheOptions
-              ?.optionsForCommands
-              ? projectConfiguration.cacheOptions?.optionsForCommands[this._commandName]
-              : undefined;
+            const commandOptions:
+              | ICacheOptionsForCommand
+              | undefined = projectConfiguration.cacheOptions.optionsForCommandsByName.get(this._commandName);
             if (commandOptions?.disableCache) {
               terminal.writeVerboseLine(
                 `Caching has been disabled for this project's "${this._commandName}" command.`

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -364,13 +364,13 @@ export class ProjectBuilder extends BaseBuilder {
           terminal
         );
         if (projectConfiguration) {
-          if (projectConfiguration.cacheOptions?.disableCache) {
+          if (projectConfiguration.cacheOptions?.disableBuildCache) {
             terminal.writeVerboseLine('Caching has been disabled for this project.');
           } else {
             const commandOptions:
               | ICacheOptionsForCommand
               | undefined = projectConfiguration.cacheOptions.optionsForCommandsByName.get(this._commandName);
-            if (commandOptions?.disableCache) {
+            if (commandOptions?.disableBuildCache) {
               terminal.writeVerboseLine(
                 `Caching has been disabled for this project's "${this._commandName}" command.`
               );

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -75,16 +75,16 @@ export class ProjectBuilder extends BaseBuilder {
     return ProjectBuilder.getTaskName(this._rushProject);
   }
 
-  public isIncrementalBuildAllowed: boolean;
+  public readonly isIncrementalBuildAllowed: boolean;
   public hadEmptyScript: boolean = false;
 
-  private _rushProject: RushConfigurationProject;
-  private _rushConfiguration: RushConfiguration;
-  private _buildCacheConfiguration: BuildCacheConfiguration | undefined;
-  private _commandName: string;
-  private _commandToRun: string;
-  private _packageChangeAnalyzer: PackageChangeAnalyzer;
-  private _packageDepsFilename: string;
+  private readonly _rushProject: RushConfigurationProject;
+  private readonly _rushConfiguration: RushConfiguration;
+  private readonly _buildCacheConfiguration: BuildCacheConfiguration | undefined;
+  private readonly _commandName: string;
+  private readonly _commandToRun: string;
+  private readonly _packageChangeAnalyzer: PackageChangeAnalyzer;
+  private readonly _packageDepsFilename: string;
   private _projectBuildCache: ProjectBuildCache | undefined;
 
   public constructor(options: IProjectBuilderOptions) {

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -31,8 +31,10 @@ import { BaseBuilder, IBuilderContext } from './BaseBuilder';
 import { ProjectLogWritable } from './ProjectLogWritable';
 import { ProjectBuildCache } from '../buildCache/ProjectBuildCache';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
-import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import { ICacheOptionsForCommand, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { CollatedTerminalProvider } from '../../utilities/CollatedTerminalProvider';
+import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
+import { RushConstants } from '../RushConstants';
 
 export interface IProjectBuildDeps {
   files: { [filePath: string]: string };
@@ -44,6 +46,7 @@ export interface IProjectBuilderOptions {
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration: BuildCacheConfiguration | undefined;
   commandToRun: string;
+  commandName: string;
   isIncrementalBuildAllowed: boolean;
   packageChangeAnalyzer: PackageChangeAnalyzer;
   packageDepsFilename: string;
@@ -78,6 +81,7 @@ export class ProjectBuilder extends BaseBuilder {
   private _rushProject: RushConfigurationProject;
   private _rushConfiguration: RushConfiguration;
   private _buildCacheConfiguration: BuildCacheConfiguration | undefined;
+  private _commandName: string;
   private _commandToRun: string;
   private _packageChangeAnalyzer: PackageChangeAnalyzer;
   private _packageDepsFilename: string;
@@ -88,6 +92,7 @@ export class ProjectBuilder extends BaseBuilder {
     this._rushProject = options.rushProject;
     this._rushConfiguration = options.rushConfiguration;
     this._buildCacheConfiguration = options.buildCacheConfiguration;
+    this._commandName = options.commandName;
     this._commandToRun = options.commandToRun;
     this.isIncrementalBuildAllowed = options.isIncrementalBuildAllowed;
     this._packageChangeAnalyzer = options.packageChangeAnalyzer;
@@ -115,11 +120,13 @@ export class ProjectBuilder extends BaseBuilder {
 
   public async tryWriteCacheEntryAsync(
     terminal: Terminal,
-    trackedFilePaths: string[]
+    trackedFilePaths: string[],
+    repoCommandLineConfiguration: CommandLineConfiguration | undefined
   ): Promise<boolean | undefined> {
     const projectBuildCache: ProjectBuildCache | undefined = await this._getProjectBuildCacheAsync(
       terminal,
-      trackedFilePaths
+      trackedFilePaths,
+      repoCommandLineConfiguration
     );
     return projectBuildCache?.trySetCacheEntryAsync(terminal);
   }
@@ -225,7 +232,8 @@ export class ProjectBuilder extends BaseBuilder {
 
       const projectBuildCache: ProjectBuildCache | undefined = await this._getProjectBuildCacheAsync(
         terminal,
-        trackedFiles
+        trackedFiles,
+        context.repoCommandLineConfiguration
       );
       const restoreFromCacheSuccess: boolean | undefined = await projectBuildCache?.tryRestoreFromCacheAsync(
         terminal
@@ -313,7 +321,8 @@ export class ProjectBuilder extends BaseBuilder {
 
           const setCacheEntryPromise: Promise<boolean | undefined> = this.tryWriteCacheEntryAsync(
             terminal,
-            trackedFiles!
+            trackedFiles!,
+            context.repoCommandLineConfiguration
           );
 
           const [, cacheWriteSuccess] = await Promise.all([writeProjectStatePromise, setCacheEntryPromise]);
@@ -342,26 +351,45 @@ export class ProjectBuilder extends BaseBuilder {
 
   private async _getProjectBuildCacheAsync(
     terminal: Terminal,
-    trackedProjectFiles: string[] | undefined
+    trackedProjectFiles: string[] | undefined,
+    commandLineConfiguration: CommandLineConfiguration | undefined
   ): Promise<ProjectBuildCache | undefined> {
     if (!this._projectBuildCache) {
       if (this._buildCacheConfiguration) {
         const projectConfiguration:
           | RushProjectConfiguration
-          | undefined = await RushProjectConfiguration.tryLoadForProjectAsync(this._rushProject, terminal);
+          | undefined = await RushProjectConfiguration.tryLoadForProjectAsync(
+          this._rushProject,
+          commandLineConfiguration,
+          terminal
+        );
         if (projectConfiguration) {
-          this._projectBuildCache = ProjectBuildCache.tryGetProjectBuildCache({
-            projectConfiguration,
-            buildCacheConfiguration: this._buildCacheConfiguration,
-            terminal,
-            command: this._commandToRun,
-            trackedProjectFiles: trackedProjectFiles,
-            packageChangeAnalyzer: this._packageChangeAnalyzer
-          });
+          if (projectConfiguration.cacheOptions?.disableCache) {
+            terminal.writeVerboseLine('Caching has been disabled for this project.');
+          } else {
+            const commandOptions: ICacheOptionsForCommand | undefined = projectConfiguration.cacheOptions
+              ?.optionsForCommands
+              ? projectConfiguration.cacheOptions?.optionsForCommands[this._commandName]
+              : undefined;
+            if (commandOptions?.disableCache) {
+              terminal.writeVerboseLine(
+                `Caching has been disabled for this project's "${this._commandName}" command.`
+              );
+            } else {
+              this._projectBuildCache = ProjectBuildCache.tryGetProjectBuildCache({
+                projectConfiguration,
+                buildCacheConfiguration: this._buildCacheConfiguration,
+                terminal,
+                command: this._commandToRun,
+                trackedProjectFiles: trackedProjectFiles,
+                packageChangeAnalyzer: this._packageChangeAnalyzer
+              });
+            }
+          }
         } else {
           terminal.writeVerboseLine(
-            'Project does not have a build-cache.json configuration file, or one provided by a rig, ' +
-              'so it does not support caching.'
+            `Project does not have a ${RushConstants.rushProjectConfigFilename} configuration file, ` +
+              'or one provided by a rig, so it does not support caching.'
           );
         }
       }

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -38,18 +38,18 @@ export class TaskRunner {
   // Format "======" lines for a shell window with classic 80 columns
   private static readonly _ASCII_HEADER_WIDTH: number = 79;
 
-  private _tasks: Task[];
-  private _changedProjectsOnly: boolean;
-  private _allowWarningsInSuccessfulBuild: boolean;
-  private _buildQueue: Task[];
-  private _quietMode: boolean;
+  private readonly _tasks: Task[];
+  private readonly _changedProjectsOnly: boolean;
+  private readonly _allowWarningsInSuccessfulBuild: boolean;
+  private readonly _buildQueue: Task[];
+  private readonly _quietMode: boolean;
+  private readonly _parallelism: number;
+  private readonly _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
   private _hasAnyFailures: boolean;
   private _hasAnyWarnings: boolean;
-  private _parallelism: number;
   private _currentActiveTasks!: number;
   private _totalTasks!: number;
   private _completedTasks!: number;
-  private _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
 
   private readonly _outputWritable: TerminalWritable;
   private readonly _colorsNewlinesTransform: TextRewriterTransform;

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -17,12 +17,14 @@ import { Stopwatch } from '../../utilities/Stopwatch';
 import { Task } from './Task';
 import { TaskStatus } from './TaskStatus';
 import { IBuilderContext } from './BaseBuilder';
+import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 
 export interface ITaskRunnerOptions {
   quietMode: boolean;
   parallelism: string | undefined;
   changedProjectsOnly: boolean;
   allowWarningsInSuccessfulBuild: boolean;
+  repoCommandLineConfiguration: CommandLineConfiguration | undefined;
   destination?: TerminalWritable;
 }
 
@@ -47,6 +49,7 @@ export class TaskRunner {
   private _currentActiveTasks!: number;
   private _totalTasks!: number;
   private _completedTasks!: number;
+  private _repoCommandLineConfiguration: CommandLineConfiguration | undefined;
 
   private readonly _outputWritable: TerminalWritable;
   private readonly _colorsNewlinesTransform: TextRewriterTransform;
@@ -55,7 +58,13 @@ export class TaskRunner {
   private _terminal: CollatedTerminal;
 
   public constructor(orderedTasks: Task[], options: ITaskRunnerOptions) {
-    const { quietMode, parallelism, changedProjectsOnly, allowWarningsInSuccessfulBuild } = options;
+    const {
+      quietMode,
+      parallelism,
+      changedProjectsOnly,
+      allowWarningsInSuccessfulBuild,
+      repoCommandLineConfiguration
+    } = options;
     this._tasks = orderedTasks;
     this._buildQueue = orderedTasks.slice(0);
     this._quietMode = quietMode;
@@ -63,6 +72,7 @@ export class TaskRunner {
     this._hasAnyWarnings = false;
     this._changedProjectsOnly = changedProjectsOnly;
     this._allowWarningsInSuccessfulBuild = allowWarningsInSuccessfulBuild;
+    this._repoCommandLineConfiguration = repoCommandLineConfiguration;
 
     // TERMINAL PIPELINE:
     //
@@ -226,6 +236,7 @@ export class TaskRunner {
 
   private async _executeTaskAndChainAsync(task: Task): Promise<void> {
     const context: IBuilderContext = {
+      repoCommandLineConfiguration: this._repoCommandLineConfiguration,
       stdioSummarizer: task.stdioSummarizer,
       collatedWriter: task.collatedWriter,
       quietMode: this._quietMode

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -66,7 +66,8 @@ describe('TaskRunner', () => {
             parallelism: 'tequila',
             changedProjectsOnly: false,
             destination: mockWritable,
-            allowWarningsInSuccessfulBuild: false
+            allowWarningsInSuccessfulBuild: false,
+            repoCommandLineConfiguration: undefined
           })
       ).toThrowErrorMatchingSnapshot();
     });
@@ -79,7 +80,8 @@ describe('TaskRunner', () => {
         parallelism: '1',
         changedProjectsOnly: false,
         destination: mockWritable,
-        allowWarningsInSuccessfulBuild: false
+        allowWarningsInSuccessfulBuild: false,
+        repoCommandLineConfiguration: undefined
       };
     });
 
@@ -135,7 +137,8 @@ describe('TaskRunner', () => {
           parallelism: '1',
           changedProjectsOnly: false,
           destination: mockWritable,
-          allowWarningsInSuccessfulBuild: false
+          allowWarningsInSuccessfulBuild: false,
+          repoCommandLineConfiguration: undefined
         };
       });
 
@@ -169,7 +172,8 @@ describe('TaskRunner', () => {
           parallelism: '1',
           changedProjectsOnly: false,
           destination: mockWritable,
-          allowWarningsInSuccessfulBuild: true
+          allowWarningsInSuccessfulBuild: true,
+          repoCommandLineConfiguration: undefined
         };
       });
 

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -88,7 +88,7 @@
             },
             "disableCache": {
               "title": "Watch For Changes",
-              "description": "Disable cache for this action.",
+              "description": "Disable cache for this action. This may be useful if this command affects state outside of projects' own folders.",
               "type": "boolean"
             }
           }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -85,6 +85,11 @@
               "title": "Watch For Changes",
               "description": "(EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a change is detected, the command will be invoked again for the changed project and any selected projects that directly or indirectly depend on it. For details, refer to the website article \"Using watch mode\".",
               "type": "boolean"
+            },
+            "disableCache": {
+              "title": "Watch For Changes",
+              "description": "Disable cache for this action.",
+              "type": "boolean"
             }
           }
         },

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -86,9 +86,9 @@
               "description": "(EXPERIMENTAL) Normally Rush terminates after the command finishes. If this option is set to \"true\" Rush will instead enter a loop where it watches the file system for changes to the selected projects. Whenever a change is detected, the command will be invoked again for the changed project and any selected projects that directly or indirectly depend on it. For details, refer to the website article \"Using watch mode\".",
               "type": "boolean"
             },
-            "disableCache": {
-              "title": "Watch For Changes",
-              "description": "Disable cache for this action. This may be useful if this command affects state outside of projects' own folders.",
+            "disableBuildCache ": {
+              "title": "Disable build cache.",
+              "description": "Disable build cache for this action. This may be useful if this command affects state outside of projects' own folders.",
               "type": "boolean"
             }
           }

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -15,11 +15,11 @@
       "type": "string"
     },
 
-    "cacheOptions": {
+    "buildCacheOptions": {
       "type": "object",
       "properties": {
-        "disableCache": {
-          "description": "NOT RECOMMENDED. Disable caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder.",
+        "disableBuildCache": {
+          "description": "NOT RECOMMENDED. Disable build caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder.",
           "type": "boolean"
         },
 
@@ -35,8 +35,8 @@
                 "description": "The command name."
               },
 
-              "disableCache": {
-                "description": "NOT RECOMMENDED. Disable caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
+              "disableBuildCache": {
+                "description": "NOT RECOMMENDED. Disable build caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
                 "type": "boolean"
               }
             }

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -19,7 +19,7 @@
       "type": "object",
       "properties": {
         "disableCache": {
-          "description": "NOT RECOMMENDED. Disable caching for this project. The project will never be restored from cache.",
+          "description": "NOT RECOMMENDED. Disable caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder.",
           "type": "boolean"
         },
 
@@ -30,7 +30,7 @@
               "type": "object",
               "properties": {
                 "disableCache": {
-                  "description": "NOT RECOMMENDED. Disable caching for this command.",
+                  "description": "NOT RECOMMENDED. Disable caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
                   "type": "boolean"
                 }
               }

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -15,6 +15,31 @@
       "type": "string"
     },
 
+    "cacheOptions": {
+      "type": "object",
+      "properties": {
+        "disableCache": {
+          "description": "NOT RECOMMENDED. Disable caching for this project. The project will never be restored from cache.",
+          "type": "boolean"
+        },
+
+        "optionsForCommands": {
+          "description": "Allows for fine-grained control of cache for individual commands.",
+          "patternProperties": {
+            ".+": {
+              "type": "object",
+              "properties": {
+                "disableCache": {
+                  "description": "NOT RECOMMENDED. Disable caching for this command.",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+
     "projectOutputFolderNames": {
       "type": "array",
       "description": "A list of folder names under the project root that should be cached. These folders should not be tracked by git.",

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -19,7 +19,7 @@
       "type": "object",
       "properties": {
         "disableBuildCache": {
-          "description": "NOT RECOMMENDED. Disable build caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder.",
+          "description": "Disable build caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder. This option is only used when the cloud build cache is enabled for the repo. You can set disableBuildCache=true to disable caching for a specific project. This is a useful workaround if that project's build scripts violate the assumptions of the cache, for example by writing files outside the project folder. Where possible, a better solution is to improve the build scripts to be compatible with caching.",
           "type": "boolean"
         },
 
@@ -36,7 +36,7 @@
               },
 
               "disableBuildCache": {
-                "description": "NOT RECOMMENDED. Disable build caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
+                "description": "Disable build caching for this command. This may be useful if this command for this project affects state outside of this project folder. This option is only used when the cloud build cache is enabled for the repo. You can set disableBuildCache=true to disable caching for a command in a specific project. This is a useful workaround if that project's build scripts violate the assumptions of the cache, for example by writing files outside the project folder. Where possible, a better solution is to improve the build scripts to be compatible with caching.",
                 "type": "boolean"
               }
             }

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -25,14 +25,19 @@
 
         "optionsForCommands": {
           "description": "Allows for fine-grained control of cache for individual commands.",
-          "patternProperties": {
-            ".+": {
-              "type": "object",
-              "properties": {
-                "disableCache": {
-                  "description": "NOT RECOMMENDED. Disable caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
-                  "type": "boolean"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The command name."
+              },
+
+              "disableCache": {
+                "description": "NOT RECOMMENDED. Disable caching for this command. This may be useful if this command for this project affects state outside of this project folder.",
+                "type": "boolean"
               }
             }
           }

--- a/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-57.json
+++ b/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a --disable-cache flag to bulk script actions.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-58.json
+++ b/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"disableCache\" to builk script command configurations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-58.json
+++ b/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "(EXPERIMENTAL) Add a \"disableBuildCache \" setting in command-line.json for disabling the build cache.",
+      "comment": "(EXPERIMENTAL) Add a \"disableBuildCache\" setting in command-line.json for disabling the build cache.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-59.json
+++ b/common/changes/@microsoft/rush/ianc-more-cache-options_2021-02-15-00-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add options in rush-project.json to disable the cache for entire projects, or for individual commands for that project.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR adds a `--disable-cache` CLI flag to bulk actions, adds a `"disableCache"` option to bulk commands in the `command-line.json` schema, and adds the following options to the `rush-project.json` schema:

```JS
{
  "cacheOptions": {
    "disableCache": true, // (defaults to false)
    "optionsForCommands": [
      {
        "name": "<command name>",
        "disableCache": true // (defaults to false)
      }
    ]
  }
}
```