### PR TITLE
[heft-jest-plugin] Include `testEnvironment` in list of resolved Jest config properties

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-ResolveJestProperties_2021-06-11-20-09.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-ResolveJestProperties_2021-06-11-20-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "\"Resolve the 'testEnvironment' Jest configuration propery in jest.config.json\"",
+      "comment": "Resolve the \"testEnvironment\" Jest configuration property in jest.config.json",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-ResolveJestProperties_2021-06-11-20-09.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-ResolveJestProperties_2021-06-11-20-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "\"Resolve the 'testEnvironment' Jest configuration propery in jest.config.json\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -106,16 +106,17 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       jsonPathMetadata: {
         // string
         '$.dependencyExtractor': nodeResolveMetadata,
+        '$.filter': nodeResolveMetadata,
         '$.globalSetup': nodeResolveMetadata,
         '$.globalTeardown': nodeResolveMetadata,
         '$.moduleLoader': nodeResolveMetadata,
-        '$.snapshotResolver': nodeResolveMetadata,
-        '$.testResultsProcessor': nodeResolveMetadata,
-        '$.testRunner': nodeResolveMetadata,
-        '$.filter': nodeResolveMetadata,
-        '$.runner': nodeResolveMetadata,
         '$.prettierPath': nodeResolveMetadata,
         '$.resolver': nodeResolveMetadata,
+        '$.runner': nodeResolveMetadata,
+        '$.snapshotResolver': nodeResolveMetadata,
+        '$.testEnvironment': nodeResolveMetadata,
+        '$.testResultsProcessor': nodeResolveMetadata,
+        '$.testRunner': nodeResolveMetadata,
         '$.testSequencer': nodeResolveMetadata,
         // string[]
         '$.setupFiles.*': nodeResolveMetadata,
@@ -124,12 +125,12 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         // reporters: (path | [ path, options ])[]
         '$.reporters[?(@ !== "default")]*@string()': nodeResolveMetadata, // string path, excluding "default"
         '$.reporters.*[?(@property == 0 && @ !== "default")]': nodeResolveMetadata, // First entry in [ path, options ], excluding "default"
-        // watchPlugins: (path | [ path, options ])[]
-        '$.watchPlugins.*@string()': nodeResolveMetadata, // string path
-        '$.watchPlugins.*[?(@property == 0)]': nodeResolveMetadata, // First entry in [ path, options ]
         // transform: { [regex]: path | [ path, options ] }
         '$.transform.*@string()': nodeResolveMetadata, // string path
-        '$.transform.*[?(@property == 0)]': nodeResolveMetadata // First entry in [ path, options ]
+        '$.transform.*[?(@property == 0)]': nodeResolveMetadata, // First entry in [ path, options ]
+        // watchPlugins: (path | [ path, options ])[]
+        '$.watchPlugins.*@string()': nodeResolveMetadata, // string path
+        '$.watchPlugins.*[?(@property == 0)]': nodeResolveMetadata // First entry in [ path, options ]
       }
     });
   }


### PR DESCRIPTION
## Summary

I missed one property (`testEnvironment`) in the Jest config mapping to modules. This change adds the property to the list of JsonPaths that need to be resolved within the settings file.
