### PR TITLE
[heft] Add `--trace` parameter to Heft to emit timeline trace in Chrome Trace Events format

### DIFF
--- a/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/heft/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandLineHelp prints the global help 1`] = `
-"usage: heft [-h] [--unmanaged] [--debug] [--plugin PATH] <command> ...
+"usage: heft [-h] [--unmanaged] [--debug] [--trace] [--plugin PATH]
+            <command> ...
 
 Heft is a pluggable build system designed for web projects.
 
@@ -22,6 +23,8 @@ Optional arguments:
                  example if you want to test a different version of Heft.
   --debug        Show the full call stack if an error occurs while executing 
                  the tool
+  --trace        Generate a timeline trace in the Chrome Trace Events format 
+                 in the working directory
   --plugin PATH  Used to specify Heft plugins.
 
 [bold]For detailed help about a specific command, use: heft <command> -h[normal]

--- a/apps/heft/src/pluginFramework/DefaultPlugins.ts
+++ b/apps/heft/src/pluginFramework/DefaultPlugins.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { IHeftPlugin } from './IHeftPlugin';
+
+import { CopyFilesPlugin } from '../plugins/CopyFilesPlugin';
+import { TypeScriptPlugin } from '../plugins/TypeScriptPlugin/TypeScriptPlugin';
+import { DeleteGlobsPlugin } from '../plugins/DeleteGlobsPlugin';
+import { CopyStaticAssetsPlugin } from '../plugins/CopyStaticAssetsPlugin';
+import { ApiExtractorPlugin } from '../plugins/ApiExtractorPlugin/ApiExtractorPlugin';
+import { JestPlugin } from '../plugins/JestPlugin/JestPlugin';
+import { BasicConfigureWebpackPlugin } from '../plugins/Webpack/BasicConfigureWebpackPlugin';
+import { WebpackPlugin } from '../plugins/Webpack/WebpackPlugin';
+import { SassTypingsPlugin } from '../plugins/SassTypingsPlugin/SassTypingsPlugin';
+import { ProjectValidatorPlugin } from '../plugins/ProjectValidatorPlugin';
+import { ToolPackageResolver } from '../utilities/ToolPackageResolver';
+
+export function getDefaultPlugins(): Iterable<IHeftPlugin> {
+  const taskPackageResolver: ToolPackageResolver = new ToolPackageResolver();
+
+  return [
+    new TypeScriptPlugin(taskPackageResolver),
+    new CopyStaticAssetsPlugin(),
+    new CopyFilesPlugin(),
+    new DeleteGlobsPlugin(),
+    new ApiExtractorPlugin(taskPackageResolver),
+    new JestPlugin(),
+    new BasicConfigureWebpackPlugin(),
+    new WebpackPlugin(),
+    new SassTypingsPlugin(),
+    new ProjectValidatorPlugin()
+  ];
+}

