### PR TITLE
[rush] Fix "rush change" warning when used with GitHub SSH authentication

### DIFF
--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -5,6 +5,7 @@ import child_process from 'child_process';
 import gitInfo = require('git-repo-info');
 import * as os from 'os';
 import * as path from 'path';
+import * as url from 'url';
 import colors from 'colors/safe';
 import { Executable, AlreadyReportedError, Path } from '@rushstack/node-core-library';
 
@@ -253,7 +254,10 @@ export class Git {
         ['remote'],
         this._rushConfiguration.rushJsonFolder
       ).trim();
-      const normalizedRepositoryUrl: string = repositoryUrl.toUpperCase();
+
+      // Apply toUpperCase() for a case-insensitive comparison
+      const normalizedRepositoryUrl: string = Git.normalizeGitUrlForComparison(repositoryUrl).toUpperCase();
+
       const matchingRemotes: string[] = output.split('\n').filter((remoteName) => {
         if (remoteName) {
           const remoteUrl: string = Utilities.executeCommandAndCaptureOutput(
@@ -266,15 +270,9 @@ export class Git {
             return false;
           }
 
-          const normalizedRemoteUrl: string = remoteUrl.toUpperCase();
-          if (normalizedRemoteUrl.toUpperCase() === normalizedRepositoryUrl) {
-            return true;
-          }
-
-          // When you copy a URL from the GitHub web site, they append the ".git" file extension to the URL.
-          // We allow that to be specified in rush.json, even though the file extension gets dropped
-          // by "git clone".
-          if (`${normalizedRemoteUrl}.GIT` === normalizedRepositoryUrl) {
+          // Also apply toUpperCase() for a case-insensitive comparison
+          const normalizedRemoteUrl: string = Git.normalizeGitUrlForComparison(remoteUrl).toUpperCase();
+          if (normalizedRemoteUrl === normalizedRepositoryUrl) {
             return true;
           }
         }
@@ -325,6 +323,75 @@ export class Git {
     return changes.filter((change) => {
       return change.trim().length > 0;
     });
+  }
+
+  /**
+   * Git remotes can use different URL syntaxes; this converts them all to a normalized HTTPS
+   * representation for matching purposes.  IF THE INPUT IS NOT ALREADY HTTPS, THE OUTPUT IS
+   * NOT NECESSARILY A VALID GIT URL.
+   *
+   * @example
+   * `git@github.com:ExampleOrg/ExampleProject.git` --> `https://github.com/ExampleOrg/ExampleProject`
+   */
+  public static normalizeGitUrlForComparison(gitUrl: string): string {
+    // Git URL formats are documented here: https://www.git-scm.com/docs/git-clone#_git_urls
+
+    let result: string = gitUrl.trim();
+
+    // [user@]host.xz:path/to/repo.git/
+    // "This syntax is only recognized if there are no slashes before the first colon. This helps
+    // differentiate a local path that contains a colon."
+    //
+    // Match patterns like this:
+    //   user@host.ext:path/to/repo
+    //   host.ext:path/to/repo
+    //   localhost:/~user/path/to/repo
+    //
+    // But not:
+    //   http://blah
+    //   c:/windows/path.txt
+    //
+    const scpLikeSyntaxRegExp: RegExp = /^(?:[^@:\/]+\@)?([^:\/]{2,})\:((?!\/\/).+)$/;
+
+    // Example: "user@host.ext:path/to/repo"
+    const scpLikeSyntaxMatch: RegExpExecArray | null = scpLikeSyntaxRegExp.exec(gitUrl);
+    if (scpLikeSyntaxMatch) {
+      // Example: "host.ext"
+      const host: string = scpLikeSyntaxMatch[1];
+      // Example: "path/to/repo"
+      const path: string = scpLikeSyntaxMatch[2];
+
+      if (path.startsWith('/')) {
+        result = `https://${host}${path}`;
+      } else {
+        result = `https://${host}/${path}`;
+      }
+    }
+
+    const parsedUrl: url.UrlWithStringQuery = url.parse(result);
+
+    // Only convert recognized schemes
+
+    switch (parsedUrl.protocol) {
+      case 'http:':
+      case 'https:':
+      case 'ssh:':
+      case 'ftp:':
+      case 'ftps:':
+      case 'git:':
+      case 'git+http:':
+      case 'git+https:':
+      case 'git+ssh:':
+      case 'git+ftp:':
+      case 'git+ftps:':
+        // Assemble the parts we want:
+        result = `https://${parsedUrl.host}${parsedUrl.pathname}`;
+        break;
+    }
+
+    // Trim ".git" or ".git/" from the end
+    result = result.replace(/.git\/?$/, '');
+    return result;
   }
 
   private _tryGetGitEmail(): IResultOrError<string> {

--- a/apps/rush-lib/src/logic/test/Git.test.ts
+++ b/apps/rush-lib/src/logic/test/Git.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Git } from '../Git';
+
+describe('Git', () => {
+  describe('normalizeGitUrlToHttps', () => {
+    it('correctly normalizes URLs', () => {
+      expect(Git.normalizeGitUrlForComparison('invalid.git')).toEqual('invalid');
+      expect(Git.normalizeGitUrlForComparison('git@github.com:ExampleOrg/ExampleProject.git')).toEqual(
+        'https://github.com/ExampleOrg/ExampleProject'
+      );
+      expect(Git.normalizeGitUrlForComparison('ssh://user@host.xz:1234/path/to/repo.git/')).toEqual(
+        'https://host.xz:1234/path/to/repo'
+      );
+      expect(Git.normalizeGitUrlForComparison('git://host.xz/path/to/repo')).toEqual(
+        'https://host.xz/path/to/repo'
+      );
+      expect(Git.normalizeGitUrlForComparison('http://host.xz:80/path/to/repo')).toEqual(
+        'https://host.xz:80/path/to/repo'
+      );
+      expect(Git.normalizeGitUrlForComparison('host.xz:path/to/repo.git/')).toEqual(
+        'https://host.xz/path/to/repo'
+      );
+
+      // "This syntax is only recognized if there are no slashes before the first colon.
+      // This helps differentiate a local path that contains a colon."
+      expect(Git.normalizeGitUrlForComparison('host/xz:path/to/repo.git/')).toEqual('host/xz:path/to/repo');
+
+      expect(Git.normalizeGitUrlForComparison('file:///path/to/repo.git/')).toEqual('file:///path/to/repo');
+      expect(Git.normalizeGitUrlForComparison('C:\\Windows\\Path.txt')).toEqual('C:\\Windows\\Path.txt');
+      expect(Git.normalizeGitUrlForComparison('c:/windows/path.git')).toEqual('c:/windows/path');
+    });
+  });
+});

--- a/common/changes/@microsoft/rush/octogonz-rush-change-ssh_2021-04-08-05-21.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-change-ssh_2021-04-08-05-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush change\" reported \"Unable to find a git remote matching the repository URL\" when used with SSH auth",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -91,7 +91,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.42.4",
-    "nextBump": "patch",
+    "nextBump": "minor",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

The `rush change` command prints this warning for users who authenticate to GitHub using [SSH authentication](https://stackoverflow.com/questions/11041729/why-does-github-recommend-https-over-ssh):

```
Starting "rush change"

Unable to find a git remote matching the repository URL 
(https://github.com/YourOrg/YourProject.git). Detected changes are likely to 
be incorrect.

The target branch is origin/master
```


<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

The problem is that **rush.json** typically specifies the repository URL using HTTPS syntax:

**rush.json**
```js
  "repository": {
    /**
     * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
     *
     * The "rush change" command needs to determine which files are affected by your PR diff.
     * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
     * should be excluded from this diff (since they belong to some other PR).  In order to do that,
     * Rush needs to know where to find the base branch for your PR.  This information cannot be
     * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
     * Rush would use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
     * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
     * of the Git remote indicated by the repository.url setting in rush.json.  If you are working in
     * a GitHub "fork" of the real repo, this setting will be different from the repository URL of your
     * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
     * to retrieve the latest activity for the remote master branch.
     */
    "url": "https://github.com/YourOrg/YourProject.git"
```

However if you authenticate using SSH, your remote will use SCP-like syntax:

```shell
$ git remote -v
origin  git@github.com:YourOrg/YourProject.git (fetch)
origin  git@github.com:YourOrg/YourProject.git (push)
```

This PR normalizes the [various supported syntaxes](https://www.git-scm.com/docs/git-clone#_git_urls) 
so that  they will still match the HTTPS URLs.  This normalization is somewhat approximate but expected
to work correctly for all realistic use cases.

Before handcoding a normalizer, I evaluated several NPM packages that seem to provide this functionality:
- https://www.npmjs.com/package/normalize-git-url
- https://www.npmjs.com/package/git-remote-protocol
- https://www.npmjs.com/package/gepo

However they are not actively maintained and/or have obvious bugs in their implementation.

## How it was tested

I performed `git clone` separately using HTTPS and SSH, and confirmed that the PR fixes the problem.

I also added unit tests for the normalization logic.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

CC @dharrie-hbo