### PR TITLE
[heft] Fix the relative path in the "sources" parameter in .js.map files

### DIFF
--- a/common/changes/@rushstack/heft/user-ianc-fix-sourcemaps_2021-05-11-19-50.json
+++ b/common/changes/@rushstack/heft/user-ianc-fix-sourcemaps_2021-05-11-19-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix the \"sources\" paths in emitted sourcemap files.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Currently there is an issue with the `"sources"` parameter in `.js.map` files emitted to `lib` folders by Heft. This PR fixes the relative paths emitted to that parameter.

## Details

Currently, the output to `/build-tests/heft-node-everything-test/lib/index.js.map` looks like this:

```JSON
{
  "version": 3,
  "file": "index.js",
  "sourceRoot": "",
  "sources": ["../../../src/index.ts"],
  "names": [],
  "mappings": ";AAAA,4FAA4F;AAC5F,2DAA2D;;;AAE3D;;GAEG;AACH,MAAa,SAAS;CAAG,CAAC,kCAAkC;AAA5D,8BAAyB",
  "sourcesContent": [
    "// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.\r\n// See LICENSE in the project root for license information.\r\n\r\n/**\r\n * @public\r\n */\r\nexport class TestClass {} // tslint:disable-line:export-name\r\n"
  ]
}
```

Notice that the path (`../../../src/index.ts`) in the `"sources"` property does not point to the correct original TS source file, relative to the `lib/index.js.map` file. Instead, it's relative to the `.heft/build-cache/lib/index.js.map` file. This can cause problems for tools like Webpack's `source-map-loader`.

This PR makes the TypeScript unaware that it's emitting files to something other than the `outDir` specified in `tsconfig.json`, so it produces correct relative paths in sourcemaps.

## How it was tested

Built the `heft-node-everything-test` project locally and confirmed that this issue no longer repros.