### PR TITLE
[heft] Fix an issue where an exception is thrown when running multiple TypeScript compilations in --debug mode

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/EmitFilesPatch.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/EmitFilesPatch.ts
@@ -43,6 +43,11 @@ export class EmitFilesPatch {
     useBuildCache: boolean,
     changedFiles?: Set<IExtendedSourceFile>
   ): void {
+    if (EmitFilesPatch._patchedTs === ts) {
+      // We already patched this instance of TS
+      return;
+    }
+
     if (EmitFilesPatch._patchedTs !== undefined) {
       throw new InternalError(
         'EmitFilesPatch.install() cannot be called without first uninstalling the existing patch'

--- a/common/changes/@rushstack/heft/ianc-dont-double-patch_2021-04-21-01-11.json
+++ b/common/changes/@rushstack/heft/ianc-dont-double-patch_2021-04-21-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where an exception is thrown when running multiple TypeScript compilations in --debug mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Currently, if a project has multiple tsconfig-*.json files in the root, and you run `heft --debug build`, an exception will be thrown saying that 'EmitFilesPatch.install() cannot be called without first uninstalling the existing patch'. This PR fixes that.

## Details

When the `--debug` parameter is used, the TypeScript builder is not run in a subprocess. When multiple TypeScript builders are run, they use the same loaded instance of TypeScript. Whichever one is invoked first will patch TypeScript's emitter first. The second will then try to patch TypeScript and throw an exception.

This change checks if the instance of TS is the instance that we already patched, and returns early in that case.

## How it was tested

Tested by running `heft --debug build --watch` on a project with a `tsconfig.json` and a `tsconfig-node.json`.