### PR TITLE
[rush-lib] Sub files for rush.json packages array

### DIFF
--- a/apps/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -118,6 +118,86 @@ describe('RushConfiguration', () => {
     done();
   });
 
+  it('can load repo/rush-npm-extended-project.json', (done: jest.DoneCallback) => {
+    const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-npm-extended-projects.json');
+
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+
+    rushConfiguration.projectsExtended = [
+      path.resolve(__dirname, 'repo', 'extended-projects', 'extended-1.json'),
+      path.resolve(__dirname, 'repo', 'extended-projects', 'extended-2.json')
+    ];
+
+    expect(rushConfiguration.packageManager).toEqual('npm');
+    assertPathProperty(
+      'committedShrinkwrapFilename',
+      rushConfiguration.committedShrinkwrapFilename,
+      './repo/common/config/rush/npm-shrinkwrap.json'
+    );
+    assertPathProperty('commonFolder', rushConfiguration.commonFolder, './repo/common');
+    assertPathProperty(
+      'commonRushConfigFolder',
+      rushConfiguration.commonRushConfigFolder,
+      './repo/common/config/rush'
+    );
+    assertPathProperty('commonTempFolder', rushConfiguration.commonTempFolder, './repo/common/temp');
+    assertPathProperty('npmCacheFolder', rushConfiguration.npmCacheFolder, './repo/common/temp/npm-cache');
+    assertPathProperty('npmTmpFolder', rushConfiguration.npmTmpFolder, './repo/common/temp/npm-tmp');
+    expect(rushConfiguration.pnpmOptions.pnpmStore).toEqual('local');
+    assertPathProperty(
+      'pnpmStorePath',
+      rushConfiguration.pnpmOptions.pnpmStorePath,
+      './repo/common/temp/pnpm-store'
+    );
+    assertPathProperty(
+      'packageManagerToolFilename',
+      rushConfiguration.packageManagerToolFilename,
+      './repo/common/temp/npm-local/node_modules/.bin/npm'
+    );
+    assertPathProperty('rushJsonFolder', rushConfiguration.rushJsonFolder, './repo');
+
+    expect(rushConfiguration.packageManagerToolVersion).toEqual('4.5.0');
+
+    expect(rushConfiguration.repositoryUrl).toEqual('someFakeUrl');
+    expect(rushConfiguration.projectFolderMaxDepth).toEqual(99);
+    expect(rushConfiguration.projectFolderMinDepth).toEqual(1);
+    expect(rushConfiguration.hotfixChangeEnabled).toEqual(true);
+
+    expect(rushConfiguration.projects).toHaveLength(3);
+
+    // "approvedPackagesPolicy" feature
+    const approvedPackagesPolicy: ApprovedPackagesPolicy = rushConfiguration.approvedPackagesPolicy;
+    expect(approvedPackagesPolicy.enabled).toEqual(true);
+    expect(Utilities.getSetAsArray(approvedPackagesPolicy.reviewCategories)).toEqual([
+      'first-party',
+      'third-party',
+      'prototype'
+    ]);
+
+    expect(Utilities.getSetAsArray(approvedPackagesPolicy.ignoredNpmScopes)).toEqual(['@types', '@internal']);
+
+    expect(approvedPackagesPolicy.browserApprovedPackages.items[0].packageName).toEqual('example');
+    expect(approvedPackagesPolicy.browserApprovedPackages.items[0].allowedCategories.size).toEqual(3);
+
+    expect(rushConfiguration.telemetryEnabled).toBe(false);
+
+    // Validate project1 settings
+    const project1: RushConfigurationProject = rushConfiguration.getProjectByName('project1')!;
+    expect(project1).toBeDefined();
+
+    expect(project1.packageName).toEqual('project1');
+    assertPathProperty('project1.projectFolder', project1.projectFolder, './repo/project1');
+    expect(project1.tempProjectName).toEqual('@rush-temp/project1');
+    expect(project1.unscopedTempProjectName).toEqual('project1');
+    expect(project1.skipRushCheck).toEqual(false);
+
+    // Validate project2 settings
+    const project2: RushConfigurationProject = rushConfiguration.getProjectByName('project2')!;
+    expect(project2.skipRushCheck).toEqual(true);
+
+    done();
+  });
+
   it('can load repo/rush-pnpm.json', (done: jest.DoneCallback) => {
     const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-pnpm.json');
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);

--- a/apps/rush-lib/src/api/test/repo/extended-projects/extended-1.json
+++ b/apps/rush-lib/src/api/test/repo/extended-projects/extended-1.json
@@ -1,0 +1,15 @@
+{
+  "projects": [
+    {
+      "packageName": "project1",
+      "projectFolder": "project1",
+      "reviewCategory": "third-party"
+    },
+    {
+      "packageName": "project2",
+      "projectFolder": "project2",
+      "reviewCategory": "third-party",
+      "skipRushCheck": true
+    }
+  ]
+}

--- a/apps/rush-lib/src/api/test/repo/extended-projects/extended-2.json
+++ b/apps/rush-lib/src/api/test/repo/extended-projects/extended-2.json
@@ -1,0 +1,9 @@
+{
+  "projects": [
+    {
+      "packageName": "project3",
+      "projectFolder": "project3",
+      "reviewCategory": "prototype"
+    }
+  ]
+}

--- a/apps/rush-lib/src/api/test/repo/rush-npm-extended-projects.json
+++ b/apps/rush-lib/src/api/test/repo/rush-npm-extended-projects.json
@@ -1,0 +1,46 @@
+{
+  "npmVersion": "4.5.0",
+  "rushVersion": "2.5.0-dev.123",
+  "projectFolderMinDepth": 1,
+  "projectFolderMaxDepth": 99,
+  "hotfixChangeEnabled": true,
+
+  "approvedPackagesPolicy": {
+    "reviewCategories": ["first-party", "third-party", "prototype"],
+    "ignoredNpmScopes": ["@types", "@internal"]
+  },
+
+  "repository": {
+    "url": "someFakeUrl"
+  },
+
+  "gitPolicy": {
+    "allowedEmailRegExps": ["[^@]+@contoso\\.com"],
+    "sampleEmail": "mrexample@contoso.com"
+  },
+
+  "eventHooks": {
+    "postRushBuild": ["do something"]
+  },
+  "projectsExtended": [],
+  "projects": [
+    {
+      "packageName": "project1",
+      "projectFolder": "project1",
+      "reviewCategory": "third-party"
+    },
+
+    {
+      "packageName": "project2",
+      "projectFolder": "project2",
+      "reviewCategory": "third-party",
+      "skipRushCheck": true
+    },
+
+    {
+      "packageName": "project3",
+      "projectFolder": "project3",
+      "reviewCategory": "prototype"
+    }
+  ]
+}

--- a/apps/rush-lib/src/schemas/projects-extended.schema.json
+++ b/apps/rush-lib/src/schemas/projects-extended.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Rush extended projects config File",
+  "description": "The configuration file for extending the main rush projects array.",
+  "type": "object",
+  "properties": {
+    "projects": {
+      "description": "A list of projects managed by this tool.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "packageName": {
+            "description": "The NPM package name of the project.",
+            "type": "string"
+          },
+          "projectFolder": {
+            "description": "The path to the project folder relative to the Rush config file.",
+            "type": "string"
+          },
+          "reviewCategory": {
+            "description": "An optional category for usage in the \"browser-approved-packages.json\" and \"nonbrowser-approved-packages.json\" files.  Only strings from reviewCategories are allowed here.",
+            "type": "string"
+          },
+          "cyclicDependencyProjects": {
+            "description": "A list of local projects that appear as devDependencies for this project, but cannot be locally linked because it would create a cyclic dependency; instead, the last published version will be installed in the Common folder.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shouldPublish": {
+            "description": "A flag indicating that changes to this project will be published to npm, which affects the Rush change and publish workflows.",
+            "type": "boolean"
+          },
+          "skipRushCheck": {
+            "description": "If true, then this project will be ignored by the \"rush check\" command.  The default value is false.",
+            "type": "boolean"
+          },
+          "versionPolicyName": {
+            "description": "An optional version policy associated with the project. Version policies are defined in \"version-policies.json\" file.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["packageName", "projectFolder"]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["projects"]
+}

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -225,6 +225,14 @@
       "description": "Indicates whether telemetry data should be collected and stored in the Rush temp folder during Rush runs.",
       "type": "boolean"
     },
+    "projectsExtended": {
+        "description": "A list of paths storing additional projects as json",
+        "type": "array",
+        "items": {
+            "description": "The relative filepath for a additional project json file",
+            "type": "string"
+        }
+    },
     "projects": {
       "description": "A list of projects managed by this tool.",
       "type": "array",


### PR DESCRIPTION
We found that with 100+ projects in our rush.json packages array it was getting difficult to maintain.

To fix this I have added a "projectsExtended" property to rush.json that stores an array of paths.
Each path in the array points to a json file that contains an array of projects (in the same format as rush.json's pacakages array.

In ```RushConfiguration._initializeAndValidateLocalProjects``` the contents of the json files are concatenated on to the original pacakges array

An extra unit test has been included in ```RushConfiguration.test.ts```.
