### PR TITLE
Feat rush upgrade self

### DIFF
--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -43,6 +43,7 @@ import { RushGlobalFolder } from '../api/RushGlobalFolder';
 import { NodeJsCompatibility } from '../logic/NodeJsCompatibility';
 import { SetupAction } from './actions/SetupAction';
 import { EnvironmentConfiguration } from '../api/EnvironmentConfiguration';
+import { UpgradeSelfAction } from './actions/UpgradeSelfAction';
 
 /**
  * Options for `RushCommandLineParser`.
@@ -178,6 +179,7 @@ export class RushCommandLineParser extends CommandLineParser {
       this.addAction(new UpdateAction(this));
       this.addAction(new UpdateAutoinstallerAction(this));
       this.addAction(new UpdateCloudCredentialsAction(this));
+      this.addAction(new UpgradeSelfAction(this));
       this.addAction(new VersionAction(this));
       this.addAction(new WriteBuildCacheAction(this));
 

--- a/apps/rush-lib/src/cli/actions/UpgradeSelfAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpgradeSelfAction.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'os';
+import colors from 'colors/safe';
+
+import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import { Import } from '@rushstack/node-core-library';
+import { BaseRushAction } from './BaseRushAction';
+import { RushCommandLineParser } from '../RushCommandLineParser';
+import { UpgradeRushSelf } from '../../logic/UpgradeRushSelf';
+
+import type * as inquirerTypes from 'inquirer';
+const inquirer: typeof inquirerTypes = Import.lazy('inquirer', require);
+
+export class UpgradeSelfAction extends BaseRushAction {
+  private _debugFlag!: CommandLineFlagParameter;
+  private _skipUpdateFlag!: CommandLineFlagParameter;
+
+  public constructor(parser: RushCommandLineParser) {
+    super({
+      actionName: 'upgrade-self',
+      summary: 'Upgrade rush version in current repository',
+      documentation:
+        'The "rush upgrade-self" command is used to upgrade rush version in current repository.' +
+        'It helps maintainer to upgrade rushVersion in rush.json, settle down the versions of the' +
+        ' dependency of rush self, and update lockfile in autoinstallers if changed.',
+      parser
+    });
+  }
+
+  protected onDefineParameters(): void {
+    this._debugFlag = this.defineFlagParameter({
+      parameterLongName: '--debug',
+      description: 'Show the full call stack if an error occurs while executing the tool'
+    });
+    this._skipUpdateFlag = this.defineFlagParameter({
+      parameterLongName: '--skip-update',
+      parameterShortName: '-s',
+      description:
+        'If specified, the "rush update" command will not be run after updating the package.json files.'
+    });
+  }
+
+  protected async runAsync(): Promise<void> {
+    const upgradeRushSelf: UpgradeRushSelf = new UpgradeRushSelf({
+      rushConfiguration: this.rushConfiguration,
+      isDebug: this._debugFlag.value
+    });
+
+    const { needRushUpdate } = await upgradeRushSelf.upgrade();
+
+    if (needRushUpdate && !this._skipUpdateFlag.value) {
+      const promptModule: inquirerTypes.PromptModule = inquirer.createPromptModule();
+      const { confirmRushUpdate } = await promptModule({
+        type: 'confirm',
+        name: 'confirmRushUpdate',
+        message: `Confirm run rush update?`
+      });
+      if (confirmRushUpdate) {
+        await this._runRushUpdate();
+      } else {
+        console.log();
+        console.log(colors.yellow('package.json changes, please run rush update by yourself :)'));
+      }
+    }
+
+    console.log(os.EOL + colors.green(`Rush version upgrade successfully`));
+  }
+
+  private async _runRushUpdate(): Promise<boolean> {
+    const parser: RushCommandLineParser = new RushCommandLineParser();
+    return await parser.execute(['update']);
+  }
+}

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -53,6 +53,7 @@ Positional arguments:
     update-cloud-credentials
                         (EXPERIMENTAL) Update the credentials used by the 
                         build cache provider.
+    upgrade-self        Upgrade rush version in current repository
     version             Manage package versions in the repo.
     write-build-cache   Writes the current state of the current project to 
                         the cache.
@@ -1090,6 +1091,23 @@ Optional arguments:
   --credential CREDENTIAL_STRING
                         A static credential, to be cached.
   -d, --delete          If specified, delete stored credentials.
+"
+`;
+
+exports[`CommandLineHelp prints the help for each action: upgrade-self 1`] = `
+"usage: rush upgrade-self [-h] [--debug] [-s]
+
+The \\"rush upgrade-self\\" command is used to upgrade rush version in current 
+repository.It helps maintainer to upgrade rushVersion in rush.json, settle 
+down the versions of the dependency of rush self, and update lockfile in 
+autoinstallers if changed.
+
+Optional arguments:
+  -h, --help         Show this help message and exit.
+  --debug            Show the full call stack if an error occurs while 
+                     executing the tool
+  -s, --skip-update  If specified, the \\"rush update\\" command will not be run 
+                     after updating the package.json files.
 "
 `;
 

--- a/apps/rush-lib/src/logic/UpgradeRushSelf.ts
+++ b/apps/rush-lib/src/logic/UpgradeRushSelf.ts
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import * as semver from 'semver';
+import * as child_process from 'child_process';
+import colors from 'colors/safe';
+import {
+  ConsoleTerminalProvider,
+  Executable,
+  FileSystem,
+  Import,
+  InternalError,
+  JsonFile,
+  JsonObject,
+  Terminal
+} from '@rushstack/node-core-library';
+
+import { RushConfiguration } from '../api/RushConfiguration';
+import type * as inquirerTypes from 'inquirer';
+import { Autoinstaller } from './Autoinstaller';
+const inquirer: typeof inquirerTypes = Import.lazy('inquirer', require);
+
+export interface IUpgradeRushSelfOptions {
+  rushConfiguration: RushConfiguration;
+  isDebug: boolean;
+}
+
+export interface IUpgradeResult {
+  needRushUpdate: boolean;
+}
+
+export class UpgradeRushSelf {
+  private readonly _rushConfiguration: RushConfiguration;
+  private readonly _terminal: Terminal;
+  private readonly _isDebug: boolean = false;
+
+  public constructor(options: IUpgradeRushSelfOptions) {
+    this._rushConfiguration = options.rushConfiguration;
+    this._isDebug = options.isDebug;
+    this._terminal = new Terminal(
+      new ConsoleTerminalProvider({
+        verboseEnabled: options.isDebug
+      })
+    );
+  }
+
+  public getAvaiableRushVersions(): string[] {
+    this._terminal.writeLine('Fetching rush versions');
+
+    const { versions }: { versions: string[] } = this._npmView('@microsoft/rush');
+    if (!Array.isArray(versions)) {
+      throw new Error('Get @microsoft/rush versions incorrectly');
+    }
+
+    return versions;
+  }
+
+  public async upgrade(): Promise<IUpgradeResult> {
+    const versions: string[] = this.getAvaiableRushVersions();
+
+    const promptModule: inquirerTypes.PromptModule = inquirer.createPromptModule();
+    const { version } = await promptModule({
+      type: 'list',
+      name: 'version',
+      message: `Select a version to upgrade`,
+      choices: versions.sort((a, b) => semver.rcompare(a, b))
+    });
+
+    // update rush.json
+    const rushJsonFile: string = this._rushConfiguration.rushJsonFile;
+    const json: JsonObject = JsonFile.load(rushJsonFile);
+    if (json.rushVersion === version) {
+      console.log();
+      console.log(colors.yellow(`upgrading same rush version: ${version}`));
+      return {
+        needRushUpdate: false
+      };
+    }
+    json.rushVersion = version;
+    JsonFile.save(json, rushJsonFile, { updateExistingFile: true, onlyIfChanged: true });
+    if (this._isDebug) {
+      console.log(colors.gray(`upgrade rushVersion in rush.json to ${version}`));
+    }
+
+    const dependencies: Record<string, string> = this._npmView(`@microsoft/rush@${version}`, 'dependencies');
+    const targetPackageNames: string[] = Object.keys(dependencies).filter(
+      (k) => k.startsWith('@microsoft/') || k.startsWith('@rushstack/')
+    );
+    let needRushUpdate: boolean = false;
+    if (targetPackageNames.length) {
+      const targetPackages: Record<string, string> = {};
+      for (const packageName of targetPackageNames) {
+        targetPackages[packageName] = dependencies[packageName];
+      }
+
+      for (const project of this._rushConfiguration.projects) {
+        const packageJsonFile: string = path.resolve(project.projectFolder, 'package.json');
+        const packageJson: JsonObject = JsonFile.load(packageJsonFile);
+        for (const [k, v] of Object.entries(targetPackages)) {
+          if ('dependencies' in packageJson && k in packageJson.dependencies) {
+            packageJson.dependencies[k] = v;
+          }
+          if ('devDependencies' in packageJson && k in packageJson.devDependencies) {
+            packageJson.devDependencies[k] = v;
+          }
+        }
+
+        const saved: boolean = JsonFile.save(packageJson, packageJsonFile, {
+          updateExistingFile: true,
+          onlyIfChanged: true
+        });
+        if (saved) {
+          if (this._isDebug) {
+            console.log(colors.gray(`${project.packageName} package.json changed`));
+          }
+          needRushUpdate = true;
+        }
+      }
+
+      // autoinstallers
+      const autoinstallerNames: string[] = FileSystem.readFolder(
+        this._rushConfiguration.commonAutoinstallersFolder
+      );
+      for (const autoinstallerName of autoinstallerNames) {
+        const autoinstaller: Autoinstaller = new Autoinstaller(autoinstallerName, this._rushConfiguration);
+        const packageJsonFile: string = autoinstaller.packageJsonPath;
+        const packageJson: JsonObject = JsonFile.load(packageJsonFile);
+        for (const [k, v] of Object.entries(targetPackages)) {
+          if ('dependencies' in packageJson && k in packageJson.dependencies) {
+            packageJson.dependencies[k] = v;
+          }
+          if ('devDependencies' in packageJson && k in packageJson.devDependencies) {
+            packageJson.devDependencies[k] = v;
+          }
+        }
+
+        const saved: boolean = JsonFile.save(packageJson, packageJsonFile, {
+          updateExistingFile: true,
+          onlyIfChanged: true
+        });
+
+        if (saved) {
+          autoinstaller.update();
+          if (this._isDebug) {
+            console.log(colors.gray(`autoinstaller ${autoinstallerName} updated`));
+          }
+        }
+      }
+    }
+
+    return {
+      needRushUpdate
+    };
+  }
+
+  private _npmView(packageIdentifier: string, key?: string): JsonObject {
+    const npmArgs: string[] = ['view', '--json', packageIdentifier];
+    if (key) {
+      npmArgs.push(key);
+    }
+    const result: child_process.SpawnSyncReturns<string> = Executable.spawnSync('npm', npmArgs, {
+      currentWorkingDirectory: this._rushConfiguration.commonRushConfigFolder,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Wait at most 10 seconds for "npm view" to succeed
+      timeoutMs: 10 * 1000
+    });
+    this._terminal.writeLine();
+    // (This is not exactly correct, for example Node.js puts a string in error.errno instead of a string.)
+    const error: (Error & Partial<NodeJS.ErrnoException>) | undefined = result.error;
+
+    if (error) {
+      if (error.code === 'ETIMEDOUT') {
+        // For example, an incorrect "https-proxy" setting can hang for a long time
+        throw new Error('The "npm view" command timed out; check your .npmrc file for an incorrect setting');
+      }
+
+      throw new Error('Error invoking "npm view": ' + result.error);
+    }
+
+    // NPM 6.x writes to stdout
+    let jsonContent: string | undefined = UpgradeRushSelf._tryFindJson(result.stdout);
+    if (jsonContent === undefined) {
+      // NPM 7.x writes dirty output to stderr; see https://github.com/npm/cli/issues/2740
+      jsonContent = UpgradeRushSelf._tryFindJson(result.stderr);
+    }
+    if (jsonContent === undefined) {
+      throw new InternalError('The "npm view" command did not return a JSON structure');
+    }
+
+    let jsonOutput: JsonObject;
+    try {
+      jsonOutput = JSON.parse(jsonContent);
+    } catch (error) {
+      this._terminal.writeVerboseLine('NPM response:\n\n--------\n' + jsonContent + '\n--------\n\n');
+      throw new InternalError('The "npm view" command returned an invalid JSON structure');
+    }
+    const errorCode: JsonObject = jsonOutput?.error?.code;
+    if (errorCode) {
+      this._terminal.writeVerboseLine('NPM response:\n' + JSON.stringify(jsonOutput, undefined, 2) + '\n\n');
+      throw new Error(`The "npm view" command returned an error code "${errorCode}"`);
+    }
+
+    return jsonOutput;
+  }
+
+  /**
+   * This is a workaround for https://github.com/npm/cli/issues/2740 where the NPM tool sometimes
+   * mixes together JSON and terminal messages in a single STDERR stream.
+   *
+   * @remarks
+   * Given an input like this:
+   * ```
+   * npm ERR! 404 Note that you can also install from a
+   * npm ERR! 404 tarball, folder, http url, or git url.
+   * {
+   *   "error": {
+   *     "code": "E404",
+   *     "summary": "Not Found - GET https://registry.npmjs.org/@rushstack%2fnonexistent-package - Not found"
+   *   }
+   * }
+   * npm ERR! A complete log of this run can be found in:
+   * ```
+   *
+   * @returns the JSON section, or `undefined` if a JSON object could not be detected
+   */
+  private static _tryFindJson(dirtyOutput: string): string | undefined {
+    const lines: string[] = dirtyOutput.split(/\r?\n/g);
+    let startIndex: number | undefined;
+    let endIndex: number | undefined;
+
+    // Find the first line that starts with "{"
+    for (let i: number = 0; i < lines.length; ++i) {
+      const line: string = lines[i];
+      if (/^\s*\{/.test(line)) {
+        startIndex = i;
+        break;
+      }
+    }
+    if (startIndex === undefined) {
+      return undefined;
+    }
+
+    // Find the last line that ends with "}"
+    for (let i: number = lines.length - 1; i >= startIndex; --i) {
+      const line: string = lines[i];
+      if (/\}\s*$/.test(line)) {
+        endIndex = i;
+        break;
+      }
+    }
+
+    if (endIndex === undefined) {
+      return undefined;
+    }
+
+    return lines.slice(startIndex, endIndex + 1).join('\n');
+  }
+}

