### PR TITLE
[heft] Fix some regressions involving jest.config.json resolution

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/octogonz-heft-jest-regressions_2021-06-18-05-26.json
+++ b/common/changes/@rushstack/heft-jest-plugin/octogonz-heft-jest-regressions_2021-06-18-05-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Fix a regression where \"testEnvironment\" did not resolve correctly (GitHub #2745)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/octogonz-heft-jest-regressions_2021-06-18-05-27.json
+++ b/common/changes/@rushstack/heft-jest-plugin/octogonz-heft-jest-regressions_2021-06-18-05-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Enable \"@rushstack/heft-jest-plugin/lib/exports/jest-global-setup.js\" to resolve for rigged projects that don't have a direct dependency on that package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -114,7 +114,8 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         '$.resolver': nodeResolveMetadata,
         '$.runner': nodeResolveMetadata,
         '$.snapshotResolver': nodeResolveMetadata,
-        '$.testEnvironment': nodeResolveMetadata,
+        // This is a name like "jsdom" that gets mapped into a package name like "jest-environment-jsdom"
+        // '$.testEnvironment': string
         '$.testResultsProcessor': nodeResolveMetadata,
         '$.testRunner': nodeResolveMetadata,
         '$.testSequencer': nodeResolveMetadata,

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -47,6 +47,8 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
   public readonly pluginName: string = PLUGIN_NAME;
   public readonly optionsSchema: JsonSchema = JsonSchema.fromFile(PLUGIN_SCHEMA_PATH);
 
+  private static _ownPackageFolder: string = path.resolve(__dirname, '..');
+
   /**
    * Returns the loader for the `config/api-extractor-task.json` config file.
    */
@@ -80,8 +82,33 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
     // that we provide to Jest. Resolve if we modified since paths containing <rootDir> should be absolute.
     const nodeResolveMetadata: IJsonPathMetadata = {
       preresolve: (jsonPath: string) => {
-        const newJsonPath: string = jsonPath.replace(/<rootDir>/g, buildFolder);
-        return jsonPath === newJsonPath ? jsonPath : path.resolve(newJsonPath);
+        // Compare with replaceRootDirInPath() from here:
+        // https://github.com/facebook/jest/blob/5f4dd187d89070d07617444186684c20d9213031/packages/jest-config/src/utils.ts#L58
+        const ROOTDIR_TOKEN: string = '<rootDir>';
+
+        // Example:  <rootDir>/path/to/file.js
+        if (jsonPath.startsWith(ROOTDIR_TOKEN)) {
+          const restOfPath: string = path.normalize('./' + jsonPath.substr(ROOTDIR_TOKEN.length));
+          return path.resolve(buildFolder, restOfPath);
+        }
+
+        // The normal PathResolutionMethod.NodeResolve will generally not be able to find @rushstack/heft-jest-plugin
+        // from a project that is using a rig.  Since it is important, and it is our own package, we resolve it
+        // manually as a special case.
+        const PLUGIN_PACKAGE_NAME: string = '@rushstack/heft-jest-plugin';
+
+        // Example:  @rushstack/heft-jest-plugin
+        if (jsonPath === PLUGIN_PACKAGE_NAME) {
+          return JestPlugin._ownPackageFolder;
+        }
+
+        // Example:  @rushstack/heft-jest-plugin/path/to/file.js
+        if (jsonPath.startsWith(PLUGIN_PACKAGE_NAME)) {
+          const restOfPath: string = path.normalize('./' + jsonPath.substr(PLUGIN_PACKAGE_NAME.length));
+          return path.join(JestPlugin._ownPackageFolder, restOfPath);
+        }
+
+        return jsonPath;
       },
       pathResolutionMethod: PathResolutionMethod.NodeResolve
     };


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes #2745

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Heft 0.32.0 completely changes how **jest.config.json** gets resolved.  

- This PR fixes a problem where "testEnvironment" was incorrectly resolved as a module path
- To prevent rigged projects from needing a dependency on `"@rushstack/heft-jest-plugin`, it adds a special case for resolving paths like `"@rushstack/heft-jest-plugin/lib/exports/jest-global-setup.js"`

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

With these changes, plus PR #2760, I was finally able to  migrate our large monorepo to use the latest Heft.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

CC @D4N14L @iclanton 