### PR TITLE
[rush] Fix `rush install` after workspace projects have been deleted upstream

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -60,9 +60,11 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
 
   /** @override */
   protected serialize(): string {
+    // Ensure stable sort order when serializing
+    Sort.sortSet(this._workspacePackages);
+
     const workspaceYaml: IPnpmWorkspaceYaml = {
-      // Ensure stable sort order when serializing
-      packages: Sort.sort(Array.from(this._workspacePackages))
+      packages: Array.from(this._workspacePackages)
     };
     return yamlModule.safeDump(workspaceYaml, PNPM_SHRINKWRAP_YAML_FORMAT);
   }

--- a/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as os from 'os';
 import * as path from 'path';
-import { FileSystem, Sort, Text, Import } from '@rushstack/node-core-library';
+import { Sort, Text, Import } from '@rushstack/node-core-library';
 
 import { BaseWorkspaceFile } from '../base/BaseWorkspaceFile';
 import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';

--- a/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -42,15 +42,9 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
     super();
 
     this.workspaceFilename = workspaceYamlFilename;
-    let workspaceYaml: IPnpmWorkspaceYaml;
-    try {
-      // Populate with the existing file, or an empty list if the file doesn't exist
-      workspaceYaml = FileSystem.exists(workspaceYamlFilename)
-        ? yamlModule.safeLoad(FileSystem.readFile(workspaceYamlFilename).toString())
-        : { packages: [] };
-    } catch (error) {
-      throw new Error(`Error reading "${workspaceYamlFilename}":${os.EOL}  ${error.message}`);
-    }
+    // Ignore any existing file since this file is generated and we need to handle deleting packages
+    // If we need to support manual customization, that should be an additional parameter for "base file"
+    const workspaceYaml: IPnpmWorkspaceYaml = { packages: [] };
 
     this._workspacePackages = new Set<string>(workspaceYaml.packages);
   }

--- a/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -43,9 +43,7 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
     this.workspaceFilename = workspaceYamlFilename;
     // Ignore any existing file since this file is generated and we need to handle deleting packages
     // If we need to support manual customization, that should be an additional parameter for "base file"
-    const workspaceYaml: IPnpmWorkspaceYaml = { packages: [] };
-
-    this._workspacePackages = new Set<string>(workspaceYaml.packages);
+    this._workspacePackages = new Set<string>();
   }
 
   /** @override */
@@ -62,11 +60,9 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
 
   /** @override */
   protected serialize(): string {
-    // Ensure stable sort order when serializing
-    Sort.sortSet(this._workspacePackages);
-
     const workspaceYaml: IPnpmWorkspaceYaml = {
-      packages: Array.from(this._workspacePackages)
+      // Ensure stable sort order when serializing
+      packages: Sort.sort(Array.from(this._workspacePackages))
     };
     return yamlModule.safeDump(workspaceYaml, PNPM_SHRINKWRAP_YAML_FORMAT);
   }

--- a/common/changes/@microsoft/rush/fix-workspace-deletion_2021-04-21-18-17.json
+++ b/common/changes/@microsoft/rush/fix-workspace-deletion_2021-04-21-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Ensure that pnpm-workspace.yaml is always fully regenerated during \"rush install\" or \"rush update\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Ensures that `rush install` does not throw an error if the last local install contained projects that have since been deleted upstream, and the user pulls latest changes and runs `rush install`

## Details
Skips reading the existing common/temp/pnpm-workspace.yaml file when constructing what the content is expected to be. Diffing at write time is still applied.

## How it was tested
Used the rush version to reinstall in rushstack.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
