### PR TITLE
[rush] Fix an issue where "rushx" CLI parameters were not escaped properly

### DIFF
--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -107,8 +107,8 @@ export class RushXCommandLine {
       let commandWithArgs: string = scriptBody;
       let commandWithArgsForDisplay: string = scriptBody;
       if (remainingArgs.length > 0) {
-        // This escaping is based on what PNPM does here:
-        // https://github.com/pnpm/pnpm/blob/a468d2b3f8e4a456b3e57ad8a013af65b29c0484/packages/lifecycle/src/runLifecycleHook.ts#L38
+        // This approach is based on what NPM 7 now does:
+        // https://github.com/npm/run-script/blob/47a4d539fb07220e7215cc0e482683b76407ef9b/lib/run-script-pkg.js#L34
         const escapedRemainingArgs: string[] = remainingArgs.map((x) => Utilities.escapeShellParameter(x));
 
         commandWithArgs += ' ' + escapedRemainingArgs.join(' ');

--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -103,12 +103,21 @@ export class RushXCommandLine {
       }
 
       const remainingArgs: string[] = args.slice(1);
+
       let commandWithArgs: string = scriptBody;
+      let commandWithArgsForDisplay: string = scriptBody;
       if (remainingArgs.length > 0) {
-        commandWithArgs += ' ' + remainingArgs.join(' ');
+        // This escaping is based on what PNPM does here:
+        // https://github.com/pnpm/pnpm/blob/a468d2b3f8e4a456b3e57ad8a013af65b29c0484/packages/lifecycle/src/runLifecycleHook.ts#L38
+        const escapedRemainingArgs: string[] = remainingArgs.map((x) => Utilities.escapeShellParameter(x));
+
+        commandWithArgs += ' ' + escapedRemainingArgs.join(' ');
+
+        // Display it nicely without the extra quotes
+        commandWithArgsForDisplay += ' ' + remainingArgs.join(' ');
       }
 
-      console.log('Executing: ' + JSON.stringify(commandWithArgs) + os.EOL);
+      console.log('Executing: ' + JSON.stringify(commandWithArgsForDisplay) + os.EOL);
 
       const packageFolder: string = path.dirname(packageJsonFilePath);
 

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -464,7 +464,9 @@ export class Utilities {
    * Example: 'hello there' --> '"hello there"'
    */
   public static escapeShellParameter(parameter: string): string {
-    return `"${parameter}"`;
+    // This approach is based on what NPM 7 now does:
+    // https://github.com/npm/run-script/blob/47a4d539fb07220e7215cc0e482683b76407ef9b/lib/run-script-pkg.js#L34
+    return JSON.stringify(parameter);
   }
 
   /**

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -854,6 +854,9 @@ export class Utilities {
     if (result.error && (result.error as any).errno === 'ENOENT') {
       // This is a workaround for GitHub issue #25330
       // https://github.com/nodejs/node-v0.x-archive/issues/25330
+      //
+      // TODO: The fully worked out solution for this problem is now provided by the "Executable" API
+      // from @rushstack/node-core-library
       result = child_process.spawnSync(command + '.cmd', args, options);
     }
 

--- a/common/changes/@microsoft/rush/octogonz-rush-issue2695_2021-05-14-22-10.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-issue2695_2021-05-14-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rushx\" CLI arguments were not escaped properly (GitHub #2695)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes #2695

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

 

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

The test CLI was:
```bash
$ rushx action a b "c&d"
```

I tried this on Windows+CMD.exe and Linux+Bash and confirmed that the invoked `process.argv` matches what we would get from `npm run`.

On Linux we can also do:
```bash
$ rushx action a b\" c
```

**Update:** My implementation uses `JSON.stringify()` based on NPM's implementation.  Originally I was using a method based on PNPM's implementation, but I found that `pnpm run` does not properly escape the second case.


<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
