### PR TITLE
[heft] Support emitting compiled files using ".cjs" for commonjs, ".mjs" for ECMAScript Modules, etc., within a single output folder

### DIFF
--- a/apps/heft/includes/jest-shared.config.json
+++ b/apps/heft/includes/jest-shared.config.json
@@ -7,7 +7,7 @@
   "rootDir": "../../../../",
 
   "//": ["Adding '<rootDir>/src' here enables src/__mocks__ to be used for mocking Node.js system modules."],
-  "roots": ["<rootDir>", "<rootDir>/src"],
+  "roots": ["<rootDir>/src"],
 
   "testURL": "http://localhost/",
 
@@ -48,7 +48,9 @@
     "  <rootDir>/src/file.ts",
     "...and ignores anything else under <rootDir>"
   ],
-  "modulePathIgnorePatterns": ["^<rootDir>/(?!(?:src/)|(?:src$))"],
+  "modulePathIgnorePatterns": [],
+  "//": "Prefer .cjs to .js to catch explicit commonjs output. Optimize for local files, which will be .ts or .tsx.",
+  "moduleFileExtensions": ["ts", "tsx", "cjs", "js", "json"],
 
   "setupFiles": ["@rushstack/heft/lib/exports/jest-global-setup.js"],
   "resolver": "@rushstack/heft/lib/exports/jest-improved-resolver.js",

