### PR TITLE
[heft] Prevent NodeServicePlugin from running with "heft build --watch"

### DIFF
--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -109,6 +109,11 @@ export class NodeServicePlugin implements IHeftPlugin {
     this._logger = heftSession.requestScopedLogger('node-service');
 
     heftSession.hooks.build.tap(PLUGIN_NAME, (build: IBuildStageContext) => {
+      if (!build.properties.serveMode) {
+        // This plugin is only used with "heft start"
+        return;
+      }
+
       build.hooks.loadStageConfiguration.tapPromise(PLUGIN_NAME, async () => {
         await this._loadStageConfiguration(heftConfiguration);
 

--- a/common/changes/@rushstack/heft/octogonz-heft-start-fix_2021-06-01-18-08.json
+++ b/common/changes/@rushstack/heft/octogonz-heft-start-fix_2021-06-01-18-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where NodeServicePlugin launched the service when \"heft build --watch\" was invoked",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

`heft start` should launch the service.

`heft build --watch` should NOT launch the service.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

 

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Tested using a local project that encountered this issue.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
