### PR TITLE
[Heft] Fix an error message.

### DIFF
--- a/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestPlugin.ts
@@ -126,7 +126,7 @@ export class JestPlugin implements IHeftPlugin {
         'The transpiler output folder does not exist:\n  ' +
           emitFolderPathForJest +
           '\nWas the compiler invoked? Is the "emitFolderNameForTests" setting correctly' +
-          ' specified in .heft/typescript.json?\n'
+          ' specified in config/typescript.json?\n'
       );
     }
   }

--- a/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
+++ b/apps/heft/src/plugins/JestPlugin/JestTypeScriptDataFile.ts
@@ -9,7 +9,7 @@ import { JsonFile } from '@rushstack/node-core-library';
  */
 export interface IJestTypeScriptDataFileJson {
   /**
-   * The "emitFolderNameForTests" from .heft/typescript.json
+   * The "emitFolderNameForTests" from config/typescript.json
    */
   emitFolderNameForTests: string;
 

--- a/common/changes/@rushstack/heft/ianc-fix-heft-error-messages_2021-03-31-01-46.json
+++ b/common/changes/@rushstack/heft/ianc-fix-heft-error-messages_2021-03-31-01-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an outdated path in an error message.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fix an error message that mentions an old path.

## Details

We moved config files from the `.heft` folder to the `config` folder, but this error message still mentions the `.heft` folder. This fixes that error message.

## How it was tested

N/A