### PR TITLE
[rush] Fix 'colors' imports.

### DIFF
--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { EOL } from 'os';
-import colors from 'colors';
+import colors from 'colors/safe';
 import { PackageJsonLookup } from '@rushstack/node-core-library';
 
 import { RushCommandLineParser } from '../cli/RushCommandLineParser';

--- a/apps/rush-lib/src/cli/CommandLineMigrationAdvisor.ts
+++ b/apps/rush-lib/src/cli/CommandLineMigrationAdvisor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import { RushConstants } from '../logic/RushConstants';
 import { Utilities } from '../utilities/Utilities';

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as colors from 'colors/safe';
+import colors from 'colors/safe';
 
 import {
   PackageName,

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 
 import { Import } from '@rushstack/node-core-library';

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -4,7 +4,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as child_process from 'child_process';
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import {
   CommandLineFlagParameter,

--- a/apps/rush-lib/src/cli/actions/CheckAction.ts
+++ b/apps/rush-lib/src/cli/actions/CheckAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import { CommandLineStringParameter, CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 import { RushCommandLineParser } from '../RushCommandLineParser';

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/apps/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';
 import { FileSystem, NewlineKind, IPackageJson, JsonFile } from '@rushstack/node-core-library';

--- a/apps/rush-lib/src/cli/actions/InitDeployAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitDeployAction.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import colors from 'colors';
+import colors from 'colors/safe';
 import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import { EOL } from 'os';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/apps/rush-lib/src/cli/actions/PurgeAction.ts
+++ b/apps/rush-lib/src/cli/actions/PurgeAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 
 import { CommandLineFlagParameter } from '@rushstack/ts-command-line';

--- a/apps/rush-lib/src/cli/actions/ScanAction.ts
+++ b/apps/rush-lib/src/cli/actions/ScanAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import builtinPackageNames from 'builtin-modules';
 

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as os from 'os';
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import { AlreadyReportedError, ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import {

--- a/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/apps/rush-lib/src/logic/Autoinstaller.ts
+++ b/apps/rush-lib/src/logic/Autoinstaller.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 
 import { FileSystem, NewlineKind } from '@rushstack/node-core-library';

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as os from 'os';
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import { EventHooks } from '../api/EventHooks';
 import { Utilities } from '../utilities/Utilities';

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -5,7 +5,7 @@ import child_process from 'child_process';
 import gitInfo = require('git-repo-info');
 import * as os from 'os';
 import * as path from 'path';
-import colors from 'colors';
+import colors from 'colors/safe';
 import { Executable, AlreadyReportedError, Path } from '@rushstack/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';

--- a/apps/rush-lib/src/logic/InstallManagerFactory.ts
+++ b/apps/rush-lib/src/logic/InstallManagerFactory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as semver from 'semver';
 
 import { AlreadyReportedError, Import } from '@rushstack/node-core-library';

--- a/apps/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/apps/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as semver from 'semver';
 
 // Minimize dependencies to avoid compatibility errors that might be encountered before

--- a/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as crypto from 'crypto';
 
 import { getPackageDeps, getGitHashForFiles } from '@rushstack/package-deps-hash';

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as semver from 'semver';
 
 import { RushConfiguration } from '../api/RushConfiguration';

--- a/apps/rush-lib/src/logic/PurgeManager.ts
+++ b/apps/rush-lib/src/logic/PurgeManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 
 import { AsyncRecycler } from '../utilities/AsyncRecycler';

--- a/apps/rush-lib/src/logic/SetupChecks.ts
+++ b/apps/rush-lib/src/logic/SetupChecks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import * as semver from 'semver';
 import { FileSystem, AlreadyReportedError } from '@rushstack/node-core-library';

--- a/apps/rush-lib/src/logic/UnlinkManager.ts
+++ b/apps/rush-lib/src/logic/UnlinkManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import { FileSystem, AlreadyReportedError } from '@rushstack/node-core-library';
 

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as fetch from 'node-fetch';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as semver from 'semver';
 import { FileSystem } from '@rushstack/node-core-library';
 

--- a/apps/rush-lib/src/logic/deploy/DeployManager.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import * as resolve from 'resolve';
 import * as npmPacklist from 'npm-packlist';

--- a/apps/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema } from '@rushstack/node-core-library';
 import { RushConfiguration } from '../../api/RushConfiguration';

--- a/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as glob from 'glob';
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import uriEncode = require('strict-uri-encode');
 import pnpmLinkBins from '@pnpm/link-bins';
 import * as semver from 'semver';
-import colors from 'colors';
+import colors from 'colors/safe';
 
 import {
   Text,

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
 import crypto from 'crypto';
-import colors from 'colors';
+import colors from 'colors/safe';
 import { FileSystem, AlreadyReportedError, Import } from '@rushstack/node-core-library';
 
 import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';

--- a/apps/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/apps/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 

--- a/apps/rush-lib/src/logic/setup/TerminalInput.ts
+++ b/apps/rush-lib/src/logic/setup/TerminalInput.ts
@@ -3,7 +3,7 @@
 
 import * as readline from 'readline';
 import * as process from 'process';
-import colors from 'colors';
+import colors from 'colors/safe';
 import { AnsiEscape } from '@rushstack/node-core-library';
 
 import { KeyboardLoop } from './KeyboardLoop';

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as os from 'os';
-import colors from 'colors';
+import colors from 'colors/safe';
 import {
   StdioSummarizer,
   TerminalWritable,

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -4,7 +4,7 @@
 // The TaskRunner prints "x.xx seconds" in TestRunner.test.ts.snap; ensure that the Stopwatch timing is deterministic
 jest.mock('../../../utilities/Utilities');
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import { EOL } from 'os';
 import { CollatedTerminal } from '@rushstack/stream-collator';
 import { MockWritable } from '@rushstack/terminal';

--- a/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import colors from 'colors';
+import colors from 'colors/safe';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../api/RushConfiguration';

--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as colors from 'colors';
+import colors from 'colors/safe';
 import * as path from 'path';
 import * as rushLib from '@microsoft/rush-lib';
 

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -18,7 +18,7 @@ const alreadyReportedNodeTooNewError: boolean = NodeJsCompatibility.warnAboutVer
   alreadyReportedNodeTooNewError: false
 });
 
-import * as colors from 'colors';
+import colors from 'colors/safe';
 import * as os from 'os';
 import * as semver from 'semver';
 

--- a/common/changes/@microsoft/rush/ianc-fix-colors-imports-in-rush_2021-03-02-21-00.json
+++ b/common/changes/@microsoft/rush/ianc-fix-colors-imports-in-rush_2021-03-02-21-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an exception thrown when rush build was run in a non-project folder.",
+      "comment": "Fix a regression where certain Rush operations reported a TypeError (GitHub #2526)",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/ianc-fix-colors-imports-in-rush_2021-03-02-21-00.json
+++ b/common/changes/@microsoft/rush/ianc-fix-colors-imports-in-rush_2021-03-02-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an exception thrown when rush build was run in a non-project folder.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/2526

Logging messages from `SelectionParameterSet.ts` throw an exception when they use `colors.red` because `colors` isn't imported correctly.

## Details

This PR changes the import in `SelectionParameterSet.ts`, and updates the rest of the `colors` imports to import from `colors/safe`.

## How it was tested

Tested by invoking `rush build` in a non-project folder.