### PR TITLE
[rush] Omit importers section from manual shrinkwrap change prevention (experiment)

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -27,6 +27,13 @@
   /*[LINE "HYPOTHETICAL"]*/ "usePnpmPreferFrozenLockfileForRushUpdate": true,
 
   /**
+   * If using the 'preventManualShrinkwrapChanges' option, restricts the hash to only include the layout of external dependencies.
+   * Used to allow links between workspace projects or the addition/removal of references to existing dependency versions to not
+   * cause hash changes.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "omitImportersFromPreventManualShrinkwrapChanges": true,
+
+  /**
    * If true, the chmod field in temporary project tar headers will not be normalized.
    * This normalization can help ensure consistent tarball integrity across platforms.
    */

--- a/apps/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/apps/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -29,6 +29,13 @@ export interface IExperimentsJson {
   usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 
   /**
+   * If using the 'preventManualShrinkwrapChanges' option, restricts the hash to only include the layout of external dependencies.
+   * Used to allow links between workspace projects or the addition/removal of references to existing dependency versions to not
+   * cause hash changes.
+   */
+  omitImportersFromPreventManualShrinkwrapChanges?: boolean;
+
+  /**
    * If true, the chmod field in temporary project tar headers will not be normalized.
    * This normalization can help ensure consistent tarball integrity across platforms.
    */

--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -205,7 +205,7 @@ export class RepoStateFile {
   private _saveIfModified(): boolean {
     if (this._modified) {
       const content: string =
-        '// DO NOT MODIFY THIS FILE. It is generated and used by Rush.' +
+        '// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.' +
         `${NewlineKind.Lf}${this._serialize()}`;
       FileSystem.writeFile(this._repoStateFilePath, content);
       this._modified = false;

--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -154,10 +154,18 @@ export class RepoStateFile {
       rushConfiguration.pnpmOptions &&
       rushConfiguration.pnpmOptions.preventManualShrinkwrapChanges;
     if (preventShrinkwrapChanges) {
+      const {
+        omitImportersFromPreventManualShrinkwrapChanges
+      } = rushConfiguration.experimentsConfiguration.configuration;
+
       const pnpmShrinkwrapFile: PnpmShrinkwrapFile | undefined = PnpmShrinkwrapFile.loadFromFile(
         rushConfiguration.getCommittedShrinkwrapFilename(this._variant),
-        rushConfiguration.pnpmOptions
+        rushConfiguration.pnpmOptions,
+        {
+          omitImporters: omitImportersFromPreventManualShrinkwrapChanges
+        }
       );
+
       if (pnpmShrinkwrapFile) {
         const shrinkwrapFileHash: string = pnpmShrinkwrapFile.getShrinkwrapHash();
         if (this._pnpmShrinkwrapHash !== shrinkwrapFileHash) {

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -102,7 +102,8 @@ interface IPnpmShrinkwrapYaml {
 
 export interface IPnpmShrinkWrapFileSerializeOptions {
   /**
-   * If set, remove the "importers" section during serialization. Used for scoping the preventManualShrinkwrapChanges option.
+   * If set to true, remove the "importers" section during serialization. Used for
+   * scoping the preventManualShrinkwrapChanges option.
    */
   omitImporters?: boolean;
 }

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -100,6 +100,13 @@ interface IPnpmShrinkwrapYaml {
   specifiers: { [dependency: string]: string };
 }
 
+export interface IPnpmShrinkWrapFileSerializeOptions {
+  /**
+   * If set, remove the "importers" section during serialization. Used for scoping the preventManualShrinkwrapChanges option.
+   */
+  omitImporters?: boolean;
+}
+
 /**
  * Given an encoded "dependency key" from the PNPM shrinkwrap file, this parses it into an equivalent
  * DependencySpecifier.
@@ -196,12 +203,18 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    */
   public readonly shrinkwrapFilename: string;
 
-  private _shrinkwrapJson: IPnpmShrinkwrapYaml;
+  private readonly _shrinkwrapJson: IPnpmShrinkwrapYaml;
+  private readonly _hashSerializeOptions: IPnpmShrinkWrapFileSerializeOptions;
 
-  private constructor(shrinkwrapJson: IPnpmShrinkwrapYaml, shrinkwrapFilename: string) {
+  private constructor(
+    shrinkwrapJson: IPnpmShrinkwrapYaml,
+    shrinkwrapFilename: string,
+    hashSerializeOptions: IPnpmShrinkWrapFileSerializeOptions
+  ) {
     super();
     this._shrinkwrapJson = shrinkwrapJson;
     this.shrinkwrapFilename = shrinkwrapFilename;
+    this._hashSerializeOptions = hashSerializeOptions;
 
     // Normalize the data
     if (!this._shrinkwrapJson.registry) {
@@ -223,7 +236,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
   public static loadFromFile(
     shrinkwrapYamlFilename: string,
-    pnpmOptions: PnpmOptionsConfiguration
+    pnpmOptions: PnpmOptionsConfiguration,
+    hashSerializeOptions?: IPnpmShrinkWrapFileSerializeOptions
   ): PnpmShrinkwrapFile | undefined {
     try {
       if (!FileSystem.exists(shrinkwrapYamlFilename)) {
@@ -232,14 +246,14 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
       const shrinkwrapContent: string = FileSystem.readFile(shrinkwrapYamlFilename);
       const parsedData: IPnpmShrinkwrapYaml = yamlModule.safeLoad(shrinkwrapContent);
-      return new PnpmShrinkwrapFile(parsedData, shrinkwrapYamlFilename);
+      return new PnpmShrinkwrapFile(parsedData, shrinkwrapYamlFilename, hashSerializeOptions || {});
     } catch (error) {
       throw new Error(`Error reading "${shrinkwrapYamlFilename}":${os.EOL}  ${error.message}`);
     }
   }
 
   public getShrinkwrapHash(): string {
-    const shrinkwrapContent: string = this.serialize();
+    const shrinkwrapContent: string = this.serialize(this._hashSerializeOptions);
     return crypto.createHash('sha1').update(shrinkwrapContent).digest('hex');
   }
 
@@ -427,13 +441,20 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    *
    * @override
    */
-  protected serialize(): string {
+  protected serialize(serializeOptions?: IPnpmShrinkWrapFileSerializeOptions): string {
     // Ensure that if any of the top-level properties are provided but empty are removed. We populate the object
     // properties when we read the shrinkwrap but PNPM does not set these top-level properties unless they are present.
-    const shrinkwrapToSerialize: { [key: string]: unknown } = { ...this._shrinkwrapJson };
-    for (const [key, value] of Object.entries(shrinkwrapToSerialize)) {
-      if (typeof value === 'object' && Object.entries(value || {}).length === 0) {
-        delete shrinkwrapToSerialize[key];
+    const shrinkwrapToSerialize: { [key: string]: unknown } = {};
+    const { omitImporters } = serializeOptions || {};
+    for (const [key, value] of Object.entries(this._shrinkwrapJson)) {
+      // The 'omitImportersFromPreventManualShrinkwrapChanges' experiment skips the 'importers' section
+      // when computing the hash, since the main concern is changes to the overall external dependency footprint
+      if (omitImporters && key === 'importers') {
+        continue;
+      }
+
+      if (!value || typeof value !== 'object' || Object.keys(value).length > 0) {
+        shrinkwrapToSerialize[key] = value;
       }
     }
 

--- a/apps/rush-lib/src/schemas/experiments.schema.json
+++ b/apps/rush-lib/src/schemas/experiments.schema.json
@@ -22,6 +22,10 @@
       "description": "By default, 'rush update' passes --no-prefer-frozen-lockfile to 'pnpm install'. Set this option to true to pass '--prefer-frozen-lockfile' instead.",
       "type": "boolean"
     },
+    "omitImportersFromPreventManualShrinkwrapChanges": {
+      "description": "If using the 'preventManualShrinkwrapChanges' option, only prevent manual changes to the total set of external dependencies referenced by the repository, not which projects reference which dependencies. This offers a balance between lockfile integrity and merge conflicts.",
+      "type": "boolean"
+    },
     "noChmodFieldInTarHeaderNormalization": {
       "description": "If true, the chmod field in temporary project tar headers will not be normalized. This normalization can help ensure consistent tarball integrity across platforms.",
       "type": "boolean"

--- a/common/changes/@microsoft/rush/reduce-importer-conflicts_2021-03-12-00-30.json
+++ b/common/changes/@microsoft/rush/reduce-importer-conflicts_2021-03-12-00-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add experiment to exclude the \"importers\" section of \"pnpm-lock.yaml\" from the \"preventManualShrinkwrapChanges\" feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -146,6 +146,7 @@ export interface IExperimentsJson {
     buildCache?: boolean;
     legacyIncrementalBuildDependencyDetection?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
+    omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 }


### PR DESCRIPTION
## Summary

The `preventManualShrinkwrapChanges` option for PNPM is useful for avoiding integrity problems in the pnpm-lock.yaml file in the event of bad merges, but it is more aggressive than it needs to be, in that it blocks both changes to the set of external package versions and to the set of references from each project. The latter is an area where developers generally know how to resolve merge conflicts correctly (it's the same as fixing them in package.json), and also accounts for a significant portion of the changes to pnpm-lock.yaml made during the course of normal developer activity (over 50% in our repos).

Adds an experiment `omitImportersFromPreventManualShrinkwrapChanges` that applies manual shrinkwrap change prevention only to the "packages" section of the lockfile, allowing the "importers" section to be resolved by git normally.

## How it was tested
Enabled the experiment in a private repo, ran `rush update` to reset the hash.
- Verified that adding a new dependency between workspace packages did not produce a change to repo-state.json
- Verified that adding a new dependency on a previously unseen external dependency produced a change to repo-state.json

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
