### PR TITLE
[rush] Fix `rush install` when omitImportersFromPreventManualShrinkwrapChanges is active

### DIFF
--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -154,19 +154,15 @@ export class RepoStateFile {
       rushConfiguration.pnpmOptions &&
       rushConfiguration.pnpmOptions.preventManualShrinkwrapChanges;
     if (preventShrinkwrapChanges) {
-      const {
-        omitImportersFromPreventManualShrinkwrapChanges
-      } = rushConfiguration.experimentsConfiguration.configuration;
-
       const pnpmShrinkwrapFile: PnpmShrinkwrapFile | undefined = PnpmShrinkwrapFile.loadFromFile(
         rushConfiguration.getCommittedShrinkwrapFilename(this._variant),
         rushConfiguration.pnpmOptions
       );
 
       if (pnpmShrinkwrapFile) {
-        const shrinkwrapFileHash: string = pnpmShrinkwrapFile.getShrinkwrapHash({
-          omitImporters: omitImportersFromPreventManualShrinkwrapChanges
-        });
+        const shrinkwrapFileHash: string = pnpmShrinkwrapFile.getShrinkwrapHash(
+          rushConfiguration.experimentsConfiguration.configuration
+        );
 
         if (this._pnpmShrinkwrapHash !== shrinkwrapFileHash) {
           this._pnpmShrinkwrapHash = shrinkwrapFileHash;

--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -160,14 +160,14 @@ export class RepoStateFile {
 
       const pnpmShrinkwrapFile: PnpmShrinkwrapFile | undefined = PnpmShrinkwrapFile.loadFromFile(
         rushConfiguration.getCommittedShrinkwrapFilename(this._variant),
-        rushConfiguration.pnpmOptions,
-        {
-          omitImporters: omitImportersFromPreventManualShrinkwrapChanges
-        }
+        rushConfiguration.pnpmOptions
       );
 
       if (pnpmShrinkwrapFile) {
-        const shrinkwrapFileHash: string = pnpmShrinkwrapFile.getShrinkwrapHash();
+        const shrinkwrapFileHash: string = pnpmShrinkwrapFile.getShrinkwrapHash({
+          omitImporters: omitImportersFromPreventManualShrinkwrapChanges
+        });
+
         if (this._pnpmShrinkwrapHash !== shrinkwrapFileHash) {
           this._pnpmShrinkwrapHash = shrinkwrapFileHash;
           this._modified = true;

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -10,6 +10,7 @@ import { DependencySpecifier, DependencySpecifierType } from '../DependencySpeci
 import { IShrinkwrapFilePolicyValidatorOptions } from '../policy/ShrinkwrapFilePolicy';
 import { PackageManagerOptionsConfigurationBase } from '../../api/RushConfiguration';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
+import { IExperimentsJson } from '../../api/ExperimentsConfiguration';
 
 /**
  * This class is a parser for both npm's npm-shrinkwrap.json and pnpm's pnpm-lock.yaml file formats.
@@ -38,7 +39,8 @@ export abstract class BaseShrinkwrapFile {
    */
   public validate(
     packageManagerOptionsConfig: PackageManagerOptionsConfigurationBase,
-    policyOptions: IShrinkwrapFilePolicyValidatorOptions
+    policyOptions: IShrinkwrapFilePolicyValidatorOptions,
+    experimentsConfig?: IExperimentsJson
   ): void {}
 
   /**

--- a/apps/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
+++ b/apps/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
@@ -11,7 +11,6 @@ import { RepoStateFile } from '../RepoStateFile';
 
 export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorOptions {
   repoState: RepoStateFile;
-  validateOnlyExternalPackageLayout?: boolean;
 }
 
 /**
@@ -32,12 +31,13 @@ export class ShrinkwrapFilePolicy {
     }
 
     // Run shrinkwrap-specific validation
-    shrinkwrapFile.validate(rushConfiguration.packageManagerOptions, {
-      ...options,
-      repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant),
-      validateOnlyExternalPackageLayout:
-        rushConfiguration.experimentsConfiguration.configuration
-          .omitImportersFromPreventManualShrinkwrapChanges
-    });
+    shrinkwrapFile.validate(
+      rushConfiguration.packageManagerOptions,
+      {
+        ...options,
+        repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant)
+      },
+      rushConfiguration.experimentsConfiguration.configuration
+    );
   }
 }

--- a/apps/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
+++ b/apps/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
@@ -11,6 +11,7 @@ import { RepoStateFile } from '../RepoStateFile';
 
 export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorOptions {
   repoState: RepoStateFile;
+  validateOnlyExternalPackageLayout?: boolean;
 }
 
 /**
@@ -33,7 +34,10 @@ export class ShrinkwrapFilePolicy {
     // Run shrinkwrap-specific validation
     shrinkwrapFile.validate(rushConfiguration.packageManagerOptions, {
       ...options,
-      repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant)
+      repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant),
+      validateOnlyExternalPackageLayout:
+        rushConfiguration.experimentsConfiguration.configuration
+          .omitImportersFromPreventManualShrinkwrapChanges
     });
   }
 }

--- a/common/changes/@microsoft/rush/fix-lockfile-importer-experiment_2021-03-16-20-08.json
+++ b/common/changes/@microsoft/rush/fix-lockfile-importer-experiment_2021-03-16-20-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix installation-time behavior of \"omitImportersFromPreventManualShrinkwrapChanges\" experiment.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

The code path for the preventManualShrinkwrapChanges validation policy during "rush install" was missed when the experiment was originally added, so running "rush update" would not alter the lockfile or the repo-state.json file, but a subsequent "rush install" from a clean state would fail.

## Details

Refactors how the parameter is passed to ensure that it is consistent between the validator and the repo-state.json generation.

## How it was tested

Ran "rush update" using the built version in another repo.
Ran "rush purge" in said repo.
Ran "rush install" in said repo, verified success.
Manually modified the "importers" section in the lockfile and a corresponding package.json
Ran "rush purge" in said repo.
Ran "rush install" in said repo, verified success.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
