### PR TITLE
[rush] Don't validate the shrinkwrap when running 'rush update'

### DIFF
--- a/apps/rush-lib/src/logic/policy/PolicyValidator.ts
+++ b/apps/rush-lib/src/logic/policy/PolicyValidator.ts
@@ -18,6 +18,10 @@ export class PolicyValidator {
     }
 
     GitEmailPolicy.validate(rushConfiguration);
-    ShrinkwrapFilePolicy.validate(rushConfiguration, options);
+    if (!options.allowShrinkwrapUpdates) {
+      // Don't validate the shrinkwrap if updates are allowed, as it's likely to change
+      // It also may have merge conflict markers, which PNPM can gracefully handle, but the validator cannot
+      ShrinkwrapFilePolicy.validate(rushConfiguration, options);
+    }
   }
 }

--- a/common/changes/@microsoft/rush/ianc-allow-pnpm-to-handle-merge-conflicts_2021-03-18-22-07.json
+++ b/common/changes/@microsoft/rush/ianc-allow-pnpm-to-handle-merge-conflicts_2021-03-18-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Don't validate the shrinkwrap when running 'rush update'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

PNPM is able to gracefully handle merge conflict markers in the `pnpm-lock` file, but that functionality during `rush update` was recently broken.

## Details

This change disables shrinkwrap validation when `rush update` is run as the validation result doesn't matter if the shrinkwrap is going to change.

## How it was tested

Tested by running `rush update` on a large repo with a merge conflict in the `pnpm-lock` file.