### PR TITLE
Disable allowUnreachableCode in tsconfig-base in the Heft rigs.

### DIFF
--- a/apps/rush-lib/src/logic/LinkManagerFactory.ts
+++ b/apps/rush-lib/src/logic/LinkManagerFactory.ts
@@ -16,8 +16,8 @@ export class LinkManagerFactory {
       case 'yarn':
         // Yarn uses the same node_modules structure as NPM
         return new NpmLinkManager(rushConfiguration);
+      default:
+        throw new Error(`Unsupported package manager: ${rushConfiguration.packageManager}`);
     }
-
-    throw new Error(`Unsupported package manager: ${rushConfiguration.packageManager}`);
   }
 }

--- a/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
+++ b/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
@@ -24,7 +24,8 @@ export class ShrinkwrapFileFactory {
         );
       case 'yarn':
         return YarnShrinkwrapFile.loadFromFile(shrinkwrapFilename);
+      default:
+        throw new Error(`Invalid package manager: ${packageManager}`);
     }
-    throw new Error(`Invalid package manager: ${packageManager}`);
   }
 }

--- a/common/changes/@microsoft/rush/user-ianc-disable-allowUnreachableCode_2021-06-10-21-47.json
+++ b/common/changes/@microsoft/rush/user-ianc-disable-allowUnreachableCode_2021-06-10-21-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-node-rig/user-ianc-disable-allowUnreachableCode_2021-06-10-21-36.json
+++ b/common/changes/@rushstack/heft-node-rig/user-ianc-disable-allowUnreachableCode_2021-06-10-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the allowUnreachableCode TypeScript compiler option.",
+      "type": "minor",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/user-ianc-disable-allowUnreachableCode_2021-06-10-21-36.json
+++ b/common/changes/@rushstack/heft-web-rig/user-ianc-disable-allowUnreachableCode_2021-06-10-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Disable the allowUnreachableCode TypeScript compiler option.",
+      "type": "minor",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/rigs/heft-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/heft-node-rig/profiles/default/tsconfig-base.json
@@ -15,6 +15,8 @@
     "strict": true,
     "esModuleInterop": true,
     "noEmitOnError": false,
+    "allowUnreachableCode": false,
+
     "types": [],
 
     "module": "commonjs",

--- a/rigs/heft-web-rig/profiles/library/tsconfig-base.json
+++ b/rigs/heft-web-rig/profiles/library/tsconfig-base.json
@@ -16,6 +16,8 @@
     "strict": true,
     "esModuleInterop": true,
     "noEmitOnError": false,
+    "allowUnreachableCode": false,
+
     "types": [],
 
     "module": "esnext",


### PR DESCRIPTION
## Summary

This PR disallows [unreachable code](https://www.typescriptlang.org/tsconfig#allowUnreachableCode) in the Heft rigs.

## How it was tested

Built the repo.