### PR TITLE
Fix an issue where build would continue even if TS reported errors.

### DIFF
--- a/common/changes/@rushstack/heft/ianc-dont-run-ae-on-compiler-failure_2021-03-02-22-56.json
+++ b/common/changes/@rushstack/heft/ianc-dont-run-ae-on-compiler-failure_2021-03-02-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where build would continue even if TS reported errors.",
+      "type": "patch",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/2478

## Details

This changes the `TypeScriptBuilder` to throw an exception if the TypeScript compilation reports any errors.

## How it was tested

Tested by following the repro steps in https://github.com/microsoft/rushstack/issues/2478.