### PR TITLE
[rush] Support PNPM 6 and Removal of pnpm-lock.yaml Rewriting

### DIFF
--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -178,6 +178,10 @@ export abstract class BaseInstallManager {
 
     const { shrinkwrapIsUpToDate, variantIsUpToDate } = await this.prepareAsync();
 
+    console.log(
+      os.EOL + colors.bold(`Checking installation in "${this.rushConfiguration.commonTempFolder}"`)
+    );
+
     // This marker file indicates that the last "rush install" completed successfully.
     // Always perform a clean install if filter flags were provided. Additionally, if
     // "--purge" was specified, or if the last install was interrupted, then we will
@@ -245,6 +249,8 @@ export abstract class BaseInstallManager {
       if (!isFilteredInstall) {
         this._commonTempInstallFlag.create();
       }
+    } else {
+      console.log('Installation is already up-to-date.');
     }
 
     // Perform any post-install work the install manager requires

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -398,6 +398,8 @@ export abstract class BaseInstallManager {
     let { shrinkwrapIsUpToDate, shrinkwrapWarnings } = await this.prepareCommonTempAsync(shrinkwrapFile);
     shrinkwrapIsUpToDate = shrinkwrapIsUpToDate && !this.options.recheckShrinkwrap;
 
+    this._syncTempShrinkwrap(shrinkwrapFile);
+
     // Write out the reported warnings
     if (shrinkwrapWarnings.length > 0) {
       console.log();
@@ -414,8 +416,6 @@ export abstract class BaseInstallManager {
       }
       console.log();
     }
-
-    this._syncTempShrinkwrap(shrinkwrapFile);
 
     // Force update if the shrinkwrap is out of date
     if (!shrinkwrapIsUpToDate) {

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -220,12 +220,7 @@ export abstract class BaseInstallManager {
       // Perform the actual install
       await this.installAsync(cleanInstall);
 
-      const usePnpmFrozenLockfile: boolean =
-        this._rushConfiguration.packageManager === 'pnpm' &&
-        this._rushConfiguration.experimentsConfiguration.configuration.usePnpmFrozenLockfileForRushInstall ===
-          true;
-
-      if (this.options.allowShrinkwrapUpdates && (usePnpmFrozenLockfile || !shrinkwrapIsUpToDate)) {
+      if (this.options.allowShrinkwrapUpdates && !shrinkwrapIsUpToDate) {
         // Copy (or delete) common\temp\pnpm-lock.yaml --> common\config\rush\pnpm-lock.yaml
         Utilities.syncFile(
           this._rushConfiguration.tempShrinkwrapFilename,
@@ -649,9 +644,14 @@ export abstract class BaseInstallManager {
 
   private _syncTempShrinkwrap(shrinkwrapFile: BaseShrinkwrapFile | undefined): void {
     if (shrinkwrapFile) {
-      // If we have a (possibly incomplete) shrinkwrap file, save it as the temporary file.
-      shrinkwrapFile.save(this.rushConfiguration.tempShrinkwrapFilename);
-      shrinkwrapFile.save(this.rushConfiguration.tempShrinkwrapPreinstallFilename);
+      Utilities.syncFile(
+        this._rushConfiguration.getCommittedShrinkwrapFilename(this.options.variant),
+        this.rushConfiguration.tempShrinkwrapFilename
+      );
+      Utilities.syncFile(
+        this._rushConfiguration.getCommittedShrinkwrapFilename(this.options.variant),
+        this.rushConfiguration.tempShrinkwrapPreinstallFilename
+      );
     } else {
       // Otherwise delete the temporary file
       FileSystem.deleteFile(this.rushConfiguration.tempShrinkwrapFilename);

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -186,7 +186,7 @@ export abstract class BaseLinkManager {
    *   if true, this option forces the links to be recreated.
    */
   public async createSymlinksForProjects(force: boolean): Promise<void> {
-    console.log('Linking projects together...');
+    console.log(os.EOL + colors.bold('Linking local projects'));
     const stopwatch: Stopwatch = Stopwatch.start();
 
     await this._linkProjects();

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -3,7 +3,6 @@
 
 import colors from 'colors/safe';
 import * as semver from 'semver';
-import { FileSystem } from '@rushstack/node-core-library';
 
 import { RushConstants } from '../../logic/RushConstants';
 import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
@@ -23,13 +22,6 @@ export abstract class BaseShrinkwrapFile {
       return dictionary[key];
     }
     return undefined;
-  }
-
-  /**
-   * Serializes and saves the shrinkwrap file to specified location
-   */
-  public save(filePath: string): void {
-    FileSystem.writeFile(filePath, this.serialize());
   }
 
   /**

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -73,13 +73,11 @@ export abstract class BaseShrinkwrapFile {
    */
   public tryEnsureCompatibleDependency(
     dependencySpecifier: DependencySpecifier,
-    tempProjectName: string,
-    tryReusingPackageVersionsFromShrinkwrap: boolean = true
+    tempProjectName: string
   ): boolean {
     const shrinkwrapDependency: DependencySpecifier | undefined = this.tryEnsureDependencyVersion(
       dependencySpecifier,
-      tempProjectName,
-      tryReusingPackageVersionsFromShrinkwrap
+      tempProjectName
     );
     if (!shrinkwrapDependency) {
       return false;
@@ -99,8 +97,7 @@ export abstract class BaseShrinkwrapFile {
   /** @virtual */
   protected abstract tryEnsureDependencyVersion(
     dependencySpecifier: DependencySpecifier,
-    tempProjectName: string,
-    tryReusingPackageVersionsFromShrinkwrap: boolean
+    tempProjectName: string
   ): DependencySpecifier | undefined;
 
   /** @virtual */

--- a/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -236,8 +236,8 @@ export class InstallHelpers {
       `${packageManager}-local`
     );
 
-    console.log(os.EOL + 'Symlinking "' + localPackageManagerToolFolder + '"');
-    console.log('  --> "' + packageManagerToolFolder + '"');
+    console.log(os.EOL + `Symlinking "${localPackageManagerToolFolder}"`);
+    console.log(`  --> "${packageManagerToolFolder}"`);
 
     // We cannot use FileSystem.exists() to test the existence of a symlink, because it will
     // return false for broken symlinks.  There is no way to test without catching an exception.

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -346,8 +346,12 @@ export class RushInstallManager extends BaseInstallManager {
         this.rushConfiguration.commonTempFolder,
         'pnpm-workspace.yaml'
       );
-      if (FileSystem.exists(workspaceFilePath)) {
-        FileSystem.deleteFile(workspaceFilePath);
+      try {
+        await FileSystem.deleteFileAsync(workspaceFilePath);
+      } catch (e) {
+        if (!FileSystem.isNotExistError(e)) {
+          throw e;
+        }
       }
     }
 

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -390,10 +390,6 @@ export class RushInstallManager extends BaseInstallManager {
     rushProject: RushConfigurationProject
   ): Promise<boolean> {
     if (shrinkwrapFile) {
-      console.log(
-        `Checking shrinkwrap local dependency tarball hashes in ${shrinkwrapFile.shrinkwrapFilename}`
-      );
-
       const tempProjectDependencyKey: string | undefined = shrinkwrapFile.getTempProjectDependencyKey(
         rushProject.tempProjectName
       );
@@ -421,14 +417,6 @@ export class RushInstallManager extends BaseInstallManager {
    * @override
    */
   protected canSkipInstall(lastModifiedDate: Date): boolean {
-    console.log(
-      os.EOL +
-        colors.bold(
-          `Checking ${RushConstants.nodeModulesFolderName} in ${this.rushConfiguration.commonTempFolder}`
-        ) +
-        os.EOL
-    );
-
     // Based on timestamps, can we skip this install entirely?
     const potentiallyChangedFiles: string[] = [];
 

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -249,27 +249,14 @@ export class RushInstallManager extends BaseInstallManager {
         // We will NOT locally link this package; add it as a regular dependency.
         tempPackageJson.dependencies![packageName] = packageVersion;
 
-        let tryReusingPackageVersionsFromShrinkwrap: boolean = true;
-
-        if (this.rushConfiguration.packageManager === 'pnpm') {
-          // Shrinkwrap churn optimization doesn't make sense when --frozen-lockfile is true
-          tryReusingPackageVersionsFromShrinkwrap = !this.rushConfiguration.experimentsConfiguration
-            .configuration.usePnpmFrozenLockfileForRushInstall;
-        }
-
-        if (shrinkwrapFile) {
-          if (
-            !shrinkwrapFile.tryEnsureCompatibleDependency(
-              dependencySpecifier,
-              rushProject.tempProjectName,
-              tryReusingPackageVersionsFromShrinkwrap
-            )
-          ) {
-            shrinkwrapWarnings.push(
-              `Missing dependency "${packageName}" (${packageVersion}) required by "${rushProject.packageName}"`
-            );
-            shrinkwrapIsUpToDate = false;
-          }
+        if (
+          shrinkwrapFile &&
+          !shrinkwrapFile.tryEnsureCompatibleDependency(dependencySpecifier, rushProject.tempProjectName)
+        ) {
+          shrinkwrapWarnings.push(
+            `Missing dependency "${packageName}" (${packageVersion}) required by "${rushProject.packageName}"`
+          );
+          shrinkwrapIsUpToDate = false;
         }
       }
 

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -21,7 +21,6 @@ import { PackageJsonEditor, DependencyType, PackageJsonDependency } from '../../
 import { PnpmWorkspaceFile } from '../pnpm/PnpmWorkspaceFile';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushConstants } from '../../logic/RushConstants';
-import { Stopwatch } from '../../utilities/Stopwatch';
 import { Utilities } from '../../utilities/Utilities';
 import { InstallHelpers } from './InstallHelpers';
 import { CommonVersionsConfiguration } from '../../api/CommonVersionsConfiguration';
@@ -65,8 +64,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
   protected async prepareCommonTempAsync(
     shrinkwrapFile: BaseShrinkwrapFile | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }> {
-    const stopwatch: Stopwatch = Stopwatch.start();
-
     // Block use of the RUSH_TEMP_FOLDER environment variable
     if (EnvironmentConfiguration.rushTempFolderOverride !== undefined) {
       throw new Error(
@@ -264,21 +261,10 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // since "rush install" will consider this timestamp
     workspaceFile.save(workspaceFile.workspaceFilename, { onlyIfChanged: true });
 
-    stopwatch.stop();
-    console.log(`Finished creating workspace (${stopwatch.toString()})`);
-
     return { shrinkwrapIsUpToDate, shrinkwrapWarnings };
   }
 
   protected canSkipInstall(lastModifiedDate: Date): boolean {
-    console.log(
-      os.EOL +
-        colors.bold(
-          `Checking ${RushConstants.nodeModulesFolderName} in ${this.rushConfiguration.commonTempFolder}`
-        ) +
-        os.EOL
-    );
-
     // Based on timestamps, can we skip this install entirely?
     const potentiallyChangedFiles: string[] = [];
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -9,11 +9,11 @@ import * as semver from 'semver';
 import colors from 'colors/safe';
 
 import {
-  Text,
+  AlreadyReportedError,
   FileSystem,
   FileConstants,
   InternalError,
-  AlreadyReportedError
+  Path
 } from '@rushstack/node-core-library';
 
 import { BaseLinkManager } from '../base/BaseLinkManager';
@@ -223,7 +223,7 @@ export class PnpmLinkManager extends BaseLinkManager {
     //   C%3A%2Fdev%2Fimodeljs%2Fimodeljs%2Fcommon%2Ftemp%2Fprojects%2Fpresentation-integration-tests.tgz_jsdom@11.12.0
     //   C%3A%2Fdev%2Fimodeljs%2Fimodeljs%2Fcommon%2Ftemp%2Fprojects%2Fbuild-tools.tgz_2a665c89609864b4e75bc5365d7f8f56
     let folderNameInLocalInstallationRoot: string =
-      uriEncode(Text.replaceAll(absolutePathToTgzFile, path.sep, '/')) + folderNameSuffix;
+      uriEncode(Path.convertToSlashes(absolutePathToTgzFile)) + folderNameSuffix;
 
     // PNPM 6 changed formatting to replace all special chars with '+'
     // e.g.: C++dev+imodeljs+imodeljs+common+temp+projects+presentation-integration-tests.tgz_jsdom@11.12.0

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -222,11 +222,17 @@ export class PnpmLinkManager extends BaseLinkManager {
     //   C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz
     //   C%3A%2Fdev%2Fimodeljs%2Fimodeljs%2Fcommon%2Ftemp%2Fprojects%2Fpresentation-integration-tests.tgz_jsdom@11.12.0
     //   C%3A%2Fdev%2Fimodeljs%2Fimodeljs%2Fcommon%2Ftemp%2Fprojects%2Fbuild-tools.tgz_2a665c89609864b4e75bc5365d7f8f56
-    const folderNameInLocalInstallationRoot: string =
+    let folderNameInLocalInstallationRoot: string =
       uriEncode(Text.replaceAll(absolutePathToTgzFile, path.sep, '/')) + folderNameSuffix;
 
-    // e.g.: C:\wbt\common\temp\node_modules\.local\C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz\node_modules
+    // PNPM 6 changed formatting to replace all special chars with '+'
+    // e.g.: C++dev+imodeljs+imodeljs+common+temp+projects+presentation-integration-tests.tgz_jsdom@11.12.0
+    if (this._pnpmVersion.major >= 6) {
+      const specialCharRegex: RegExp = /%[a-fA-FA-F0-9]{2}/g;
+      folderNameInLocalInstallationRoot = folderNameInLocalInstallationRoot.replace(specialCharRegex, '+');
+    }
 
+    // e.g.: C:\wbt\common\temp\node_modules\.local\C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz\node_modules
     const pathToLocalInstallation: string = this._getPathToLocalInstallation(
       folderNameInLocalInstallationRoot
     );
@@ -300,8 +306,17 @@ export class PnpmLinkManager extends BaseLinkManager {
   }
 
   private _getPathToLocalInstallation(folderNameInLocalInstallationRoot: string): string {
-    // See https://github.com/pnpm/pnpm/releases/tag/v4.0.0
-    if (this._pnpmVersion.major >= 4) {
+    if (this._pnpmVersion.major >= 6) {
+      // See https://github.com/pnpm/pnpm/releases/tag/v6.0.0
+      return path.join(
+        this._rushConfiguration.commonTempFolder,
+        RushConstants.nodeModulesFolderName,
+        '.pnpm',
+        `local+${folderNameInLocalInstallationRoot}`,
+        RushConstants.nodeModulesFolderName
+      );
+    } else if (this._pnpmVersion.major >= 4) {
+      // See https://github.com/pnpm/pnpm/releases/tag/v4.0.0
       return path.join(
         this._rushConfiguration.commonTempFolder,
         RushConstants.nodeModulesFolderName,

--- a/apps/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
@@ -86,15 +86,6 @@ describe('pnpm ShrinkwrapFile', () => {
 
     expect(tempProjectNames).toEqual(['@rush-temp/project1', '@rush-temp/project2', '@rush-temp/project3']);
   });
-
-  it('can reuse the latest version that another temp package is providing', () => {
-    expect(
-      shrinkwrapFile.tryEnsureCompatibleDependency(
-        new DependencySpecifier('jquery', '>=2.0.0 <3.0.0'),
-        '@rush-temp/project3'
-      )
-    ).toEqual(true);
-  });
 });
 
 function testParsePnpmDependencyKey(packageName: string, key: string): string | undefined {

--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -65,7 +65,8 @@ function _parsePackageSpecifier(rawPackageSpecifier: string): IPackageSpecifier 
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities.copyAndTrimNpmrcFile()
  */
 function _copyAndTrimNpmrcFile(sourceNpmrcPath: string, targetNpmrcPath: string): void {
-  console.log(`Copying ${sourceNpmrcPath} --> ${targetNpmrcPath}`); // Verbose
+  console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
+  console.log(`  --> "${targetNpmrcPath}"`);
   let npmrcFileLines: string[] = fs.readFileSync(sourceNpmrcPath).toString().split('\n');
   npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
   const resultLines: string[] = [];

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -522,7 +522,8 @@ export class Utilities {
    * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH _copyAndTrimNpmrcFile() FROM scripts/install-run.ts
    */
   public static copyAndTrimNpmrcFile(sourceNpmrcPath: string, targetNpmrcPath: string): void {
-    console.log(`Copying ${sourceNpmrcPath} --> ${targetNpmrcPath}`); // Verbose
+    console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
+    console.log(`  --> "${targetNpmrcPath}"`);
     let npmrcFileLines: string[] = FileSystem.readFile(sourceNpmrcPath).split('\n');
     npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
     const resultLines: string[] = [];
@@ -573,7 +574,8 @@ export class Utilities {
    */
   public static syncFile(sourcePath: string, destinationPath: string): void {
     if (FileSystem.exists(sourcePath)) {
-      console.log(`Updating ${destinationPath}`);
+      console.log(`Copying "${sourcePath}"`);
+      console.log(`  --> "${destinationPath}"`);
       FileSystem.copyFile({ sourcePath, destinationPath });
     } else {
       if (FileSystem.exists(destinationPath)) {

--- a/common/changes/@microsoft/rush/user-danade-pnpm6_2021-04-14-21-22.json
+++ b/common/changes/@microsoft/rush/user-danade-pnpm6_2021-04-14-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for PNPM 6",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Adds support for PNPM 6 in Rush!

## Details

- Fixes #2601 by using new path format to exploded tarball for local dependency
- Removes `pnpm-lock.yaml` modification of tarball integrity hashes for local projects in non-workspaces PNPM installs and replaces it with validation prior to running PNPM install
- Removes `pnpm-lock.yaml` shrinkwrap churn optimization in favor of built-in shrinkwrap churn optimization in PNPM
- Fixes #2602 where a bug in Rush caused double-quotes to be added in the `pnpm-lock.yaml` in some scenarios
- Only attempts to delete `pnpm-workspace.yaml` once instead of for each local package

`pnpm-lock.yaml` modification by Rush has been something that we have been attempting to remove for some time. With PNPM 6 using a new `pnpm-lock.yaml` format, this felt like a good time to remove this functionality instead of updating and special-casing writing of the file even further. There were two things that were being done with this manual modification:

1. Shrinkwrap churn optimization on behalf of PNPM prior to running install in order to reduce the amount of churn in the `pnpm-lock.yaml` file when adding a dependency that may be satisfied by an existing instance of that package elsewhere in the monorepo. This optimization was confusing for devs (#1142), and the PNPM-side resolution strategy `fewer-dependencies` has been the default since v3 and is the only option as of [v5](https://github.com/pnpm/pnpm/releases/tag/v5.0.1). Additionally, this churn optimization would happen during normal `rush install`, which means that this feature was breaking the expectation that "install" would perform install with the lockfile in it's current state. We even had to disable this feature specifically when using the PNPM `frozen-lockfile` feature, even though this is _not_ documented anywhere. In my opinion, PNPM has gotten much better at this, to the point that it doesn't make sense to keep maintaining the feature within Rush.
2. Manual tarball integrity hash updates for local packages. These were performed in a narrow use-case of non-workspace installs using PNPM, with the `usePnpmFrozenLockfileForRushInstall` experiment set to `true`. This was implemented in order to smooth over issues with using the `frozen-lockfile` feature in PNPM that were found when monorepo packages had versions bumped. When this happens (or when the contents of a `package.json` is changed at all in a way that affects the temp `package.json` in `common/temp`, really), the lockfile integrity hash would become out of date, causing the install to fail. This is an artifact of how Rush uses tarballs for local package installs in non-workspace monorepos. I've replaced this with a validation check prior to running install that should clearly describe to the developer how to resolve the out-of-date hash (running `rush update`). Removing this will mean that people in this narrow use-case will need to run `rush update` more frequently.

The net result of these changes is that we no longer have any need to directly modify the `pnpm-lock.yaml` file, and can instead leave that entirely up to PNPM to handle. This goes hand-in-hand with the goal of decoupling Rush from specific package managers.

## How it was tested

Ran installs against legacy Rush repo (tsdoc) as well as more recent Rush repo. Validated that install completed successfully and that builds could run as expected. Validated that changes to package versions in non-workspace monorepos with `usePnpmFrozenLockfileForRushInstall` set to `true` would result in integrity hash differences that require `rush update` to be run. Validated that `rush update` resolved the issue. 
