### PR TITLE
[rush] Remove chokidar dependency

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -30,7 +30,6 @@
     "@rushstack/ts-command-line": "workspace:*",
     "@yarnpkg/lockfile": "~1.0.2",
     "builtin-modules": "~3.1.0",
-    "chokidar": "~3.4.0",
     "cli-table": "~0.3.1",
     "colors": "~1.2.1",
     "git-repo-info": "~2.1.0",

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Import, Path, Terminal } from '@rushstack/node-core-library';
+import * as fs from 'fs';
+import * as os from 'os';
+import { once } from 'events';
+import { Path, Terminal } from '@rushstack/node-core-library';
 
 import { PackageChangeAnalyzer } from './PackageChangeAnalyzer';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
-
-// Use lazy import because we don't need this immediately
-const chokidar: typeof import('chokidar') = Import.lazy('chokidar', require);
 
 export interface IProjectWatcherOptions {
   debounceMilliseconds?: number;
@@ -57,7 +57,7 @@ export class ProjectWatcher {
    * Will return immediately the first time it is invoked, since no state has been recorded.
    * If no change is currently present, watches the source tree of all selected projects for file changes.
    */
-  public async waitForChange(): Promise<IProjectChangeResult> {
+  public async waitForChange(onWatchingFiles?: () => void): Promise<IProjectChangeResult> {
     const initialChangeResult: IProjectChangeResult = await this._computeChanged();
     // Ensure that the new state is recorded so that we don't loop infinitely
     this._commitChanges(initialChangeResult.state);
@@ -65,20 +65,29 @@ export class ProjectWatcher {
       return initialChangeResult;
     }
 
-    const watcher: import('chokidar').FSWatcher = new chokidar.FSWatcher({
-      persistent: true,
-      cwd: Path.convertToSlashes(this._rushConfiguration.rushJsonFolder),
-      followSymlinks: false,
-      ignoreInitial: true,
-      ignored: /(?:^|[\\\/])node_modules/g,
-      disableGlobbing: true,
-      interval: 1000
-    });
+    const previousState: PackageChangeAnalyzer = initialChangeResult.state;
+    const repoRoot: string = Path.convertToSlashes(this._rushConfiguration.rushJsonFolder);
 
-    // Only watch for changes in the requested project folders
+    const pathsToWatch: Set<string> = new Set();
+
+    const isRecursiveSupported: boolean = os.platform() === 'win32';
+
     for (const project of this._projectsToWatch) {
-      watcher.add(Path.convertToSlashes(project.projectFolder));
+      const projectState: Map<string, string> = (await previousState.getPackageDeps(project.packageName, this._terminal))!;
+      const projectFolder: string = project.projectRelativeFolder;
+      // Watch files in the root of the project, or
+      for (const fileName of projectState.keys()) {
+        for (const pathToWatch of ProjectWatcher._enumeratePathsToWatch(
+          fileName,
+          projectFolder,
+          isRecursiveSupported
+        )) {
+          pathsToWatch.add(`${repoRoot}/${pathToWatch}`);
+        }
+      }
     }
+
+    const watchers: Map<string, fs.FSWatcher> = new Map();
 
     const watchedResult: IProjectChangeResult = await new Promise(
       (resolve: (result: IProjectChangeResult) => void, reject: (err: Error) => void) => {
@@ -115,10 +124,57 @@ export class ProjectWatcher {
           }
         };
 
-        watcher.on('all', () => {
+        const onError = (err: Error): void => {
+          if (terminated) {
+            return;
+          }
+
+          terminated = true;
+          reject(err);
+        };
+
+        const addWatcher = (
+          watchedPath: string,
+          listener: (event: string, fileName: string | Buffer) => void
+        ) => {
+          const watcher: fs.FSWatcher = fs.watch(
+            watchedPath,
+            {
+              encoding: 'utf-8',
+              recursive: isRecursiveSupported
+            },
+            listener
+          );
+          watchers.set(watchedPath, watcher);
+          watcher.on('error', (err) => {
+            watchers.delete(watchedPath);
+            onError(err);
+          });
+        };
+
+        const changeListener = (event: string, fileName: string | Buffer): void => {
           try {
             if (terminated) {
               return;
+            }
+
+            // Handling for added directories
+            if (!isRecursiveSupported) {
+              const decodedName: string = fileName && fileName.toString();
+              const normalizedName: string = decodedName && Path.convertToSlashes(decodedName);
+
+              if (normalizedName && !watchers.has(normalizedName)) {
+                try {
+                  const stat: fs.Stats = fs.statSync(fileName);
+                  if (stat.isDirectory()) {
+                    addWatcher(normalizedName, changeListener);
+                  }
+                } catch (err) {
+                  if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+                    throw err;
+                  }
+                }
+              }
             }
 
             // Use a timeout to debounce changes, e.g. bulk copying files into the directory while the watcher is running.
@@ -131,11 +187,29 @@ export class ProjectWatcher {
             terminated = true;
             reject(err);
           }
-        });
+        };
+
+        for (const pathToWatch of pathsToWatch) {
+          addWatcher(pathToWatch, changeListener);
+        }
+
+        if (onWatchingFiles) {
+          onWatchingFiles();
+        }
       }
     );
 
-    await watcher.close();
+    const closePromises: Promise<void>[] = [];
+    for (const [watchedPath, watcher] of watchers) {
+      closePromises.push(
+        once(watcher, 'close').then(() => {
+          watchers.delete(watchedPath);
+        })
+      );
+      watcher.close();
+    }
+
+    await Promise.all(closePromises);
 
     return watchedResult;
   }
@@ -200,5 +274,30 @@ export class ProjectWatcher {
     }
 
     return false;
+  }
+
+  private static *_enumeratePathsToWatch(
+    path: string,
+    projectRelativeFolder: string,
+    isRecursiveSupported: boolean
+  ): Iterable<string> {
+    const rootSlashIndex: number = path.indexOf('/', projectRelativeFolder.length + 2);
+
+    if (rootSlashIndex < 0) {
+      yield path;
+      return;
+    }
+
+    yield path.slice(0, rootSlashIndex);
+
+    if (isRecursiveSupported) {
+      return;
+    }
+
+    let slashIndex: number = path.lastIndexOf('/');
+    while (slashIndex > rootSlashIndex) {
+      yield path.slice(0, slashIndex);
+      slashIndex = path.lastIndexOf('/', slashIndex - 1);
+    }
   }
 }

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -31,6 +31,10 @@ export interface IProjectChangeResult {
 /**
  * This class is for incrementally watching a set of projects in the repository for changes.
  *
+ * We are manually using fs.watch() instead of `chokidar` because all we want from the file system watcher is a boolean
+ * signal indicating that "at least 1 file in a watched project changed". We then defer to PackageChangeAnalyzer (which
+ * is responsible for change detection in all incremental builds) to determine what actually chanaged.
+ *
  * Calling `waitForChange()` will return a promise that resolves when the package-deps of one or
  * more projects differ from the value the previous time it was invoked. The first time will always resolve with the full selection.
  */
@@ -138,7 +142,7 @@ export class ProjectWatcher {
         const addWatcher = (
           watchedPath: string,
           listener: (event: string, fileName: string | Buffer) => void
-        ) => {
+        ): void => {
           const watcher: fs.FSWatcher = fs.watch(
             watchedPath,
             {

--- a/common/changes/@microsoft/rush/remove-chokidar_2021-04-23-23-34.json
+++ b/common/changes/@microsoft/rush/remove-chokidar_2021-04-23-23-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Removed dependency on chokidar from BulkScriptAction in watch mode, since it adds unnecessary overhead.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -256,7 +256,6 @@ importers:
       '@types/z-schema': 3.16.31
       '@yarnpkg/lockfile': ~1.0.2
       builtin-modules: ~3.1.0
-      chokidar: ~3.4.0
       cli-table: ~0.3.1
       colors: ~1.2.1
       git-repo-info: ~2.1.0
@@ -295,7 +294,6 @@ importers:
       '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       '@yarnpkg/lockfile': 1.0.2
       builtin-modules: 3.1.0
-      chokidar: 3.4.3
       cli-table: 0.3.6
       colors: 1.2.5
       git-repo-info: 2.1.1

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ae73867dac98f9b3dd014c707ff81563d0924c93",
+  "pnpmShrinkwrapHash": "b19dc050ee3d9eca444ae6b1565ab3033b609873",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
The `chokidar` package provides a bunch of signal normalization that is redundant for the watch capabilities of rush, because the actual set of changed files is used purely as a boolean signal that is then handed off to the `PackageChangeAnalyzer` to determine what actually changed.

We already use `PackageChangeAnalyzer` (which is powered by `git diff` and is very, very fast) to determine the answer to "what changed" between incremental builds; as such, we prefer to also leverage it for the diffing in the watch case for consistent behavior.

This PR removes `chokidar` and replaces it with native `fs.watch` calls (carefully scoped to only watch directories), such that we can get a basic "hey, something (anything) changed, go poke git" notification as simply as possible.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Local verification that a custom command using watch mode still behaves as expected.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