--- a/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
@@ -89,7 +89,7 @@ export class JestPlugin implements IHeftPlugin {
 
     if (test.properties.findRelatedTests && test.properties.findRelatedTests.length > 0) {
       jestArgv.findRelatedTests = true;
-      // This is Jest's weird way of representing space-delimited CLI parameters
+      // Pass test names as the command line remainder
       jestArgv._ = [...test.properties.findRelatedTests];
     }
 

--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -14,6 +14,11 @@ export interface IJestTypeScriptDataFileJson {
   emitFolderNameForTests: string;
 
   /**
+   * The file extension attached to compiled test files.
+   */
+  extensionForTests: '.js' | '.cjs' | '.mjs';
+
+  /**
    * Normally the jest-build-transform compares the timestamps of the .js output file and .ts source file
    * to determine whether the TypeScript compiler has completed.  However this heuristic is only necessary
    * in the interactive "--watch" mode, since otherwise Heft doesn't invoke Jest until after the compiler

--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -65,7 +65,7 @@ export function process(
       jestOptions.rootDir,
       jestTypeScriptDataFile.emitFolderNameForTests,
       srcRelativeFolderPath,
-      `${parsedFilename.name}.js`
+      `${parsedFilename.name}${jestTypeScriptDataFile.extensionForTests}`
     );
 
     const startOfLoopMs: number = new Date().getTime();

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -773,7 +773,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       this._addModuleKindToEmit(
         ts.ModuleKind.CommonJS,
         tsconfig.options.outDir!,
-        tsconfig.options.module === ts.ModuleKind.CommonJS,
+        /* isPrimary */ tsconfig.options.module === ts.ModuleKind.CommonJS,
         '.cjs'
       );
 
@@ -792,7 +792,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       this._addModuleKindToEmit(
         ts.ModuleKind.ESNext,
         tsconfig.options.outDir!,
-        tsconfig.options.module === ts.ModuleKind.ESNext,
+        /* isPrimary */ tsconfig.options.module === ts.ModuleKind.ESNext,
         '.mjs'
       );
 
@@ -856,7 +856,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
           const outFolderKey: string = this._addModuleKindToEmit(
             moduleKind,
             additionalModuleKindToEmit.outFolderName,
-            false,
+            /* isPrimary */ false,
             undefined
           );
 

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -770,7 +770,12 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
     }
 
     if (this._configuration.emitCjsExtensionForCommonJS) {
-      this._addModuleKindToEmit(ts.ModuleKind.CommonJS, tsconfig.options.outDir!, false, '.cjs');
+      this._addModuleKindToEmit(
+        ts.ModuleKind.CommonJS,
+        tsconfig.options.outDir!,
+        tsconfig.options.module === ts.ModuleKind.CommonJS,
+        '.cjs'
+      );
 
       const cjsReason: IModuleKindReason = {
         outDir: tsconfig.options.outDir!,
@@ -780,11 +785,16 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       };
 
       specifiedKinds.set(ts.ModuleKind.CommonJS, cjsReason);
-      specifiedOutDirs.set(`${tsconfig.options.outDir!}:.js`, cjsReason);
+      specifiedOutDirs.set(`${tsconfig.options.outDir!}:.cjs`, cjsReason);
     }
 
     if (this._configuration.emitMjsExtensionForESModule) {
-      this._addModuleKindToEmit(ts.ModuleKind.ESNext, tsconfig.options.outDir!, false, '.mjs');
+      this._addModuleKindToEmit(
+        ts.ModuleKind.ESNext,
+        tsconfig.options.outDir!,
+        tsconfig.options.module === ts.ModuleKind.ESNext,
+        '.mjs'
+      );
 
       const mjsReason: IModuleKindReason = {
         outDir: tsconfig.options.outDir!,
@@ -794,7 +804,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       };
 
       specifiedKinds.set(ts.ModuleKind.CommonJS, mjsReason);
-      specifiedOutDirs.set(`${tsconfig.options.outDir!}:.js`, mjsReason);
+      specifiedOutDirs.set(`${tsconfig.options.outDir!}:.mjs`, mjsReason);
     }
 
     if (!specifiedKinds.has(tsconfig.options.module)) {
@@ -834,11 +844,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         const existingKind: IModuleKindReason | undefined = specifiedKinds.get(moduleKind);
         const existingDir: IModuleKindReason | undefined = specifiedOutDirs.get(outDirKey);
 
-        if (tsconfig.options.module === moduleKind) {
-          throw new Error(
-            `Module kind "${additionalModuleKindToEmit.moduleKind}" is already specified in the tsconfig file.`
-          );
-        } else if (existingKind) {
+        if (existingKind) {
           throw new Error(
             `Module kind "${additionalModuleKindToEmit.moduleKind}" is already emitted at ${existingKind.outDir} with extension '${existingKind.extension}' by option ${existingKind.reason}.`
           );

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -762,7 +762,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       tsconfigOutFolderName = this._addModuleKindToEmit(
         tsconfig.options.module,
         tsconfig.options.outDir!,
-        true
+        /* isPrimary */ true,
+        /* jsExtensionOverride */ undefined
       );
     }
 
@@ -798,7 +799,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
           const outFolderPath: string = this._addModuleKindToEmit(
             moduleKind,
             additionalModuleKindToEmit.outFolderName,
-            false
+            false,
+            additionalModuleKindToEmit.jsExtensionOverride
           );
           specifiedKinds.add(moduleKind);
           specifiedOutDirs.add(outFolderPath);
@@ -810,7 +812,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
   private _addModuleKindToEmit(
     moduleKind: TTypescript.ModuleKind,
     outFolderPath: string,
-    isPrimary: boolean
+    isPrimary: boolean,
+    jsExtensionOverride: string | undefined
   ): string {
     let outFolderName: string;
     if (path.isAbsolute(outFolderPath)) {
@@ -826,6 +829,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       cacheOutFolderPath: Path.convertToSlashes(
         path.resolve(this._configuration.buildCacheFolder, outFolderName)
       ),
+      jsExtensionOverride,
 
       isPrimary
     });

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -71,12 +71,12 @@ export interface ISharedTypeScriptConfiguration {
   additionalModuleKindsToEmit?: IEmitModuleKind[] | undefined;
 
   /**
-   * If 'true', will emit CommonJS output into the TSConfig outDir with the file extension '.cjs'
+   * If 'true', emit CommonJS output into the TSConfig outDir with the file extension '.cjs'
    */
   emitCjsExtensionForCommonJS?: boolean | undefined;
 
   /**
-   * If 'true', will emit ESModule output into the TSConfig outDir with the file extension '.mjs'
+   * If 'true', emit ESModule output into the TSConfig outDir with the file extension '.mjs'
    */
   emitMjsExtensionForESModule?: boolean | undefined;
 

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -51,6 +51,8 @@ interface IRunBuilderForTsconfigOptions {
 
   terminalProvider: ITerminalProvider;
   terminalPrefixLabel: string | undefined;
+  emitCjsExtensionForCommonJS: boolean;
+  emitMjsExtensionForESModule: boolean;
   additionalModuleKindsToEmit: IEmitModuleKind[] | undefined;
 }
 
@@ -71,12 +73,12 @@ export interface ISharedTypeScriptConfiguration {
   /**
    * If 'true', will emit CommonJS output into the TSConfig outDir with the file extension '.cjs'
    */
-  emitCjsExtensionForCommonJS?: boolean;
+  emitCjsExtensionForCommonJS?: boolean | undefined;
 
   /**
    * If 'true', will emit ESModule output into the TSConfig outDir with the file extension '.mjs'
    */
-  emitMjsExtensionForESModule?: boolean;
+  emitMjsExtensionForESModule?: boolean | undefined;
 
   /**
    * Specifies the intermediary folder that tests will use.  Because Jest uses the
@@ -263,14 +265,14 @@ export class TypeScriptPlugin implements IHeftPlugin {
       | 'terminalProvider'
       | 'tsconfigFilePath'
       | 'additionalModuleKindsToEmit'
-      | 'emitCjsExtensionForCommonJS'
-      | 'emitMjsExtensionForESModule'
       | 'terminalPrefixLabel'
       | 'firstEmitCallback'
     > = {
       heftSession: heftSession,
       heftConfiguration,
       toolPackageResolution,
+      emitCjsExtensionForCommonJS: !!typeScriptConfiguration.emitCjsExtensionForCommonJS,
+      emitMjsExtensionForESModule: !!typeScriptConfiguration.emitMjsExtensionForESModule,
       lintingEnabled: !!typeScriptConfiguration.isLintingEnabled,
       copyFromCacheMode: typeScriptConfiguration.copyFromCacheMode,
       watchMode: watchMode,
@@ -348,6 +350,8 @@ export class TypeScriptPlugin implements IHeftPlugin {
       lintingEnabled: options.lintingEnabled,
       buildCacheFolder: options.heftConfiguration.buildCacheFolder,
       additionalModuleKindsToEmit: options.additionalModuleKindsToEmit,
+      emitCjsExtensionForCommonJS: options.emitCjsExtensionForCommonJS,
+      emitMjsExtensionForESModule: options.emitMjsExtensionForESModule,
       copyFromCacheMode: options.copyFromCacheMode,
       watchMode: options.watchMode,
       loggerPrefixLabel: options.terminalPrefixLabel,

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -69,6 +69,16 @@ export interface ISharedTypeScriptConfiguration {
   additionalModuleKindsToEmit?: IEmitModuleKind[] | undefined;
 
   /**
+   * If 'true', will emit CommonJS output into the TSConfig outDir with the file extension '.cjs'
+   */
+  emitCjsExtensionForCommonJS?: boolean;
+
+  /**
+   * If 'true', will emit ESModule output into the TSConfig outDir with the file extension '.mjs'
+   */
+  emitMjsExtensionForESModule?: boolean;
+
+  /**
    * Specifies the intermediary folder that tests will use.  Because Jest uses the
    * Node.js runtime to execute tests, the module format must be CommonJS.
    *
@@ -213,6 +223,8 @@ export class TypeScriptPlugin implements IHeftPlugin {
     const typeScriptConfiguration: ITypeScriptConfiguration = {
       copyFromCacheMode: typescriptConfigurationJson?.copyFromCacheMode,
       additionalModuleKindsToEmit: typescriptConfigurationJson?.additionalModuleKindsToEmit,
+      emitCjsExtensionForCommonJS: typescriptConfigurationJson?.emitCjsExtensionForCommonJS,
+      emitMjsExtensionForESModule: typescriptConfigurationJson?.emitMjsExtensionForESModule,
       emitFolderNameForTests: typescriptConfigurationJson?.emitFolderNameForTests,
       maxWriteParallelism: typescriptConfigurationJson?.maxWriteParallelism || 50,
       isLintingEnabled: !(buildProperties.lite || typescriptConfigurationJson?.disableTslint)
@@ -251,6 +263,8 @@ export class TypeScriptPlugin implements IHeftPlugin {
       | 'terminalProvider'
       | 'tsconfigFilePath'
       | 'additionalModuleKindsToEmit'
+      | 'emitCjsExtensionForCommonJS'
+      | 'emitMjsExtensionForESModule'
       | 'terminalPrefixLabel'
       | 'firstEmitCallback'
     > = {
@@ -264,8 +278,9 @@ export class TypeScriptPlugin implements IHeftPlugin {
     };
 
     JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, {
-      emitFolderNameForTests: typescriptConfigurationJson?.emitFolderNameForTests || 'lib',
-      skipTimestampCheck: !options.watchMode
+      emitFolderNameForTests: typeScriptConfiguration.emitFolderNameForTests || 'lib',
+      skipTimestampCheck: !options.watchMode,
+      extensionForTests: typeScriptConfiguration.emitCjsExtensionForCommonJS ? '.cjs' : '.js'
     });
 
     const callbacksForTsconfigs: Set<() => void> = new Set<() => void>();

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -34,6 +34,7 @@ interface IRunTypeScriptOptions {
 interface IEmitModuleKind {
   moduleKind: 'commonjs' | 'amd' | 'umd' | 'system' | 'es2015' | 'esnext';
   outFolderName: string;
+  jsExtensionOverride?: string;
 }
 
 interface IRunBuilderForTsconfigOptions {

--- a/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
@@ -12,7 +12,9 @@ export interface IEmitResolver {}
 /**
  * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/types.ts#L5969-L5988
  */
-export interface IEmitHost {}
+export interface IEmitHost {
+  writeFile: TTypescript.WriteFileCallback;
+}
 
 /**
  * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/types.ts#L3338-L3341

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -44,12 +44,12 @@
     },
 
     "emitCjsExtensionForCommonJS": {
-      "description": "If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.",
+      "description": "If true, emit CommonJS module output to the folder specified in the tsconfig \"outDir\" compiler option with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.",
       "type": "boolean"
     },
 
     "emitMjsExtensionForESModule": {
-      "description": "If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.",
+      "description": "If true, emit ESNext module output to the folder specified in the tsconfig \"outDir\" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.",
       "type": "boolean"
     },
 

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -37,6 +37,12 @@
           "outFolderName": {
             "type": "string",
             "pattern": "[^\\\\\\/]"
+          },
+
+          "jsExtensionOverride": {
+            "type": "string",
+            "description": "If provided, use this extension instead of .js for emitted ECMAScript files, e.g. .cjs for commonjs or .mjs for esnext.",
+            "pattern": "^\\.[^\\\\\\/]+$"
           }
         },
         "required": ["moduleKind", "outFolderName"]

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -37,16 +37,20 @@
           "outFolderName": {
             "type": "string",
             "pattern": "[^\\\\\\/]"
-          },
-
-          "jsExtensionOverride": {
-            "type": "string",
-            "description": "If provided, use this extension instead of .js for emitted ECMAScript files, e.g. .cjs for commonjs or .mjs for esnext.",
-            "pattern": "^\\.[^\\\\\\/]+$"
           }
         },
         "required": ["moduleKind", "outFolderName"]
       }
+    },
+
+    "emitCjsExtensionForCommonJS": {
+      "description": "If specified, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.",
+      "type": "string"
+    },
+
+    "emitMjsExtensionForESModule": {
+      "description": "If specified, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.",
+      "type": "string"
     },
 
     "emitFolderNameForTests": {

--- a/apps/heft/src/schemas/typescript.schema.json
+++ b/apps/heft/src/schemas/typescript.schema.json
@@ -44,13 +44,13 @@
     },
 
     "emitCjsExtensionForCommonJS": {
-      "description": "If specified, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.",
-      "type": "string"
+      "description": "If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.",
+      "type": "boolean"
     },
 
     "emitMjsExtensionForESModule": {
-      "description": "If specified, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.",
-      "type": "string"
+      "description": "If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.",
+      "type": "boolean"
     },
 
     "emitFolderNameForTests": {

--- a/apps/heft/src/templates/typescript.json
+++ b/apps/heft/src/templates/typescript.json
@@ -37,12 +37,12 @@
   ],
 
   /**
-   * If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.
+   * If true, emit CommonJS module output to the folder specified in the tsconfig "outDir" compiler option with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.
    */
   // "emitCjsExtensionForCommonJS": true,
 
   /**
-   * If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   // "emitMjsExtensionForESModule": true,
 

--- a/apps/heft/src/templates/typescript.json
+++ b/apps/heft/src/templates/typescript.json
@@ -37,6 +37,16 @@
   ],
 
   /**
+   * If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.
+   */
+  // "emitCjsExtensionForCommonJS": true,
+
+  /**
+   * If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   */
+  // "emitMjsExtensionForESModule": true,
+
+  /**
    * Specifies the intermediary folder that tests will use.  Because Jest uses the
    * Node.js runtime to execute tests, the module format must be CommonJS.
    *

--- a/build-tests/heft-jest-reporters-test/config/jest.config.json
+++ b/build-tests/heft-jest-reporters-test/config/jest.config.json
@@ -1,5 +1,4 @@
 {
   "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json",
-  "reporters": ["default", "./lib/test/customJestReporter.js"],
-  "moduleFileExtensions": ["cjs", "js", "json"]
+  "reporters": ["default", "./lib/test/customJestReporter.js"]
 }

--- a/build-tests/heft-jest-reporters-test/config/jest.config.json
+++ b/build-tests/heft-jest-reporters-test/config/jest.config.json
@@ -1,4 +1,5 @@
 {
   "preset": "./node_modules/@rushstack/heft/includes/jest-shared.config.json",
-  "reporters": ["default", "./lib/test/customJestReporter.js"]
+  "reporters": ["default", "./lib/test/customJestReporter.js"],
+  "moduleFileExtensions": ["cjs", "js", "json"]
 }

--- a/build-tests/heft-jest-reporters-test/config/typescript.json
+++ b/build-tests/heft-jest-reporters-test/config/typescript.json
@@ -31,12 +31,12 @@
   ],
 
   /**
-   * If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.
+   * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   "emitCjsExtensionForCommonJS": true,
 
   /**
-   * If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   // "emitMjsExtensionForESModule": true,
 

--- a/build-tests/heft-jest-reporters-test/config/typescript.json
+++ b/build-tests/heft-jest-reporters-test/config/typescript.json
@@ -28,12 +28,17 @@
     //    */
     //    "outFolderName": "lib-amd"
     // }
-    {
-      "moduleKind": "commonjs",
-      "outFolderName": "lib",
-      "jsExtensionOverride": ".cjs"
-    }
   ],
+
+  /**
+   * If true, will emit CommonJS module output to \"lib\" with the .cjs extension alongside (or instead of, if TSConfig specifies CommonJS) the default compilation output.
+   */
+  "emitCjsExtensionForCommonJS": true,
+
+  /**
+   * If true, will emit ESNext module output to \"lib\" with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   */
+  // "emitMjsExtensionForESModule": true,
 
   /**
    * Specifies the intermediary folder that tests will use.  Because Jest uses the

--- a/build-tests/heft-jest-reporters-test/config/typescript.json
+++ b/build-tests/heft-jest-reporters-test/config/typescript.json
@@ -30,7 +30,8 @@
     // }
     {
       "moduleKind": "commonjs",
-      "outFolderName": "lib-commonjs"
+      "outFolderName": "lib",
+      "jsExtensionOverride": ".cjs"
     }
   ],
 
@@ -40,7 +41,7 @@
    *
    * The default value is "lib".
    */
-  "emitFolderNameForTests": "lib-commonjs",
+  // "emitFolderNameForTests": "lib",
 
   /**
    * If set to "true", the TSlint task will not be invoked.

--- a/common/changes/@rushstack/heft/heft-js-extension-override_2021-03-03-00-05.json
+++ b/common/changes/@rushstack/heft/heft-js-extension-override_2021-03-03-00-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "Support jsExtensionOverride to emit e.g. \".cjs\" files for commonjs or \".mjs\" files for esnext modules in Heft",
+      "comment": "Add emitCjsExtensionForCommonJS and emitMjsExtensionForESModule options to config/typescript.json to support emitting commonJS and ESModule output files with the \".cjs\" and \".mjs\" respectively, alongside the normal \".js\" output files.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/heft-js-extension-override_2021-03-03-00-05.json
+++ b/common/changes/@rushstack/heft/heft-js-extension-override_2021-03-03-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Support jsExtensionOverride to emit e.g. \".cjs\" files for commonjs or \".mjs\" files for esnext modules in Heft",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Adds two TypeScript configuration options:
- `emitCjsExtensionForCommonJS`
- `emitMjsExtensionForESModule`

Example use case:
Compile commonjs to `lib/**/*.cjs`
Compile esm to `lib/**/*.js`
Have Jest look for `.cjs` first, so that you can refer to files via deep imports and not need to use alias mappings.

Also relevant to node 14, in that it makes assumptions about files based on the .cjs, .mjs, or .js extension.

## Details

## How it was tested
Added to the heft-jest-reporters-test to emit commonjs at lib/**/*.cjs and have Jest look for .cjs extensions first when resolving modules.
Verified the presence of the expected .cjs output files alongside the .js ESM files.