### PR TITLE
[rush] Fix bad clientPnpmfile extension on PNPM 6

### DIFF
--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -461,7 +461,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       // Attempt to move the existing pnpmfile if there is one
       await FileSystem.moveAsync({
         sourcePath: filename,
-        destinationPath: path.join(pnpmfileDir, `clientPnpmfile${path.extname(filename)}`)
+        destinationPath: path.join(pnpmfileDir, `clientPnpmfile.js`)
       });
       pnpmfileExists = true;
     } catch (error) {

--- a/common/changes/@microsoft/rush/user-danade-FixPnpmfileExt_2021-04-22-22-16.json
+++ b/common/changes/@microsoft/rush/user-danade-FixPnpmfileExt_2021-04-22-22-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix bad installs with when using pnpmfile in PNPM 6",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

The client pnpmfile was being copied in with a bad extension, causing PNPM 6 installs to be broken after purge of the temp dir.

## How it was tested

In a repo with PNPM 6 installed.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
