### PR TITLE
[rush] Fix "rush publish" handling of verisons with a SemVer build metadata suffix

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -474,7 +474,27 @@ export class PublishAction extends BaseRushAction {
       env,
       args
     );
-    return publishedVersions.indexOf(packageConfig.packageJson.version) >= 0;
+
+    const packageVersion: string = packageConfig.packageJsonEditor.version;
+
+    // SemVer supports an obscure (and generally deprecated) feature where "build metadata" can be
+    // appended to a version.  For if our version is "1.2.3-beta.4+extra567" then "+extra567" is the
+    // build metadata part.  It has no effect on version comparisons and is mostly ignored by the NPM registry.
+    // Importantly, the queried version number will not include it, so we need to discard it before
+    // comparing against the list of already published versions.
+    const parsedVersion: semver.SemVer | null = semver.parse(packageVersion);
+    if (!parsedVersion) {
+      throw new Error(`The package "${packageConfig.packageName}" has an invalid "version" value`);
+    }
+
+    // For example, normalize "1.2.3-beta.4+extra567" -->"1.2.3-beta.4".
+    //
+    // This is redundant in the current API, but might change in the future:
+    // https://github.com/npm/node-semver/issues/264
+    parsedVersion.build = [];
+    const normalizedVersion: string = parsedVersion.format();
+
+    return publishedVersions.indexOf(normalizedVersion) >= 0;
   }
 
   private _npmPack(packageName: string, project: RushConfigurationProject): void {

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -478,10 +478,10 @@ export class PublishAction extends BaseRushAction {
     const packageVersion: string = packageConfig.packageJsonEditor.version;
 
     // SemVer supports an obscure (and generally deprecated) feature where "build metadata" can be
-    // appended to a version.  For if our version is "1.2.3-beta.4+extra567" then "+extra567" is the
-    // build metadata part.  It has no effect on version comparisons and is mostly ignored by the NPM registry.
-    // Importantly, the queried version number will not include it, so we need to discard it before
-    // comparing against the list of already published versions.
+    // appended to a version.  For example if our version is "1.2.3-beta.4+extra567", then "+extra567" is the
+    // build metadata part.  The suffix has no effect on version comparisons and is mostly ignored by
+    // the NPM registry.  Importantly, the queried version number will not include it, so we need to discard
+    // it before comparing against the list of already published versions.
     const parsedVersion: semver.SemVer | null = semver.parse(packageVersion);
     if (!parsedVersion) {
       throw new Error(`The package "${packageConfig.packageName}" has an invalid "version" value`);

--- a/common/changes/@microsoft/rush/octogonz-rush-semver-metadata-fix_2021-04-08-00-05.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-semver-metadata-fix_2021-04-08-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush publish\" reported 403 errors if the package version included a SemVer build metadata suffix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

SemVer supports an obscure (and generally deprecated) feature where "build metadata" can be
appended to a version.  For example if our version is `1.2.3-beta.4+extra567`, then `+extra567` is the
build metadata part.  

These versions cause "rush publish" to fail even if everything has already been published successfully.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

The error:
```
npm ERR! code E403
npm ERR! 403 403 Forbidden - PUT https://xxxxx - forbidden
npm ERR! 403 In most cases, you or one of your dependencies are requesting
npm ERR! 403 a package version that is forbidden by your security policy.
```

What's happening:
1. `rush publish` checks to see if the package `1.2.3-beta.4+extra567` is published
2. The registry reports it as `1.2.3-beta.4` which does not match `1.2.3-beta.4+extra567`
3. So Rush tries to publish it again.
4. The 403 error is (confusingly) telling us that we "don't have permission" to publish a version that already exists

The fix is to discard the suffix before comparing.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Confirmed that it fixes the repro in our monorepo.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
