### PR TITLE
[heft] fix(typings): don't generate typings from watched file if it's ignored

### DIFF
--- a/common/changes/@rushstack/typings-generator/master_2021-03-28-23-37.json
+++ b/common/changes/@rushstack/typings-generator/master_2021-03-28-23-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "fixes a bug where watched files would not honor typings generation excludeFiles settings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator",
+  "email": "scamden@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/typings-generator/master_2021-03-28-23-37.json
+++ b/common/changes/@rushstack/typings-generator/master_2021-03-28-23-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/typings-generator",
-      "comment": "fixes a bug where watched files would not honor typings generation excludeFiles settings",
+      "comment": "Fix a bug where watched files would not honor typings generation excludeFiles settings",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
centralizes the logic of ignoring into the function that does the typing generation so all calls to the function will respect the ignore paths, also lazy loads the ignore paths

fixes #2577

@octogonz (my first contribution hopefully simple enough to get merged! hope to contribute lots as we plan to use this tool heavily!)