### PR TITLE
[rush] Eliminate "phantom node_modules" warning on Azure DevOps build agents

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-ado-phantom-workaround_2021-04-01-01-14.json
+++ b/common/changes/@microsoft/rush/octogonz-ado-phantom-workaround_2021-04-01-01-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Eliminate a spurious warning that was displayed on Azure DevOps build agents: A phantom \"node_modules\" folder was found.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Our Azure DevOps build agents always print this warning:

```
Starting "rush install"

Warning: A phantom "node_modules" folder was found. This defeats Rush's
protection against NPM phantom dependencies and may cause confusing build
errors. It is recommended to delete this folder:
"/home/vsts/work/node_modules"
```
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

The Azure DevOps agent installs the [vso-task-lib](https://www.npmjs.com/package/vso-task-lib) package in a top-level folder such as `/home/vsts/work/node_modules/vso-task-lib`.

I suspect it was intentionally a phantom dependency, i.e. so that any script in any folder could import that package. 

Interestingly, there is no `/home/vsts/work/package.json` file; it must simply get unzipped in that location.

In any case, this NPM package is now deprecated.  And the warning creates a false alarm that everybody ignores, which defeats the purpose of having Rush check for legitimate phantom dependency issues.

Ideally we should fix the ADO build agent.  But that might be involved.  A simple workaround is for Rush to detect this very specific special case and ignore it (which is safe because the edge case is harmless).

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Manually created the `node_modules/vso-task-lib` folder to repro the error, then confirmed that my PR fixed it.  I will test it in a real CI environment after Rush is published.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
