### PR TITLE
[rush-lib] Improve support for S3 storage for the buildCache

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/AmazonS3/AmazonS3Client.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3/AmazonS3Client.ts
@@ -133,7 +133,7 @@ export class AmazonS3Client {
         '', // we don't use query strings for these requests
         ...canonicalHeaders,
         '',
-        signedHeaderNames,
+        signedHeaderNames.join(';'),
         bodyHash
       ].join('\n');
       const canonicalRequestHash: string = this._getSha256(canonicalRequest);

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3/test/AmazonS3Client.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3/test/AmazonS3Client.test.ts
@@ -1,67 +1,93 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { IAmazonS3BuildCacheProviderOptions } from '../AmazonS3BuildCacheProvider';
-import { AmazonS3Client } from '../AmazonS3Client';
+import { Response, ResponseInit } from 'node-fetch';
 
-const DUMMY_OPTIONS: Omit<IAmazonS3BuildCacheProviderOptions, 's3Bucket'> = {
+import { IAmazonS3BuildCacheProviderOptions } from '../AmazonS3BuildCacheProvider';
+import { AmazonS3Client, IAmazonS3Credentials } from '../AmazonS3Client';
+import { WebClient } from '../../../../utilities/WebClient';
+
+const DUMMY_OPTIONS_WITHOUT_BUCKET: Omit<IAmazonS3BuildCacheProviderOptions, 's3Bucket'> = {
   s3Region: 'us-east-1',
   isCacheWriteAllowed: true
 };
 
+const DUMMY_OPTIONS: IAmazonS3BuildCacheProviderOptions = {
+  ...DUMMY_OPTIONS_WITHOUT_BUCKET,
+  s3Bucket: 'test-s3-bucket'
+};
+
+class MockedDate extends Date {
+  public constructor() {
+    super(2020, 3, 18, 12, 32, 42, 493);
+  }
+
+  public toISOString(): string {
+    return '2020-04-18T12:32:42.493Z';
+  }
+}
+
 describe('AmazonS3Client', () => {
   it('Rejects invalid S3 bucket names', () => {
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: undefined!, ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: undefined!, ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: '-abc', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: '-abc', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'a!bc', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'a!bc', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'a', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'a', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: '10.10.10.10', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: '10.10.10.10', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'abc..d', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc..d', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'abc.-d', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc.-d', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'abc-.d', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc-.d', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
 
     expect(
-      () => new AmazonS3Client(undefined, { s3Bucket: 'abc-', ...DUMMY_OPTIONS })
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc-', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
     ).toThrowErrorMatchingSnapshot();
   });
 
   it('Accepts valid S3 bucket names', () => {
-    expect(() => new AmazonS3Client(undefined, { s3Bucket: 'abc123', ...DUMMY_OPTIONS })).not.toThrow();
+    expect(
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc123', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
+    ).not.toThrow();
 
-    expect(() => new AmazonS3Client(undefined, { s3Bucket: 'abc', ...DUMMY_OPTIONS })).not.toThrow();
+    expect(
+      () => new AmazonS3Client(undefined, { s3Bucket: 'abc', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
+    ).not.toThrow();
 
-    expect(() => new AmazonS3Client(undefined, { s3Bucket: 'foo-bar-baz', ...DUMMY_OPTIONS })).not.toThrow();
+    expect(
+      () => new AmazonS3Client(undefined, { s3Bucket: 'foo-bar-baz', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
+    ).not.toThrow();
 
-    expect(() => new AmazonS3Client(undefined, { s3Bucket: 'foo.bar.baz', ...DUMMY_OPTIONS })).not.toThrow();
+    expect(
+      () => new AmazonS3Client(undefined, { s3Bucket: 'foo.bar.baz', ...DUMMY_OPTIONS_WITHOUT_BUCKET })
+    ).not.toThrow();
   });
 
   it('Does not allow upload without credentials', async () => {
     const client: AmazonS3Client = new AmazonS3Client(undefined, {
       s3Bucket: 'foo.bar.baz',
-      ...DUMMY_OPTIONS
+      ...DUMMY_OPTIONS_WITHOUT_BUCKET
     });
     try {
       await client.uploadObjectAsync('temp', undefined!);
@@ -69,5 +95,258 @@ describe('AmazonS3Client', () => {
     } catch (e) {
       expect(e).toMatchSnapshot();
     }
+  });
+
+  describe('Making requests', () => {
+    interface IResponseOptions {
+      body?: string;
+      responseInit: ResponseInit;
+    }
+
+    let realDate: typeof Date;
+    beforeEach(() => {
+      realDate = global.Date;
+      global.Date = MockedDate as typeof Date;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      global.Date = realDate;
+    });
+
+    async function makeS3ClientRequestAsync<TResponse>(
+      credentials: IAmazonS3Credentials | undefined,
+      options: IAmazonS3BuildCacheProviderOptions,
+      request: (s3Client: AmazonS3Client) => Promise<TResponse>,
+      response: IResponseOptions
+    ): Promise<TResponse> {
+      const spy: jest.SpyInstance = jest
+        .spyOn(WebClient.prototype, 'fetchAsync')
+        .mockReturnValue(Promise.resolve(new Response(response.body, response.responseInit)));
+
+      const s3Client: AmazonS3Client = new AmazonS3Client(credentials, options);
+      let result: TResponse;
+      let error: Error | undefined;
+      try {
+        result = await request(s3Client);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0]).toMatchSnapshot();
+
+      if (error) {
+        throw error;
+      } else {
+        return result!;
+      }
+    }
+
+    async function runAndExpectErrorAsync(fnAsync: () => Promise<unknown>): Promise<void> {
+      try {
+        await fnAsync();
+        fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).toMatchSnapshot();
+      }
+    }
+
+    describe('Getting an object', () => {
+      async function makeGetRequestAsync(
+        credentials: IAmazonS3Credentials | undefined,
+        options: IAmazonS3BuildCacheProviderOptions,
+        objectName: string,
+        response: IResponseOptions
+      ): Promise<Buffer | undefined> {
+        return await makeS3ClientRequestAsync(
+          credentials,
+          options,
+          async (s3Client) => {
+            return await s3Client.getObjectAsync(objectName);
+          },
+          response
+        );
+      }
+
+      function registerGetTests(credentials: IAmazonS3Credentials | undefined): void {
+        it('Can get an object', async () => {
+          const expectedContents: string = 'abc123-contents';
+
+          const result: Buffer | undefined = await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+            body: expectedContents,
+            responseInit: {
+              status: 200
+            }
+          });
+          expect(result).toBeDefined();
+          expect(result?.toString()).toBe(expectedContents);
+        });
+
+        it('Can get an object from a different region', async () => {
+          const expectedContents: string = 'abc123-contents';
+
+          const result: Buffer | undefined = await makeGetRequestAsync(
+            credentials,
+            { ...DUMMY_OPTIONS, s3Region: 'us-west-1' },
+            'abc123',
+            {
+              body: expectedContents,
+              responseInit: {
+                status: 200
+              }
+            }
+          );
+          expect(result).toBeDefined();
+          expect(result?.toString()).toBe(expectedContents);
+        });
+
+        it('Handles a missing object', async () => {
+          const result: Buffer | undefined = await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+            responseInit: {
+              status: 404,
+              statusText: 'Not Found'
+            }
+          });
+          expect(result).toBeUndefined();
+        });
+
+        it('Handles an unexpected error', async () => {
+          await runAndExpectErrorAsync(
+            async () =>
+              await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+                responseInit: {
+                  status: 500,
+                  statusText: 'Server Error'
+                }
+              })
+          );
+        });
+      }
+
+      describe('Without credentials', () => {
+        registerGetTests(undefined);
+
+        it('Handles missing credentials object', async () => {
+          const result: Buffer | undefined = await makeGetRequestAsync(undefined, DUMMY_OPTIONS, 'abc123', {
+            responseInit: {
+              status: 403,
+              statusText: 'Unauthorized'
+            }
+          });
+          expect(result).toBeUndefined();
+        });
+      });
+
+      function registerGetWithCredentialsTests(credentials: IAmazonS3Credentials): void {
+        registerGetTests(credentials);
+
+        it('Handles a 403 error', async () => {
+          await runAndExpectErrorAsync(
+            async () =>
+              await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+                responseInit: {
+                  status: 403,
+                  statusText: 'Unauthorized'
+                }
+              })
+          );
+        });
+      }
+
+      describe('With credentials', () => {
+        registerGetWithCredentialsTests({
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: undefined
+        });
+      });
+
+      describe('With credentials including a session token', () => {
+        registerGetWithCredentialsTests({
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken'
+        });
+      });
+    });
+
+    describe('Uploading an object', () => {
+      async function makeUploadRequestAsync(
+        credentials: IAmazonS3Credentials | undefined,
+        options: IAmazonS3BuildCacheProviderOptions,
+        objectName: string,
+        objectContents: string,
+        response: IResponseOptions
+      ): Promise<void> {
+        return await makeS3ClientRequestAsync(
+          credentials,
+          options,
+          async (s3Client) => {
+            return await s3Client.uploadObjectAsync(objectName, Buffer.from(objectContents));
+          },
+          response
+        );
+      }
+
+      it('Throws an error if credentials are not provided', async () => {
+        await runAndExpectErrorAsync(
+          async () =>
+            await makeUploadRequestAsync(undefined, DUMMY_OPTIONS, 'abc123', 'abc123-contents', undefined!)
+        );
+      });
+
+      function registerUploadTests(credentials: IAmazonS3Credentials): void {
+        it('Uploads an object', async () => {
+          await makeUploadRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', 'abc123-contents', {
+            responseInit: {
+              status: 200
+            }
+          });
+        });
+
+        it('Uploads an object to a different region', async () => {
+          await makeUploadRequestAsync(
+            credentials,
+            { ...DUMMY_OPTIONS, s3Region: 'us-west-1' },
+            'abc123',
+            'abc123-contents',
+            {
+              responseInit: {
+                status: 200
+              }
+            }
+          );
+        });
+
+        it('Handles an unexpected error code', async () => {
+          await runAndExpectErrorAsync(
+            async () =>
+              await makeUploadRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', 'abc123-contents', {
+                responseInit: {
+                  status: 500,
+                  statusText: 'Server Error'
+                }
+              })
+          );
+        });
+      }
+
+      describe('With credentials', () => {
+        registerUploadTests({
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: undefined
+        });
+      });
+
+      describe('With credentials including a session token', () => {
+        registerUploadTests({
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken'
+        });
+      });
+    });
   });
 });

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3/test/__snapshots__/AmazonS3Client.test.ts.snap
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3/test/__snapshots__/AmazonS3Client.test.ts.snap
@@ -2,6 +2,613 @@
 
 exports[`AmazonS3Client Does not allow upload without credentials 1`] = `[Error: Credentials are required to upload objects to S3.]`;
 
