### PR TITLE
[api-extractor-model] Fix typo in api-extractor-model README

### DIFF
--- a/apps/api-extractor-model/README.md
+++ b/apps/api-extractor-model/README.md
@@ -43,7 +43,7 @@ might look like this:
         - ApiMethodSignature
         - ApiPropertySignature
       - ApiNamespace
-        - (ApiClass, ApiEnum, ApiInterace, ...)
+        - (ApiClass, ApiEnum, ApiInterface, ...)
 ```
 
 You can use the `ApiItem.members` property to traverse this tree.

--- a/common/changes/@microsoft/api-extractor-model/patch-1_2021-04-08-05-41.json
+++ b/common/changes/@microsoft/api-extractor-model/patch-1_2021-04-08-05-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Fix minor typo in README.md",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Just a small README typo fix! :)