### PR TITLE
[rush] Allow prerelease versions of PNPM in workspaces

### DIFF
--- a/apps/rush-lib/src/logic/InstallManagerFactory.ts
+++ b/apps/rush-lib/src/logic/InstallManagerFactory.ts
@@ -28,7 +28,11 @@ export class InstallManagerFactory {
       rushConfiguration.pnpmOptions &&
       rushConfiguration.pnpmOptions.useWorkspaces
     ) {
-      if (!semver.satisfies(rushConfiguration.packageManagerToolVersion, '>=4.14.3')) {
+      if (
+        !semver.satisfies(rushConfiguration.packageManagerToolVersion, '>=4.14.3', {
+          includePrerelease: true
+        })
+      ) {
         console.log();
         console.log(
           colors.red(

--- a/common/changes/@microsoft/rush/user-danade-AllowPrereleasePnpm_2021-04-23-19-07.json
+++ b/common/changes/@microsoft/rush/user-danade-AllowPrereleasePnpm_2021-04-23-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow prerelease versions of PNPM to be used in workspaces mode",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Allow prerelease versions of PNPM to be used when `useWorkspaces` is enabled.

## How it was tested

Manually in node by validating a prerelease version using the existing package version check.