--- a/apps/rush-lib/src/logic/buildCache/test/__snapshots__/AzureStorageBuildCacheProvider.test.ts.snap
+++ b/apps/rush-lib/src/logic/buildCache/test/__snapshots__/AzureStorageBuildCacheProvider.test.ts.snap
@@ -14,6 +14,4 @@ Array [
 ]
 `;
 
-exports[`AzureStorageBuildCacheProvider Uses a correct list of Azure authority hosts 1`] = `"The specified Azure Environment (\\"INCORRECT_AZURE_ENVIRONMENT\\") is invalid. If it is specified, it must be one of: AzureChina, AzureGermany, AzureGovernment, AzurePublicCloud"`;
-
 exports[`AzureStorageBuildCacheProvider uses a correct list of Azure authority hosts 1`] = `"The specified Azure Environment (\\"INCORRECT_AZURE_ENVIRONMENT\\") is invalid. If it is specified, it must be one of: AzureChina, AzureGermany, AzureGovernment, AzurePublicCloud"`;

--- a/common/changes/@microsoft/rush/feat-rush-upgrade-self_2021-06-07-13-06.json
+++ b/common/changes/@microsoft/rush/feat-rush-upgrade-self_2021-06-07-13-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "add rush upgrade-self action",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chengcyber@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

add feature for: https://github.com/microsoft/rushstack/issues/2635

## Details

Add `rush upgrade-self` command line

1. fetch `microsoft/rush` versions with npm
2. prompt user to select a version
3. setup specified version into `rush.json`
4. retrieve all package.json in rush projects to update dependencies like `@microsoft/rush-lib`, `rushstack/node-core-library`
5. retrieve all autoinstallers' package.json to update dependencies as well, update lockfile if necessary
6. prompt user to `rush update`

## How it was tested

Tested local
