### PR TITLE
[rush-lib] Update rush publish -p flag description

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -83,7 +83,7 @@ export class PublishAction extends BaseRushAction {
     this._publish = this.defineFlagParameter({
       parameterLongName: '--publish',
       parameterShortName: '-p',
-      description: 'If this flag is specified, applied changes will be published to npm.'
+      description: 'If this flag is specified, applied changes will be published to the NPM registry.'
     });
     this._addCommitDetails = this.defineFlagParameter({
       parameterLongName: '--add-commit-details',

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -723,7 +723,7 @@ Optional arguments:
                         deleted change requests will be committed and merged 
                         into the target branch.
   -p, --publish         If this flag is specified, applied changes will be 
-                        published to npm.
+                        published to the NPM registry.
   --add-commit-details  Adds commit author and hash to the changelog.json 
                         files for each change.
   --regenerate-changelogs

--- a/common/changes/@microsoft/rush/publish-flag-doc_2021-03-28-08-39.json
+++ b/common/changes/@microsoft/rush/publish-flag-doc_2021-03-28-08-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update rush publish -p flag description",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "bbenoist@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

I've updated the `--publish` flag description so that it reflects the fact that a repository is not necessarily hosted on npmjs.org.

## Details

Diff:

```text
        -p, --publish         If this flag is specified, applied changes will be 
    -                         published to npm.
    +                         published to the NPM registry.
```

## How it was tested

```text
rush build
```

## Side notes

<details>
  <summary>Note 1</summary>

With a fresh repository, I wanted to test the code but `rush build -t rush` failed on my WSL2 instance.

Maybe that's because there is a missing dependency in the chain?

```text
$ rush build -t rush


Rush Multi-Project Build Tool 5.41.0 - https://rushjs.io
Node.js version is 14.16.0 (LTS)


Starting "rush build"

Executing a maximum of 16 simultaneous processes...

==[ @rushstack/tree-pattern ]=====================================[ 1 of 20 ]==
"@rushstack/tree-pattern" completed successfully in 4.01 seconds.

==[ @rushstack/eslint-patch ]=====================================[ 2 of 20 ]==
"tar" exited with code 2 while attempting to create the cache entry. Rush will attempt to create the cache entry with a JavaScript implementation of tar.

"@rushstack/eslint-patch" completed successfully in 1.80 seconds.

==[ @rushstack/eslint-plugin ]====================================[ 3 of 20 ]==
"@rushstack/eslint-plugin" completed successfully in 5.13 seconds.

==[ @rushstack/eslint-plugin-security ]===========================[ 4 of 20 ]==
"@rushstack/eslint-plugin-security" completed successfully in 3.71 seconds.

==[ @rushstack/eslint-plugin-packlets ]===========================[ 5 of 20 ]==
"@rushstack/eslint-plugin-packlets" completed successfully in 3.76 seconds.

==[ @rushstack/eslint-config ]====================================[ 6 of 20 ]==
"@rushstack/eslint-config" had an empty script.

==[ @rushstack/node-core-library ]================================[ 7 of 20 ]==
  ● LockFile › Linux and Mac › cannot acquire a lock if another valid lock exists

    expect(received).toBeUndefined()

    Received: {"_dirtyWhenAcquired": true, "_filePath": "/home/bbenoist/perso/src/rushstack/master/libraries/node-core-library/src/test/2/test#1922.lock", "_fileWriter": {"_fileDescriptor": 19, "filePath": "/home/bbenoist/perso/src/rushstack/master/libraries/node-core-library/src/test/2/test#1922.lock"}}

      166 |
      167 |         // this lock should be undefined since there is an existing lock
    > 168 |         expect(lock).toBeUndefined();
          |                      ^
      169 |       });
      170 |     });
      171 |   }

      at Object.<anonymous> (src/test/LockFile.test.ts:168:22)

[jest] Error: 1 Jest test failed
Encountered 1 errors:
  [jest] 1 Jest test failed
Returned error code: 1
"@rushstack/node-core-library" failed to build.
"@microsoft/rush" is blocked by "@rushstack/node-core-library".
"@microsoft/rush-lib" is blocked by "@rushstack/node-core-library".
"@rushstack/heft" is blocked by "@rushstack/node-core-library".
"@rushstack/heft-node-rig" is blocked by "@rushstack/node-core-library".
"@rushstack/package-deps-hash" is blocked by "@rushstack/node-core-library".
"@rushstack/stream-collator" is blocked by "@rushstack/node-core-library".
"@rushstack/terminal" is blocked by "@rushstack/node-core-library".
"@rushstack/heft-config-file" is blocked by "@rushstack/node-core-library".
"@rushstack/typings-generator" is blocked by "@rushstack/node-core-library".
"@microsoft/api-extractor" is blocked by "@rushstack/node-core-library".
"@microsoft/api-extractor-model" is blocked by "@rushstack/node-core-library".

==[ @rushstack/rig-package ]=====================================[ 19 of 20 ]==
"@rushstack/rig-package" completed successfully in 5.84 seconds.

==[ @rushstack/ts-command-line ]=================================[ 20 of 20 ]==
"@rushstack/ts-command-line" completed successfully in 7.08 seconds.



==[ SUCCESS: 8 projects ]======================================================

These projects completed successfully:
  @rushstack/eslint-config
  @rushstack/eslint-patch              1.80 seconds
  @rushstack/eslint-plugin             5.13 seconds
  @rushstack/eslint-plugin-packlets    3.76 seconds
  @rushstack/eslint-plugin-security    3.71 seconds
  @rushstack/rig-package               5.84 seconds
  @rushstack/tree-pattern              4.01 seconds
  @rushstack/ts-command-line           7.08 seconds

==[ BLOCKED: 11 projects ]=====================================================

These projects were blocked by dependencies that failed:
  @microsoft/api-extractor
  @microsoft/api-extractor-model
  @microsoft/rush
  @microsoft/rush-lib
  @rushstack/heft
  @rushstack/heft-config-file
  @rushstack/heft-node-rig
  @rushstack/package-deps-hash
  @rushstack/stream-collator
  @rushstack/terminal
  @rushstack/typings-generator

==[ FAILURE: 1 project ]=======================================================

--[ FAILURE: @rushstack/node-core-library ]-----------------[ 10.35 seconds ]--

  ● LockFile › Linux and Mac › cannot acquire a lock if another valid lock exists

    expect(received).toBeUndefined()

    Received: {"_dirtyWhenAcquired": true, "_filePath": "/home/bbenoist/perso/src/rushstack/master/libraries/node-core-library/src/test/2/test#1922.lock", "_fileWriter": {"_fileDescriptor": 19, "filePath": "/home/bbenoist/perso/src/rushstack/master/libraries/node-core-library/src/test/2/test#1922.lock"}}

      166 |
      167 |         // this lock should be undefined since there is an existing lock
    > 168 |         expect(lock).toBeUndefined();
          |                      ^
      169 |       });
      170 |     });
      171 |   }

      at Object.<anonymous> (src/test/LockFile.test.ts:168:22)

[jest] Error: 1 Jest test failed
Encountered 1 errors:
  [jest] 1 Jest test failed


Projects failed to build.

rush build (19.59 seconds)
```

</details>
