### PR TITLE
[heft] Add an 'afterCompile' build hook.

### DIFF
--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -37,6 +37,7 @@ export { StageHooksBase, IStageContext } from './stages/StageBase';
 export {
   BuildStageHooks,
   BuildSubstageHooksBase,
+  CompileSubstageHooks,
   BundleSubstageHooks,
   CopyFromCacheMode,
   IBuildStageContext,

--- a/common/changes/@rushstack/heft/ianc-add-post-compile-hook_2021-04-02-22-07.json
+++ b/common/changes/@rushstack/heft/ianc-add-post-compile-hook_2021-04-02-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add an \"afterCompile\" hook that runs after compilation.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -53,6 +53,12 @@ export class CleanStageHooks extends StageHooksBase<ICleanStageProperties> {
 }
 
 // @public (undocumented)
+export class CompileSubstageHooks extends BuildSubstageHooksBase {
+    // (undocumented)
+    readonly afterCompile: AsyncParallelHook;
+}
+
+// @public (undocumented)
 export type CopyFromCacheMode = 'hardlink' | 'copy';
 
 // @beta (undocumented)
@@ -152,7 +158,7 @@ export interface ICleanStageProperties {
 }
 
 // @public (undocumented)
-export interface ICompileSubstage extends IBuildSubstage<BuildSubstageHooksBase, ICompileSubstageProperties> {
+export interface ICompileSubstage extends IBuildSubstage<CompileSubstageHooks, ICompileSubstageProperties> {
 }
 
 // @public (undocumented)


### PR DESCRIPTION
## Summary

Adds an `afterCompile` hook to the `build` command's `compile` substage.