### PR TITLE
[heft] Rework the compile-related hooks.

### DIFF
--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -125,8 +125,8 @@ export class NodeServicePlugin implements IHeftPlugin {
           });
 
           build.hooks.compile.tap(PLUGIN_NAME, (compile: ICompileSubstage) => {
-            compile.hooks.afterCompile.tap(PLUGIN_NAME, this._compileHooks_afterEachIteration);
-            compile.hooks.afterRecompile.tap(PLUGIN_NAME, this._compileHooks_afterEachIteration);
+            compile.hooks.afterCompile.tap(PLUGIN_NAME, this._compileHooks_afterEachCompile);
+            compile.hooks.afterRecompile.tap(PLUGIN_NAME, this._compileHooks_afterEachCompile);
           });
         }
       });
@@ -205,7 +205,7 @@ export class NodeServicePlugin implements IHeftPlugin {
     this._restartChild();
   }
 
-  private _compileHooks_afterEachIteration = (): void => {
+  private _compileHooks_afterEachCompile = (): void => {
     this._trapUnhandledException(() => {
       // We've recompiled, so try launching again
       this._childProcessFailed = false;

--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -125,7 +125,8 @@ export class NodeServicePlugin implements IHeftPlugin {
           });
 
           build.hooks.compile.tap(PLUGIN_NAME, (compile: ICompileSubstage) => {
-            compile.hooks.afterEachIteration.tap(PLUGIN_NAME, this._compileHooks_afterEachIteration);
+            compile.hooks.afterCompile.tap(PLUGIN_NAME, this._compileHooks_afterEachIteration);
+            compile.hooks.afterRecompile.tap(PLUGIN_NAME, this._compileHooks_afterEachIteration);
           });
         }
       });

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -41,6 +41,11 @@ export type CopyFromCacheMode = 'hardlink' | 'copy';
  * @public
  */
 export class CompileSubstageHooks extends BuildSubstageHooksBase {
+  /**
+   * The `afterCompile` event is fired exactly once, after the "compile" stage completes its first operation.
+   * The "bundle" stage will not begin until all event handlers have resolved their promises.  The behavior
+   * of this event is the same in watch mode and non-watch mode.
+   */
   public readonly afterCompile: AsyncParallelHook = new AsyncParallelHook();
   public readonly afterRecompile: AsyncParallelHook = new AsyncParallelHook();
 }

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -47,6 +47,11 @@ export class CompileSubstageHooks extends BuildSubstageHooksBase {
    * of this event is the same in watch mode and non-watch mode.
    */
   public readonly afterCompile: AsyncParallelHook = new AsyncParallelHook();
+  /**
+   * The `afterRecompile` event is only used in watch mode.  It fires whenever the compiler's outputs have
+   * been rebuilt.  The initial compilation fires the `afterCompile` event only, and then all subsequent iterations
+   * fire the `afterRecompile` event only. Heft does not wait for the `afterRecompile` promises to resolve.
+   */
   public readonly afterRecompile: AsyncParallelHook = new AsyncParallelHook();
 }
 

--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -42,8 +42,7 @@ export type CopyFromCacheMode = 'hardlink' | 'copy';
  */
 export class CompileSubstageHooks extends BuildSubstageHooksBase {
   public readonly afterCompile: AsyncParallelHook = new AsyncParallelHook();
-
-  public readonly afterEachIteration: SyncHook = new SyncHook();
+  public readonly afterRecompile: AsyncParallelHook = new AsyncParallelHook();
 }
 
 /**

--- a/common/changes/@rushstack/heft/ianc-update-ts-hooks_2021-06-16-00-12.json
+++ b/common/changes/@rushstack/heft/ianc-update-ts-hooks_2021-06-16-00-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "(BREAKING CHANGE) Remove the \"afterEachIteration\" compile substage and replace its functionality with a \"afterRecompile\" compile substage hook.",
+      "comment": "(BREAKING CHANGE) Remove the \"afterEachIteration\" compile substage and replace its functionality with a more versatile \"afterRecompile\" compile substage hook.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/ianc-update-ts-hooks_2021-06-16-00-12.json
+++ b/common/changes/@rushstack/heft/ianc-update-ts-hooks_2021-06-16-00-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "(BREAKING CHANGE) Remove the \"afterEachIteration\" compile substage and replace its functionality with a \"afterRecompile\" compile substage hook.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -56,7 +56,7 @@ export class CompileSubstageHooks extends BuildSubstageHooksBase {
     // (undocumented)
     readonly afterCompile: AsyncParallelHook;
     // (undocumented)
-    readonly afterEachIteration: SyncHook;
+    readonly afterRecompile: AsyncParallelHook;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -53,9 +53,7 @@ export class CleanStageHooks extends StageHooksBase<ICleanStageProperties> {
 
 // @public (undocumented)
 export class CompileSubstageHooks extends BuildSubstageHooksBase {
-    // (undocumented)
     readonly afterCompile: AsyncParallelHook;
-    // (undocumented)
     readonly afterRecompile: AsyncParallelHook;
 }
 


### PR DESCRIPTION
## Summary

This PR goes in after https://github.com/microsoft/rushstack/pull/2749.

This PR removes the `afterEachIteration` compilation substage hook and introduces a `afterRecompile` compilation substage hook that is called each time a compilation happens in `--watch` mode, except after the first time (when `afterCompile` is called).

## Details

The motivation for this change is to allow a plugin author to generate assets to be used by a bundle substage operation (like Webpack) that take assets generated by the TypeScript compiler as inputs. The plugin should tap the `afterCompile` hook to generate the assets (and block the bundle substage) and tap the `afterRecompile` to update them after each compilation run.

## How it was tested

Built this repo. @MickeyPhoenix may want to test as well.