### PR TITLE
Add Jest data sourced from Typescript into the build properties

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -275,11 +275,17 @@ export class TypeScriptPlugin implements IHeftPlugin {
       maxWriteParallelism: typeScriptConfiguration.maxWriteParallelism
     };
 
+    // Set some properties used by the Jest plugin
     JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, {
       emitFolderNameForTests: typeScriptConfiguration.emitFolderNameForTests || 'lib',
       skipTimestampCheck: !options.watchMode,
       extensionForTests: typeScriptConfiguration.emitCjsExtensionForCommonJS ? '.cjs' : '.js'
     });
+
+    buildProperties.emitFolderNameForTests = typeScriptConfiguration.emitFolderNameForTests || 'lib';
+    buildProperties.emitExtensionForTests = typeScriptConfiguration.emitCjsExtensionForCommonJS
+      ? '.cjs'
+      : '.js';
 
     const callbacksForTsconfigs: Set<() => void> = new Set<() => void>();
     function getFirstEmitCallbackForTsconfig(): () => void {

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -125,6 +125,7 @@ export class BuildStageHooks extends StageHooksBase<IBuildStageProperties> {
  * @public
  */
 export interface IBuildStageProperties {
+  // Input
   production: boolean;
   lite: boolean;
   locale?: string;
@@ -132,6 +133,10 @@ export interface IBuildStageProperties {
   watchMode: boolean;
   serveMode: boolean;
   webpackStats?: unknown;
+
+  // Output
+  emitFolderNameForTests?: string;
+  emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
 }
 
 /**

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -135,7 +135,13 @@ export interface IBuildStageProperties {
   webpackStats?: unknown;
 
   // Output
+  /**
+   * @beta
+   */
   emitFolderNameForTests?: string;
+  /**
+   * @beta
+   */
   emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
 }
 

--- a/common/changes/@rushstack/heft/user-danade-PrepareForJestPlugin_2021-05-27-23-11.json
+++ b/common/changes/@rushstack/heft/user-danade-PrepareForJestPlugin_2021-05-27-23-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Prepare to split JestPlugin into a dedicated package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -86,13 +86,6 @@
       "~0.6.1" // API Extractor is using an older version of source-map because newer versions are async
     ],
 
-    "@rushstack/heft": [
-      // This is needed for the rush-stack-compiler-x.x projects which cannot build using
-      // the latest Heft due to a regression from PR #2073 that prevents the same plugin from
-      // being applied multiple times
-      "0.8.0"
-    ],
-
     "webpack": ["~5.35.1"],
 
     // Use two different versions of @types/webpack-dev-server to allow pnpmfile.js to bring in

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -111,6 +111,10 @@ export interface IBuildStageContext extends IStageContext<BuildStageHooks, IBuil
 // @public (undocumented)
 export interface IBuildStageProperties {
     // (undocumented)
+    emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
+    // (undocumented)
+    emitFolderNameForTests?: string;
+    // (undocumented)
     lite: boolean;
     // (undocumented)
     locale?: string;

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -110,9 +110,9 @@ export interface IBuildStageContext extends IStageContext<BuildStageHooks, IBuil
 
 // @public (undocumented)
 export interface IBuildStageProperties {
-    // (undocumented)
+    // @beta (undocumented)
     emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
-    // (undocumented)
+    // @beta (undocumented)
     emitFolderNameForTests?: string;
     // (undocumented)
     lite: boolean;


### PR DESCRIPTION
## Summary

Add Jest data to the `IBuildProperties`, such that the `JestPlugin` can be split out from the parent `@rushstack/heft` package and into it's own.

## Details

In attempting to split the `JestPlugin` out into it's own package, we will need to set some build properties that can be passed through the `HeftSession` into the plugin. Since the split-out `JestPlugin` will need to build using the `heft-node-rig`, which itself will _also_ depend on `JestPlugin` (to include in the default rig), we need to make both `heft` and `heft-node-rig` be cyclic dependencies of the new package. This change is being made in advance of those changes (along with a publish run of `heft`) in order to prepare to split JestPlugin out.

## How it was tested

Build and validation in PR. Change is simply adding (not moving) data to a new place that is not yet consumed elsewhere.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
