### PR TITLE
[node-core-library] Remove the copyFileToManyAsync API

### DIFF
--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -161,14 +161,14 @@ export class CopyFilesPlugin implements IHeftPlugin {
       async (copyDescriptor: ICopyFileDescriptor) => {
         if (copyDescriptor.hardlink) {
           linkedFileCount++;
-          return FileSystem.createHardLinkAsync({
+          await FileSystem.createHardLinkAsync({
             linkTargetPath: copyDescriptor.sourceFilePath,
             newLinkPath: copyDescriptor.destinationFilePath,
             alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
           });
         } else {
           copiedFileCount++;
-          return FileSystem.copyFileAsync({
+          await FileSystem.copyFileAsync({
             sourcePath: copyDescriptor.sourceFilePath,
             destinationPath: copyDescriptor.destinationFilePath,
             alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -36,7 +36,7 @@ const HEFT_STAGE_TAP: TapOptions<'promise'> = {
 
 interface ICopyFileDescriptor {
   sourceFilePath: string;
-  destinationFilePaths: string[];
+  destinationFilePath: string;
   hardlink: boolean;
 }
 
@@ -135,7 +135,7 @@ export class CopyFilesPlugin implements IHeftPlugin {
       return;
     }
 
-    const { copiedFileCount, linkedFileCount } = await this.copyFilesAsync(copyDescriptors);
+    const { copiedFileCount, linkedFileCount } = await this._copyFilesAsync(copyDescriptors);
     const duration: number = performance.now() - startTime;
     logger.terminal.writeLine(
       `Copied ${copiedFileCount} file${copiedFileCount === 1 ? '' : 's'} and ` +
@@ -148,7 +148,7 @@ export class CopyFilesPlugin implements IHeftPlugin {
     }
   }
 
-  protected async copyFilesAsync(copyDescriptors: ICopyFileDescriptor[]): Promise<ICopyFilesResult> {
+  private async _copyFilesAsync(copyDescriptors: ICopyFileDescriptor[]): Promise<ICopyFilesResult> {
     if (copyDescriptors.length === 0) {
       return { copiedFileCount: 0, linkedFileCount: 0 };
     }
@@ -160,35 +160,19 @@ export class CopyFilesPlugin implements IHeftPlugin {
       Constants.maxParallelism,
       async (copyDescriptor: ICopyFileDescriptor) => {
         if (copyDescriptor.hardlink) {
-          const hardlinkPromises: Promise<void>[] = copyDescriptor.destinationFilePaths.map(
-            (destinationFilePath) => {
-              return FileSystem.createHardLinkAsync({
-                linkTargetPath: copyDescriptor.sourceFilePath,
-                newLinkPath: destinationFilePath,
-                alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
-              });
-            }
-          );
-          await Promise.all(hardlinkPromises);
-
           linkedFileCount++;
+          return FileSystem.createHardLinkAsync({
+            linkTargetPath: copyDescriptor.sourceFilePath,
+            newLinkPath: copyDescriptor.destinationFilePath,
+            alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
+          });
         } else {
-          // If it's a copy, we will call the copy function
-          if (copyDescriptor.destinationFilePaths.length === 1) {
-            await FileSystem.copyFileAsync({
-              sourcePath: copyDescriptor.sourceFilePath,
-              destinationPath: copyDescriptor.destinationFilePaths[0],
-              alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
-            });
-          } else {
-            await FileSystem.copyFileToManyAsync({
-              sourcePath: copyDescriptor.sourceFilePath,
-              destinationPaths: copyDescriptor.destinationFilePaths,
-              alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
-            });
-          }
-
           copiedFileCount++;
+          return FileSystem.copyFileAsync({
+            sourcePath: copyDescriptor.sourceFilePath,
+            destinationPath: copyDescriptor.destinationFilePath,
+            alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
+          });
         }
       }
     );
@@ -203,11 +187,11 @@ export class CopyFilesPlugin implements IHeftPlugin {
     buildFolder: string,
     copyConfigurations: IResolvedDestinationCopyConfiguration[]
   ): Promise<ICopyFileDescriptor[]> {
-    // Create a map to deduplicate and prevent double-writes. The key in this map is the copy/link destination
-    // file path
+    const processedCopyDescriptors: ICopyFileDescriptor[] = [];
+
+    // Create a map to deduplicate and prevent double-writes
+    // resolvedDestinationFilePath -> descriptor
     const destinationCopyDescriptors: Map<string, ICopyFileDescriptor> = new Map();
-    // And a map to contain the actual results. The key in this map is the copy/link source file path
-    const sourceCopyDescriptors: Map<string, ICopyFileDescriptor> = new Map();
 
     for (const copyConfiguration of copyConfigurations) {
       // Resolve the source folder path which is where the glob will be run from
@@ -248,28 +232,20 @@ export class CopyFilesPlugin implements IHeftPlugin {
             );
           }
 
-          // Finally, add to the map and default hardlink to false
-          let sourceCopyDescriptor: ICopyFileDescriptor | undefined =
-            sourceCopyDescriptors.get(resolvedSourceFilePath);
-          if (!sourceCopyDescriptor) {
-            sourceCopyDescriptor = {
-              sourceFilePath: resolvedSourceFilePath,
-              destinationFilePaths: [resolvedDestinationFilePath],
-              hardlink: !!copyConfiguration.hardlink
-            };
-            sourceCopyDescriptors.set(resolvedSourceFilePath, sourceCopyDescriptor);
-          } else {
-            sourceCopyDescriptor.destinationFilePaths.push(resolvedDestinationFilePath);
-          }
-
-          // Add to other map to allow deduping
-          destinationCopyDescriptors.set(resolvedDestinationFilePath, sourceCopyDescriptor);
+          // Finally, default hardlink to false, add to the result, and add to the map for deduping
+          const processedCopyDescriptor: ICopyFileDescriptor = {
+            sourceFilePath: resolvedSourceFilePath,
+            destinationFilePath: resolvedDestinationFilePath,
+            hardlink: !!copyConfiguration.hardlink
+          };
+          processedCopyDescriptors.push(processedCopyDescriptor);
+          destinationCopyDescriptors.set(resolvedDestinationFilePath, processedCopyDescriptor);
         }
       }
     }
 
     // We're done with the map, grab the values and return
-    return Array.from(sourceCopyDescriptors.values());
+    return processedCopyDescriptors;
   }
 
   private _getIncludedGlobPatterns(copyConfiguration: IExtendedSharedCopyConfiguration): string[] {
@@ -319,20 +295,18 @@ export class CopyFilesPlugin implements IHeftPlugin {
         });
 
         const copyAsset: (relativeAssetPath: string) => Promise<void> = async (relativeAssetPath: string) => {
-          const { copiedFileCount, linkedFileCount } = await this.copyFilesAsync([
-            {
-              sourceFilePath: path.join(resolvedSourceFolderPath, relativeAssetPath),
-              destinationFilePaths: copyConfiguration.resolvedDestinationFolderPaths.map(
-                (resolvedDestinationFolderPath) => {
-                  return path.join(
-                    resolvedDestinationFolderPath,
-                    copyConfiguration.flatten ? path.basename(relativeAssetPath) : relativeAssetPath
-                  );
-                }
-              ),
-              hardlink: !!copyConfiguration.hardlink
-            }
-          ]);
+          const { copiedFileCount, linkedFileCount } = await this._copyFilesAsync(
+            copyConfiguration.resolvedDestinationFolderPaths.map((resolvedDestinationFolderPath) => {
+              return {
+                sourceFilePath: path.join(resolvedSourceFolderPath, relativeAssetPath),
+                destinationFilePath: path.join(
+                  resolvedDestinationFolderPath,
+                  copyConfiguration.flatten ? path.basename(relativeAssetPath) : relativeAssetPath
+                ),
+                hardlink: !!copyConfiguration.hardlink
+              };
+            })
+          );
           logger.terminal.writeLine(
             copyConfiguration.hardlink
               ? `Linked ${linkedFileCount} file${linkedFileCount === 1 ? '' : 's'}`
@@ -340,16 +314,20 @@ export class CopyFilesPlugin implements IHeftPlugin {
           );
         };
 
+        const deleteAsset: (relativeAssetPath: string) => Promise<void> = async (relativeAssetPath) => {
+          const deletePromises: Promise<void>[] = copyConfiguration.resolvedDestinationFolderPaths.map(
+            (resolvedDestinationFolderPath) =>
+              FileSystem.deleteFileAsync(path.resolve(resolvedDestinationFolderPath, relativeAssetPath))
+          );
+          await Promise.all(deletePromises);
+          logger.terminal.writeLine(
+            `Deleted ${deletePromises.length} file${deletePromises.length === 1 ? '' : 's'}`
+          );
+        };
+
         watcher.on('add', copyAsset);
         watcher.on('change', copyAsset);
-        watcher.on('unlink', (relativeAssetPath) => {
-          let deleteCount: number = 0;
-          for (const resolvedDestinationFolderPath of copyConfiguration.resolvedDestinationFolderPaths) {
-            FileSystem.deleteFile(path.resolve(resolvedDestinationFolderPath, relativeAssetPath));
-            deleteCount++;
-          }
-          logger.terminal.writeLine(`Deleted ${deleteCount} file${deleteCount === 1 ? '' : 's'}`);
-        });
+        watcher.on('unlink', deleteAsset);
       }
     }
 

--- a/common/changes/@rushstack/heft/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
+++ b/common/changes/@rushstack/heft/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix bug in CopyFilesPlugin that caused 0-length files to be generated",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Deprecate copyFileToManyAsync API. It was determined that this API was a likely source of 0-length file copies. Recommended replacement is to call copyFileAsync.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-DeprecateCopyFilesToMany_2021-06-04-18-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Deprecate copyFileToManyAsync API. It was determined that this API was a likely source of 0-length file copies. Recommended replacement is to call copyFileAsync.",
+      "comment": "BREAKING CHANGE: Remove FileSystem.copyFileToManyAsync API. It was determined that this API was a likely source of 0-length file copies. Recommended replacement is to call copyFileAsync.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -191,7 +191,6 @@ export class FileSystem {
     static copyFileAsync(options: IFileSystemCopyFileOptions): Promise<void>;
     static copyFiles(options: IFileSystemCopyFilesOptions): void;
     static copyFilesAsync(options: IFileSystemCopyFilesOptions): Promise<void>;
-    static copyFileToManyAsync(options: IFileSystemCopyFileToManyOptions): Promise<void>;
     static createHardLink(options: IFileSystemCreateLinkOptions): void;
     static createHardLinkAsync(options: IFileSystemCreateLinkOptions): Promise<void>;
     static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void;
@@ -341,11 +340,6 @@ export interface IFileSystemCopyFilesAsyncOptions {
 // @public
 export interface IFileSystemCopyFilesOptions extends IFileSystemCopyFilesAsyncOptions {
     filter?: FileSystemCopyFilesFilter;
-}
-
-// @public
-export interface IFileSystemCopyFileToManyOptions extends IFileSystemCopyFileBaseOptions {
-    destinationPaths: string[];
 }
 
 // @public

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -67,7 +67,6 @@ export {
   IFileSystemCopyFileOptions,
   IFileSystemCopyFilesAsyncOptions,
   IFileSystemCopyFilesOptions,
-  IFileSystemCopyFileToManyOptions,
   IFileSystemCreateLinkOptions,
   IFileSystemDeleteFileOptions,
   IFileSystemMoveOptions,


### PR DESCRIPTION
## Summary

Fixes #2724

An investigation performed by @octogonz in #2724 has led to the likely conclusion that reading/writing to multiple streams is likely the culprit causing 0-length files. Additionally, the API itself likely provided little real-world benefit given that it relies on the Node Stream APIs, while the actual file copy APIs use libuv. Given these, it seemed best to just remove the broken `copyFileToManyAsync` API and replace it with parallelized calls to `copyFileAsync` in the `CopyFilesPlugin`.

## Details

- Removed the `copyFileToManyAsync` API completely due to the broken state
- Replaced usage with a combination of `Async.forEachAsync` and `FileSystem.copyFileAsync` in `CopyFilesPlugin`.

## How it was tested

Ran rebuild in projects using the plugin to confirm that the copy files plugin was continuing to copy static assets as expected.
