### PR TITLE
[heft] Populate `IBuildStageProperties.isTypeScriptProject` in the `TypeScriptPlugin`

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -298,6 +298,12 @@ export class TypeScriptPlugin implements IHeftPlugin {
     };
 
     // Set some properties used by the Jest plugin
+    JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, {
+      emitFolderNameForTests: typeScriptConfiguration.emitFolderNameForTests || 'lib',
+      skipTimestampCheck: !options.watchMode,
+      extensionForTests: typeScriptConfiguration.emitCjsExtensionForCommonJS ? '.cjs' : '.js'
+    });
+
     buildProperties.emitFolderNameForTests = typeScriptConfiguration.emitFolderNameForTests || 'lib';
     buildProperties.emitExtensionForTests = typeScriptConfiguration.emitCjsExtensionForCommonJS
       ? '.cjs'

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -234,11 +234,10 @@ export class TypeScriptPlugin implements IHeftPlugin {
       }
     );
 
-    if (tsconfigPaths.length === 0) {
+    buildProperties.isTypeScriptProject = tsconfigPaths.length > 0;
+    if (!buildProperties.isTypeScriptProject) {
       // If there are no TSConfigs, we have nothing to do
       return;
-    } else {
-      buildProperties.isTypeScriptProject = true;
     }
 
     const typeScriptConfiguration: ITypeScriptConfiguration = {

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -238,7 +238,7 @@ export class TypeScriptPlugin implements IHeftPlugin {
       // If there are no TSConfigs, we have nothing to do
       return;
     } else {
-      buildProperties.isTypescriptProject = true;
+      buildProperties.isTypeScriptProject = true;
     }
 
     const typeScriptConfiguration: ITypeScriptConfiguration = {

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -237,6 +237,8 @@ export class TypeScriptPlugin implements IHeftPlugin {
     if (tsconfigPaths.length === 0) {
       // If there are no TSConfigs, we have nothing to do
       return;
+    } else {
+      buildProperties.isTypescriptProject = true;
     }
 
     const typeScriptConfiguration: ITypeScriptConfiguration = {
@@ -296,12 +298,6 @@ export class TypeScriptPlugin implements IHeftPlugin {
     };
 
     // Set some properties used by the Jest plugin
-    JestTypeScriptDataFile.saveForProject(heftConfiguration.buildFolder, {
-      emitFolderNameForTests: typeScriptConfiguration.emitFolderNameForTests || 'lib',
-      skipTimestampCheck: !options.watchMode,
-      extensionForTests: typeScriptConfiguration.emitCjsExtensionForCommonJS ? '.cjs' : '.js'
-    });
-
     buildProperties.emitFolderNameForTests = typeScriptConfiguration.emitFolderNameForTests || 'lib';
     buildProperties.emitExtensionForTests = typeScriptConfiguration.emitCjsExtensionForCommonJS
       ? '.cjs'

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -140,7 +140,7 @@ export interface IBuildStageProperties {
   /**
    * @beta
    */
-  isTypescriptProject?: boolean;
+  isTypeScriptProject?: boolean;
   /**
    * @beta
    */

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -140,6 +140,10 @@ export interface IBuildStageProperties {
   /**
    * @beta
    */
+  isTypescriptProject?: boolean;
+  /**
+   * @beta
+   */
   emitFolderNameForTests?: string;
   /**
    * @beta

--- a/common/changes/@rushstack/heft/user-danade-AddIsTypescriptProperty_2021-06-04-18-38.json
+++ b/common/changes/@rushstack/heft/user-danade-AddIsTypescriptProperty_2021-06-04-18-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add IBuildStage output property 'isTypeScriptProject' and populate in TypeScriptPlugin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -116,6 +116,8 @@ export interface IBuildStageProperties {
     emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
     // @beta (undocumented)
     emitFolderNameForTests?: string;
+    // @beta (undocumented)
+    isTypeScriptProject?: boolean;
     // (undocumented)
     lite: boolean;
     // (undocumented)


### PR DESCRIPTION
## Summary

Add `IBuildStageProperties.isTypeScriptProject` output property and populate in the `TypeScriptPlugin`. This will be used in #2721 to eventually f.ix (avoiding auto-resolve) #2711 (thanks @idahogurl !!) in a method consistent with @iclanton 's comment here: https://github.com/microsoft/rushstack/pull/2711#issuecomment-854080989
