### PR TITLE
Fix parameter typo

### DIFF
--- a/apps/heft/src/cli/actions/CustomAction.ts
+++ b/apps/heft/src/cli/actions/CustomAction.ts
@@ -34,7 +34,7 @@ export interface ICustomActionParameterStringList extends ICustomActionParameter
 export interface ICustomActionParameterBase<TParameter extends CustomActionParameterType> {
   kind: 'flag' | 'integer' | 'string' | 'stringList'; // TODO: Add "choice"
 
-  paramterLongName: string;
+  parameterLongName: string;
   description: string;
 }
 
@@ -100,7 +100,7 @@ export class CustomAction<TParameters> extends HeftActionBase {
       switch (parameterOption.kind) {
         case 'flag': {
           const parameter: CommandLineFlagParameter = this.defineFlagParameter({
-            parameterLongName: parameterOption.paramterLongName,
+            parameterLongName: parameterOption.parameterLongName,
             description: parameterOption.description
           });
           getParameterValue = () => parameter.value;
@@ -109,7 +109,7 @@ export class CustomAction<TParameters> extends HeftActionBase {
 
         case 'string': {
           const parameter: CommandLineStringParameter = this.defineStringParameter({
-            parameterLongName: parameterOption.paramterLongName,
+            parameterLongName: parameterOption.parameterLongName,
             description: parameterOption.description,
             argumentName: 'VALUE'
           });
@@ -119,7 +119,7 @@ export class CustomAction<TParameters> extends HeftActionBase {
 
         case 'integer': {
           const parameter: CommandLineIntegerParameter = this.defineIntegerParameter({
-            parameterLongName: parameterOption.paramterLongName,
+            parameterLongName: parameterOption.parameterLongName,
             description: parameterOption.description,
             argumentName: 'VALUE'
           });
@@ -129,7 +129,7 @@ export class CustomAction<TParameters> extends HeftActionBase {
 
         case 'stringList': {
           const parameter: CommandLineStringListParameter = this.defineStringListParameter({
-            parameterLongName: parameterOption.paramterLongName,
+            parameterLongName: parameterOption.parameterLongName,
             description: parameterOption.description,
             argumentName: 'VALUE'
           });
@@ -139,7 +139,7 @@ export class CustomAction<TParameters> extends HeftActionBase {
 
         default: {
           throw new Error(
-            `Unrecognized parameter kind "${parameterOption.kind}" for parameter "${parameterOption.paramterLongName}`
+            `Unrecognized parameter kind "${parameterOption.kind}" for parameter "${parameterOption.parameterLongName}`
           );
         }
       }

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -203,7 +203,7 @@ export class ChangeAction extends BaseRushAction {
       if (!email) {
         throw new Error(
           "Unable to detect Git email and an email address wasn't provided using the " +
-            `${this._changeEmailParameter.longName} paramter.`
+            `${this._changeEmailParameter.longName} parameter.`
         );
       }
 

--- a/build-tests/heft-action-plugin/src/index.ts
+++ b/build-tests/heft-action-plugin/src/index.ts
@@ -19,7 +19,7 @@ class HeftActionPlugin implements IHeftPlugin {
       parameters: {
         production: {
           kind: 'flag',
-          paramterLongName: '--production',
+          parameterLongName: '--production',
           description: 'Run in production mode'
         }
       },

--- a/common/changes/@microsoft/gulp-core-build-serve/master_2021-04-08-01-57.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/master_2021-04-08-01-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Fix parameter name typo.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2021-04-08-01-57.json
+++ b/common/changes/@microsoft/rush/master_2021-04-08-01-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix parameter name typo.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/master_2021-04-08-01-57.json
+++ b/common/changes/@rushstack/heft/master_2021-04-08-01-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix parameter name typo.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/localization-plugin/master_2021-04-08-01-57.json
+++ b/common/changes/@rushstack/localization-plugin/master_2021-04-08-01-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-plugin",
+      "comment": "Fix parameter name typo.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/localization-plugin",
+  "email": "halfnibble@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -193,7 +193,7 @@ export interface ICustomActionParameterBase<TParameter extends CustomActionParam
     // (undocumented)
     kind: 'flag' | 'integer' | 'string' | 'stringList';
     // (undocumented)
-    paramterLongName: string;
+    parameterLongName: string;
 }
 
 // @beta (undocumented)

--- a/core-build/gulp-core-build-serve/README.md
+++ b/core-build/gulp-core-build-serve/README.md
@@ -112,7 +112,7 @@ Because of this issue `gulp-core-build-serve` also provides functionality to gen
 
 1. By setting the `ServeTask`'s `tryCreateDevCertificate` configuration option to `true`. This option
 will make the serve task attempt to generate and trust a development certificate before starting the
-server if a certificate wasn't specified using the `keyPath` and `certPath` paramters or the `pfxPath`
+server if a certificate wasn't specified using the `keyPath` and `certPath` parameters or the `pfxPath`
 parameter.
 
 2. By invoking the `TrustCertTask` build task.

--- a/webpack/localization-plugin/src/interfaces.ts
+++ b/webpack/localization-plugin/src/interfaces.ts
@@ -101,7 +101,7 @@ export interface ILocalizedData {
   translatedStrings: ILocalizedStrings;
 
   /**
-   * Use this paramter to specify a function used to load translations missing from
+   * Use this parameter to specify a function used to load translations missing from
    * the {@link ILocalizedData.translatedStrings} parameter.
    */
   resolveMissingTranslatedStrings?: (locales: string[], filePath: string) => IResolvedMissingTranslations;


### PR DESCRIPTION

## Summary

This fixes all found instances of the typo `paramter`
And replaces it with `parameter`

## Details

I chose this as a "minor" change since it's just a typo, but it will break everyone with custom heft actions. So it's kind of major?

## How it was tested

Not tested. I just did a regex replace and built the monorepo. 

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
