### PR TITLE
Verify changefile schema when running `rush change --verify`

### DIFF
--- a/apps/rush-lib/src/logic/ChangeFiles.ts
+++ b/apps/rush-lib/src/logic/ChangeFiles.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
 import { EOL } from 'os';
-import { JsonFile, Import } from '@rushstack/node-core-library';
+import { JsonFile, JsonSchema, Import } from '@rushstack/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';
 import { IChangeInfo } from '../api/ChangeManagement';
@@ -34,11 +35,15 @@ export class ChangeFiles {
     changedPackages: string[],
     rushConfiguration: RushConfiguration
   ): void {
+    const schema: JsonSchema = JsonSchema.fromFile(
+      path.resolve(__dirname, '..', 'schemas', 'change-file.schema.json')
+    );
+
     const projectsWithChangeDescriptions: Set<string> = new Set<string>();
     newChangeFilePaths.forEach((filePath) => {
       console.log(`Found change file: ${filePath}`);
 
-      const changeFile: IChangeInfo = JsonFile.load(filePath);
+      const changeFile: IChangeInfo = JsonFile.loadAndValidate(filePath, schema);
 
       if (rushConfiguration.hotfixChangeEnabled) {
         if (changeFile && changeFile.changes) {

--- a/apps/rush-lib/src/schemas/change-file.schema.json
+++ b/apps/rush-lib/src/schemas/change-file.schema.json
@@ -4,7 +4,6 @@
   "description": "For use with the Rush tool, this file tracks changes that are made to individual packages within the Rush repo. See http://rushjs.io for details.",
 
   "type": "object",
-  "required": ["changes", "packageName", "email"],
   "properties": {
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",

--- a/apps/rush-lib/src/schemas/change-file.schema.json
+++ b/apps/rush-lib/src/schemas/change-file.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Generated Rush changefiles",
+  "description": "For use with the Rush tool, this file tracks changes that are made to individual packages within the Rush repo. See http://rushjs.io for details.",
+
+  "type": "object",
+  "required": ["changes", "packageName", "email"],
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+    "changes": {
+      "description": "A list of changes that apply to the specified package. These changes will cause the specified package and all dependent packages ",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["packageName", "comment", "type"],
+        "properties": {
+          "packageName": {
+            "type": "string",
+            "description": "The name of the package that the change applies to."
+          },
+          "comment": {
+            "type": "string",
+            "description": "A comment that describes the change being made."
+          },
+          "type": {
+            "type": "string",
+            "description": "The change type associated with the change.",
+            "enum": ["none", "dependency", "hotfix", "patch", "minor", "major"]
+          }
+        }
+      }
+    },
+    "packageName": {
+      "description": "The name of the package that the change file applies to.",
+      "type": "string"
+    },
+    "email": {
+      "description": "The email address for the author of the change.",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
Fixes an issue where non-valid changefiles would slip past `rush change --verify` due to verify only checking the changefiles satisfy the changes made in the project.

## Details
To fix, I created a schema to loosely validate the structure of the changefile and any fields that are required to have specific values. I validate against this schema while parsing out the changefiles during `rush change --verify`.

## How it was tested
Made a change in a repo and manually modified the `type` field to be invalid. Confirmed that the validation logic threw.
