### PR TITLE
[rush] Fix Rush to use new .pnpmfile.cjs filename in PNPM 6

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -636,6 +636,7 @@ export class RushConfiguration {
     RushConfiguration._validateCommonRushConfigFolder(
       this._commonRushConfigFolder,
       this.packageManager,
+      this._packageManagerToolVersion,
       this._shrinkwrapFilename,
       this._experimentsConfiguration
     );
@@ -929,6 +930,15 @@ export class RushConfiguration {
   }
 
   /**
+   * Returns the pnpmfile filename for the version of PNPM supplied.
+   */
+  private static _getPnpmfileFilename(packageManagerToolVersion: string): string {
+    return semver.gte(packageManagerToolVersion, '6.0.0')
+      ? RushConstants.pnpmfileV6Filename
+      : RushConstants.pnpmfileV1Filename;
+  }
+
+  /**
    * If someone adds a config file in the "common/rush/config" folder, it would be a bad
    * experience for Rush to silently ignore their file simply because they misspelled the
    * filename, or maybe it's an old format that's no longer supported.  The
@@ -938,6 +948,7 @@ export class RushConfiguration {
   private static _validateCommonRushConfigFolder(
     commonRushConfigFolder: string,
     packageManager: PackageManagerName,
+    packageManagerToolVersion: string,
     shrinkwrapFilename: string,
     experiments: ExperimentsConfiguration
   ): void {
@@ -982,7 +993,7 @@ export class RushConfiguration {
 
       // If the package manager is pnpm, then also add the pnpm file to the known set.
       if (packageManager === 'pnpm') {
-        knownSet.add(RushConstants.pnpmfileFilename.toUpperCase());
+        knownSet.add(RushConfiguration._getPnpmfileFilename(packageManagerToolVersion).toUpperCase());
       }
 
       // Is the filename something we know?  If not, report an error.
@@ -1560,7 +1571,10 @@ export class RushConfiguration {
   public getPnpmfilePath(variant?: string | undefined): string {
     const variantConfigFolderPath: string = this._getVariantConfigFolderPath(variant);
 
-    return path.join(variantConfigFolderPath, RushConstants.pnpmfileFilename);
+    return path.join(
+      variantConfigFolderPath,
+      RushConfiguration._getPnpmfileFilename(this.packageManagerToolVersion)
+    );
   }
 
   /**

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -635,9 +635,7 @@ export class RushConfiguration {
 
     RushConfiguration._validateCommonRushConfigFolder(
       this._commonRushConfigFolder,
-      this.packageManager,
-      this._packageManagerToolVersion,
-      this._shrinkwrapFilename,
+      this._packageManagerWrapper,
       this._experimentsConfiguration
     );
 
@@ -930,15 +928,6 @@ export class RushConfiguration {
   }
 
   /**
-   * Returns the pnpmfile filename for the version of PNPM supplied.
-   */
-  private static _getPnpmfileFilename(packageManagerToolVersion: string): string {
-    return semver.gte(packageManagerToolVersion, '6.0.0')
-      ? RushConstants.pnpmfileV6Filename
-      : RushConstants.pnpmfileV1Filename;
-  }
-
-  /**
    * If someone adds a config file in the "common/rush/config" folder, it would be a bad
    * experience for Rush to silently ignore their file simply because they misspelled the
    * filename, or maybe it's an old format that's no longer supported.  The
@@ -947,9 +936,7 @@ export class RushConfiguration {
    */
   private static _validateCommonRushConfigFolder(
     commonRushConfigFolder: string,
-    packageManager: PackageManagerName,
-    packageManagerToolVersion: string,
-    shrinkwrapFilename: string,
+    packageManagerWrapper: PackageManager,
     experiments: ExperimentsConfiguration
   ): void {
     if (!FileSystem.exists(commonRushConfigFolder)) {
@@ -989,11 +976,11 @@ export class RushConfiguration {
       }
 
       // Add the shrinkwrap filename for the package manager to the known set.
-      knownSet.add(shrinkwrapFilename.toUpperCase());
+      knownSet.add(packageManagerWrapper.shrinkwrapFilename.toUpperCase());
 
       // If the package manager is pnpm, then also add the pnpm file to the known set.
-      if (packageManager === 'pnpm') {
-        knownSet.add(RushConfiguration._getPnpmfileFilename(packageManagerToolVersion).toUpperCase());
+      if (packageManagerWrapper.packageManager === 'pnpm') {
+        knownSet.add((packageManagerWrapper as PnpmPackageManager).pnpmfileFilename.toUpperCase());
       }
 
       // Is the filename something we know?  If not, report an error.
@@ -1573,7 +1560,7 @@ export class RushConfiguration {
 
     return path.join(
       variantConfigFolderPath,
-      RushConfiguration._getPnpmfileFilename(this.packageManagerToolVersion)
+      (this.packageManagerWrapper as PnpmPackageManager).pnpmfileFilename
     );
   }
 

--- a/apps/rush-lib/src/api/packageManager/PnpmPackageManager.ts
+++ b/apps/rush-lib/src/api/packageManager/PnpmPackageManager.ts
@@ -10,6 +10,8 @@ import * as path from 'path';
  * Support for interacting with the PNPM package manager.
  */
 export class PnpmPackageManager extends PackageManager {
+  protected _pnpmfileFilename: string;
+
   /**
    * PNPM only.  True if `--resolution-strategy` is supported.
    */
@@ -25,6 +27,13 @@ export class PnpmPackageManager extends PackageManager {
     const parsedVersion: semver.SemVer = new semver.SemVer(version);
 
     this.supportsResolutionStrategy = false;
+
+    if (parsedVersion.major >= 6) {
+      // Introduced in version 6.0.0
+      this._pnpmfileFilename = RushConstants.pnpmfileV6Filename;
+    } else {
+      this._pnpmfileFilename = RushConstants.pnpmfileV1Filename;
+    }
 
     if (parsedVersion.major >= 3) {
       this._shrinkwrapFilename = RushConstants.pnpmV3ShrinkwrapFilename;
@@ -49,5 +58,15 @@ export class PnpmPackageManager extends PackageManager {
       // See https://github.com/pnpm/pnpm/releases/tag/v4.0.0 for more details.
       this.internalShrinkwrapRelativePath = path.join('node_modules', '.pnpm', 'lock.yaml');
     }
+  }
+
+  /**
+   * The filename of the shrinkwrap file that is used by the package manager.
+   *
+   * @remarks
+   * Example: `pnpmfile.js` or `.pnpmfile.cjs`
+   */
+  public get pnpmfileFilename(): string {
+    return this._pnpmfileFilename;
   }
 }

--- a/apps/rush-lib/src/logic/RushConstants.ts
+++ b/apps/rush-lib/src/logic/RushConstants.ts
@@ -87,9 +87,14 @@ export class RushConstants {
   public static readonly pnpmV3ShrinkwrapFilename: string = 'pnpm-lock.yaml';
 
   /**
-   * The filename ("pnpmfile.js") used to add custom configuration to PNPM
+   * The filename ("pnpmfile.js") used to add custom configuration to PNPM (PNPM version 1.x and later).
    */
-  public static readonly pnpmfileFilename: string = 'pnpmfile.js';
+  public static readonly pnpmfileV1Filename: string = 'pnpmfile.js';
+
+  /**
+   * The filename (".pnpmfile.cjs") used to add custom configuration to PNPM (PNPM version 6.x and later).
+   */
+  public static readonly pnpmfileV6Filename: string = '.pnpmfile.cjs';
 
   /**
    * The filename ("shrinkwrap.yaml") used to store state for pnpm

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -260,8 +260,7 @@ export abstract class BaseInstallManager {
   }
 
   protected abstract prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined,
-    variant: string | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }>;
 
   protected abstract canSkipInstall(lastInstallDate: Date): boolean;
@@ -402,10 +401,7 @@ export abstract class BaseInstallManager {
 
     // Allow for package managers to do their own preparation and check that the shrinkwrap is up to date
     // eslint-disable-next-line prefer-const
-    let { shrinkwrapIsUpToDate, shrinkwrapWarnings } = await this.prepareCommonTempAsync(
-      shrinkwrapFile,
-      this._options.variant
-    );
+    let { shrinkwrapIsUpToDate, shrinkwrapWarnings } = await this.prepareCommonTempAsync(shrinkwrapFile);
     shrinkwrapIsUpToDate = shrinkwrapIsUpToDate && !this.options.recheckShrinkwrap;
 
     this._syncTempShrinkwrap(shrinkwrapFile);

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -392,7 +392,7 @@ export abstract class BaseInstallManager {
       const committedPnpmFilePath: string = this._rushConfiguration.getPnpmfilePath(this._options.variant);
       const tempPnpmFilePath: string = path.join(
         this._rushConfiguration.commonTempFolder,
-        path.basename(committedPnpmFilePath)
+        (this._rushConfiguration.packageManagerWrapper as PnpmPackageManager).pnpmfileFilename
       );
 
       // ensure that we remove any old one that may be hanging around

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -260,7 +260,8 @@ export abstract class BaseInstallManager {
   }
 
   protected abstract prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined,
+    variant: string | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }>;
 
   protected abstract canSkipInstall(lastInstallDate: Date): boolean;
@@ -392,7 +393,7 @@ export abstract class BaseInstallManager {
       const committedPnpmFilePath: string = this._rushConfiguration.getPnpmfilePath(this._options.variant);
       const tempPnpmFilePath: string = path.join(
         this._rushConfiguration.commonTempFolder,
-        RushConstants.pnpmfileFilename
+        path.basename(committedPnpmFilePath)
       );
 
       // ensure that we remove any old one that may be hanging around
@@ -401,7 +402,10 @@ export abstract class BaseInstallManager {
 
     // Allow for package managers to do their own preparation and check that the shrinkwrap is up to date
     // eslint-disable-next-line prefer-const
-    let { shrinkwrapIsUpToDate, shrinkwrapWarnings } = await this.prepareCommonTempAsync(shrinkwrapFile);
+    let { shrinkwrapIsUpToDate, shrinkwrapWarnings } = await this.prepareCommonTempAsync(
+      shrinkwrapFile,
+      this._options.variant
+    );
     shrinkwrapIsUpToDate = shrinkwrapIsUpToDate && !this.options.recheckShrinkwrap;
 
     this._syncTempShrinkwrap(shrinkwrapFile);

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -78,7 +78,8 @@ export class RushInstallManager extends BaseInstallManager {
    * @override
    */
   public async prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined,
+    variant: string | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }> {
     const stopwatch: Stopwatch = Stopwatch.start();
 

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -78,8 +78,7 @@ export class RushInstallManager extends BaseInstallManager {
    * @override
    */
   public async prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined,
-    variant: string | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }> {
     const stopwatch: Stopwatch = Stopwatch.start();
 

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -28,6 +28,7 @@ import { RepoStateFile } from '../RepoStateFile';
 import { IPnpmfileShimSettings } from '../pnpm/IPnpmfileShimSettings';
 import { PnpmProjectDependencyManifest } from '../pnpm/PnpmProjectDependencyManifest';
 import { PnpmShrinkwrapFile, IPnpmShrinkwrapImporterYaml } from '../pnpm/PnpmShrinkwrapFile';
+import { PnpmPackageManager } from '../../api/packageManager/PnpmPackageManager';
 import { LastLinkFlagFactory } from '../../api/LastLinkFlag';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 
@@ -62,8 +63,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
    * @override
    */
   protected async prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined,
-    variant: string | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }> {
     // Block use of the RUSH_TEMP_FOLDER environment variable
     if (EnvironmentConfiguration.rushTempFolderOverride !== undefined) {
@@ -83,7 +83,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm') {
       const tempPnpmFilePath: string = path.join(
         this.rushConfiguration.commonTempFolder,
-        path.basename(this.rushConfiguration.getPnpmfilePath(variant))
+        (this.rushConfiguration.packageManagerWrapper as PnpmPackageManager).pnpmfileFilename
       );
       await this.createShimPnpmfileAsync(tempPnpmFilePath);
     }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -62,7 +62,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
    * @override
    */
   protected async prepareCommonTempAsync(
-    shrinkwrapFile: BaseShrinkwrapFile | undefined
+    shrinkwrapFile: BaseShrinkwrapFile | undefined,
+    variant: string | undefined
   ): Promise<{ shrinkwrapIsUpToDate: boolean; shrinkwrapWarnings: string[] }> {
     // Block use of the RUSH_TEMP_FOLDER environment variable
     if (EnvironmentConfiguration.rushTempFolderOverride !== undefined) {
@@ -82,7 +83,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm') {
       const tempPnpmFilePath: string = path.join(
         this.rushConfiguration.commonTempFolder,
-        RushConstants.pnpmfileFilename
+        path.basename(this.rushConfiguration.getPnpmfilePath(variant))
       );
       await this.createShimPnpmfileAsync(tempPnpmFilePath);
     }
@@ -460,7 +461,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       // Attempt to move the existing pnpmfile if there is one
       await FileSystem.moveAsync({
         sourcePath: filename,
-        destinationPath: path.join(pnpmfileDir, 'clientPnpmfile.js')
+        destinationPath: path.join(pnpmfileDir, `clientPnpmfile${path.extname(filename)}`)
       });
       pnpmfileExists = true;
     } catch (error) {

--- a/common/changes/@microsoft/rush/user-danade-FixPnpmfile_2021-04-21-22-03.json
+++ b/common/changes/@microsoft/rush/user-danade-FixPnpmfile_2021-04-21-22-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix support for PNPM 6 and use .pnpmfile.cjs",
+      "comment": "Fix support for pnpmfile in PNPM 6.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/user-danade-FixPnpmfile_2021-04-21-22-03.json
+++ b/common/changes/@microsoft/rush/user-danade-FixPnpmfile_2021-04-21-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix support for PNPM 6 and use .pnpmfile.cjs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

In preparing to use PNPM 6, it was determined that the new `.pnpmfile.cjs` filename is required when copying in the pnpmfile or creating our own shim pnpmfile in workspaces. This change updates Rush to copy `.pnpmfile.cjs` for PNPM 6 and above, and continues to use `pnpmfile.js` for below. Fixes #2629 

## How it was tested

Tested by performing install and validating that `pnpm-lock.yaml` changes are included and correct in PNPM 6-enabled monorepo.
