### PR TITLE
[heft] Remove the ability to run multiple TypeScript compilers in a project.

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/LinterBase.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/LinterBase.ts
@@ -15,7 +15,6 @@ import { IScopedLogger } from '../../pluginFramework/logging/ScopedLogger';
 export interface ILinterBaseOptions {
   ts: IExtendedTypeScript;
   scopedLogger: IScopedLogger;
-  terminalPrefixLabel: string | undefined;
   buildFolderPath: string;
   buildCacheFolderPath: string;
   linterConfigFilePath: string;

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -44,12 +44,6 @@ export interface ITypeScriptBuilderConfiguration extends ISharedTypeScriptConfig
   tslintToolPath: string | undefined;
   eslintToolPath: string | undefined;
 
-  /**
-   * If provided, this is included in the logging prefix. For example, if this
-   * is set to "other-tsconfig", logging lines will start with [typescript (other-tsconfig)].
-   */
-  loggerPrefixLabel: string | undefined;
-
   lintingEnabled: boolean;
 
   watchMode: boolean;
@@ -157,10 +151,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
   }
 
   public async invokeAsync(): Promise<void> {
-    const loggerPrefixLabel: string | undefined = this._configuration.loggerPrefixLabel;
-    this._typescriptLogger = await this.requestScopedLoggerAsync(
-      loggerPrefixLabel ? `typescript (${loggerPrefixLabel})` : 'typescript'
-    );
+    this._typescriptLogger = await this.requestScopedLoggerAsync('typescript');
     this._typescriptTerminal = this._typescriptLogger.terminal;
 
     // Determine the compiler version
@@ -274,14 +265,11 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         throw new Error('Unable to resolve "tslint" package');
       }
 
-      const tslintScopedLogger: IScopedLogger = await this.requestScopedLoggerAsync(
-        loggerPrefixLabel ? `tslint (${loggerPrefixLabel})` : 'tslint'
-      );
+      const tslintLogger: IScopedLogger = await this.requestScopedLoggerAsync('tslint');
       tslint = new Tslint({
         ts: ts,
         tslintPackagePath: this._configuration.tslintToolPath,
-        terminalPrefixLabel: this._configuration.loggerPrefixLabel,
-        scopedLogger: tslintScopedLogger,
+        scopedLogger: tslintLogger,
         buildFolderPath: this._configuration.buildFolder,
         buildCacheFolderPath: this._configuration.buildCacheFolder,
         linterConfigFilePath: this._tslintConfigFilePath,
@@ -296,14 +284,11 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         throw new Error('Unable to resolve "eslint" package');
       }
 
-      const eslintScopedLogger: IScopedLogger = await this.requestScopedLoggerAsync(
-        loggerPrefixLabel ? `eslint (${loggerPrefixLabel})` : 'eslint'
-      );
+      const eslintLogger: IScopedLogger = await this.requestScopedLoggerAsync('eslint');
       eslint = new Eslint({
         ts: ts,
         eslintPackagePath: this._configuration.eslintToolPath,
-        terminalPrefixLabel: this._configuration.loggerPrefixLabel,
-        scopedLogger: eslintScopedLogger,
+        scopedLogger: eslintLogger,
         buildFolderPath: this._configuration.buildFolder,
         buildCacheFolderPath: this._configuration.buildCacheFolder,
         linterConfigFilePath: this._eslintConfigFilePath,

--- a/common/changes/@rushstack/heft/ianc-remove-multiple-tsconfigs_2021-06-15-23-38.json
+++ b/common/changes/@rushstack/heft/ianc-remove-multiple-tsconfigs_2021-06-15-23-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "(BREAKING CHANGE) Remove the ability to run multiple TypeScript compilers in a project.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

This PR removes the functionality that runs a TypeScript builder for `tsconfig-*.json` files, now supporting only `tsconfig.json`.

## How it was tested

Built the repo.