### PR TITLE
[rush] Allow merge conflicts in repo-state.json to be automatically resolved.

### DIFF
--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -42,15 +42,18 @@ export class RepoStateFile {
   private _variant: string | undefined;
   private _pnpmShrinkwrapHash: string | undefined;
   private _preferredVersionsHash: string | undefined;
+  private _isValid: boolean;
   private _modified: boolean = false;
 
   private constructor(
     repoStateJson: IRepoStateJson | undefined,
+    isValid: boolean,
     filePath: string,
     variant: string | undefined
   ) {
     this._repoStateFilePath = filePath;
     this._variant = variant;
+    this._isValid = isValid;
 
     if (repoStateJson) {
       this._pnpmShrinkwrapHash = repoStateJson.pnpmShrinkwrapHash;
@@ -80,6 +83,13 @@ export class RepoStateFile {
   }
 
   /**
+   * If false, the repo-state.json file is not valid and its values cannot be relied upon
+   */
+  public get isValid(): boolean {
+    return this._isValid;
+  }
+
+  /**
    * Loads the repo-state.json data from the specified file path.
    * If the file has not been created yet, then an empty object is returned.
    *
@@ -87,16 +97,46 @@ export class RepoStateFile {
    * @param variant - The variant currently being used by Rush.
    */
   public static loadFromFile(jsonFilename: string, variant: string | undefined): RepoStateFile {
-    let repoStateJson: IRepoStateJson | undefined = undefined;
+    let fileContents: string | undefined;
     try {
-      repoStateJson = JsonFile.loadAndValidate(jsonFilename, RepoStateFile._jsonSchema);
+      fileContents = FileSystem.readFile(jsonFilename);
     } catch (error) {
       if (!FileSystem.isNotExistError(error)) {
         throw error;
       }
     }
 
-    return new RepoStateFile(repoStateJson, jsonFilename, variant);
+    let foundMergeConflictMarker: boolean = false;
+    let repoStateJson: IRepoStateJson | undefined = undefined;
+    if (fileContents) {
+      try {
+        repoStateJson = JsonFile.parseString(fileContents);
+      } catch (error) {
+        // Look for a Git merge conflict marker. PNPM gracefully handles merge conflicts in pnpm-lock.yaml,
+        // so a user should be able to just run "rush update" if they get conflicts in pnpm-lock.yaml
+        // and repo-state.json and have Rush update both.
+        for (
+          let nextNewlineIndex: number = 0;
+          nextNewlineIndex > -1;
+          nextNewlineIndex = fileContents.indexOf('\n', nextNewlineIndex + 1)
+        ) {
+          if (fileContents.substr(nextNewlineIndex + 1, 7) === '<<<<<<<') {
+            foundMergeConflictMarker = true;
+            repoStateJson = {
+              preferredVersionsHash: 'INVALID',
+              pnpmShrinkwrapHash: 'INVALID'
+            };
+            break;
+          }
+        }
+      }
+
+      if (repoStateJson) {
+        this._jsonSchema.validateObject(repoStateJson, jsonFilename);
+      }
+    }
+
+    return new RepoStateFile(repoStateJson, !foundMergeConflictMarker, jsonFilename, variant);
   }
 
   /**
@@ -144,6 +184,9 @@ export class RepoStateFile {
       this._preferredVersionsHash = undefined;
       this._modified = true;
     }
+
+    // Now that the file has been refreshed, we know its contents are valid
+    this._isValid = true;
 
     return this._saveIfModified();
   }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -114,16 +114,24 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
     }
 
-    // If preferred versions have been updated, then we can't be certain of the state of the shrinkwrap
+    // If preferred versions have been updated, or if the repo-state.json is invalid,
+    // we can't be certain of the state of the shrinkwrap
     const repoState: RepoStateFile = this.rushConfiguration.getRepoState(this.options.variant);
-    const commonVersions: CommonVersionsConfiguration = this.rushConfiguration.getCommonVersions(
-      this.options.variant
-    );
-    if (repoState.preferredVersionsHash !== commonVersions.getPreferredVersionsHash()) {
+    if (!repoState.isValid) {
       shrinkwrapWarnings.push(
-        `Preferred versions from ${RushConstants.commonVersionsFilename} have been modified.`
+        `The ${RushConstants.repoStateFilename} file is invalid. There may be a merge conflict marker in the file.`
       );
       shrinkwrapIsUpToDate = false;
+    } else {
+      const commonVersions: CommonVersionsConfiguration = this.rushConfiguration.getCommonVersions(
+        this.options.variant
+      );
+      if (repoState.preferredVersionsHash !== commonVersions.getPreferredVersionsHash()) {
+        shrinkwrapWarnings.push(
+          `Preferred versions from ${RushConstants.commonVersionsFilename} have been modified.`
+        );
+        shrinkwrapIsUpToDate = false;
+      }
     }
 
     // To generate the workspace file, we will add each project to the file as we loop through and validate

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -16,6 +16,7 @@ import {
 } from '../../api/RushConfiguration';
 import { IShrinkwrapFilePolicyValidatorOptions } from '../policy/ShrinkwrapFilePolicy';
 import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';
+import { RushConstants } from '../RushConstants';
 
 const yamlModule: typeof import('js-yaml') = Import.lazy('js-yaml', require);
 
@@ -252,28 +253,40 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       throw new Error('The provided package manager options are not valid for PNPM shrinkwrap files.');
     }
 
-    // Only check the hash if allowShrinkwrapUpdates is false. If true, the shrinkwrap file
-    // may have changed and the hash could be invalid.
-    if (packageManagerOptionsConfig.preventManualShrinkwrapChanges && !policyOptions.allowShrinkwrapUpdates) {
-      if (!policyOptions.repoState.pnpmShrinkwrapHash) {
+    if (!policyOptions.allowShrinkwrapUpdates) {
+      if (!policyOptions.repoState.isValid) {
         console.log(
           colors.red(
-            'The existing shrinkwrap file hash could not be found. You may need to run "rush update" to ' +
-              'populate the hash. See the "preventManualShrinkwrapChanges" setting documentation for details.'
+            `The ${RushConstants.repoStateFilename} file is invalid. There may be a merge conflict marker ` +
+              'in the file. You may need to run "rush update" to refresh its contents.'
           ) + os.EOL
         );
         throw new AlreadyReportedError();
       }
 
-      if (this.getShrinkwrapHash() !== policyOptions.repoState.pnpmShrinkwrapHash) {
-        console.log(
-          colors.red(
-            'The shrinkwrap file hash does not match the expected hash. Please run "rush update" to ensure the ' +
-              'shrinkwrap file is up to date. See the "preventManualShrinkwrapChanges" setting documentation for ' +
-              'details.'
-          ) + os.EOL
-        );
-        throw new AlreadyReportedError();
+      // Only check the hash if allowShrinkwrapUpdates is false. If true, the shrinkwrap file
+      // may have changed and the hash could be invalid.
+      if (packageManagerOptionsConfig.preventManualShrinkwrapChanges) {
+        if (!policyOptions.repoState.pnpmShrinkwrapHash) {
+          console.log(
+            colors.red(
+              'The existing shrinkwrap file hash could not be found. You may need to run "rush update" to ' +
+                'populate the hash. See the "preventManualShrinkwrapChanges" setting documentation for details.'
+            ) + os.EOL
+          );
+          throw new AlreadyReportedError();
+        }
+
+        if (this.getShrinkwrapHash() !== policyOptions.repoState.pnpmShrinkwrapHash) {
+          console.log(
+            colors.red(
+              'The shrinkwrap file hash does not match the expected hash. Please run "rush update" to ensure the ' +
+                'shrinkwrap file is up to date. See the "preventManualShrinkwrapChanges" setting documentation for ' +
+                'details.'
+            ) + os.EOL
+          );
+          throw new AlreadyReportedError();
+        }
       }
     }
   }

--- a/common/changes/@microsoft/rush/ianc-merge-conflict-repo-state_2021-03-07-03-36.json
+++ b/common/changes/@microsoft/rush/ianc-merge-conflict-repo-state_2021-03-07-03-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow merge conflicts in repo-state.json to be automatically resolved.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -308,6 +308,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @public
 export class RepoStateFile {
     get filePath(): string;
+    get isValid(): boolean;
     static loadFromFile(jsonFilename: string, variant: string | undefined): RepoStateFile;
     get pnpmShrinkwrapHash(): string | undefined;
     get preferredVersionsHash(): string | undefined;


### PR DESCRIPTION
## Summary

When the `preventManualShrinkwrapChanges` option in `rush.json` is turned on, the `repo-state.json` file contains a hash of the shrinkwrap file. Whenever a merge conflict is encountered in the shrinkwrap file, one is almost guaranteed to occur in `repo-state.json`. PNPM gracefully handles merge conflicts in the `pnpm-lock.yaml` file, and this PR adds that same graceful handling to `repo-state.json` when the user runs `rush update`.

## Details

This change detects a merge conflict marker in `repo-state.json` and marks the file as "not valid," but doesn't throw an exception if `rush update` is being run.

## How it was tested

I intentionally caused a merge conflict in `repo-state.json` and ran `rush update` (with the changes in this PR) on that repo. I also tested that `rush install` and `rush update` still work as expected with these changes when there isn't a conflict.