### PR TITLE
[rush] Remove Rush's own validation of the PNPM lockfile

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
@@ -175,7 +175,7 @@ export class PnpmProjectDependencyManifest {
       return;
     }
 
-    for (const [peerDependencyName] of Object.entries(shrinkwrapEntry.peerDependencies)) {
+    for (const peerDependencyName of Object.keys(shrinkwrapEntry.peerDependencies)) {
       // Check to see if the peer dependency is satisfied with the current shrinkwrap
       // entry. If not, check the parent shrinkwrap entry. Finally, if neither have
       // the specified dependency, check that the parent mentions the dependency in

--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectDependencyManifest.ts
@@ -2,18 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import * as semver from 'semver';
 import crypto from 'crypto';
 import { JsonFile, InternalError, FileSystem } from '@rushstack/node-core-library';
 
-import {
-  PnpmShrinkwrapFile,
-  IPnpmShrinkwrapDependencyYaml,
-  parsePnpmDependencyKey
-} from './PnpmShrinkwrapFile';
+import { PnpmShrinkwrapFile, IPnpmShrinkwrapDependencyYaml } from './PnpmShrinkwrapFile';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushConstants } from '../RushConstants';
-import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
+import { DependencySpecifier } from '../DependencySpecifier';
 
 export interface IPnpmProjectDependencyManifestOptions {
   pnpmShrinkwrapFile: PnpmShrinkwrapFile;
@@ -168,124 +163,48 @@ export class PnpmProjectDependencyManifest {
       }
     }
 
+    // When using workspaces, hoisting of peer dependencies to a singular top-level project is not possible.
+    // Therefore, all packages that are consumed should be specified in the dependency tree. Given this, there
+    // is no need to look for peer dependencies, since it is simply a constraint to be validated by the
+    // package manager. Also return if we have no peer dependencies to scavenge through.
     if (
-      this._project.rushConfiguration.pnpmOptions &&
-      this._project.rushConfiguration.pnpmOptions.useWorkspaces
+      (this._project.rushConfiguration.pnpmOptions &&
+        this._project.rushConfiguration.pnpmOptions.useWorkspaces) ||
+      !shrinkwrapEntry.peerDependencies
     ) {
-      // When using workspaces, hoisting of dependencies is not possible. Therefore, all packages that are consumed
-      // should be specified as direct dependencies in the shrinkwrap. Given this, there is no need to look for peer
-      // dependencies, since it is simply a constraint to be validated by the package manager.
       return;
     }
 
-    for (const [peerDependencyName, peerDependencyVersion] of Object.entries(
-      shrinkwrapEntry.peerDependencies || {}
-    )) {
+    for (const [peerDependencyName] of Object.entries(shrinkwrapEntry.peerDependencies)) {
       // Check to see if the peer dependency is satisfied with the current shrinkwrap
-      // entry and if not, check the parent shrinkwrap entry. Finally, if neither have
-      // the specified dependency, validate that the parent mentions the dependency in
+      // entry. If not, check the parent shrinkwrap entry. Finally, if neither have
+      // the specified dependency, check that the parent mentions the dependency in
       // it's own peer dependencies. If it is, we can rely on the package manager and
       // make the assumption that we've already found it further up the stack.
       if (
-        this._validatePeerDependencyVersion(shrinkwrapEntry, peerDependencyName, peerDependencyVersion) ||
-        this._validatePeerDependencyVersion(
-          parentShrinkwrapEntry,
-          peerDependencyName,
-          peerDependencyVersion
-        ) ||
+        (shrinkwrapEntry.dependencies && shrinkwrapEntry.dependencies.hasOwnProperty(peerDependencyName)) ||
+        (parentShrinkwrapEntry.dependencies &&
+          parentShrinkwrapEntry.dependencies.hasOwnProperty(peerDependencyName)) ||
         (parentShrinkwrapEntry.peerDependencies &&
           parentShrinkwrapEntry.peerDependencies.hasOwnProperty(peerDependencyName))
       ) {
         continue;
       }
 
-      // The parent doesn't have a version that satisfies the range. As a last attempt, check
-      // if it's been hoisted up as a top-level dependency.
+      // As a last attempt, check if it's been hoisted up as a top-level dependency. If
+      // we can't find it, we can assume that it's already been provided somewhere up the
+      // dependency tree.
       const topLevelDependencySpecifier:
         | DependencySpecifier
         | undefined = this._pnpmShrinkwrapFile.getTopLevelDependencyVersion(peerDependencyName);
 
-      if (!topLevelDependencySpecifier) {
-        // We couldn't find the peer dependency. Let's trust the package manager and assume that
-        // the install is valid and skip including this dependency in the manifest.
-        continue;
-      }
-
-      // Found it hoisted to the top level.
-      this._addDependencyInternal(
-        peerDependencyName,
-        this._pnpmShrinkwrapFile.getTopLevelDependencyKey(peerDependencyName)!,
-        shrinkwrapEntry
-      );
-    }
-  }
-
-  private _validatePeerDependencyVersion(
-    shrinkwrapEntry: Pick<
-      IPnpmShrinkwrapDependencyYaml,
-      'dependencies' | 'optionalDependencies' | 'peerDependencies'
-    >,
-    peerDependencyName: string,
-    peerDependencyVersion: string
-  ): boolean {
-    // Check the current package to see if the dependency is already satisfied
-    if (shrinkwrapEntry.dependencies && shrinkwrapEntry.dependencies.hasOwnProperty(peerDependencyName)) {
-      let dependencySpecifier: DependencySpecifier | undefined = parsePnpmDependencyKey(
-        peerDependencyName,
-        shrinkwrapEntry.dependencies[peerDependencyName]
-      );
-      if (dependencySpecifier) {
-        if (
-          dependencySpecifier.specifierType === DependencySpecifierType.Alias &&
-          dependencySpecifier.aliasTarget
-        ) {
-          dependencySpecifier = dependencySpecifier.aliasTarget;
-        }
-
-        if (!semver.valid(dependencySpecifier.versionSpecifier)) {
-          throw new InternalError(
-            `The version '${peerDependencyVersion}' of peer dependency '${peerDependencyName}' is invalid`
-          );
-        }
-
-        return true;
+      if (topLevelDependencySpecifier) {
+        this._addDependencyInternal(
+          peerDependencyName,
+          this._pnpmShrinkwrapFile.getTopLevelDependencyKey(peerDependencyName)!,
+          shrinkwrapEntry
+        );
       }
     }
-
-    return false;
-  }
-
-  /**
-   * The version specifier for a dependency can sometimes come in the form of
-   * '{semVer}_peerDep1@1.2.3+peerDep2@4.5.6'. This is parsed and returned as a dictionary mapping
-   * the peer dependency to it's appropriate PNPM dependency key.
-   */
-  private _parsePeerDependencyKeysFromSpecifier(specifier: string): { [peerDependencyName: string]: string } {
-    const parsedPeerDependencyKeys: { [peerDependencyName: string]: string } = {};
-
-    const specifierMatches: RegExpExecArray | null = /^[^_]+_(.+)$/.exec(specifier);
-    if (specifierMatches) {
-      const combinedPeerDependencies: string = specifierMatches[1];
-      // "eslint@6.6.0+typescript@3.6.4+@types+webpack@4.1.9" --> ["eslint@6.6.0", "typescript@3.6.4", "@types", "webpack@4.1.9"]
-      const peerDependencies: string[] = combinedPeerDependencies.split('+');
-      for (let i: number = 0; i < peerDependencies.length; i++) {
-        // Scopes are also separated by '+', so reduce the proceeding value into it
-        if (peerDependencies[i].indexOf('@') === 0) {
-          peerDependencies[i] = `${peerDependencies[i]}/${peerDependencies[i + 1]}`;
-          peerDependencies.splice(i + 1, 1);
-        }
-
-        // Parse "eslint@6.6.0" --> "eslint", "6.6.0"
-        const peerMatches: RegExpExecArray | null = /^(@?[^+@]+)@(.+)$/.exec(peerDependencies[i]);
-        if (peerMatches) {
-          const peerDependencyName: string = peerMatches[1];
-          const peerDependencyVersion: string = peerMatches[2];
-          const peerDependencyKey: string = `/${peerDependencyName}/${peerDependencyVersion}`;
-          parsedPeerDependencyKeys[peerDependencyName] = peerDependencyKey;
-        }
-      }
-    }
-
-    return parsedPeerDependencyKeys;
   }
 }

--- a/common/changes/@microsoft/rush/user-danade-FixProjectDependencyManifest_2021-02-21-00-26.json
+++ b/common/changes/@microsoft/rush/user-danade-FixProjectDependencyManifest_2021-02-21-00-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Make Rush per-project manifest generation more reliable and remove PNPM shrinkwrap validation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes #2227 

After looking at the issue specified above, as well as the repro produced by @chengcyber (thank you!!), I determined that the bug was being caused by a chained peer dependency within Jest, eventually resulting in a dependency on ts-node 8.10.2 as specified on the Rush project that was attempting to be installed. The per project manifest generator (that produces `shrinkwrap-deps.json`) was crawling through peer dependencies to determine the version of the package actually consumed, so as to add the integrity hash to the shrinkwrap, however it couldn't find the required dependency because it was aquired through a chained peer dependency, which the generator did not expect, causing generation and thus linking to fail.

## Details

After thinking on it, I came to the conclusion that Rush really has no business in validating that the PNPM shrinkwrap is valid/the install is valid (that determination belongs to the package manager) while crawling for dependencies. All we are trying to do is figure out which packages are actually used throughout the dependency stack. Given this understanding, we can remove the validation logic and boil it down to some base assumptions:
- is the peer dependency satisfied by the package itself? If yes, it should already be in the dependency tree. If not...
- is the peer dependency satisfied by the parent package (or any other parent package reachable via peer dependency chaining for that matter)? If yes, it should already be in the dependency tree. If not...
- is the peer dependency hoisted up to the root level? If yes, then add the dependency to the dependency tree. If not...
- assume that the package manager knows what it's doing, that the install is valid, and that the dependency must already be included somewhere up the dependency tree

When taking this all into account, it means that we can write the manifest generation logic in such a way that, even when we can't find what we're looking for (likely due to a chained peer dependency), we can assume the package manager already did for us, and that package should be recorded in the dependency stack.

## How it was tested

Ran solution against the provided repro and confirmed that the required peer dependency was specified in the shrinkwrap-deps.json file (the per-project manifest that is generated)

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
