### PR TITLE
[rush-lib] Fix issue on Windows with paths that contains spaces

### DIFF
--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -452,9 +452,16 @@ export function installAndRun(
   const originalEnvPath: string = process.env.PATH || '';
   let result: childProcess.SpawnSyncReturns<Buffer>;
   try {
+    // Node.js on Windows can not spawn a file when the path has a space on it
+    // unless the path gets wrapped in a cmd friendly way and shell mode is used
+    const shouldUseShell: boolean = binPath.includes(' ') && os.platform() === 'win32';
+    const platformBinPath: string = shouldUseShell ? `"${binPath}"` : binPath;
+
     process.env.PATH = [binFolderPath, originalEnvPath].join(path.delimiter);
-    result = childProcess.spawnSync(binPath, packageBinArgs, {
+    result = childProcess.spawnSync(platformBinPath, packageBinArgs, {
       stdio: 'inherit',
+      windowsVerbatimArguments: false,
+      shell: shouldUseShell,
       cwd: process.cwd(),
       env: process.env
     });

--- a/common/changes/@microsoft/rush/fix-windows-support-install-scripts_2021-04-20-23-21.json
+++ b/common/changes/@microsoft/rush/fix-windows-support-install-scripts_2021-04-20-23-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Rush fails to run on Windows when the repository absolute path contains a space",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "manrueda@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Currently all Rush commands that involve the `install-run` scripts fail on Windows when the project's absolute path has a space (" ") on it.

This is caused by a limitation of Node.js's `spawn` method that cannot execute a binary using a path with spaces on it. The limitation is known, and the recommended path is to execute the binary on shell mode and wrap the path in double quotes to allow Windows shell (CMD) properly resolve the path.


## Details

My changes involve the detection of the failing case (space on path + Windows OS) and only in that case use the shell mode + quotes wrapping on the path.

In this way we ensure that only the case with issue will change and use shell mode, Linux and MacOS does not work if the path gets wrapped in quotes.

## How it was tested

I build the project and copy the resulting `install-run.js` content into a project that had the issue and confirm that it works.

Also test it on MacOS to confirm that no side-effects were introduced.
