### PR TITLE
[rush] The "rushx" command should warn if invoked in a leftover project folder

### DIFF
--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -60,8 +60,14 @@ export class RushXCommandLine {
         return;
       }
 
-      if (rushConfiguration && !rushConfiguration?.tryGetProjectForPath(process.cwd())) {
-        console.log(colors.yellow('Warning: You are running rushx under a Rush repo but current project is not registered to Rush config.'));
+      if (rushConfiguration && !rushConfiguration.tryGetProjectForPath(process.cwd())) {
+        // GitHub #2713: Users reported confusion resulting from a situation where "rush install"
+        // did not install the project's dependencies, because the project was not registered.
+        console.log(
+          colors.yellow(
+            'Warning: You are invoking "rushx" inside a Rush repository, but this project is not registered in rush.json.'
+          )
+        );
       }
 
       const packageJson: IPackageJson = packageJsonLookup.loadPackageJson(packageJsonFilePath);

--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -60,6 +60,10 @@ export class RushXCommandLine {
         return;
       }
 
+      if (rushConfiguration && !rushConfiguration?.tryGetProjectForPath(process.cwd())) {
+        console.log(colors.yellow('Warning: You are running rushx under a Rush repo but current project is not registered to Rush config.'));
+      }
+
       const packageJson: IPackageJson = packageJsonLookup.loadPackageJson(packageJsonFilePath);
 
       const projectCommandSet: ProjectCommandSet = new ProjectCommandSet(packageJson);

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -46,11 +46,14 @@ describe('CLI', () => {
       'node',
       [startPath, 'show-args', '1', '2', '-x'],
       path.join(__dirname, 'repo', 'rushx-not-in-rush-project')
-    )
+    );
 
+    console.log(output);
 
-    console.log(output)
-
-    expect(output).toEqual(expect.stringMatching('Warning: You are running rushx under a Rush repo but current project is not registered to Rush config.'));
+    expect(output).toEqual(
+      expect.stringMatching(
+        'Warning: You are invoking "rushx" inside a Rush repository, but this project is not registered in rush.json.'
+      )
+    );
   });
 });

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -37,4 +37,20 @@ describe('CLI', () => {
         .pop() || '';
     expect(lastLine).toEqual('build.js: ARGS=["1","2","-x"]');
   });
+
+  it('rushx should fail in un-rush project', () => {
+    // Invoke "rushx"
+    const startPath: string = path.resolve(path.join(__dirname, '../../../lib/startx.js'));
+
+    const output = Utilities.executeCommandAndCaptureOutput(
+      'node',
+      [startPath, 'show-args', '1', '2', '-x'],
+      path.join(__dirname, 'repo', 'rushx-not-in-rush-project')
+    )
+
+
+    console.log(output)
+
+    expect(output).toEqual(expect.stringMatching('Warning: You are running rushx under a Rush repo but current project is not registered to Rush config.'));
+  });
 });

--- a/apps/rush-lib/src/cli/test/repo/rush.json
+++ b/apps/rush-lib/src/cli/test/repo/rush.json
@@ -1,5 +1,10 @@
 {
   "pnpmVersion": "4.5.0",
   "rushVersion": "5.0.0",
-  "projects": []
+  "projects": [
+    {
+      "packageName": "rushx-project",
+      "projectFolder": "rushx-project"
+    }
+  ]
 }

--- a/apps/rush-lib/src/cli/test/repo/rushx-not-in-rush-project/build.js
+++ b/apps/rush-lib/src/cli/test/repo/rushx-not-in-rush-project/build.js
@@ -1,0 +1,2 @@
+// slice(2) trims away "node.exe" and "build.js" from the array
+console.log('build.js: ARGS=' + JSON.stringify(process.argv.slice(2)));

--- a/apps/rush-lib/src/cli/test/repo/rushx-not-in-rush-project/package.json
+++ b/apps/rush-lib/src/cli/test/repo/rushx-not-in-rush-project/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rushx-not-in-rush-project",
+  "version": "0.0.0",
+  "scripts": {
+    "show-args": "node ./build.js"
+  }
+}

--- a/common/changes/@microsoft/rush/feat-add-rushx-project-check_2021-05-26-03-12.json
+++ b/common/changes/@microsoft/rush/feat-add-rushx-project-check_2021-05-26-03-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "add rush project check before rushx command",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "m1heng@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/feat-add-rushx-project-check_2021-05-26-03-12.json
+++ b/common/changes/@microsoft/rush/feat-add-rushx-project-check_2021-05-26-03-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "add rush project check before rushx command",
+      "comment": "The \"rushx\" command now reports a warning when invoked in a project folder that is not registered in rush.json",
       "type": "none"
     }
   ],


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

add check before rushx 

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Before 'rushx' is executed, check wether current project is one of the projects from rush.json

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

should fail in project which is not in rush.json

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
