### PR TITLE
[heft] Fix an issue where Heft would return only the sourcemap if the compiled .js file is missing the sourceMappingURL comment.

### DIFF
--- a/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
+++ b/apps/heft/src/plugins/JestPlugin/jest-build-transform.ts
@@ -178,9 +178,19 @@ export function process(
     const encodedSourceMap: string =
       'data:application/json;charset=utf-8;base64,' +
       Buffer.from(correctedSourceMap, 'utf8').toString('base64');
-    const stringToFind: string = 'sourceMappingURL=';
-    const libCodeWithSourceMap: string =
-      libCode.slice(0, libCode.lastIndexOf(stringToFind) + stringToFind.length) + encodedSourceMap;
+
+    const sourceMappingUrlToken: string = 'sourceMappingURL=';
+    const sourceMappingCommentIndex: number = libCode.lastIndexOf(sourceMappingUrlToken);
+    let libCodeWithSourceMap: string;
+    if (sourceMappingCommentIndex !== -1) {
+      libCodeWithSourceMap =
+        libCode.slice(0, sourceMappingCommentIndex + sourceMappingUrlToken.length) + encodedSourceMap;
+    } else {
+      // If there isn't a sourceMappingURL comment, inject one
+      const sourceMapComment: string =
+        (libCode.endsWith('\n') ? '' : '\n') + `//# ${sourceMappingUrlToken}${encodedSourceMap}`;
+      libCodeWithSourceMap = libCode + sourceMapComment;
+    }
 
     return libCodeWithSourceMap;
   } else {

--- a/common/changes/@rushstack/heft/ianc-fix-heft-jest-transform-issue_2021-05-13-01-18.json
+++ b/common/changes/@rushstack/heft/ianc-fix-heft-jest-transform-issue_2021-05-13-01-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where Heft would return only the sourcemap if the compiled .js file is missing the sourceMappingURL comment.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

If the `.js` files in `lib` (or `lib-commonjs`) are missing the `//# sourceMappingURL=...` comments, the `jest-build-transform` transformer will erroneously return only the encoded sourcemap instead of the JS code + the sourcemap.

## Details

Heft currently assumes that the JS files it loads for its Jest transformer end with a `//# sourceMappingURL=...` comment. If that comment is missing, the transformer will incorrectly split the compiled JS and return only the encoded sourcemap, leading to a very confusing error.

This fix injects the comment if one doesn't exist, in addition to handling the case where the comment does exist.

## How it was tested

Tested by replacing the `jest-build-transform.js` script in a repro experiencing this problem.