### PR TITLE
[rush] Handle a 'conflict' error from Azure Storage.

### DIFF
--- a/common/changes/@microsoft/rush/ianc-handle-azure-409_2021-03-17-07-52.json
+++ b/common/changes/@microsoft/rush/ianc-handle-azure-409_2021-03-17-07-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Gracefully handle a simultaneous upload to Azure Storage.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Azure Storage returns a 409 error code if two simultaneous modifications occur on the same blob. This PR adds graceful handling to that case.

## Details

We have a CI job that populates our build cache and occasionally two jobs run at the same time, populating the same cache entry, causing warnings (which fail our build). This PR handles that case and treats it as success.

## How it was tested

Manually created a write conflict to ensure this is handled correctly.