### PR TITLE
[rush] Fix "rush setup" incompatibility with NPM 7.x

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-rush-setup-npm7_2021-02-20-06-21.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-setup-npm7_2021-02-20-06-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush setup\" did not work correctly with NPM 7.x due to an NPM regression",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION

## Summary

The `rush setup` command relies on the `--json` CLI parameter for NPM, which is currently broken in NPM 7.x.  (See [NPM issue #2740](https://bit.ly/3scrV1b))

## Details

With NPM 7.x we get output like this:
```
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
{
  "error": {
    "code": "E404",
    "summary": "Not Found - GET https://registry.npmjs.org/@rushstack%2fnonexistent-package - Not found"
  }
}
npm ERR! A complete log of this run can be found in:
```
...when we're supposed to get output like this:
```
{
  "error": {
    "code": "E404",
    "summary": "Not Found - GET https://registry.npmjs.org/@rushstack%2fnonexistent-package - Not found"
  }
}
```

The workaround is to search for the first line starting with `{` and the last line ending with `}` and parse that subrange of the output.

It should be a fairly robust solution since NPM indents its `--json` output and the terminal output is generally prefixed with the usual `npm ERR!` and thus won't contain `{`. 

For NPM 6.x and any future fixed version of NPM, the clean STDOUT output will take precedence with 100% correct parsing.

## How it was tested

Confirmed that `rush setup` works with NPM versions 7.5.4 (which has the bug) and 6.14.10 (which doesn't).

CC @filipe-araujo-hbo