### PR TITLE
[heft] fix(webpack): fix an issue with webpack 5 where persistent cache isn't saved

### DIFF
--- a/common/changes/@rushstack/heft-webpack5-plugin/pr-webpack5-caching-fix_2021-04-14-21-57.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/pr-webpack5-caching-fix_2021-04-14-21-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Fix webpack5 persistent cache in production mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin",
+  "email": "scamden@users.noreply.github.com"
+}

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -210,6 +210,7 @@ export class WebpackPlugin implements IHeftPlugin {
           stats = await LegacyAdapters.convertCallbackToPromise(
             (compiler as webpack.Compiler).run.bind(compiler)
           );
+          await LegacyAdapters.convertCallbackToPromise(compiler.close.bind(compiler));
         } catch (e) {
           logger.emitError(e);
         }


### PR DESCRIPTION
@iclanton webpack compiler needs to be closed in webpack 5 in order to write it's persistent cache.

as per: https://github.com/webpack/webpack/issues/12345
and example here: https://github.com/webpack/webpack/blob/master/lib/webpack.js#L125

(tangent: would be cool for heft to potentially get into the incremental webpack build game now that webpack allows it. setting up the cache is fairly simple, but invalidating it takes some customization that would warrant discussion.)