### PR TITLE
[rush] Print a log file to "<project-root>/.rush/build-cache-tar.log" when the native "tar" is invoked for debugging purposes.

### DIFF
--- a/apps/rush-lib/src/utilities/TarExecutable.ts
+++ b/apps/rush-lib/src/utilities/TarExecutable.ts
@@ -82,6 +82,7 @@ export class TarExecutable {
     // The log file looks like this:
     //
     // Windows:
+    // Start time: Mon Apr 19 2021 13:06:40 GMT-0700 (Pacific Daylight Time)
     // Invoking "C:\WINDOWS\system32\tar.exe -x -f E:\rush-cache\d18105f7f83eb610b468be4e2421681f4a52e44d"
     //
     // ======= BEGIN PROCESS OUTPUT =======
@@ -92,6 +93,7 @@ export class TarExecutable {
     // Exited with code "0"
     //
     // Linux:
+    // Start time: Mon Apr 19 2021 13:06:40 GMT-0700 (Pacific Daylight Time)
     // Invoking "/bin/tar -x -f /home/username/rush-cache/d18105f7f83eb610b468be4e2421681f4a52e44d"
     //
     // ======= BEGIN PROCESS OUTPUT =======
@@ -105,6 +107,7 @@ export class TarExecutable {
     const fileWriter: FileWriter = FileWriter.open(logFilePath);
     fileWriter.write(
       [
+        `Start time: ${new Date().toString()}`,
         `Invoking "${this._tarExecutablePath} ${args.join(' ')}"`,
         '',
         '======= BEGIN PROCESS OUTPUT =======',

--- a/apps/rush-lib/src/utilities/TarExecutable.ts
+++ b/apps/rush-lib/src/utilities/TarExecutable.ts
@@ -78,6 +78,29 @@ export class TarExecutable {
     currentWorkingDirectory: string,
     logFilePath: string
   ): Promise<number> {
+    // Runs "tar" with the specified args and logs its output to the specified location.
+    // The log file looks like this:
+    //
+    // Windows:
+    // Invoking "C:\WINDOWS\system32\tar.exe -x -f E:\rush-cache\d18105f7f83eb610b468be4e2421681f4a52e44d"
+    //
+    // ======= BEGIN PROCESS OUTPUT =======
+    // [stdout] <tar stdout output>
+    // [stderr] <tar stderr output>
+    // ======== END PROCESS OUTPUT ========
+    //
+    // Exited with code "0"
+    //
+    // Linux:
+    // Invoking "/bin/tar -x -f /home/username/rush-cache/d18105f7f83eb610b468be4e2421681f4a52e44d"
+    //
+    // ======= BEGIN PROCESS OUTPUT =======
+    // [stdout] <tar stdout output>
+    // [stderr] <tar stderr output>
+    // ======== END PROCESS OUTPUT ========
+    //
+    // Exited with code "0"
+
     await FileSystem.ensureFolderAsync(path.dirname(logFilePath));
     const fileWriter: FileWriter = FileWriter.open(logFilePath);
     fileWriter.write(

--- a/common/changes/@microsoft/rush/ianc-tar-logging_2021-04-19-19-34.json
+++ b/common/changes/@microsoft/rush/ianc-tar-logging_2021-04-19-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Print a log file to \"<project-root>/.rush/build-cache-tar.log\" when the native \"tar\" is invoked for debugging purposes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ianc-tar-logging_2021-04-19-19-34.json
+++ b/common/changes/@microsoft/rush/ianc-tar-logging_2021-04-19-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Print a log file to \"<project-root>/.rush/build-cache-tar.log\" when the native \"tar\" is invoked for debugging purposes.",
+      "comment": "Print diagnostic information to a log file \"<project-root>/.rush/build-cache-tar.log\" when the native \"tar\" is invoked.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary

This will help to investigate https://github.com/microsoft/rushstack/issues/2622

## Details

This PR adds functionality to create a `<project-root>/.rush/build-cache-tar.log` file when the native `tar` is invoked with the following format:

```
Start time: Mon Apr 19 2021 13:06:40 GMT-0700 (Pacific Daylight Time)
Invoking "C:\WINDOWS\system32\tar.exe -x -f E:\rush-cache\d18105f7f83eb610b468be4e2421681f4a52e44d"

======= BEGIN PROCESS OUTPUT =======
<output from tar>
======== END PROCESS OUTPUT ========

Exited with code "0"
```

It also prints this file path as part of the "tar exited with code X" warning.

## How it was tested

Built locally with normal and with invalid `tar` arguments.