--- a/apps/heft/src/plugins/TimelineTracePlugin.ts
+++ b/apps/heft/src/plugins/TimelineTracePlugin.ts
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { FileWriter } from '@rushstack/node-core-library';
+
+import { HeftConfiguration } from '../configuration/HeftConfiguration';
+import { IHeftPlugin } from '../pluginFramework/IHeftPlugin';
+import { HeftSession } from '../pluginFramework/HeftSession';
+import { IHeftLifecycle } from '../pluginFramework/HeftLifecycle';
+import { HookInterceptor, SyncHook, Tap, TapOptions } from 'tapable';
+import { IBuildStageContext } from '../stages/BuildStage';
+import { ITestStageContext } from '../stages/TestStage';
+import { ICleanStageContext } from '../stages/CleanStage';
+
+const PLUGIN_NAME: 'TimelineTracePlugin' = 'TimelineTracePlugin';
+
+/**
+ * This plugin generates a timeline trace of the Heft execution in the Chrome Trace Events format.
+ */
+export class TimelineTracePlugin implements IHeftPlugin {
+  public readonly pluginName: 'TimelineTracePlugin' = PLUGIN_NAME;
+
+  public apply(heftSession: HeftSession, heftConfiguration: HeftConfiguration): void {
+    const traceFileName: string = `${heftConfiguration.buildFolder}/heft.trace.${Date.now()}.json`;
+    const writer: FileWriter = FileWriter.open(traceFileName);
+    writer.write(
+      `[${JSON.stringify({
+        args: {
+          name: 'Heft'
+        },
+        cat: '__metadata',
+        name: 'thread_name',
+        tid: 0,
+        ph: 'M',
+        pid: process.pid,
+        ts: 0
+      })}`
+    );
+
+    const now: bigint = process.hrtime.bigint();
+    const start: bigint = now - BigInt(process.uptime() * 1e6);
+
+    const nanoToMicro: bigint = BigInt(1e3);
+
+    function asTimestamp(time: bigint): number {
+      return Number(time / nanoToMicro);
+    }
+
+    function logCompleteEvent(name: string, startTimeNs: bigint, endTimeNs: bigint): void {
+      writer.write(
+        `,\n${JSON.stringify({
+          cat: 'devtools.timeline',
+          name,
+          tid: 0,
+          ph: 'X',
+          pid: process.pid,
+          ts: asTimestamp(startTimeNs),
+          dur: asTimestamp(endTimeNs - startTimeNs)
+        })}`
+      );
+    }
+
+    logCompleteEvent('boot', start, now);
+
+    // Ensure that the log file is complete.
+    process.on('exit', () => {
+      writer.write(']');
+      writer.close();
+    });
+
+    function createInterceptor(context: string): HookInterceptor {
+      return {
+        register: (tap: Tap): Tap => {
+          if (tap.name === PLUGIN_NAME) {
+            // Avoid intercepting the interceptor
+            return tap;
+          }
+
+          // eslint-disable-next-line @typescript-eslint/ban-types
+          const innerFunction: Function = tap.fn;
+          const name: string = `${context}.${tap.name}`;
+
+          switch (tap.type) {
+            case 'sync':
+              return {
+                ...tap,
+                fn: function syncInterceptor(...args: unknown[]): unknown {
+                  const startTimeNs: bigint = process.hrtime.bigint();
+                  try {
+                    return innerFunction.apply(this, args);
+                  } finally {
+                    logCompleteEvent(name, startTimeNs, process.hrtime.bigint());
+                  }
+                }
+              };
+            case 'async':
+              return {
+                ...tap,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                fn: function asyncInterceptor(...args: any[]): any {
+                  const startTimeNs: bigint = process.hrtime.bigint();
+                  const callback: (err: unknown, result: unknown) => void = args.pop();
+                  args.push((err: unknown, result: unknown): void => {
+                    logCompleteEvent(name, startTimeNs, process.hrtime.bigint());
+                    callback(err, result);
+                  });
+
+                  return innerFunction.apply(this, args);
+                }
+              };
+            case 'promise':
+              return {
+                ...tap,
+                fn: function promiseInterceptor(...args: unknown[]): Promise<unknown> {
+                  const startTimeNs: bigint = process.hrtime.bigint();
+                  return innerFunction.apply(this, args).then(
+                    (result: unknown) => {
+                      logCompleteEvent(name, startTimeNs, process.hrtime.bigint());
+                      return result;
+                    },
+                    (err: Error) => {
+                      logCompleteEvent(name, startTimeNs, process.hrtime.bigint());
+                      return Promise.reject(err);
+                    }
+                  );
+                }
+              };
+            default:
+              throw new Error(`Unknown tap type ${tap.type}`);
+          }
+        }
+      };
+    }
+
+    const interceptorStageOptions: TapOptions<'sync'> = {
+      name: PLUGIN_NAME,
+      stage: -Infinity
+    };
+
+    function applyInterceptors(context: string, hooks: object): void {
+      for (const [name, hook] of Object.entries(hooks)) {
+        if (hook && typeof hook.intercept === 'function') {
+          hook.intercept(createInterceptor(`${context}.${name}`));
+        }
+      }
+    }
+
+    function applySubstageInterceptors<K extends string>(
+      context: string,
+      stage: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        hooks: { [P in K]: SyncHook<any> };
+      },
+      keys: K[]
+    ): void {
+      for (const key of keys) {
+        stage.hooks[key].tap(interceptorStageOptions, (substage: { hooks: object }) => {
+          applyInterceptors(`${context}.${key}`, substage.hooks);
+        });
+      }
+    }
+
+    heftSession.hooks.heftLifecycle.tap(interceptorStageOptions, (heftLifecycle: IHeftLifecycle) => {
+      applyInterceptors('heftSession.heftLifecycle', heftLifecycle.hooks);
+    });
+
+    heftSession.hooks.build.tap(interceptorStageOptions, (buildStage: IBuildStageContext) => {
+      applySubstageInterceptors('heftSession.build', buildStage, [
+        'preCompile',
+        'compile',
+        'bundle',
+        'postBuild'
+      ]);
+      applyInterceptors('heftSession.build', buildStage.hooks);
+    });
+
+    heftSession.hooks.clean.tap(interceptorStageOptions, (cleanStage: ICleanStageContext) => {
+      applyInterceptors('heftSession.clean', cleanStage.hooks);
+    });
+
+    heftSession.hooks.test.tap(interceptorStageOptions, (testStage: ITestStageContext) => {
+      applyInterceptors('heftSession.test', testStage.hooks);
+    });
+
+    applyInterceptors('heftSession.metricsCollector', heftSession.hooks.metricsCollector);
+    applyInterceptors('heftSession', heftSession.hooks);
+  }
+}

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -307,7 +307,8 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
     buildStage,
     watchMode
   }: IRunSubstageWithLoggingOptions): Promise<void> {
-    if (buildStage.hooks.run.isUsed()) {
+    // isUsed() also checks interceptors
+    if (buildStage.hooks.run.taps.length) {
       await Logging.runFunctionWithLoggingBoundsAsync(
         this.globalTerminal,
         buildStageName,

--- a/apps/heft/src/stages/StageBase.ts
+++ b/apps/heft/src/stages/StageBase.ts
@@ -80,7 +80,8 @@ export abstract class StageBase<
   }
 
   public async executeAsync(): Promise<void> {
-    if (this.stageHooks.overrideStage.isUsed()) {
+    // isUsed() also checks interceptors
+    if (this.stageHooks.overrideStage.taps.length) {
       await this.stageHooks.overrideStage.promise(this.stageProperties);
     } else {
       await this.executeInnerAsync();

--- a/apps/heft/src/utilities/Constants.ts
+++ b/apps/heft/src/utilities/Constants.ts
@@ -12,5 +12,7 @@ export class Constants {
 
   public static debugParameterLongName: string = '--debug';
 
+  public static traceParameterLongName: string = '--trace';
+
   public static maxParallelism: number = 100;
 }

--- a/common/changes/@rushstack/heft/heft-tracing_2021-03-27-00-27.json
+++ b/common/changes/@rushstack/heft/heft-tracing_2021-03-27-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Support timeline tracing via \"heft --trace build\" or similar. Records times for all plugin hook executions in Chrome Trace Events format.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
Adds support for `heft --trace <command>` to record a timeline view in Chrome Trace Events format of all tap invocations.

## Details
Logs all tap invocations, listing the name of the plugin and of the hook. The stack view is a bit misleading due to the viewer assuming that durations that fully intersect other durations are sub-operations.

![image](https://user-images.githubusercontent.com/26827560/112704879-83d5ea00-8e59-11eb-89e1-3c446aff5c66.png)

## How it was tested
Running locally to compile rush-lib, and loading the output file into Edge Dev Tools.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
