### PR TITLE
[rush] Fix a minor issue with the "rush init" template

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/artifactory.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/artifactory.json
@@ -22,7 +22,7 @@
      *
      *   https://your-company.jfrog.io/your-project/api/npm/npm-private/
      */
-    // "registryUrl": "",
+    "registryUrl": "",
 
     /**
      * A list of custom strings that "rush setup" should add to the user's ~/.npmrc file at the time
@@ -44,7 +44,7 @@
      * It should look something like this example:  https://your-company.jfrog.io/
      * Specify an empty string to suppress this line entirely.
      */
-    // "artifactoryWebsiteUrl": "",
+    "artifactoryWebsiteUrl": "",
 
     /**
      * These settings allow the "rush setup" interactive prompts to be customized, for

--- a/common/changes/@microsoft/rush/octogonz-rush-artifactory-error_2021-02-17-02-18.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-artifactory-error_2021-02-17-02-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a minor issue with the \"rush init\" template",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -91,7 +91,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.40.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

After running `rush init`, an error is reported for the **artifactory.json** config file because the `registryUrl` field is "required" but not specified.  Artifactory is initially disabled, so the user shouldn't be expected to assign this setting.

 

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Run `rush init` and confirm there is no error.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