+exports[`AmazonS3Client Making requests Getting an object With credentials Can get an object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=11441edef046611ecf352daa2bcae55584d302a31b3390ee865781671caf791a",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Can get an object from a different region 1`] = `
+Array [
+  "https://test-s3-bucket.s3-us-west-1.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-west-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=19d94ed314002214315e8e9816ca31c97e7c834f7494c3c61046550f12358c21",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Handles a 403 error 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=11441edef046611ecf352daa2bcae55584d302a31b3390ee865781671caf791a",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Handles a 403 error 2`] = `[Error: Amazon S3 responded with status code 403 (Unauthorized)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Handles a missing object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=11441edef046611ecf352daa2bcae55584d302a31b3390ee865781671caf791a",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Handles an unexpected error 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=11441edef046611ecf352daa2bcae55584d302a31b3390ee865781671caf791a",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Can get an object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=242129cdc7470382920680b887e5899a56eb94103e11ef9b96a45ee0d2bff5c7",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Can get an object from a different region 1`] = `
+Array [
+  "https://test-s3-bucket.s3-us-west-1.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-west-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=b3f43b86838b915e38f9900e5049870ca53db5792b578403f2d46185cc6bb3f1",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles a 403 error 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=242129cdc7470382920680b887e5899a56eb94103e11ef9b96a45ee0d2bff5c7",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles a 403 error 2`] = `[Error: Amazon S3 responded with status code 403 (Unauthorized)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles a missing object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=242129cdc7470382920680b887e5899a56eb94103e11ef9b96a45ee0d2bff5c7",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles an unexpected error 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=242129cdc7470382920680b887e5899a56eb94103e11ef9b96a45ee0d2bff5c7",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Can get an object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Can get an object from a different region 1`] = `
+Array [
+  "https://test-s3-bucket.s3-us-west-1.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles a missing object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles an unexpected error 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles missing credentials object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object Throws an error if credentials are not provided 1`] = `[TypeError: Cannot read property 'body' of undefined]`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials Handles an unexpected error code 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=1db5024ed7d91ac512762a2c70490754def64dc5ed61e3e98d090233ebe0f79c",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials Handles an unexpected error code 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials Uploads an object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=1db5024ed7d91ac512762a2c70490754def64dc5ed61e3e98d090233ebe0f79c",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials Uploads an object to a different region 1`] = `
+Array [
+  "https://test-s3-bucket.s3-us-west-1.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-west-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,Signature=35a4edef214657ec5799666681f637951d01b3cbf9ec3754f858ce8b722c026c",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials including a session token Handles an unexpected error code 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=f50f9b3a7b33b58809a8da7216b68ca8730fd157cc7aef4c945fa5df1a22cd03",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials including a session token Handles an unexpected error code 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials including a session token Uploads an object 1`] = `
+Array [
+  "https://test-s3-bucket.s3.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=f50f9b3a7b33b58809a8da7216b68ca8730fd157cc7aef4c945fa5df1a22cd03",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Uploading an object With credentials including a session token Uploads an object to a different region 1`] = `
+Array [
+  "https://test-s3-bucket.s3-us-west-1.amazonaws.com/abc123",
+  Object {
+    "body": Object {
+      "data": Array [
+        97,
+        98,
+        99,
+        49,
+        50,
+        51,
+        45,
+        99,
+        111,
+        110,
+        116,
+        101,
+        110,
+        116,
+        115,
+      ],
+      "type": "Buffer",
+    },
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-west-1/s3/aws4_request,SignedHeaders=host,x-amz-content-sha256,x-amz-date,x-amz-security-token,Signature=e846064053af5730311f5a8dd565139c9fdc9de4f9d1c12b8f2f77f619b7d2e1",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "f8e4bdb2ca9c0f90b0fe56e32bf509ba44b73e2f52af123832f9ddbfe7e8fafa",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "PUT",
+  },
+]
+`;
+
 exports[`AmazonS3Client Rejects invalid S3 bucket names 1`] = `"A S3 bucket name must be provided"`;
 
 exports[`AmazonS3Client Rejects invalid S3 bucket names 2`] = `"The bucket name \\"-abc\\" is invalid. A S3 bucket name must start with a lowercase alphanumerical character."`;

--- a/common/changes/@microsoft/rush/s3_2021-04-15-21-04.json
+++ b/common/changes/@microsoft/rush/s3_2021-04-15-21-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "The build cache can now use buckets outside the default region",
+      "comment": "The Amazon S3 build cloud cache provider can now use buckets outside the default region",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/s3_2021-04-15-21-04.json
+++ b/common/changes/@microsoft/rush/s3_2021-04-15-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "The build cache can now use buckets outside the default region",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nelson.work@gmail.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Improve support for S3 storage when enabling the build cache (feature added as part of conversation in https://github.com/microsoft/rushstack/issues/2393).

 - Allow S3 buckets outside the default (us-east-1) region in AWS
 - Support temporary credentials (generated using an IAM Profile or sts:assume-role)

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
When an S3 bucket is created outside the default region, the URL generated for presigning includes a region suffix (for example, `mybucket.s3-us-west-1.amazonaws.com`).  If this isn't taken into account, the signed request will not be valid and the request will return a `403`.

When the user's credentials are temporary credentials (generated by assuming a role or using an assigned IAM Profile), you need _three_ pieces of information and not 2: the key, the secret, and the session token.  The user needs a way to give this information and the signing logic needs to include it in the appropriate places.

  - User can now set the `RUSH_BUILD_CACHE_WRITE_CREDENTIAL` to the value `KEY:SECRET:TOKEN`, with three fields, instead of just two.  I believe this is considered just a string outside this context and doesn't require changes elsewhere.
  - For the signing logic, the `x-amz-security-token` header needs to be included in 3 places: in the request body used to generate a signature, in the list of headers inside the same request body, and as a header on the actual request (passed to fetch).

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->
"It works on my machine."

(I wouldn't mind adding some new unit tests for this functionality, but I think at minimum they'd require mocking `node-fetch`, and I don't see a lot of mocking going on in this area of the codebase.  Any advice on usual patterns to use here are appreciated.)

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
