### PR TITLE
[heft] Fix an issue where heft would crash when copying static assets in --watch mode.

### DIFF
--- a/common/changes/@rushstack/heft/ianc-fix-copy-watch_2021-03-17-01-17.json
+++ b/common/changes/@rushstack/heft/ianc-fix-copy-watch_2021-03-17-01-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where heft would crash when copying static assets in --watch mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

There is an issue where `heft build --watch` will crash when a file listed as a static asset to copy to the "lib" folder(s) is edited. This issue was introduced when support for automatically detecting the "lib" folder specified as the `outDir` in `tsconfig.json` was added. That path has to be resolved relative to the `tsconfig.json` file that specifies it, which may be a file specified in an `"extends"` property.

## Details

This PR adds a `resolvedDestinationFolderPaths` property to the `CopyFilesPlugin` copy operation descriptor which is preemptively resolved to an absolute path.

## How it was tested

Tested by building a large project containing .scss files both in `--watch` and not in `--watch` mode.