### PR TITLE
[rush-lib] Add CI skipping to default version & changelog commits

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -266,7 +266,7 @@
      * you might configure your system's trigger to look for a special string such as "[skip-ci]"
      * in the commit message, and then customize Rush's message to contain that string.
      */
-    /*[LINE "DEMO"]*/ "versionBumpCommitMessage": "Applying package updates. [skip-ci]",
+    /*[LINE "DEMO"]*/ "versionBumpCommitMessage": "Bump versions [skip ci]",
 
     /**
      * The commit message to use when committing changes during 'rush version'.
@@ -275,7 +275,7 @@
      * you might configure your system's trigger to look for a special string such as "[skip-ci]"
      * in the commit message, and then customize Rush's message to contain that string.
      */
-    /*[LINE "DEMO"]*/ "changeLogUpdateCommitMessage": "Deleting change files and updating change logs for package updates. [skip-ci]"
+    /*[LINE "DEMO"]*/ "changeLogUpdateCommitMessage": "Update changelogs [skip ci]"
   },
 
   "repository": {

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -18,9 +18,8 @@ import { Git } from '../../logic/Git';
 import type * as VersionManagerTypes from '../../logic/VersionManager';
 const versionManagerModule: typeof VersionManagerTypes = Import.lazy('../../logic/VersionManager', require);
 
-export const DEFAULT_PACKAGE_UPDATE_MESSAGE: string = 'Applying package updates.';
-export const DEFAULT_CHANGELOG_UPDATE_MESSAGE: string =
-  'Deleting change files and updating change logs for package updates.';
+export const DEFAULT_PACKAGE_UPDATE_MESSAGE: string = 'Bump versions [skip ci]';
+export const DEFAULT_CHANGELOG_UPDATE_MESSAGE: string = 'Update changelogs [skip ci]';
 
 export class VersionAction extends BaseRushAction {
   private _ensureVersionPolicy!: CommandLineFlagParameter;

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -174,11 +174,11 @@
           "type": "string"
         },
         "versionBumpCommitMessage": {
-          "description": "The commit message to use when committing changes during \"rush publish\". Defaults to \"Applying package updates.\"",
+          "description": "The commit message to use when committing changes during \"rush publish\". Defaults to \"Bump versions [skip ci]\"",
           "type": "string"
         },
         "changeLogUpdateCommitMessage": {
-          "description": "The commit message to use when committing change log files \"rush version\". Defaults to \"Deleting change files and updating change logs for package updates.\"",
+          "description": "The commit message to use when committing change log files \"rush version\". Defaults to \"Update changelogs [skip ci]\"",
           "type": "string"
         }
       },

--- a/common/changes/@microsoft/rush/default-ci-skip_2021-05-08-17-28.json
+++ b/common/changes/@microsoft/rush/default-ci-skip_2021-05-08-17-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add CI skipping to default version & changelog commits",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "hi@olivierlacan.com"
+}


### PR DESCRIPTION
I apologize for not opening an issue, but considering this was a simple change suggestion that mostly involved prose, it was more effort to explain than implement.

This PR addresses two issues:
- Rush commits for version bumps and changelog updates are too
generic, and don't use imperative.
- These commits aren't skipped by CI system by default which triggers infinite 
CI job loops out of the box.

You could argue that the CI skipping trigger statement (I'm avoiding referencing it directly in this commit to not have this commit be skipped, see [this prior issue for context][2]) could be included but not in the title of the commit. I 
would argue that people might miss that they're intended not to trigger a CI run and be confused as to why they don't since most CI provider respects these skip triggers in any part of the commit message.

The way I rewrote the Rush commits is more philosophical in nature. I didn't set up our original CI/CD pipeline at work and I genuinely had no idea whether GitLab was creating those commits or Rush until it was my turn to configure a new build pipeline.

## Version Bump commit

> Applying package updates.

While technically correct, it does absolutely nothing to describe the actual changeset of the commit itself: version numbers. I believe this change is much clearer: 

> Bump versions [skip ci]

It's also common language in open source projects.

## Changelog commit

> Deleting change files and updating change logs for package updates.

When it comes to the changelog commit, I find that newer commit message worse. It's far too long. So long it wraps by being longer (67 characters) than most git commit message title standards (50 characters max).

It's also strange that both commits include a period, which is unnecessary. I understand these commits are customizable, but good defaults go a long way.

The change is very much "what it says on the tin" applied to a commit:
> Update changelogs [skip ci]

The added advantage is that these skip triggers allow Rush commits to be easily differentiated from other commits in the history as well.

For reference, [Chris Beams offers good longer form explanations on his blog][1] on why imperative mood and no punctuation makes sense.

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/microsoft/rushstack/issues/1030#issuecomment-455902057