### PR TITLE
[Rush] Use simpler and more accurate check before skipping installs in workspaces

### DIFF
--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -10,7 +10,7 @@ import { IShrinkwrapFilePolicyValidatorOptions } from '../policy/ShrinkwrapFileP
 import { PackageManagerOptionsConfigurationBase } from '../../api/RushConfiguration';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
 import { IExperimentsJson } from '../../api/ExperimentsConfiguration';
-import { PackageJsonEditor } from '../../api/PackageJsonEditor';
+import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 
 /**
  * This class is a parser for both npm's npm-shrinkwrap.json and pnpm's pnpm-lock.yaml file formats.
@@ -126,7 +126,7 @@ export abstract class BaseShrinkwrapFile {
    *
    * @virtual
    */
-  public abstract isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean;
+  public abstract isWorkspaceProjectModified(project: RushConfigurationProject): boolean;
 
   /** @virtual */
   protected abstract serialize(): string;

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -239,7 +239,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
 
       // Now validate that the shrinkwrap file matches what is in the package.json
       if (shrinkwrapFile?.isWorkspaceProjectModified(rushProject)) {
-        shrinkwrapWarnings.push(`Modified package.json found for "${rushProject.packageName}"`);
+        shrinkwrapWarnings.push(`Dependencies of project "${rushProject.packageName}" do not match the current shinkwrap.`);
         shrinkwrapIsUpToDate = false;
       }
     }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -238,7 +238,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
 
       // Now validate that the shrinkwrap file matches what is in the package.json
-      if (shrinkwrapFile && shrinkwrapFile.isWorkspaceProjectModified(rushProject)) {
+      if (shrinkwrapFile?.isWorkspaceProjectModified(rushProject)) {
         shrinkwrapWarnings.push(`Modified package.json found for "${rushProject.packageName}"`);
         shrinkwrapIsUpToDate = false;
       }

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -225,23 +225,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           // Already specified as a local project. Allow the package manager to validate this
           continue;
         }
-
-        // It is not a local dependency, validate that it is compatible
-        if (
-          shrinkwrapFile &&
-          !shrinkwrapFile.hasCompatibleWorkspaceDependency(
-            dependencySpecifier,
-            shrinkwrapFile.getWorkspaceKeyByPath(
-              this.rushConfiguration.commonTempFolder,
-              rushProject.projectFolder
-            )
-          )
-        ) {
-          shrinkwrapWarnings.push(
-            `Missing dependency "${name}" (${version}) required by "${rushProject.packageName}"`
-          );
-          shrinkwrapIsUpToDate = false;
-        }
       }
 
       // Save the package.json if we modified the version references and warn that the package.json was modified
@@ -252,6 +235,21 @@ export class WorkspaceInstallManager extends BaseInstallManager {
               'notation. The package.json has been modified and must be committed to source control.'
           )
         );
+      }
+
+      // Now validate that the shrinkwrap file matches what is in the package.json
+      if (
+        shrinkwrapFile &&
+        shrinkwrapFile.isWorkspaceProjectModified(
+          shrinkwrapFile.getWorkspaceKeyByPath(
+            this.rushConfiguration.commonTempFolder,
+            rushProject.projectFolder
+          ),
+          packageJson
+        )
+      ) {
+        shrinkwrapWarnings.push(`Modified package.json found for "${rushProject.packageName}"`);
+        shrinkwrapIsUpToDate = false;
       }
     }
 

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -238,16 +238,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
 
       // Now validate that the shrinkwrap file matches what is in the package.json
