### PR TITLE
[ts-command-line] fix Dynamic Model example in docs

### DIFF
--- a/common/changes/@rushstack/ts-command-line/patch-1_2021-03-16-18-54.json
+++ b/common/changes/@rushstack/ts-command-line/patch-1_2021-03-16-18-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "fix documentation sample code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "6276426+kbkk@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/patch-1_2021-03-16-18-54.json
+++ b/common/changes/@rushstack/ts-command-line/patch-1_2021-03-16-18-54.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/ts-command-line",
-      "comment": "fix documentation sample code",
-      "type": "patch"
+      "comment": "Fix a mistake in sample code in the README.",
+      "type": "none"
     }
   ],
   "packageName": "@rushstack/ts-command-line",

--- a/libraries/ts-command-line/README.md
+++ b/libraries/ts-command-line/README.md
@@ -226,7 +226,7 @@ action.defineChoiceParameter({
 });
 
 // Parse the command line
-commandLineParser.execute(process.argv).then(() => {
+commandLineParser.execute().then(() => {
   console.log('The action is: ' + commandLineParser.selectedAction!.actionName);
   console.log('The force flag is: ' + action.getFlagParameter('--force').value);
 });


### PR DESCRIPTION
## Summary

According to https://github.com/microsoft/rushstack/issues/1287 the correct way to execute a command is to either provide nothing to `execute()` or call it with `process.argv.slice(2)`.

## How it was tested

```
await commandLineParser.execute(process.argv);
```

resulted in

```
error: argument "<command>": Invalid choice: /Users/jakubkisielewski/WebstormProjects/cli/node_modules/.bin/ts-node (choose from [prepare])
```

while
```
await commandLineParser.execute();
```
executes the command just fine