### PR TITLE
[rush] Fix an issue where Rush would fail to restore from cache but report success when Git isn't present.

### DIFF
--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -111,7 +111,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
       repoCommandLineConfiguration
     );
     if (cacheWriteSuccess === undefined) {
-      terminal.writeErrorLine('This project does not support caching');
+      terminal.writeErrorLine('This project does not support caching or Git is not present.');
       throw new AlreadyReportedError();
     } else if (cacheWriteSuccess === false) {
       terminal.writeErrorLine('Writing cache entry failed.');

--- a/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
@@ -18,7 +18,11 @@ export class PackageChangeAnalyzer {
   // Allow this function to be overwritten during unit tests
   public static getPackageDeps: typeof getPackageDeps;
 
-  private _data: Map<string, Map<string, string>>;
+  /**
+   * null === we haven't looked
+   * undefined === data isn't available (i.e. - git isn't present)
+   */
+  private _data: Map<string, Map<string, string>> | undefined | null = null;
   private _projectStateCache: Map<string, string> = new Map<string, string>();
   private _rushConfiguration: RushConfiguration;
   private readonly _git: Git;
@@ -30,11 +34,11 @@ export class PackageChangeAnalyzer {
   }
 
   public getPackageDeps(projectName: string): Map<string, string> | undefined {
-    if (!this._data) {
+    if (this._data === null) {
       this._data = this._getData();
     }
 
-    return this._data.get(projectName);
+    return this._data?.get(projectName);
   }
 
   /**
@@ -71,17 +75,10 @@ export class PackageChangeAnalyzer {
     return projectState;
   }
 
-  private _getData(): Map<string, Map<string, string>> {
+  private _getData(): Map<string, Map<string, string>> | undefined {
     // If we are not in a unit test, use the correct resources
     if (!PackageChangeAnalyzer.getPackageDeps) {
       PackageChangeAnalyzer.getPackageDeps = getPackageDeps;
-    }
-
-    const projectHashDeps: Map<string, Map<string, string>> = new Map<string, Map<string, string>>();
-
-    // pre-populate the map with the projects from the config
-    for (const project of this._rushConfiguration.projects) {
-      projectHashDeps.set(project.packageName, new Map<string, string>());
     }
 
     let repoDeps: Map<string, string>;
@@ -91,7 +88,7 @@ export class PackageChangeAnalyzer {
         const gitPath: string = this._git.getGitPathOrThrow();
         repoDeps = PackageChangeAnalyzer.getPackageDeps(this._rushConfiguration.rushJsonFolder, [], gitPath);
       } else {
-        return projectHashDeps;
+        return undefined;
       }
     } catch (e) {
       // If getPackageDeps fails, don't fail the whole build. Treat this case as if we don't know anything about
@@ -102,7 +99,14 @@ export class PackageChangeAnalyzer {
         )
       );
 
-      return projectHashDeps;
+      return undefined;
+    }
+
+    const projectHashDeps: Map<string, Map<string, string>> = new Map<string, Map<string, string>>();
+
+    // pre-populate the map with the projects from the config
+    for (const project of this._rushConfiguration.projects) {
+      projectHashDeps.set(project.packageName, new Map<string, string>());
     }
 
     // Sort each project folder into its own package deps hash

--- a/common/changes/@microsoft/rush/ianc-fix-non-git-build_2021-02-25-23-11.json
+++ b/common/changes/@microsoft/rush/ianc-fix-non-git-build_2021-02-25-23-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Rush would fail to restore from cache but report success when Git isn't present.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/2505

## Details

There was an issue in `PackageChangeAnalyzer` where if Git wasn't present, it would report that the project contained no tracked files instead of returning `undefined`. This caused the incremental build feature and the build cache feature to believe that nothing was changed.

## How it was tested

Tested by building this repo both with and without Git on the PATH.