### PR TITLE
[rush] Improve cache read/write perf by attempting to use the "tar" binary.

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -3,7 +3,6 @@
 
 import * as events from 'events';
 import * as crypto from 'crypto';
-import * as path from 'path';
 import type * as stream from 'stream';
 import * as tar from 'tar';
 import { FileSystem, LegacyAdapters, Path, Terminal } from '@rushstack/node-core-library';
@@ -85,7 +84,7 @@ export class ProjectBuildCache {
     const outputFolders: string[] = [];
     if (projectConfiguration.projectOutputFolderNames) {
       for (const outputFolderName of projectConfiguration.projectOutputFolderNames) {
-        outputFolders.push(`${path.posix.join(normalizedProjectRelativeFolder, outputFolderName)}/`);
+        outputFolders.push(`${normalizedProjectRelativeFolder}/${outputFolderName}/`);
       }
     }
 
@@ -157,7 +156,7 @@ export class ProjectBuildCache {
     terminal.writeVerboseLine(`Clearing cached folders: ${this._projectOutputFolderNames.join(', ')}`);
     await Promise.all(
       this._projectOutputFolderNames.map((outputFolderName: string) =>
-        FileSystem.deleteFolderAsync(path.join(projectFolderPath, outputFolderName))
+        FileSystem.deleteFolderAsync(`${projectFolderPath}/${outputFolderName}`)
       )
     );
 
@@ -317,7 +316,7 @@ export class ProjectBuildCache {
     const projectFolderPath: string = this._project.projectFolder;
     const outputFolderNamesThatExist: boolean[] = await Promise.all(
       this._projectOutputFolderNames.map((outputFolderName) =>
-        FileSystem.existsAsync(path.join(projectFolderPath, outputFolderName))
+        FileSystem.existsAsync(`${projectFolderPath}/${outputFolderName}`)
       )
     );
     const filteredOutputFolderNames: string[] = [];
@@ -343,7 +342,7 @@ export class ProjectBuildCache {
         terminal,
         symbolicLinkPathCallback,
         filteredOutputFolderName,
-        projectFolderPath + path.sep + filteredOutputFolderName
+        `${projectFolderPath}/${filteredOutputFolderName}`
       );
 
       for await (const outputFilePath of outputFilePathsForFolder) {
@@ -379,7 +378,7 @@ export class ProjectBuildCache {
           terminal,
           symbolicLinkPathCallback,
           entryPath,
-          folderPath + path.sep + folderEntry.name
+          `${folderPath}/${folderEntry.name}`
         );
       } else {
         yield entryPath;

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -329,7 +329,7 @@ export class ProjectBuilder extends BaseBuilder {
 
           if (terminalProvider.hasErrors) {
             status = TaskStatus.Failure;
-          } else if (cacheWriteSuccess === false || terminalProvider.hasWarnings) {
+          } else if (cacheWriteSuccess === false) {
             status = TaskStatus.SuccessWithWarning;
           }
         }

--- a/apps/rush-lib/src/utilities/TarExecutable.ts
+++ b/apps/rush-lib/src/utilities/TarExecutable.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Executable, FileSystem, Terminal } from '@rushstack/node-core-library';
+import { ChildProcess } from 'child_process';
+import * as events from 'events';
+import { RushConfigurationProject } from '../api/RushConfigurationProject';
+
+export class TarExecutable {
+  private _tarExecutablePath: string;
+
+  private constructor(tarExecutablePath: string) {
+    this._tarExecutablePath = tarExecutablePath;
+  }
+
+  public static tryInitialize(terminal: Terminal): TarExecutable | undefined {
+    terminal.writeVerboseLine('Trying to find "tar" binary');
+    const tarExecutablePath: string | undefined = Executable.tryResolve('tar');
+    if (!tarExecutablePath) {
+      terminal.writeVerboseLine('"tar" was not found on the PATH');
+      return undefined;
+    }
+
+    return new TarExecutable(tarExecutablePath);
+  }
+
+  public async tryUntarAsync(archivePath: string, outputFolderPath: string): Promise<boolean> {
+    const childProcess: ChildProcess = Executable.spawn(this._tarExecutablePath, ['-x', '-f', archivePath], {
+      currentWorkingDirectory: outputFolderPath
+    });
+    const [tarExitCode] = await events.once(childProcess, 'exit');
+    return tarExitCode === 0;
+  }
+
+  public async tryCreateArchiveFromProjectPathsAsync(
+    archivePath: string,
+    paths: string[],
+    project: RushConfigurationProject
+  ): Promise<boolean> {
+    const pathsListFilePath: string = `${project.projectRushTempFolder}/tarPaths_${Date.now()}`;
+    await FileSystem.writeFileAsync(pathsListFilePath, paths.join('\n'));
+
+    const projectFolderPath: string = project.projectFolder;
+    const childProcess: ChildProcess = Executable.spawn(
+      this._tarExecutablePath,
+      ['-c', '-f', archivePath, '-z', '-C', projectFolderPath, '--files-from', pathsListFilePath],
+      {
+        currentWorkingDirectory: projectFolderPath
+      }
+    );
+    const [tarExitCode] = await events.once(childProcess, 'exit');
+    await FileSystem.deleteFileAsync(pathsListFilePath);
+
+    return tarExitCode === 0;
+  }
+}

--- a/apps/rush-lib/src/utilities/TarExecutable.ts
+++ b/apps/rush-lib/src/utilities/TarExecutable.ts
@@ -24,19 +24,27 @@ export class TarExecutable {
     return new TarExecutable(tarExecutablePath);
   }
 
-  public async tryUntarAsync(archivePath: string, outputFolderPath: string): Promise<boolean> {
+  /**
+   * @returns
+   * The "tar" exit code
+   */
+  public async tryUntarAsync(archivePath: string, outputFolderPath: string): Promise<number> {
     const childProcess: ChildProcess = Executable.spawn(this._tarExecutablePath, ['-x', '-f', archivePath], {
       currentWorkingDirectory: outputFolderPath
     });
     const [tarExitCode] = await events.once(childProcess, 'exit');
-    return tarExitCode === 0;
+    return tarExitCode;
   }
 
+  /**
+   * @returns
+   * The "tar" exit code
+   */
   public async tryCreateArchiveFromProjectPathsAsync(
     archivePath: string,
     paths: string[],
     project: RushConfigurationProject
-  ): Promise<boolean> {
+  ): Promise<number> {
     const pathsListFilePath: string = `${project.projectRushTempFolder}/tarPaths_${Date.now()}`;
     await FileSystem.writeFileAsync(pathsListFilePath, paths.join('\n'));
 
@@ -51,6 +59,6 @@ export class TarExecutable {
     const [tarExitCode] = await events.once(childProcess, 'exit');
     await FileSystem.deleteFileAsync(pathsListFilePath);
 
-    return tarExitCode === 0;
+    return tarExitCode;
   }
 }

--- a/common/changes/@microsoft/rush/ianc-faster-tar_2021-02-15-05-38.json
+++ b/common/changes/@microsoft/rush/ianc-faster-tar_2021-02-15-05-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve cache read/write perf by attempting to use the \"tar\" binary.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Currently, Rush uses the `tar` NPM package to create and extract cache entries. This works well, but isn't as fast as `tar` executable. This PR adds the ability to use `tar` if it is on the PATH.

## How it was tested

I've tested this on two repos: this one (rushstack) and a large internal repo. Things work fine, and archives created with older versions of Rush are able to be read by Rush with these changes, and vise-versa.

For the rushstack repo, restoring from cache took 8.23 seconds before, and now takes 3.05 seconds. In the large internal repo, restoring from cache took 10 minutes and 51.1 seconds, and now takes 1 minute and 35 seconds.