### PR TITLE
[rush] Update the modification time for files restored from the build cache

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -202,7 +202,11 @@ export class ProjectBuildCache {
 
       // If we don't have tar on the PATH, if we failed to update the local cache entry,
       // or if the tar binary failed, untar in-memory
-      const tarStream: stream.Writable = tar.extract({ cwd: projectFolderPath });
+      const tarStream: stream.Writable = tar.extract({
+        cwd: projectFolderPath,
+        // Set to true to omit writing mtime value for extracted entries.
+        m: true
+      });
       try {
         const tarPromise: Promise<unknown> = events.once(tarStream, 'drain');
         tarStream.write(cacheEntryBuffer);

--- a/apps/rush-lib/src/utilities/TarExecutable.ts
+++ b/apps/rush-lib/src/utilities/TarExecutable.ts
@@ -47,7 +47,16 @@ export class TarExecutable {
    */
   public async tryUntarAsync(options: IUntarOptions): Promise<number> {
     return await this._spawnTarWithLoggingAsync(
-      ['-x', '-f', options.archivePath],
+      // These parameters are chosen for compatibility with the very primitive bsdtar 3.3.2 shipped with Windows 10.
+      [
+        // [Windows bsdtar 3.3.2] Extract: tar -x [options] [<patterns>]
+        '-x',
+        // [Windows bsdtar 3.3.2] -m    Don't restore modification times
+        '-m',
+        // [Windows bsdtar 3.3.2] -f <filename>  Location of archive (default \\.\tape0)
+        '-f',
+        options.archivePath
+      ],
       options.outputFolderPath,
       options.logFilePath
     );
@@ -68,7 +77,24 @@ export class TarExecutable {
 
     const projectFolderPath: string = project.projectFolder;
     const tarExitCode: number = await this._spawnTarWithLoggingAsync(
-      ['-c', '-f', archivePath, '-z', '-C', projectFolderPath, '--files-from', pathsListFilePath],
+      // These parameters are chosen for compatibility with the very primitive bsdtar 3.3.2 shipped with Windows 10.
+      [
+        // [Windows bsdtar 3.3.2] -c Create
+        '-c',
+        // [Windows bsdtar 3.3.2] -f <filename>  Location of archive (default \\.\tape0)
+        '-f',
+        archivePath,
+        // [Windows bsdtar 3.3.2] -z, -j, -J, --lzma  Compress archive with gzip/bzip2/xz/lzma
+        '-z',
+        // [Windows bsdtar 3.3.2] -C <dir>  Change to <dir> before processing remaining files
+        '-C',
+        projectFolderPath,
+        // [GNU tar 1.33] -T, --files-from=FILE      get names to extract or create from FILE
+        //
+        // Windows bsdtar does not document this parameter, but seems to accept it.
+        '--files-from',
+        pathsListFilePath
+      ],
       projectFolderPath,
       logFilePath
     );

--- a/common/changes/@microsoft/rush/octogonz-build-cache-timestamps_2021-06-14-23-55.json
+++ b/common/changes/@microsoft/rush/octogonz-build-cache-timestamps_2021-06-14-23-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where files restored by the build cache did not have a current modification time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

In the current implementation, when Rush restores output files from the build cache cache, the `tar` command preserves the original timestamp.  This is confusing for tools that compare timestamps to detect changes.

This PR ensures that the extracted files will have a current modification time.  (As a point of reference, Git always applies a current modification time for files restored from the Git history.)
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Tested on Windows, which has he most primitive `tar` implementation.

I also tested the fallback JavaScript implementation that is used when the `tar` binary is unavailable.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->


CC @MickeyPhoenix