### PR TITLE
Replace deprecated node-sass with sass in gulp-core-build-sass

### DIFF
--- a/build-tests/web-library-build-test/src/test.sass
+++ b/build-tests/web-library-build-test/src/test.sass
@@ -1,5 +1,5 @@
 body
-  background: red;
+  background: red
 
 .foo
-  border: 1px solid red;
+  border: 1px solid red

--- a/common/changes/@microsoft/gulp-core-build-sass/keco-use-sass_2021-05-07-05-03.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/keco-use-sass_2021-05-07-05-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Replace deprecated node-sass with sass",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -9,10 +9,6 @@
     {
       "name": "react-dom",
       "allowedCategories": [ "tests" ]
-    },
-    {
-      "name": "sass",
-      "allowedCategories": [ "libraries" ]
     }
   ]
 }

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -9,6 +9,10 @@
     {
       "name": "react-dom",
       "allowedCategories": [ "tests" ]
+    },
+    {
+      "name": "sass",
+      "allowedCategories": [ "libraries" ]
     }
   ]
 }

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -695,6 +695,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "sass",
+      "allowedCategories": [ "libraries", "tests" ]
+    },
+    {
       "name": "sass-loader",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1151,9 +1151,9 @@ importers:
       autoprefixer: 9.8.6
       clean-css: 4.2.1
       glob: 7.0.6
-      node-sass: 5.0.0
       postcss: 7.0.32
       postcss-modules: 1.5.0
+      sass: 1.32.12
     devDependencies:
       '@microsoft/node-library-build': link:../node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
@@ -1162,7 +1162,7 @@ importers:
       '@types/clean-css': 4.2.1
       '@types/glob': 7.1.1
       '@types/jest': 25.2.1
-      '@types/node-sass': 4.11.1
+      '@types/sass': 1.16.0
       gulp: 4.0.2
       jest: 25.4.0
     specifiers:
@@ -1178,15 +1178,15 @@ importers:
       '@types/gulp': 4.0.6
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
-      '@types/node-sass': 4.11.1
+      '@types/sass': 1.16.0
       autoprefixer: ~9.8.0
       clean-css: 4.2.1
       glob: ~7.0.5
       gulp: ~4.0.2
       jest: ~25.4.0
-      node-sass: 5.0.0
       postcss: 7.0.32
       postcss-modules: ~1.5.0
+      sass: 1.32.12
   ../../core-build/gulp-core-build-serve:
     dependencies:
       '@microsoft/gulp-core-build': link:../gulp-core-build
@@ -3868,6 +3868,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  /@types/sass/1.16.0:
+    dependencies:
+      '@types/node': 10.17.13
+    dev: true
+    resolution:
+      integrity: sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
   /@types/semver/7.3.5:
     resolution:
       integrity: sha512-iotVxtCCsPLRAvxMFFgxL8HD2l4mAZ2Oin7/VJ2ooWO0VOK4EGOGmZWZn1uCq7RofR3I/1IOSjCHlFT71eVK0Q==
@@ -12060,6 +12066,15 @@ packages:
         optional: true
     resolution:
       integrity: sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==
+  /sass/1.32.12:
+    dependencies:
+      chokidar: 3.4.3
+    dev: false
+    engines:
+      node: '>=8.9.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==
   /sax/1.2.4:
     resolution:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -15153,3 +15168,4 @@ packages:
       commander: 2.20.3
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
+registry: ''

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1b5156e7e0bf08ebe892b023a0092c3efa98d8be",
+  "pnpmShrinkwrapHash": "fecca34741b404d4edfed8a8f39da5224b4dc815",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -21,7 +21,7 @@
     "autoprefixer": "~9.8.0",
     "clean-css": "4.2.1",
     "glob": "~7.0.5",
-    "node-sass": "5.0.0",
+    "sass": "1.32.12",
     "postcss": "7.0.32",
     "postcss-modules": "~1.5.0"
   },
@@ -33,7 +33,7 @@
     "@types/clean-css": "4.2.1",
     "@types/glob": "7.1.1",
     "@types/jest": "25.2.1",
-    "@types/node-sass": "4.11.1",
+    "@types/sass": "1.16.0",
     "gulp": "~4.0.2",
     "jest": "~25.4.0"
   }

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -9,7 +9,7 @@ import { GulpTask } from '@microsoft/gulp-core-build';
 import { splitStyles } from '@microsoft/load-themed-styles';
 import { FileSystem, JsonFile, LegacyAdapters, JsonObject } from '@rushstack/node-core-library';
 import * as glob from 'glob';
-import * as nodeSass from 'node-sass';
+import * as sass from 'sass';
 import * as postcss from 'postcss';
 import * as CleanCss from 'clean-css';
 import * as autoprefixer from 'autoprefixer';
@@ -153,7 +153,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       cssOutputPathAbsolute = path.join(this.buildConfig.rootPath, cssOutputPath);
     }
 
-    return LegacyAdapters.convertCallbackToPromise(nodeSass.render, {
+    return LegacyAdapters.convertCallbackToPromise(sass.render, {
       file: filePath,
       importer: (url: string) => ({ file: this._patchSassUrl(url) }),
       sourceMap: this.taskConfig.dropCssFiles,
@@ -161,11 +161,11 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       omitSourceMapUrl: true,
       outFile: cssOutputPath
     })
-      .catch((error: nodeSass.SassError) => {
+      .catch((error: sass.SassException) => {
         this.fileError(filePath, error.line, error.column, error.name, error.message);
         throw new Error(error.message);
       })
-      .then((result: nodeSass.Result) => {
+      .then((result: sass.Result) => {
         const options: postcss.ProcessOptions = {
           from: filePath
         };


### PR DESCRIPTION
Addresses #1666. `node-sass` has been deprecated and `dart-sass` via `sass` is the recommended replacement moving forward.

> Warning: LibSass and Node Sass are deprecated. While they will continue to receive maintenance releases indefinitely, there are no plans to add additional features or compatibility with any new CSS or Sass features. Projects that still use it should move onto Dart Sass.
> https://github.com/sass/node-sass/blob/master/README.md#node-sass

This change will remove `node-sass`'s `node-gyp` `postInstall` scripts from `gulp-core-build-sass` which can cause issues with future Node releases. It will allow for the use of newer SASS features such as the [@use](https://sass-lang.com/documentation/at-rules/use) keyword by third-party developers.

Based on my grep, first-party tooling has moved to `sass-loader` which recommends `dart-sass` also.
