### PR TITLE
[debug-certificate-manager] Fix an issue where calling certmgr on Windows can sometimes fail to look up the executable's path correctly.

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/ianc-remove-where-from-dcm_2021-04-29-23-04.json
+++ b/common/changes/@rushstack/debug-certificate-manager/ianc-remove-where-from-dcm_2021-04-29-23-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix an issue where certmgr.exe sometimes could not be found on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Someone encountered the opposite of this issue https://github.com/microsoft/rushstack/pull/2571, where `Executable.spawn` attempted to call `C:\\Windows\\System32\\certmgr.exe\r\n`. This PR hands off looking up the path to `certmgr` entirely to `Executable.spawn`.

## Details

`Executable.spawn` effectively has a JS implementation of the `where` command on Windows, so the way `CertificateManager` was looking up the resolved path to `certmgr` was unnecessary, and was causing problems in certain situations. This PR removes the `where` lookup and instead just uses `Executable.spawn`.

## How it was tested

Tested locally on Windows. `certmgr` is correctly found and invoked.