### PR TITLE
[rush-lib] Ignore specified files when calculating project state hash

### DIFF
--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -21,6 +21,18 @@ interface IRushProjectJson {
    */
   projectOutputFolderNames?: string[];
 
+  /**
+   * The incremental analyzer can skip Rush commands for projects whose input files have
+   * not changed since the last build. Normally, every Git-tracked file under the project
+   * folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific
+   * files, specified as globs relative to the project folder. The list of file globs will
+   * be interpreted the same way your .gitignore file is.
+   */
+  incrementalBuildIgnoredGlobs?: string[];
+
+  /**
+   * Additional project-specific options related to build caching.
+   */
   buildCacheOptions?: IBuildCacheOptionsJson;
 }
 
@@ -86,6 +98,9 @@ export class RushProjectConfiguration {
         projectOutputFolderNames: {
           inheritanceType: InheritanceType.append
         },
+        incrementalBuildIgnoredGlobs: {
+          inheritanceType: InheritanceType.replace
+        },
         buildCacheOptions: {
           inheritanceType: InheritanceType.custom,
           inheritanceFunction: (
@@ -122,6 +137,15 @@ export class RushProjectConfiguration {
   public readonly projectOutputFolderNames?: string[];
 
   /**
+   * The incremental analyzer can skip Rush commands for projects whose input files have
+   * not changed since the last build. Normally, every Git-tracked file under the project
+   * folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific
+   * files, specified as globs relative to the project folder. The list of file globs will
+   * be interpreted the same way your .gitignore file is.
+   */
+  public readonly incrementalBuildIgnoredGlobs?: string[];
+
+  /**
    * Project-specific cache options.
    */
   public readonly cacheOptions: IBuildCacheOptions;
@@ -130,6 +154,8 @@ export class RushProjectConfiguration {
     this.project = project;
 
     this.projectOutputFolderNames = rushProjectJson.projectOutputFolderNames;
+
+    this.incrementalBuildIgnoredGlobs = rushProjectJson.incrementalBuildIgnoredGlobs;
 
     const optionsForCommandsByName: Map<string, ICacheOptionsForCommand> = new Map<
       string,

--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -87,7 +87,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
     });
 
     const trackedFiles: string[] = Array.from(
-      packageChangeAnalyzer.getPackageDeps(project.packageName)!.keys()
+      (await packageChangeAnalyzer.getPackageDeps(project.packageName, terminal))!.keys()
     );
     const commandLineConfigFilePath: string = path.join(
       this.rushConfiguration.commonRushConfigFolder,

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -191,7 +191,8 @@ export class BulkScriptAction extends BaseScriptAction {
     const projectWatcher: typeof ProjectWatcher.prototype = new ProjectWatcher({
       debounceMilliseconds: 1000,
       rushConfiguration: this.rushConfiguration,
-      projectsToWatch
+      projectsToWatch,
+      terminal
     });
 
     let isInitialPass: boolean = true;

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -17,7 +17,7 @@ interface ITestOptions {
 }
 
 describe('ProjectBuildCache', () => {
-  function prepareSubject(options: Partial<ITestOptions>): ProjectBuildCache | undefined {
+  async function prepareSubject(options: Partial<ITestOptions>): Promise<ProjectBuildCache | undefined> {
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
     const packageChangeAnalyzer = ({
       getProjectStateHash: () => {
@@ -25,7 +25,7 @@ describe('ProjectBuildCache', () => {
       }
     } as unknown) as PackageChangeAnalyzer;
 
-    const subject: ProjectBuildCache | undefined = ProjectBuildCache.tryGetProjectBuildCache({
+    const subject: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCache({
       buildCacheConfiguration: ({
         buildCacheEnabled: options.hasOwnProperty('enabled') ? options.enabled : true,
         getCacheEntryId: (options: IGenerateCacheEntryIdOptions) =>
@@ -53,16 +53,16 @@ describe('ProjectBuildCache', () => {
   }
 
   describe('tryGetProjectBuildCache', () => {
-    it('returns a ProjectBuildCache with a calculated cacheId value', () => {
-      const subject: ProjectBuildCache = prepareSubject({})!;
+    it('returns a ProjectBuildCache with a calculated cacheId value', async () => {
+      const subject: ProjectBuildCache = (await prepareSubject({}))!;
       expect(subject['_cacheId']).toMatchInlineSnapshot(
         `"acme-wizard/e229f8765b7d450a8a84f711a81c21e37935d661"`
       );
     });
 
-    it('returns undefined if the tracked file list is undefined', () => {
+    it('returns undefined if the tracked file list is undefined', async () => {
       expect(
-        prepareSubject({
+        await prepareSubject({
           trackedProjectFiles: undefined
         })
       ).toBe(undefined);

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -210,8 +210,9 @@ export class ProjectBuilder extends BaseBuilder {
       let projectBuildDeps: IProjectBuildDeps | undefined;
       let trackedFiles: string[] | undefined;
       try {
-        const fileHashes: Map<string, string> | undefined = this._packageChangeAnalyzer.getPackageDeps(
-          this._rushProject.packageName
+        const fileHashes: Map<string, string> | undefined = await this._packageChangeAnalyzer.getPackageDeps(
+          this._rushProject.packageName,
+          terminal
         );
 
         if (fileHashes) {
@@ -391,7 +392,7 @@ export class ProjectBuilder extends BaseBuilder {
                 `Caching has been disabled for this project's "${this._commandName}" command.`
               );
             } else {
-              this._projectBuildCache = ProjectBuildCache.tryGetProjectBuildCache({
+              this._projectBuildCache = await ProjectBuildCache.tryGetProjectBuildCache({
                 projectConfiguration,
                 buildCacheConfiguration: this._buildCacheConfiguration,
                 terminal,

--- a/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/PackageChangeAnalyzer.test.ts
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 
 describe('PackageChangeAnalyzer', () => {
   beforeEach(() => {
     jest.spyOn(EnvironmentConfiguration, 'gitBinaryPath', 'get').mockReturnValue(undefined);
+    jest.spyOn(RushProjectConfiguration, 'tryLoadForProjectAsync').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -41,25 +44,127 @@ describe('PackageChangeAnalyzer', () => {
   }
 
   describe('getPackageDeps', () => {
-    it('returns the files for the specified project', () => {
+    it('returns the files for the specified project', async () => {
       const projects: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject,
-        { packageName: 'banana', projectRelativeFolder: 'apps/banana' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject,
+        {
+          packageName: 'banana',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/banana'
+        } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([
         ['apps/apple/core.js', 'a101'],
         ['apps/banana/peel.js', 'b201']
       ]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
-      expect(subject.getPackageDeps('banana')).toEqual(new Map([['apps/banana/peel.js', 'b201']]));
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+        new Map([['apps/apple/core.js', 'a101']])
+      );
+      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
+        new Map([['apps/banana/peel.js', 'b201']])
+      );
     });
 
-    it('includes the committed shrinkwrap file as a dep for all projects', () => {
+    it('ignores files specified by project configuration files, relative to project folder', async () => {
+      // rush-project.json configuration for 'apple'
+      jest.spyOn(RushProjectConfiguration, 'tryLoadForProjectAsync').mockResolvedValueOnce({
+        incrementalBuildIgnoredGlobs: ['assets/*.png', '*.js.map']
+      } as RushProjectConfiguration);
+      // rush-project.json configuration for 'banana' does not exist
+      jest.spyOn(RushProjectConfiguration, 'tryLoadForProjectAsync').mockResolvedValueOnce(undefined);
+
       const projects: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject,
-        { packageName: 'banana', projectRelativeFolder: 'apps/banana' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject,
+        {
+          packageName: 'banana',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/banana'
+        } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([
+        ['apps/apple/core.js', 'a101'],
+        ['apps/apple/core.js.map', 'a102'],
+        ['apps/apple/assets/one.jpg', 'a103'],
+        ['apps/apple/assets/two.png', 'a104'],
+        ['apps/banana/peel.js', 'b201'],
+        ['apps/banana/peel.js.map', 'b202']
+      ]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
+
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+        new Map([
+          ['apps/apple/core.js', 'a101'],
+          ['apps/apple/assets/one.jpg', 'a103']
+        ])
+      );
+      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
+        new Map([
+          ['apps/banana/peel.js', 'b201'],
+          ['apps/banana/peel.js.map', 'b202']
+        ])
+      );
+    });
+
+    it('interprets ignored globs as a dot-ignore file (not as individually handled globs)', async () => {
+      // rush-project.json configuration for 'apple'
+      jest.spyOn(RushProjectConfiguration, 'tryLoadForProjectAsync').mockResolvedValue({
+        incrementalBuildIgnoredGlobs: ['*.png', 'assets/*.psd', '!assets/important/**']
+      } as RushProjectConfiguration);
+
+      const projects: RushConfigurationProject[] = [
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
+      ];
+      const files: Map<string, string> = new Map([
+        ['apps/apple/one.png', 'a101'],
+        ['apps/apple/assets/two.psd', 'a102'],
+        ['apps/apple/assets/three.png', 'a103'],
+        ['apps/apple/assets/important/four.png', 'a104'],
+        ['apps/apple/assets/important/five.psd', 'a105'],
+        ['apps/apple/src/index.ts', 'a106']
+      ]);
+      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
+
+      // In a dot-ignore file, the later rule '!assets/important/**' should override the previous
+      // rule of '*.png'. This unit test verifies that this behavior doesn't change later if
+      // we modify the implementation.
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+        new Map([
+          ['apps/apple/assets/important/four.png', 'a104'],
+          ['apps/apple/assets/important/five.psd', 'a105'],
+          ['apps/apple/src/index.ts', 'a106']
+        ])
+      );
+    });
+
+    it('includes the committed shrinkwrap file as a dep for all projects', async () => {
+      const projects: RushConfigurationProject[] = [
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject,
+        {
+          packageName: 'banana',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/banana'
+        } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([
         ['apps/apple/core.js', 'a101'],
@@ -68,14 +173,15 @@ describe('PackageChangeAnalyzer', () => {
         ['tools/random-file.js', 'e00e']
       ]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(subject.getPackageDeps('apple')).toEqual(
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/core.js', 'a101'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
         ])
       );
-      expect(subject.getPackageDeps('banana')).toEqual(
+      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
         new Map([
           ['apps/banana/peel.js', 'b201'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
@@ -83,39 +189,57 @@ describe('PackageChangeAnalyzer', () => {
       );
     });
 
-    it('returns undefined if the specified project does not exist', () => {
+    it('returns undefined if the specified project does not exist', async () => {
       const projects: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(subject.getPackageDeps('carrot')).toBeUndefined();
+      expect(await subject.getPackageDeps('carrot', terminal)).toBeUndefined();
     });
 
-    it('lazy-loads project data and caches it for future calls', () => {
+    it('lazy-loads project data and caches it for future calls', async () => {
       const projects: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       // Because other unit tests rely on the fact that a freshly instantiated
       // PackageChangeAnalyzer is inert until someone actually requests project data,
       // this test makes that expectation explicit.
 
       expect(subject['_data']).toBeNull();
-      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+        new Map([['apps/apple/core.js', 'a101']])
+      );
       expect(subject['_data']).toBeDefined();
-      expect(subject.getPackageDeps('apple')).toEqual(new Map([['apps/apple/core.js', 'a101']]));
+      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+        new Map([['apps/apple/core.js', 'a101']])
+      );
       expect(subject['_getRepoDeps']).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getProjectStateHash', () => {
-    it('returns a fixed hash snapshot for a set of project deps', () => {
+    it('returns a fixed hash snapshot for a set of project deps', async () => {
       const projects: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([
         ['apps/apple/core.js', 'a101'],
@@ -123,15 +247,20 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/slices.js', 'a102']
       ]);
       const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(subject.getProjectStateHash('apple')).toMatchInlineSnapshot(
+      expect(await subject.getProjectStateHash('apple', terminal)).toMatchInlineSnapshot(
         `"265536e325cdfac3fa806a51873d927a712fc6c9"`
       );
     });
 
-    it('returns the same hash regardless of dep order', () => {
+    it('returns the same hash regardless of dep order', async () => {
       const projectsA: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
       ];
       const filesA: Map<string, string> = new Map([
         ['apps/apple/core.js', 'a101'],
@@ -141,7 +270,11 @@ describe('PackageChangeAnalyzer', () => {
       const subjectA: PackageChangeAnalyzer = createTestSubject(projectsA, filesA);
 
       const projectsB: RushConfigurationProject[] = [
-        { packageName: 'apple', projectRelativeFolder: 'apps/apple' } as RushConfigurationProject
+        {
+          packageName: 'apple',
+          projectFolder: 'apps/apple',
+          projectRelativeFolder: 'apps/apple'
+        } as RushConfigurationProject
       ];
       const filesB: Map<string, string> = new Map([
         ['apps/apple/slices.js', 'a102'],
@@ -150,7 +283,10 @@ describe('PackageChangeAnalyzer', () => {
       ]);
       const subjectB: PackageChangeAnalyzer = createTestSubject(projectsB, filesB);
 
-      expect(subjectA.getProjectStateHash('apple')).toEqual(subjectB.getProjectStateHash('apple'));
+      const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
+      expect(await subjectA.getProjectStateHash('apple', terminal)).toEqual(
+        await subjectB.getProjectStateHash('apple', terminal)
+      );
     });
   });
 });

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -52,6 +52,14 @@
         "type": "string"
       },
       "uniqueItems": true
+    },
+
+    "incrementalBuildIgnoredGlobs": {
+      "type": "array",
+      "description": "The incremental analyzer can skip Rush commands for projects whose input files have not changed since the last build. Normally, every Git-tracked file under the project folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific files, specified as globs relative to the project folder. The list of file globs will be interpreted the same way your .gitignore file is.",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/common/changes/@microsoft/rush/t3_2021-04-28-14-31.json
+++ b/common/changes/@microsoft/rush/t3_2021-04-28-14-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow rush-project.json to specify incrementalBuildIgnoredGlobs (GitHub issue #2618)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nelson.work@gmail.com"
+}


### PR DESCRIPTION
## Summary

Implementation of https://github.com/microsoft/rushstack/issues/2618.  The intent is to allow each project (in its `rush-project.json` file) to optionally specify glob patterns that should be ignored when calculating project state, which in turn, will allow those files to be ignored for the purposes of incremental build watching, cloud build cache hits, etc.

The new option is called `incrementalBuildIgnoredGlobs`, and is interpreted as a dot-ignore file.

## Details

PR needs a little cleanup, but it does work (tested locally on our monorepo here and does exactly what I was hoping).  Hoping to get feedback before I finish up the PR, to make sure this approach makes sense.

The new model of `ConfigurationFile`, which helps define riggable / extendable configuration files, is all `async`-based and takes a `Terminal` for possible warning output; this means that anything above it that uses it _also_ needs to be async and to accept a Terminal.  This requires a little bit of hacking on several chains (like `ProjectWatcher` -> `ProjectBuildCache` -> `PackageChangeAnalyzer` etc.).

It's worth noting that `ProjectBuildCache()` always accepted a `RushProjectConfiguration` that was previously loaded, but, that wasn't that useful in this situation.  That config is for the project for which a hash is being calculated; if, for example, `A` is dependent on `B`, if `B` specified `disableBuildCache` in its project configuration, that doesn't stop `A` from calculating the files in `B` as part of its hash.  But for this new feature, we _do_ need `A` to ignore files that `B` ignores, so we need to load the project configuration for every project in the repo essentially.  (Or, possibly, load them on the fly as we hit projects we haven't loaded the project configuration for yet; I opted for the former approach for simplicity but we can enhance that.)

## How it was tested

Currently tested in our current monorepo, for example, with project A depending on B:

 - Add `ignoreChangedFiles: "*.md"` to B's `rush-project.json`.
 - Tweak `B/src/index.ts` and `rush build`; rebuilds B and A as expected.
 - Tweak `B/README.md` and `rush build`; B and A get cache hits as expected.
 - Add `ignoreChangedFiles: "*.png"` to A's `rush-project.json`.
 - Tweak `A/logo.png` and `rush build`; A gets cache hit as expected.
 - Tweak `B/logo.png` and `rush build`; rebuilds B and A as expected (A is ignoring PNGs, but B is not)

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
