### PR TITLE
[rush] Disable the AWS credential provider logic to mitigate a problematic peer dependency

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -55,8 +55,7 @@
     "tar": "~5.0.5",
     "true-case-path": "~2.2.1",
     "wordwrap": "~1.0.0",
-    "z-schema": "~3.18.3",
-    "@aws-sdk/credential-provider-node": "~3.4.1"
+    "z-schema": "~3.18.3"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3BuildCacheProvider.ts
@@ -4,7 +4,7 @@
 import { Readable } from 'stream';
 import { Terminal } from '@rushstack/node-core-library';
 import { S3Client, GetObjectCommand, PutObjectCommand, GetObjectCommandOutput } from '@aws-sdk/client-s3';
-import { defaultProvider as awsCredentialsProvider } from '@aws-sdk/credential-provider-node';
+// import { defaultProvider as awsCredentialsProvider } from '@aws-sdk/credential-provider-node';
 
 import { EnvironmentConfiguration, EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
 import { CloudBuildCacheProviderBase } from './CloudBuildCacheProviderBase';
@@ -104,16 +104,22 @@ export class AmazonS3BuildCacheProvider extends CloudBuildCacheProviderBase {
             credentials = this._deserializeCredentials(cacheEntry?.credential);
           }
         } else {
-          try {
-            credentials = await awsCredentialsProvider()();
-          } catch {
-            throw new Error(
-              "An Amazon S3 credential hasn't been provided, or has expired. " +
-                `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", ` +
-                `or provide an <AccessKeyId>:<SecretAccessKey> pair in the ` +
-                `${EnvironmentVariableNames.RUSH_BUILD_CACHE_WRITE_CREDENTIAL} environment variable`
-            );
-          }
+          // This logic was temporarily disabled to eliminate the dependency on @aws-sdk/credential-provider-node
+          // which caused this issue:
+          //
+          // "[rush] Broken peer dependency error when installing @microsoft/rush-lib"
+          // https://github.com/microsoft/rushstack/issues/2547
+
+          // try {
+          //  credentials = await awsCredentialsProvider()();
+          // } catch {
+          throw new Error(
+            "An Amazon S3 credential hasn't been provided, or has expired. " +
+              `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", ` +
+              `or provide an <AccessKeyId>:<SecretAccessKey> pair in the ` +
+              `${EnvironmentVariableNames.RUSH_BUILD_CACHE_WRITE_CREDENTIAL} environment variable`
+          );
+          // }
         }
       }
 

--- a/common/changes/@microsoft/rush/octogonz-issue-2547_2021-03-12-01-37.json
+++ b/common/changes/@microsoft/rush/octogonz-issue-2547_2021-03-12-01-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Temporarily disable the AWS S3 credential provider logic to mitigate a problematic peer dependency (GitHub #2547)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -91,7 +91,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.42.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
## Summary

Mitigates https://github.com/microsoft/rushstack/issues/2547

## How it was tested

The problematic dependency is eliminated.  The feature is still partially usable via the RUSH_BUILD_CACHE_WRITE_CREDENTIAL environment variable.