-      if (
-        shrinkwrapFile &&
-        shrinkwrapFile.isWorkspaceProjectModified(
-          shrinkwrapFile.getWorkspaceKeyByPath(
-            this.rushConfiguration.commonTempFolder,
-            rushProject.projectFolder
-          ),
-          packageJson
-        )
-      ) {
+      if (shrinkwrapFile && shrinkwrapFile.isWorkspaceProjectModified(rushProject)) {
         shrinkwrapWarnings.push(`Modified package.json found for "${rushProject.packageName}"`);
         shrinkwrapIsUpToDate = false;
       }

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -7,6 +7,7 @@ import { JsonFile, FileSystem, InternalError } from '@rushstack/node-core-librar
 
 import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 import { DependencySpecifier } from '../DependencySpecifier';
+import { PackageJsonEditor } from '../../api/PackageJsonEditor';
 
 interface INpmShrinkwrapDependencyJson {
   version: string;
@@ -129,10 +130,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /** @override */
-  protected getWorkspaceDependencyVersion(
-    dependencySpecifier: DependencySpecifier,
-    workspaceKey: string
-  ): DependencySpecifier | undefined {
+  public isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean {
     throw new InternalError('Not implemented');
   }
 }

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -7,7 +7,7 @@ import { JsonFile, FileSystem, InternalError } from '@rushstack/node-core-librar
 
 import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 import { DependencySpecifier } from '../DependencySpecifier';
-import { PackageJsonEditor } from '../../api/PackageJsonEditor';
+import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 
 interface INpmShrinkwrapDependencyJson {
   version: string;
@@ -130,7 +130,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /** @override */
-  public isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean {
+  public isWorkspaceProjectModified(project: RushConfigurationProject): boolean {
     throw new InternalError('Not implemented');
   }
 }

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -523,10 +523,11 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // First, get the unique package names and map them to package versions.
     const dependencyVersions: Map<string, PackageJsonDependency> = new Map();
     for (const packageDependency of [...packageJson.dependencyList, ...packageJson.devDependencyList]) {
-      // We will also filter out peer dependencies since these are not included by the shrinkwrap.
+      // We will also filter out peer dependencies since these are not installed at development time.
       if (packageDependency.dependencyType === DependencyType.Peer) {
         continue;
       }
+
       const foundDependency: PackageJsonDependency | undefined = dependencyVersions.get(
         packageDependency.name
       );

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -19,7 +19,6 @@ import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';
 import { RushConstants } from '../RushConstants';
 import { IExperimentsJson } from '../../api/ExperimentsConfiguration';
 import { DependencyType, PackageJsonEditor } from '../../api/PackageJsonEditor';
-import { InternalError } from '@rushstack/node-core-library';
 
 const yamlModule: typeof import('js-yaml') = Import.lazy('js-yaml', require);
 
@@ -518,7 +517,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   public isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean {
     const importer: IPnpmShrinkwrapImporterYaml | undefined = this.getWorkspaceImporter(workspaceKey);
     if (!importer) {
-      throw new InternalError(`Unable to find importer for workspace key "${workspaceKey}".`);
+      return true;
     }
 
     // First, get the unique package names and map them to package versions. We will also filter out peer

--- a/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { Sort, Text, Import } from '@rushstack/node-core-library';
+import { Sort, Import, Path } from '@rushstack/node-core-library';
 
 import { BaseWorkspaceFile } from '../base/BaseWorkspaceFile';
 import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';
@@ -54,7 +54,7 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
     }
 
     // Glob can't handle Windows paths
-    const globPath: string = Text.replaceAll(packagePath, '\\', '/');
+    const globPath: string = Path.convertToSlashes(packagePath);
     this._workspacePackages.add(globEscape(globPath));
   }
 

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -7,7 +7,7 @@ import { FileSystem, IParsedPackageNameOrError, InternalError, Import } from '@r
 import { RushConstants } from '../RushConstants';
 import { DependencySpecifier } from '../DependencySpecifier';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
-import { PackageJsonEditor } from '../../api/PackageJsonEditor';
+import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 
 /**
  * @yarnpkg/lockfile doesn't have types
@@ -277,7 +277,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /** @override */
-  public isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean {
+  public isWorkspaceProjectModified(project: RushConfigurationProject): boolean {
     throw new InternalError('Not implemented');
   }
 }

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -7,6 +7,7 @@ import { FileSystem, IParsedPackageNameOrError, InternalError, Import } from '@r
 import { RushConstants } from '../RushConstants';
 import { DependencySpecifier } from '../DependencySpecifier';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
+import { PackageJsonEditor } from '../../api/PackageJsonEditor';
 
 /**
  * @yarnpkg/lockfile doesn't have types
@@ -276,10 +277,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /** @override */
-  protected getWorkspaceDependencyVersion(
-    dependencySpecifier: DependencySpecifier,
-    workspaceKey: string
-  ): DependencySpecifier | undefined {
+  public isWorkspaceProjectModified(workspaceKey: string, packageJson: PackageJsonEditor): boolean {
     throw new InternalError('Not implemented');
   }
 }

--- a/common/changes/@microsoft/rush/user-danade-BetterModificationCheck_2021-04-27-01-23.json
+++ b/common/changes/@microsoft/rush/user-danade-BetterModificationCheck_2021-04-27-01-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use simpler and more accurate check before skipping installs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

A couple issues with the install state check were encountered recently in Rush workspaces:
- When only deletions are performed in package.json, the check would errantly allow for skipping install because we would only validate that the packages in package.json are present (and compatible) in the lockfile
- Merge issues in git repos that allow non-binary merge that became apparent after fixing a bug that would incidentally force merge conflicts (#2610)

## Details

The method used to determine whether or not the shrinkwrap is up-to-date was made to provide the same functionality as PNPM, which can be found here: [https://github.com/pnpm/pnpm/blob/main/packages/lockfile-utils/src/satisfiesPackageManifest.ts](https://github.com/pnpm/pnpm/blob/main/packages/lockfile-utils/src/satisfiesPackageManifest.ts)

This will allow for much increased accuracy on whether or not the shrinkwrap needs to be updated, reducing false positives and dev headaches with trying to force Rush to update. While we do provide a method to override this check (`--recheck`), this is not the most obvious. I briefly discussed with @iclanton if we should even be bothering with the "up-to-date" check in the case of updates, but this functionality is still useful and time-saving here as long as we assume that the check is _correct_.

## How it was tested

Tested in a large monorepo that contained a bad merge conflict that was passing through the existing "up-to-date" check when running `rush install` even though it was out-of-date. Once the changes were validated to match what PNPM reports, I ran `rush update` to update the shrinkwrap, and again ran `rush install` to validate that the check passing as expected.
