### PR TITLE
[rush-lib] Reorganize unit tests for PackageChangeAnalyzer

### DIFF
--- a/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
@@ -1,24 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
-
 import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
-import { LookupByPath } from '../LookupByPath';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
-
-const packageA: string = 'project-a';
-// Git will always return paths with '/' as the delimiter
-const packageAPath: string = path.posix.join('tools', packageA);
-const fileA: string = path.posix.join(packageAPath, 'src/index.ts');
-// const packageB: string = 'project-b';
-// const packageBPath: string = path.join('tools', packageB);
-// const fileB: string = path.join(packageBPath, 'src/index.ts');
-// const packageBPath: string = path.join('tools', packageB);
-const HASH: string = '12345abcdef';
-// const looseFile: string = 'some/other/folder/index.ts';
 
 describe('PackageChangeAnalyzer', () => {
   beforeEach(() => {
@@ -29,75 +15,140 @@ describe('PackageChangeAnalyzer', () => {
     jest.resetAllMocks();
   });
 
-  it('can associate a file in a project folder with a project', () => {
-    const repoHashDeps: Map<string, string> = new Map<string, string>([
-      [fileA, HASH],
-      [path.posix.join('common', 'config', 'rush', 'pnpm-lock.yaml'), HASH]
-    ]);
-
-    const project: RushConfigurationProject = {
-      packageName: packageA,
-      projectRelativeFolder: packageAPath
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const pathTree: LookupByPath<RushConfigurationProject> = new LookupByPath([
-      [packageAPath.replace(/\\/g, '/'), project]
-    ]);
-
-    PackageChangeAnalyzer.getPackageDeps = () => repoHashDeps;
+  function createTestSubject(
+    projects: RushConfigurationProject[],
+    files: Map<string, string>
+  ): PackageChangeAnalyzer {
     const rushConfiguration: RushConfiguration = {
       commonRushConfigFolder: '',
-      projects: [project],
+      projects,
       rushJsonFolder: '',
       getCommittedShrinkwrapFilename(): string {
         return 'common/config/rush/pnpm-lock.yaml';
       },
       findProjectForPosixRelativePath(path: string): object | undefined {
-        return pathTree.findChildPath(path);
+        return projects.find((project) => path.startsWith(project.projectRelativeFolder));
       }
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    } as RushConfiguration;
 
-    const packageChangeAnalyzer: PackageChangeAnalyzer = new PackageChangeAnalyzer(rushConfiguration);
-    const packageDeps: Map<string, string> | undefined = packageChangeAnalyzer.getPackageDeps(packageA);
-    expect(packageDeps).toEqual(repoHashDeps);
-  });
+    const subject: PackageChangeAnalyzer = new PackageChangeAnalyzer(rushConfiguration);
 
-  /*
-  it('associates a file that is not in a project with all projects', () => {
-    const repoHashDeps: IPackageDeps = {
-      files: {
-        [looseFile]: HASH,
-        [fileA]: HASH,
-        [fileB]: HASH
-      }
-    };
-
-    PackageChangeAnalyzer.getPackageDeps = (path: string, ignored: string[]) => repoHashDeps;
-    PackageChangeAnalyzer.rushConfig = {
-      projects: [{
-        packageName: packageA,
-        projectRelativeFolder: packageAPath
-      },
-      {
-        packageName: packageB,
-        projectRelativeFolder: packageBPath
-      }]
-    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    let packageDeps: IPackageDeps = PackageChangeAnalyzer.instance.getPackageDepsHash(packageA);
-    expect(packageDeps).toEqual({
-      files: {
-        [looseFile]: HASH,
-        [fileA]: HASH
-      }
+    subject['_getRepoDeps'] = jest.fn(() => {
+      return files;
     });
 
-    packageDeps = PackageChangeAnalyzer.instance.getPackageDepsHash(packageB);
-    expect(packageDeps).toEqual({
-      files: {
-        [looseFile]: HASH,
-        [fileB]: HASH
-      }
+    return subject;
+  }
+
+  describe('getPackageDeps', () => {
+    it('returns the files for the specified project', () => {
+      const projects: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject,
+        { packageName: 'banana', projectRelativeFolder: 'apps/banana' } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([
+        ['apps/apple/core.js', 'a101'],
+        ['apps/banana/peel.js', 'b201']
+      ]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+
+      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
+      expect(subject.getPackageDeps('banana')).toEqual(new Map([['apps/banana/peel.js', 'b201']]));
+    });
+
+    it('includes the committed shrinkwrap file as a dep for all projects', () => {
+      const projects: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject,
+        { packageName: 'banana', projectRelativeFolder: 'apps/banana' } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([
+        ['apps/apple/core.js', 'a101'],
+        ['apps/banana/peel.js', 'b201'],
+        ['common/config/rush/pnpm-lock.yaml', 'ffff'],
+        ['tools/random-file.js', 'e00e']
+      ]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+
+      expect(subject.getPackageDeps('apple')).toEqual(
+        new Map([
+          ['apps/apple/core.js', 'a101'],
+          ['common/config/rush/pnpm-lock.yaml', 'ffff']
+        ])
+      );
+      expect(subject.getPackageDeps('banana')).toEqual(
+        new Map([
+          ['apps/banana/peel.js', 'b201'],
+          ['common/config/rush/pnpm-lock.yaml', 'ffff']
+        ])
+      );
+    });
+
+    it('returns undefined if the specified project does not exist', () => {
+      const projects: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+
+      expect(subject.getPackageDeps('carrot')).toBeUndefined();
+    });
+
+    it('lazy-loads project data and caches it for future calls', () => {
+      const projects: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+
+      // Because other unit tests rely on the fact that a freshly instantiated
+      // PackageChangeAnalyzer is inert until someone actually requests project data,
+      // this test makes that expectation explicit.
+
+      expect(subject['_data']).toBeNull();
+      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
+      expect(subject['_data']).toBeDefined();
+      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
+      expect(subject['_getRepoDeps']).toHaveBeenCalledTimes(1);
     });
   });
-  */
+
+  describe('getProjectStateHash', () => {
+    it('returns a fixed hash snapshot for a set of project deps', () => {
+      const projects: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([
+        ['apps/apple/core.js', 'a101'],
+        ['apps/apple/juice.js', 'e333'],
+        ['apps/apple/slices.js', 'a102']
+      ]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+
+      expect(subject.getProjectStateHash('apple')).toMatchSnapshot();
+    });
+
+    it('returns the same hash regardless of dep order', () => {
+      const projectsA: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+      ];
+      const filesA: Map<string, string> = new Map([
+        ['apps/apple/core.js', 'a101'],
+        ['apps/apple/juice.js', 'e333'],
+        ['apps/apple/slices.js', 'a102']
+      ]);
+      const subjectA: PackageChangeAnalyzer = createTestSubject(projectsA, filesA);
+
+      const projectsB: RushConfigurationProject[] = [
+        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+      ];
+      const filesB: Map<string, string> = new Map([
+        ['apps/apple/slices.js', 'a102'],
+        ['apps/apple/core.js', 'a101'],
+        ['apps/apple/juice.js', 'e333']
+      ]);
+      const subjectB: PackageChangeAnalyzer = createTestSubject(projectsB, filesB);
+
+      expect(subjectA.getProjectStateHash('apple')).toEqual(subjectB.getProjectStateHash('apple'));
+    });
+  });
 });

--- a/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
@@ -124,7 +124,9 @@ describe('PackageChangeAnalyzer', () => {
       ]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
 
-      expect(subject.getProjectStateHash('apple')).toMatchSnapshot();
+      expect(subject.getProjectStateHash('apple')).toMatchInlineSnapshot(
+        `"265536e325cdfac3fa806a51873d927a712fc6c9"`
+      );
     });
 
     it('returns the same hash regardless of dep order', () => {

--- a/apps/rush-lib/src/logic/test/__snapshots__/PackageChangeAnalyzer.test.ts.snap
+++ b/apps/rush-lib/src/logic/test/__snapshots__/PackageChangeAnalyzer.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`PackageChangeAnalyzer getProjectStateHash returns a fixed hash snapshot for a set of project deps 1`] = `"265536e325cdfac3fa806a51873d927a712fc6c9"`;

--- a/apps/rush-lib/src/logic/test/__snapshots__/PackageChangeAnalyzer.test.ts.snap
+++ b/apps/rush-lib/src/logic/test/__snapshots__/PackageChangeAnalyzer.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PackageChangeAnalyzer getProjectStateHash returns a fixed hash snapshot for a set of project deps 1`] = `"265536e325cdfac3fa806a51873d927a712fc6c9"`;

--- a/common/changes/@microsoft/rush/change-analyzer-tests_2021-04-20-05-45.json
+++ b/common/changes/@microsoft/rush/change-analyzer-tests_2021-04-20-05-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nelson.work@gmail.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

In preparation for some future changes to `PackageChangeAnalyzer`, I've done some (very light) refactoring in the code and rewritten the unit tests to cover most of the functionality in the class.  The goal is to make it easier to prove that future changes don't break the existing API.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

 - For callers of `PackageChangeAnalyzer`, the only change in this PR is that _constructing_ a PackageChangeAnalyzer no longer immediately queries the state of git (file system).  The methods `getPackageDeps` and `getProjectStateHash` are now "lazy-load" instead of "eager-load".  This change makes the class easier to reason about and write unit tests for.

 - Unit tests now cover the two primary responsibilities of this class (one is to produce the list of dependencies relevant for each project, the other to take those dependencies and turn them into a final hash value).

 - Removed the sort-of-injector pattern in favor of a traditional jest mock on the test subject and cleaned up `any` usage.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
