### PR TITLE
[rush-lib] Improve user error messages for common credential issues

### DIFF
--- a/common/changes/@microsoft/rush/build-cache-errors_2021-04-23-18-49.json
+++ b/common/changes/@microsoft/rush/build-cache-errors_2021-04-23-18-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve diagnostic messages printed by the rush build cache",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nelson.work@gmail.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

There are some corner cases while using the rush build cache feature that result in unhelpful error messages.  Improve error messages displayed to the user so they have more immediate direction.  (This PR focuses on the Azure Storage Blob provider.)

The `RestError` that can be thrown when reading the cache is now formatted with the status code and error code, in addition to error-specific detail, for example:

```
// Old message
Error getting cache entry from Azure Storage: RestError

// New message
Error getting cache entry from Azure Storage: RestError 409 PublicAccessNotPermitted

You need to configure Azure Storage SAS credentials to access the build cache.
Update the credentials by running "rush update-cloud-credentials",
or provide a SAS in the RUSH_BUILD_CACHE_WRITE_CREDENTIAL environment variable.
```

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

 - If you turn on cache writing, but your credentials are invalid (as in, they cannot read OR write from the cache), then the check for blob existence after the build blows up silently, causing the build to fail (this is extra confusing because the only warning printed is the warning about your bad credentials at the top of the build, which makes it look like having bad credentials is _supposed_ to fail your build, which isn't the case).  Wrapping the blob check and printing the error prevents this potential build failure.

 - If you have valid credentials, but those credentials don't have read permission, you get an unhelpful `RestError` message.  Generally this issue is because your user doesn't have permission to read data blobs from your account storage, so let's point the user in that direction.  (In addition to printing out the actual error code and name.)

 - If you have configured your Azure Storage account to require credentials for read access, but you don't have any credentials, the storage provider will default to attempting to read the cache with no credentials.  Provide the user the standard "set up your credentials" speech in this case.  (In addition to printing out the actual error code and name.)

 - If you have configured the build cache and have credentials but those credentials are invalid (a bad copy/paste into the environment variable, or maybe even you configured the cache with S3 and then switched it to Azure, or the credentials used to be valid and were invalidated manually), give the user the standard "set up your credentials" speech in this case.  (In addition to printing out the actual error code and name.)

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Manually tested situations by:

(1) Set up cloud credentials, then manually corrupted the saved cloud credentials in `~/.rush-user` and ran a build.

(2) Turned on cache write, set up cloud credentials, then manually corrupted the credentials and ran a build.

(3) Set up cloud credentials, removed storage blob data reader permissions in Azure Portal, then ran a build.

(4) Turned off cache write, connected to private storage account, cleared cloud credentials, then ran a build.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
