### PR TITLE
[rush] Don't try to upload a cache entry to Azure Storage if it already exists.

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
@@ -119,12 +119,19 @@ export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase 
 
     const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId);
     const blockBlobClient: BlockBlobClient = blobClient.getBlockBlobClient();
-    try {
-      await blockBlobClient.upload(entryStream, entryStream.length);
+
+    const blobAlreadyExists: boolean = await blockBlobClient.exists();
+    if (blobAlreadyExists) {
+      terminal.writeVerboseLine('Build cache entry blob already exists.');
       return true;
-    } catch (e) {
-      terminal.writeWarningLine(`Error uploading cache entry to Azure Storage: ${e}`);
-      return false;
+    } else {
+      try {
+        await blockBlobClient.upload(entryStream, entryStream.length);
+        return true;
+      } catch (e) {
+        terminal.writeWarningLine(`Error uploading cache entry to Azure Storage: ${e}`);
+        return false;
+      }
     }
   }
 

--- a/common/changes/@microsoft/rush/ianc-check-if-blob-exists_2021-02-15-18-50.json
+++ b/common/changes/@microsoft/rush/ianc-check-if-blob-exists_2021-02-15-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Don't upload build cache entries to Azure if the cache entry already exists.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
We have a CI job that populates our Azure Storage cache. It occasionally fails if two jobs run at the same time and both try to upload the same blob cache entry to Azure.

This change checks if the blob exists right before trying to upload. If the blob exists, we'll consider the upload "successful" because it would have been filled from cache if it had existed when the project's build started.