### PR TITLE
[rush-lib]:fix pnpm ensure dep version

### DIFF
--- a/common/changes/@microsoft/rush/fix-pnpm-ensure-dep-version_2021-02-28-06-12.json
+++ b/common/changes/@microsoft/rush/fix-pnpm-ensure-dep-version_2021-02-28-06-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix pnpm ensure dependency version logic",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "liucheng.tech@outlook.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

fix `tryEnsureDependencyVersion` logic

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

projectA package.json

```
"dependencies": {
  "foo": "^1.0.0",
  "other": "1.2.3"
}
```

pnpm lockfile

```
file:projects/projectA.tgz_xxx
  dependenceis:
    'other': 1.2.3 // <-- 1. no foo version here
file: projects/projectB.tgz_xxx
  dependencies:
    'foo': 1.0.1_peerDep@1.0.0  <-- 2. other project has a version with peer dep suffix.


/foo/1.0.1_peerDep@1.0.0: <-- 3. version with peer dep suffix.
  dependencies:
```

In this case, `tryEnsureDependencyVersion` will patch `foo: 1.0.1` to projectA's shrinkWrapJson. but /foo/1.0.1 does not exists in lockfile.

So the correct version is `1.0.1_peerDep@1.0.0` should be patched to projectA's shrinkWrapJson.


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

It might be hard to provide a minimal reproduce repo...I will try...

Question: I don't know the reason why dependency in package.json is missing in lockfile, just like `foo` in `projectA`

## How it was tested



<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
