### PR TITLE
[heft] Remove the hardcoded "lib" static assets output folder name

### DIFF
--- a/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
+++ b/apps/heft/src/plugins/CopyStaticAssetsPlugin.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
 import { Terminal } from '@rushstack/node-core-library';
+import { ConfigurationFile, InheritanceType, PathResolutionMethod } from '@rushstack/heft-config-file';
 
 import { HeftSession } from '../pluginFramework/HeftSession';
 import { HeftConfiguration } from '../configuration/HeftConfiguration';
@@ -13,7 +15,56 @@ import { CopyFilesPlugin } from './CopyFilesPlugin';
 
 const PLUGIN_NAME: string = 'CopyStaticAssetsPlugin';
 
+interface IPartialTsconfigCompilerOptions {
+  outDir?: string;
+}
+
+interface IPartialTsconfig {
+  compilerOptions?: IPartialTsconfigCompilerOptions;
+}
+
 export class CopyStaticAssetsPlugin extends CopyFilesPlugin {
+  private static __partialTsconfigFileLoader: ConfigurationFile<IPartialTsconfig> | undefined;
+
+  private static get _partialTsconfigFileLoader(): ConfigurationFile<IPartialTsconfig> {
+    if (!CopyStaticAssetsPlugin.__partialTsconfigFileLoader) {
+      const schemaPath: string = path.resolve(__dirname, '..', 'schemas', 'anything.schema.json');
+      CopyStaticAssetsPlugin.__partialTsconfigFileLoader = new ConfigurationFile<IPartialTsconfig>({
+        projectRelativeFilePath: 'tsconfig.json',
+        jsonSchemaPath: schemaPath,
+        propertyInheritance: {
+          compilerOptions: {
+            inheritanceType: InheritanceType.custom,
+            inheritanceFunction: (
+              currentObject: IPartialTsconfigCompilerOptions | undefined,
+              parentObject: IPartialTsconfigCompilerOptions | undefined
+            ) => {
+              if (currentObject && !parentObject) {
+                return currentObject;
+              } else if (!currentObject && parentObject) {
+                return parentObject;
+              } else if (parentObject && currentObject) {
+                return {
+                  ...parentObject,
+                  ...currentObject
+                };
+              } else {
+                return undefined;
+              }
+            }
+          }
+        },
+        jsonPathMetadata: {
+          '$.compilerOptions.outDir': {
+            pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToConfigurationFile
+          }
+        }
+      });
+    }
+
+    return CopyStaticAssetsPlugin.__partialTsconfigFileLoader;
+  }
+
   /**
    * @override
    */
@@ -56,9 +107,18 @@ export class CopyStaticAssetsPlugin extends CopyFilesPlugin {
       heftConfiguration.rigConfig
     );
 
-    const destinationFolders: string[] = ['lib'];
+    const destinationFolders: Set<string> = new Set<string>();
+
+    const tsconfigDestinationFolder: string | undefined = await this._tryGetTsconfigOutDirAsync(
+      heftConfiguration.buildFolder,
+      terminal
+    );
+    if (tsconfigDestinationFolder) {
+      destinationFolders.add(tsconfigDestinationFolder);
+    }
+
     for (const emitModule of typescriptConfiguration?.additionalModuleKindsToEmit || []) {
-      destinationFolders.push(emitModule.outFolderName);
+      destinationFolders.add(emitModule.outFolderName);
     }
 
     return {
@@ -66,9 +126,22 @@ export class CopyStaticAssetsPlugin extends CopyFilesPlugin {
 
       // For now - these may need to be revised later
       sourceFolder: 'src',
-      destinationFolders,
+      destinationFolders: Array.from(destinationFolders),
       flatten: false,
       hardlink: false
     };
+  }
+
+  private async _tryGetTsconfigOutDirAsync(
+    projectFolder: string,
+    terminal: Terminal
+  ): Promise<string | undefined> {
+    const partialTsconfig:
+      | IPartialTsconfig
+      | undefined = await CopyStaticAssetsPlugin._partialTsconfigFileLoader.tryLoadConfigurationFileForProjectAsync(
+      terminal,
+      projectFolder
+    );
+    return partialTsconfig?.compilerOptions?.outDir;
   }
 }

--- a/apps/heft/src/schemas/anything.schema.json
+++ b/apps/heft/src/schemas/anything.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema that matches anything",
+
+  "oneOf": [
+    {
+      "type": "array"
+    },
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "integer"
+    },
+    {
+      "type": "null"
+    },
+    {
+      "type": "number"
+    },
+    {
+      "type": "object"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft/ianc-fix-output-dir_2021-03-02-06-50.json
+++ b/common/changes/@rushstack/heft/ianc-fix-output-dir_2021-03-02-06-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Determine the default static assets destination folder from the TSConfig's \"outDir\" property, instead of hardcoding \"lib.\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/2513

## Details

We had "lib" hardcoded as the default output folder for the `CopyStaticAssetsPlugin`. This PR changes that to instead gets that folder from the `compilerOptions.outDir` property in `tsconfig.json`

## How it was tested

Tested on this repo and on https://github.com/xc2/GithubIssues/tree/main/heft-issue-staticAssetsToCopy