### PR TITLE
[eslint plugins] Fix unlisted dependency on `@typescript-eslint/experimental-utils`

### DIFF
--- a/common/changes/@rushstack/eslint-config/patch-1_2021-03-05-21-34.json
+++ b/common/changes/@rushstack/eslint-config/patch-1_2021-03-05-21-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Switch to range version specifier for Typescript experimental utils",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "sargun.vohra@gmail.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/patch-1_2021-03-01-00-35.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/patch-1_2021-03-01-00-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Fix unlisted dependency on @typescript-eslint/experimental-utils",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "sargun.vohra@gmail.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/patch-1_2021-03-05-21-34.json
+++ b/common/changes/@rushstack/eslint-plugin-security/patch-1_2021-03-05-21-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "Fix unlisted dependency on @typescript-eslint/experimental-utils",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security",
+  "email": "sargun.vohra@gmail.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/patch-1_2021-03-05-21-34.json
+++ b/common/changes/@rushstack/eslint-plugin/patch-1_2021-03-05-21-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Fix unlisted dependency on @typescript-eslint/experimental-utils",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "sargun.vohra@gmail.com"
+}

--- a/stack/eslint-config/package.json
+++ b/stack/eslint-config/package.json
@@ -29,7 +29,7 @@
     "@rushstack/eslint-plugin-packlets": "workspace:*",
     "@rushstack/eslint-plugin-security": "workspace:*",
     "@typescript-eslint/eslint-plugin": "3.4.0",
-    "@typescript-eslint/experimental-utils": "3.4.0",
+    "@typescript-eslint/experimental-utils": "^3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",
     "eslint-plugin-promise": "~4.2.1",

--- a/stack/eslint-plugin-packlets/package.json
+++ b/stack/eslint-plugin-packlets/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@rushstack/tree-pattern": "workspace:*",
-    "@typescript-eslint/experimental-utils": "3.4.0"
+    "@typescript-eslint/experimental-utils": "^3.4.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"

--- a/stack/eslint-plugin-packlets/package.json
+++ b/stack/eslint-plugin-packlets/package.json
@@ -19,7 +19,8 @@
     "build": "heft test --clean"
   },
   "dependencies": {
-    "@rushstack/tree-pattern": "workspace:*"
+    "@rushstack/tree-pattern": "workspace:*",
+    "@typescript-eslint/experimental-utils": "3.4.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"
@@ -31,7 +32,6 @@
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
-    "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",
     "eslint": "~7.12.1",

--- a/stack/eslint-plugin-security/package.json
+++ b/stack/eslint-plugin-security/package.json
@@ -18,7 +18,8 @@
     "build": "heft test --clean"
   },
   "dependencies": {
-    "@rushstack/tree-pattern": "workspace:*"
+    "@rushstack/tree-pattern": "workspace:*",
+    "@typescript-eslint/experimental-utils": "^3.4.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"
@@ -30,7 +31,6 @@
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
-    "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",
     "eslint": "~7.12.1",

--- a/stack/eslint-plugin/package.json
+++ b/stack/eslint-plugin/package.json
@@ -22,7 +22,8 @@
     "build": "heft test --clean"
   },
   "dependencies": {
-    "@rushstack/tree-pattern": "workspace:*"
+    "@rushstack/tree-pattern": "workspace:*",
+    "@typescript-eslint/experimental-utils": "^3.4.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"
@@ -34,7 +35,6 @@
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
-    "@typescript-eslint/experimental-utils": "3.4.0",
     "@typescript-eslint/parser": "3.4.0",
     "@typescript-eslint/typescript-estree": "3.4.0",
     "eslint": "~7.12.1",


### PR DESCRIPTION
## Summary

This plugin doesn't currently work under strict dependency linkers such as Yarn's PnP, because it uses `@typescript-eslint/experimental-utils` without actually declaring it as a dependency.

It just happens to work under a `node_modules` setup because other packages depend on it (`@typescript-eslint/eslint-plugin` probably).

Fixes #2518.

## Details

A couple examples of where it's required:

https://github.com/microsoft/rushstack/blob/a3e697d93e8fa7ad54bd2eeb7b10e8181d3a70df/stack/eslint-plugin-packlets/src/mechanics.ts#L4-L5

https://github.com/microsoft/rushstack/blob/a3e697d93e8fa7ad54bd2eeb7b10e8181d3a70df/stack/eslint-plugin-packlets/src/circular-deps.ts#L7-L8

## How it was tested

Used's Yarn's `packageExtensions` config feature to override this manually in my repo, and got it working under PnP strict mode. See https://github.com/microsoft/rushstack/issues/2518#issuecomment-787553366 for details and the repro repo
