### PR TITLE
[debug-certificate-manager] Fixes bug resolving the path of certutil.exe on Windows.

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/user-halfnibble-fix-certutil-path_2021-03-25-02-39.json
+++ b/common/changes/@rushstack/debug-certificate-manager/user-halfnibble-fix-certutil-path_2021-03-25-02-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix bug resolving the path of certutil.exe on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -252,9 +252,9 @@ export class CertificateManager {
       terminal.writeErrorLine(`Error finding certUtil command: "${whereErr}"`);
       return undefined;
     } else {
-      const lines: string[] = where.stdout.toString().trim().split(EOL);
-      // eslint-disable-next-line require-atomic-updates
-      return lines[0].trim();
+      const lines: string[] = where.stdout;
+      // The first line should be the path of certutil.exe
+      return lines[0];
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes bug resolving the path of certutil.exe on Windows.

## Details

The `runAsync` method produces an array of output on Windows machines:

```
[
  'C:\\Windows\\System32\\certutil.exe',
  '\r\n'
]
```
Currently, when running `.toString()` on this array, a string with a comma character (`,`) is generated, which leads to the invalid path of:
```
'C:\\Windows\\System32\\certutil.exe,'
```

## How it was tested

I wrote a little script in to test it on Windows. 

```typescript
import { Terminal, ConsoleTerminalProvider } from '@rushstack/node-core-library';
import { CertificateManager, ICertificate } from './CertificateManager';

const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
const certificateManager: CertificateManager = new CertificateManager();

// tslint-disable-next-line: no-debugger
debugger;
certificateManager
  .untrustCertificateAsync(terminal)
  .then(() => {
    terminal.writeLine('untrust success.');
    certificateManager
      .ensureCertificateAsync(true, terminal)
      .then((cert: ICertificate) => {
        terminal.writeLine('SUCCESS!');
      })
      .catch((err) => {
        terminal.writeError(err);
      });
  })
  .catch((err) => {
    terminal.writeError(err);
  });
```

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
