### PR TITLE
[node-core-library] Add `ignoreUndefinedValues` option to JsonFile serialization APIs

### DIFF
--- a/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
+++ b/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add `dropUndefinedValues` option to JSONFile to discard keys with undefined values during serialization, i.e. the standard behavior of JSON.stringify() and other JSON serializers.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
+++ b/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add `ignoreUndefinedValues` option to JSONFile to discard keys with undefined values during serialization, i.e. the standard behavior of JSON.stringify() and other JSON serializers.",
+      "comment": "Add `ignoreUndefinedValues` option to JsonFile to discard keys with undefined values during serialization; this is the standard behavior of `JSON.stringify()` and other JSON serializers.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
+++ b/common/changes/@rushstack/node-core-library/json-file-undefined_2021-05-13-21-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add `dropUndefinedValues` option to JSONFile to discard keys with undefined values during serialization, i.e. the standard behavior of JSON.stringify() and other JSON serializers.",
+      "comment": "Add `ignoreUndefinedValues` option to JSONFile to discard keys with undefined values during serialization, i.e. the standard behavior of JSON.stringify() and other JSON serializers.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -424,6 +424,7 @@ export interface IJsonFileSaveOptions extends IJsonFileStringifyOptions {
 
 // @public
 export interface IJsonFileStringifyOptions {
+    dropUndefinedValues?: boolean;
     headerComment?: string;
     newlineConversion?: NewlineKind;
     prettyFormatting?: boolean;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -424,8 +424,8 @@ export interface IJsonFileSaveOptions extends IJsonFileStringifyOptions {
 
 // @public
 export interface IJsonFileStringifyOptions {
-    dropUndefinedValues?: boolean;
     headerComment?: string;
+    ignoreUndefinedValues?: boolean;
     newlineConversion?: NewlineKind;
     prettyFormatting?: boolean;
 }

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -53,7 +53,7 @@ export interface IJsonFileStringifyOptions {
    * If true, conforms to the standard behavior of JSON.stringify() when a property has the value `undefined`.
    * Specifically, the key will be dropped from the emitted object.
    */
-  dropUndefinedValues?: boolean;
+  ignoreUndefinedValues?: boolean;
 
   /**
    * If true, then the "jju" library will be used to improve the text formatting.
@@ -236,7 +236,7 @@ export class JsonFile {
       options = {};
     }
 
-    if (!options.dropUndefinedValues) {
+    if (!options.ignoreUndefinedValues) {
       // Standard handling of `undefined` in JSON stringification is to discard the key.
       JsonFile.validateNoUndefinedMembers(newJsonObject);
     }

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -50,6 +50,12 @@ export interface IJsonFileStringifyOptions {
   newlineConversion?: NewlineKind;
 
   /**
+   * If true, conforms to the standard behavior of JSON.stringify() when a property has the value `undefined`.
+   * Specifically, the key will be dropped from the emitted object.
+   */
+  dropUndefinedValues?: boolean;
+
+  /**
    * If true, then the "jju" library will be used to improve the text formatting.
    * Note that this is slightly slower than the native JSON.stringify() implementation.
    */
@@ -230,7 +236,10 @@ export class JsonFile {
       options = {};
     }
 
-    JsonFile.validateNoUndefinedMembers(newJsonObject);
+    if (!options.dropUndefinedValues) {
+      // Standard handling of `undefined` in JSON stringification is to discard the key.
+      JsonFile.validateNoUndefinedMembers(newJsonObject);
+    }
 
     let stringified: string;
 

--- a/libraries/node-core-library/src/test/JsonFile.test.ts
+++ b/libraries/node-core-library/src/test/JsonFile.test.ts
@@ -32,7 +32,7 @@ describe('JsonFile tests', () => {
       JsonFile.stringify(
         { abc: undefined },
         {
-          dropUndefinedValues: true
+          ignoreUndefinedValues: true
         }
       )
     ).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe('JsonFile tests', () => {
       JsonFile.stringify(
         { abc: undefined },
         {
-          dropUndefinedValues: true,
+          ignoreUndefinedValues: true,
           prettyFormatting: true
         }
       )

--- a/libraries/node-core-library/src/test/JsonFile.test.ts
+++ b/libraries/node-core-library/src/test/JsonFile.test.ts
@@ -27,4 +27,14 @@ describe('JsonFile tests', () => {
       )
     ).toMatchSnapshot();
   });
+  it('allows undefined values when asked', () => {
+    expect(
+      JsonFile.stringify(
+        { abc: undefined },
+        {
+          dropUndefinedValues: true
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/libraries/node-core-library/src/test/JsonFile.test.ts
+++ b/libraries/node-core-library/src/test/JsonFile.test.ts
@@ -36,5 +36,15 @@ describe('JsonFile tests', () => {
         }
       )
     ).toMatchSnapshot();
+
+    expect(
+      JsonFile.stringify(
+        { abc: undefined },
+        {
+          dropUndefinedValues: true,
+          prettyFormatting: true
+        }
+      )
+    ).toMatchSnapshot();
   });
 });

--- a/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
@@ -20,3 +20,8 @@ exports[`JsonFile tests allows undefined values when asked 1`] = `
 "{}
 "
 `;
+
+exports[`JsonFile tests allows undefined values when asked 2`] = `
+"{}
+"
+`;

--- a/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
@@ -15,3 +15,8 @@ exports[`JsonFile tests adds an empty header comment 1`] = `
 }
 "
 `;
+
+exports[`JsonFile tests allows undefined values when asked 1`] = `
+"{}
+"
+`;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Adds a configuration option `ignoreUndefinedValues` to the JsonFile serialization APIs to make their behavior consistent with `JSON.stringify()` for the common case of setting values to be discarded as `undefined`. This is generally preferred because the `delete` operator is notoriously bad for performance.

## Details
The underlying APIs already drop keys with `undefined` values, the JsonFile class added an extra validation layer in front of serialization that turned this standard behavior into an error. Passing `ignoreUndefinedValues: true` in the options simply turns off this extra validation and defers to `JSON.stringify()` or `jju.stringify()`.

## How it was tested
Added unit test cases for keys with `undefined` as their value and the `ignoreUndefinedValues: true` option.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

Edited: `dropUndefinedValues` -> `ignoreUndefinedValues`