### PR TITLE
[rush-lib] Fix "rush deploy" to include devDependencies for rush projects only

### DIFF
--- a/apps/rush-lib/src/logic/deploy/DeployManager.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployManager.ts
@@ -170,7 +170,7 @@ export class DeployManager {
     for (const name of Object.keys(packageJson.dependencies || {})) {
       dependencyNamesToProcess.add(name);
     }
-    if (deployState.scenarioConfiguration.json.includeDevDependencies) {
+    if (deployState.scenarioConfiguration.json.includeDevDependencies && sourceFolderInfo?.isRushProject) {
       for (const name of Object.keys(packageJson.devDependencies || {})) {
         dependencyNamesToProcess.add(name);
       }

--- a/common/changes/@microsoft/rush/stekycz-2551-includeDevDependencies_2021-03-13-23-00.json
+++ b/common/changes/@microsoft/rush/stekycz-2551-includeDevDependencies_2021-03-13-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix \"rush deploy\" having \"includeDevDependencies\" turned on to deploy \"devDependencies\" for rush projects only",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "martin.stekl@gmail.com"
+}


### PR DESCRIPTION
## Summary

Fixes #2551

## Details

I have the following options (already described in the issue)

1. devDeps of the main project only?
2. devDeps of the main project and all additionalProjectsToInclude as well?
3. devDeps of all projects managed by rush?
4. devDeps of all projects in the repository? (I guess this is not an option because rush cannot work with other projects than managed.)
5. devDeps of all packages installed? (This is the current behavior.)

I have chosen the 3rd option because it is easy to make without more code changes and also makes sense to solve the issue. Option 1 seems too strict IMO and option 2 would require more code changes but might perform better.

## How it was tested

I did not test it so far. I will do so after your confirmation the solution makes sense.

I will run the command `rush deploy` for a scenario with `"includeDevDependencies": true` to confirm it is not failing in a repository that it was failing before. I will then go to the deploy directory and node_modules of projects to confirm "dependencies" were installed correctly (as it is now) and "devDependencies" were installed as well but for rush projects only.