### PR TITLE
[heft] Emit an error if two different TypeScript module kinds are to be emitted to nested folders.

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -888,7 +888,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
     }
 
     outFolderPath = Path.convertToSlashes(outFolderPath);
-    outFolderPath = outFolderPath.replace(/(\/*)$/, '/'); // Ensure the outFolderPath ends with a slash
+    outFolderPath = outFolderPath.replace(/\/*$/, '/'); // Ensure the outFolderPath ends with a slash
 
     for (const existingModuleKindToEmit of this._moduleKindsToEmit) {
       let errorText: string | undefined;

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -857,15 +857,17 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
             `Output folder "${additionalModuleKindToEmit.outFolderName}" already contains module kind ${existingDir.kind} with extension '${existingDir.extension}', specified by option ${existingDir.reason}.`
           );
         } else {
-          const outFolderKey: string = this._addModuleKindToEmit(
+          const outFolderKey: string | undefined = this._addModuleKindToEmit(
             moduleKind,
             additionalModuleKindToEmit.outFolderName,
             /* isPrimary */ false,
             undefined
           );
 
-          specifiedKinds.set(moduleKind, moduleKindReason);
-          specifiedOutDirs.set(outFolderKey, moduleKindReason);
+          if (outFolderKey) {
+            specifiedKinds.set(moduleKind, moduleKindReason);
+            specifiedOutDirs.set(outFolderKey, moduleKindReason);
+          }
         }
       }
     }
@@ -876,7 +878,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
     outFolderPath: string,
     isPrimary: boolean,
     jsExtensionOverride: string | undefined
-  ): string {
+  ): string | undefined {
     let outFolderName: string;
     if (path.isAbsolute(outFolderPath)) {
       outFolderName = path.relative(this._configuration.buildFolder, outFolderPath);
@@ -885,8 +887,45 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       outFolderPath = path.resolve(this._configuration.buildFolder, outFolderPath);
     }
 
+    outFolderPath = Path.convertToSlashes(outFolderPath);
+    outFolderPath = outFolderPath.replace(/(\/*)$/, '/'); // Ensure the outFolderPath ends with a slash
+
+    for (const existingModuleKindToEmit of this._moduleKindsToEmit) {
+      let errorText: string | undefined;
+
+      if (existingModuleKindToEmit.outFolderPath === outFolderPath) {
+        if (existingModuleKindToEmit.jsExtensionOverride === jsExtensionOverride) {
+          errorText =
+            'Unable to output two different module kinds with the same ' +
+            `module extension (${jsExtensionOverride || '.js'}) to the same ` +
+            `folder ("${outFolderPath}").`;
+        }
+      } else {
+        let parentFolder: string | undefined;
+        let childFolder: string | undefined;
+        if (outFolderPath.startsWith(existingModuleKindToEmit.outFolderPath)) {
+          parentFolder = outFolderPath;
+          childFolder = existingModuleKindToEmit.outFolderPath;
+        } else if (existingModuleKindToEmit.outFolderPath.startsWith(outFolderPath)) {
+          parentFolder = existingModuleKindToEmit.outFolderPath;
+          childFolder = outFolderPath;
+        }
+
+        if (parentFolder) {
+          errorText =
+            'Unable to output two different module kinds to nested folders ' +
+            `("${parentFolder}" and "${childFolder}").`;
+        }
+      }
+
+      if (errorText) {
+        this._typescriptLogger.emitError(new Error(errorText));
+        return undefined;
+      }
+    }
+
     this._moduleKindsToEmit.push({
-      outFolderPath: Path.convertToSlashes(outFolderPath),
+      outFolderPath,
       moduleKind,
       cacheOutFolderPath: Path.convertToSlashes(
         path.resolve(this._configuration.buildCacheFolder, outFolderName)

--- a/common/changes/@rushstack/heft/ianc-check-for-nested-output-folders_2021-05-21-19-24.json
+++ b/common/changes/@rushstack/heft/ianc-check-for-nested-output-folders_2021-05-21-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Emit an error if two different TypeScript module kinds are to be emitted to nested folders.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ianc-check-for-nested-output-folders_2021-05-21-19-24.json
+++ b/common/changes/@rushstack/heft/ianc-check-for-nested-output-folders_2021-05-21-19-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "Emit an error if two different TypeScript module kinds are to be emitted to nested folders.",
+      "comment": "Report an error to prevent two different TypeScript module kinds from being emitted into nested folders",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
## Summary

Addresses an issue identified in https://github.com/microsoft/rushstack/issues/2704.

## Details

Currently Heft silently misbehaves if TypeScript is configured to emit two different module kinds to nested folders (i.e. - esnext to `lib` and CommonJS to `lib/cjs`). This PR adds a check for that scenario and emits an error when it is encountered.

## How it was tested

Tested by changing the [`outFolderName`](https://github.com/microsoft/rushstack/blob/master/build-tests/heft-webpack4-everything-test/config/typescript.json#L33) in `heft-webpack4-everything-test` to `lib/commonjs` and `lib` and verifying that there is an error.