### PR TITLE
[ts-command-line] Add ChoiceList and IntegerList parameters (fixes #2330)

### DIFF
--- a/common/changes/@rushstack/ts-command-line/new-param-types_2021-06-18-05-24.json
+++ b/common/changes/@rushstack/ts-command-line/new-param-types_2021-06-18-05-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Add ChoiceList and IntegerList parameter types",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "elliot-nelson@users.noreply.github.com"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -25,6 +25,20 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 }
 
 // @public
+export class CommandLineChoiceListParameter extends CommandLineParameter {
+    // @internal
+    constructor(definition: ICommandLineChoiceListDefinition);
+    readonly alternatives: ReadonlyArray<string>;
+    // @override
+    appendToArgList(argList: string[]): void;
+    readonly completions: (() => Promise<string[]>) | undefined;
+    get kind(): CommandLineParameterKind;
+    // @internal
+    _setValue(data: any): void;
+    get values(): ReadonlyArray<string>;
+    }
+
+// @public
 export class CommandLineChoiceParameter extends CommandLineParameter {
     // @internal
     constructor(definition: ICommandLineChoiceDefinition);
@@ -62,6 +76,18 @@ export class CommandLineFlagParameter extends CommandLineParameter {
 export class CommandLineHelper {
     static isTabCompletionActionRequest(argv: string[]): boolean;
 }
+
+// @public
+export class CommandLineIntegerListParameter extends CommandLineParameterWithArgument {
+    // @internal
+    constructor(definition: ICommandLineIntegerListDefinition);
+    // @override
+    appendToArgList(argList: string[]): void;
+    get kind(): CommandLineParameterKind;
+    // @internal
+    _setValue(data: any): void;
+    get values(): ReadonlyArray<number>;
+    }
 
 // @public
 export class CommandLineIntegerParameter extends CommandLineParameterWithArgument {
@@ -104,8 +130,10 @@ export abstract class CommandLineParameter {
 // @public
 export enum CommandLineParameterKind {
     Choice = 0,
+    ChoiceList = 5,
     Flag = 1,
     Integer = 2,
+    IntegerList = 6,
     String = 3,
     StringList = 4
 }
@@ -114,16 +142,20 @@ export enum CommandLineParameterKind {
 export abstract class CommandLineParameterProvider {
     // @internal
     constructor();
+    defineChoiceListParameter(definition: ICommandLineChoiceListDefinition): CommandLineChoiceListParameter;
     defineChoiceParameter(definition: ICommandLineChoiceDefinition): CommandLineChoiceParameter;
     defineCommandLineRemainder(definition: ICommandLineRemainderDefinition): CommandLineRemainder;
     defineFlagParameter(definition: ICommandLineFlagDefinition): CommandLineFlagParameter;
+    defineIntegerListParameter(definition: ICommandLineIntegerListDefinition): CommandLineIntegerListParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
     defineStringListParameter(definition: ICommandLineStringListDefinition): CommandLineStringListParameter;
     defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter;
     // @internal
     protected abstract _getArgumentParser(): argparse.ArgumentParser;
+    getChoiceListParameter(parameterLongName: string): CommandLineChoiceListParameter;
     getChoiceParameter(parameterLongName: string): CommandLineChoiceParameter;
     getFlagParameter(parameterLongName: string): CommandLineFlagParameter;
+    getIntegerListParameter(parameterLongName: string): CommandLineIntegerListParameter;
     getIntegerParameter(parameterLongName: string): CommandLineIntegerParameter;
     getStringListParameter(parameterLongName: string): CommandLineStringListParameter;
     getStringParameter(parameterLongName: string): CommandLineStringParameter;
@@ -242,12 +274,22 @@ export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition
 }
 
 // @public
+export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefinition {
+    alternatives: string[];
+    completions?: () => Promise<string[]>;
+}
+
+// @public
 export interface ICommandLineFlagDefinition extends IBaseCommandLineDefinition {
 }
 
 // @public
 export interface ICommandLineIntegerDefinition extends IBaseCommandLineDefinitionWithArgument {
     defaultValue?: number;
+}
+
+// @public
+export interface ICommandLineIntegerListDefinition extends IBaseCommandLineDefinitionWithArgument {
 }
 
 // @internal

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -16,7 +16,9 @@ export {
   ICommandLineStringDefinition,
   ICommandLineStringListDefinition,
   ICommandLineIntegerDefinition,
+  ICommandLineIntegerListDefinition,
   ICommandLineChoiceDefinition,
+  ICommandLineChoiceListDefinition,
   ICommandLineRemainderDefinition
 } from './parameters/CommandLineDefinition';
 
@@ -30,7 +32,9 @@ export { CommandLineFlagParameter } from './parameters/CommandLineFlagParameter'
 export { CommandLineStringParameter } from './parameters/CommandLineStringParameter';
 export { CommandLineStringListParameter } from './parameters/CommandLineStringListParameter';
 export { CommandLineIntegerParameter } from './parameters/CommandLineIntegerParameter';
+export { CommandLineIntegerListParameter } from './parameters/CommandLineIntegerListParameter';
 export { CommandLineChoiceParameter } from './parameters/CommandLineChoiceParameter';
+export { CommandLineChoiceListParameter } from './parameters/CommandLineChoiceListParameter';
 export { CommandLineRemainder } from './parameters/CommandLineRemainder';
 
 export {

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -17,7 +17,11 @@ export enum CommandLineParameterKind {
   /** Indicates a CommandLineStringParameter */
   String,
   /** Indicates a CommandLineStringListParameter */
-  StringList
+  StringList,
+  /** Indicates a CommandLineChoiceListParameter */
+  ChoiceList,
+  /** Indicates a CommandLineIntegerListParameter */
+  IntegerList
 }
 
 /**

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -104,8 +104,9 @@ export interface IBaseCommandLineDefinitionWithArgument extends IBaseCommandLine
 }
 
 /**
- * For use with CommandLineParser, this interface represents a parameter which is constrained to
- * a list of possible options
+ * For use with {@link CommandLineParameterProvider.defineChoiceParameter},
+ * this interface defines a command line parameter which is constrained to a list of possible
+ * options.
  *
  * @public
  */
@@ -119,6 +120,28 @@ export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition
    * {@inheritDoc ICommandLineStringDefinition.defaultValue}
    */
   defaultValue?: string;
+
+  /**
+   * An optional callback that provides a list of custom choices for tab completion.
+   * @remarks
+   * This option is only used when `ICommandLineParserOptions.enableTabCompletionAction`
+   * is enabled.
+   */
+  completions?: () => Promise<string[]>;
+}
+
+/**
+ * For use with {@link CommandLineParameterProvider.defineChoiceListParameter},
+ * this interface defines a command line parameter which is constrained to a list of possible
+ * options. The parameter can be specified multiple times to build a list.
+ *
+ * @public
+ */
+export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefinition {
+  /**
+   * A list of strings (which contain no spaces), of possible options which can be selected
+   */
+  alternatives: string[];
 
   /**
    * An optional callback that provides a list of custom choices for tab completion.
@@ -149,6 +172,15 @@ export interface ICommandLineIntegerDefinition extends IBaseCommandLineDefinitio
    */
   defaultValue?: number;
 }
+
+/**
+ * For use with {@link CommandLineParameterProvider.defineIntegerListParameter},
+ * this interface defines a command line parameter whose argument is an integer value. The
+ * parameter can be specified multiple times to build a list.
+ *
+ * @public
+ */
+export interface ICommandLineIntegerListDefinition extends IBaseCommandLineDefinitionWithArgument {}
 
 /**
  * For use with {@link CommandLineParameterProvider.defineStringParameter},

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
@@ -1,25 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { ICommandLineStringListDefinition } from './CommandLineDefinition';
+import { ICommandLineIntegerListDefinition } from './CommandLineDefinition';
 import { CommandLineParameterWithArgument, CommandLineParameterKind } from './BaseClasses';
 import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 
 /**
- * The data type returned by {@link CommandLineParameterProvider.defineStringListParameter}.
+ * The data type returned by {@link CommandLineParameterProvider.defineIntegerListParameter}.
  * @public
  */
-export class CommandLineStringListParameter extends CommandLineParameterWithArgument {
-  private _values: string[] = [];
+export class CommandLineIntegerListParameter extends CommandLineParameterWithArgument {
+  private _values: number[] = [];
 
   /** @internal */
-  public constructor(definition: ICommandLineStringListDefinition) {
+  public constructor(definition: ICommandLineIntegerListDefinition) {
     super(definition);
   }
 
   /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.StringList;
+    return CommandLineParameterKind.IntegerList;
   }
 
   /**
@@ -34,7 +34,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
         this.reportInvalidData(data);
       }
       for (const arrayItem of data) {
-        if (typeof arrayItem !== 'string') {
+        if (typeof arrayItem !== 'number') {
           this.reportInvalidData(data);
         }
       }
@@ -46,24 +46,35 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     if (this.environmentVariable !== undefined) {
       const values: string[] | undefined = EnvironmentVariableParser.parseAsList(this.environmentVariable);
       if (values) {
-        this._values = values;
+        const parsedValues: number[] = [];
+        for (const value of values) {
+          const parsed: number = parseInt(value, 10);
+          if (isNaN(parsed) || value.indexOf('.') >= 0) {
+            throw new Error(
+              `Invalid value "${value}" for the environment variable` +
+                ` ${this.environmentVariable}.  It must be an integer value.`
+            );
+          }
+          parsedValues.push(parsed);
+        }
+        this._values = parsedValues;
         return;
       }
     }
 
-    // (No default value for string lists)
+    // (No default value for integer lists)
 
     this._values = [];
   }
 
   /**
-   * Returns the string arguments for a string list parameter that was parsed from the command line.
+   * Returns the integer arguments for an integer list parameter that was parsed from the command line.
    *
    * @remarks
    * The array will be empty if the command-line has not been parsed yet,
    * or if the parameter was omitted and has no default value.
    */
-  public get values(): ReadonlyArray<string> {
+  public get values(): ReadonlyArray<number> {
     return this._values;
   }
 
@@ -72,7 +83,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     if (this.values.length > 0) {
       for (const value of this.values) {
         argList.push(this.longName);
-        argList.push(value);
+        argList.push(String(value));
       }
     }
   }

--- a/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
+++ b/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * Some parameter types can receive their values from an environment variable instead of
+ * a command line argument. This class provides some utility methods for parsing environment
+ * variable values.
+ * @internal
+ */
+export class EnvironmentVariableParser {
+  public static parseAsList(envVarName: string): string[] | undefined {
+    const environmentValue: string | undefined = process.env[envVarName];
+
+    if (environmentValue !== undefined) {
+      // NOTE: If the environment variable is defined as an empty string,
+      // here we will accept the empty string as our value.  (For number/flag we don't do that.)
+
+      if (environmentValue.trimLeft()[0] === '[') {
+        // Specifying multiple items in an environment variable is a somewhat rare case.  But environment
+        // variables are actually a pretty reliable way for a tool to avoid shell escaping problems
+        // when spawning another tool.  For this case, we need a reliable way to pass an array of strings
+        // that could contain any character.  For example, if we simply used ";" as the list delimiter,
+        // then what to do if a string contains that character?  We'd need to design an escaping mechanism.
+        // Since JSON is simple and standard and can escape every possible string, it's a better option
+        // than a custom delimiter.
+        try {
+          const parsedJson: unknown = JSON.parse(environmentValue);
+          if (
+            !Array.isArray(parsedJson) ||
+            !parsedJson.every((x) => typeof x === 'string' || typeof x === 'boolean' || typeof x === 'number')
+          ) {
+            throw new Error(
+              `The ${environmentValue} environment variable value must be a JSON ` +
+                ` array containing only strings, numbers, and booleans.`
+            );
+          }
+          return parsedJson.map((x) => x.toString());
+        } catch (ex) {
+          throw new Error(
+            `The ${environmentValue} environment variable value looks like a JSON array` +
+              ` but failed to parse: ` +
+              ex.message
+          );
+        }
+      } else {
+        // As a shorthand, a single value may be specified without JSON encoding, as long as it does not
+        // start with the "[" character.
+        return [environmentValue];
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -8,6 +8,11 @@ Array [
   "### --choice-with-default output: ###",
   "--choice-with-default",
   "two",
+  "### --choice-list output: ###",
+  "--choice-list",
+  "red",
+  "--choice-list",
+  "green",
   "### --flag output: ###",
   "--flag",
   "### --integer output: ###",
@@ -19,6 +24,13 @@ Array [
   "### --integer-required output: ###",
   "--integer-required",
   "6",
+  "### --integer-list output: ###",
+  "--integer-list",
+  "1",
+  "--integer-list",
+  "2",
+  "--integer-list",
+  "3",
   "### --string output: ###",
   "--string",
   "Hello, world!",
@@ -33,6 +45,12 @@ Array [
   "simple text",
 ]
 `;
+
+exports[`CommandLineParameter choice list raises an error if env var value is json containing non-scalars 1`] = `"The [{}] environment variable value looks like a JSON array but failed to parse: The [{}] environment variable value must be a JSON  array containing only strings, numbers, and booleans."`;
+
+exports[`CommandLineParameter choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
+
+exports[`CommandLineParameter choice list raises an error if env var value is not valid json 1`] = `"The [u environment variable value looks like a JSON array but failed to parse: Unexpected token u in JSON at position 1"`;
 
 exports[`CommandLineParameter parses an input with ALL parameters 1`] = `
 Object {
@@ -83,6 +101,24 @@ exports[`CommandLineParameter parses an input with ALL parameters 4`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
+  "description": "This parameter may be specified multiple times to make a list of choices",
+  "environmentVariable": "ENV_CHOICE_LIST",
+  "kind": 5,
+  "longName": "--choice-list",
+  "required": false,
+  "shortName": "-C",
+  "value": undefined,
+  "values": Array [
+    "red",
+    "blue",
+  ],
+}
+`;
+
+exports[`CommandLineParameter parses an input with ALL parameters 5`] = `
+Object {
+  "argumentName": undefined,
+  "defaultValue": undefined,
   "description": "A flag",
   "environmentVariable": "ENV_FLAG",
   "kind": 1,
@@ -94,7 +130,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 5`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 6`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -109,7 +145,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 6`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 7`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": 123,
@@ -124,7 +160,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 7`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 8`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -139,7 +175,25 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 8`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 9`] = `
+Object {
+  "argumentName": "LIST_ITEM",
+  "defaultValue": undefined,
+  "description": "This parameter may be specified multiple times to make a list of integers",
+  "environmentVariable": "ENV_INTEGER_LIST",
+  "kind": 6,
+  "longName": "--integer-list",
+  "required": false,
+  "shortName": "-I",
+  "value": undefined,
+  "values": Array [
+    37,
+    -404,
+  ],
+}
+`;
+
+exports[`CommandLineParameter parses an input with ALL parameters 10`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": undefined,
@@ -154,7 +208,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 9`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 11`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": "123",
@@ -169,11 +223,11 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 10`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 12`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
-  "description": "This parameter be specified multiple times to make a list of strings",
+  "description": "This parameter may be specified multiple times to make a list of strings",
   "environmentVariable": "ENV_STRING_LIST",
   "kind": 4,
   "longName": "--string-list",
@@ -187,7 +241,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 11`] = `
+exports[`CommandLineParameter parses an input with ALL parameters 13`] = `
 Array [
   "### --choice output: ###",
   "--choice",
@@ -195,6 +249,11 @@ Array [
   "### --choice-with-default output: ###",
   "--choice-with-default",
   "default",
+  "### --choice-list output: ###",
+  "--choice-list",
+  "red",
+  "--choice-list",
+  "blue",
   "### --flag output: ###",
   "--flag",
   "### --integer output: ###",
@@ -206,6 +265,11 @@ Array [
   "### --integer-required output: ###",
   "--integer-required",
   "321",
+  "### --integer-list output: ###",
+  "--integer-list",
+  "37",
+  "--integer-list",
+  "-404",
   "### --string output: ###",
   "--string",
   "hello",
@@ -270,6 +334,21 @@ exports[`CommandLineParameter parses an input with NO parameters 4`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
+  "description": "This parameter may be specified multiple times to make a list of choices",
+  "environmentVariable": "ENV_CHOICE_LIST",
+  "kind": 5,
+  "longName": "--choice-list",
+  "required": false,
+  "shortName": "-C",
+  "value": undefined,
+  "values": Array [],
+}
+`;
+
+exports[`CommandLineParameter parses an input with NO parameters 5`] = `
+Object {
+  "argumentName": undefined,
+  "defaultValue": undefined,
   "description": "A flag",
   "environmentVariable": "ENV_FLAG",
   "kind": 1,
@@ -281,7 +360,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 5`] = `
+exports[`CommandLineParameter parses an input with NO parameters 6`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -296,7 +375,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 6`] = `
+exports[`CommandLineParameter parses an input with NO parameters 7`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": 123,
@@ -311,7 +390,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 7`] = `
+exports[`CommandLineParameter parses an input with NO parameters 8`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -326,7 +405,22 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 8`] = `
+exports[`CommandLineParameter parses an input with NO parameters 9`] = `
+Object {
+  "argumentName": "LIST_ITEM",
+  "defaultValue": undefined,
+  "description": "This parameter may be specified multiple times to make a list of integers",
+  "environmentVariable": "ENV_INTEGER_LIST",
+  "kind": 6,
+  "longName": "--integer-list",
+  "required": false,
+  "shortName": "-I",
+  "value": undefined,
+  "values": Array [],
+}
+`;
+
+exports[`CommandLineParameter parses an input with NO parameters 10`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": undefined,
@@ -341,7 +435,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 9`] = `
+exports[`CommandLineParameter parses an input with NO parameters 11`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": "123",
@@ -356,11 +450,11 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 10`] = `
+exports[`CommandLineParameter parses an input with NO parameters 12`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
-  "description": "This parameter be specified multiple times to make a list of strings",
+  "description": "This parameter may be specified multiple times to make a list of strings",
   "environmentVariable": "ENV_STRING_LIST",
   "kind": 4,
   "longName": "--string-list",
@@ -371,12 +465,13 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 11`] = `
+exports[`CommandLineParameter parses an input with NO parameters 13`] = `
 Array [
   "### --choice output: ###",
   "### --choice-with-default output: ###",
   "--choice-with-default",
   "default",
+  "### --choice-list output: ###",
   "### --flag output: ###",
   "### --integer output: ###",
   "### --integer-with-default output: ###",
@@ -385,6 +480,7 @@ Array [
   "### --integer-required output: ###",
   "--integer-required",
   "123",
+  "### --integer-list output: ###",
   "### --string output: ###",
   "### --string-with-default output: ###",
   "--string-with-default",
@@ -402,6 +498,11 @@ Array [
   "### --choice-with-default output: ###",
   "--choice-with-default",
   "two",
+  "### --choice-list output: ###",
+  "--choice-list",
+  "red",
+  "--choice-list",
+  "green",
   "### --flag output: ###",
   "--flag",
   "### --integer output: ###",
@@ -413,6 +514,13 @@ Array [
   "### --integer-required output: ###",
   "--integer-required",
   "1",
+  "### --integer-list output: ###",
+  "--integer-list",
+  "1",
+  "--integer-list",
+  "2",
+  "--integer-list",
+  "3",
   "### --string output: ###",
   "--string",
   "Hello, world!",
@@ -435,9 +543,10 @@ Array [
 
 exports[`CommandLineParameter prints the action help 1`] = `
 "usage: example do:the-job [-h] [-c {one,two,three,default}]
-                          [--choice-with-default {one,two,three,default}] [-f]
-                          [-i NUMBER] [--integer-with-default NUMBER]
-                          --integer-required NUMBER [-s TEXT]
+                          [--choice-with-default {one,two,three,default}]
+                          [-C {red,green,blue}] [-f] [-i NUMBER]
+                          [--integer-with-default NUMBER] --integer-required
+                          NUMBER [-I LIST_ITEM] [-s TEXT]
                           [--string-with-default TEXT]
                           [--string-with-undocumented-synonym TEXT]
                           [-l LIST_ITEM]
@@ -455,6 +564,11 @@ Optional arguments:
                         \\"quoted word\\". This parameter may alternatively be 
                         specified via the ENV_CHOICE2 environment variable. 
                         The default value is \\"default\\".
+  -C {red,green,blue}, --choice-list {red,green,blue}
+                        This parameter may be specified multiple times to 
+                        make a list of choices. This parameter may 
+                        alternatively be specified via the ENV_CHOICE_LIST 
+                        environment variable.
   -f, --flag            A flag. This parameter may alternatively be specified 
                         via the ENV_FLAG environment variable.
   -i NUMBER, --integer NUMBER
@@ -466,6 +580,11 @@ Optional arguments:
                         environment variable. The default value is 123.
   --integer-required NUMBER
                         An integer
+  -I LIST_ITEM, --integer-list LIST_ITEM
+                        This parameter may be specified multiple times to 
+                        make a list of integers. This parameter may 
+                        alternatively be specified via the ENV_INTEGER_LIST 
+                        environment variable.
   -s TEXT, --string TEXT
                         A string. This parameter may alternatively be 
                         specified via the ENV_STRING environment variable.
@@ -476,10 +595,10 @@ Optional arguments:
   --string-with-undocumented-synonym TEXT
                         A string with an undocumented synonym
   -l LIST_ITEM, --string-list LIST_ITEM
-                        This parameter be specified multiple times to make a 
-                        list of strings. This parameter may alternatively be 
-                        specified via the ENV_STRING_LIST environment 
-                        variable.
+                        This parameter may be specified multiple times to 
+                        make a list of strings. This parameter may 
+                        alternatively be specified via the ENV_STRING_LIST 
+                        environment variable.
 "
 `;
 


### PR DESCRIPTION
## Summary

Mirror `StringList` parameter with `ChoiceList` and `IntegerList` parameter types.

## Details

I've pulled out the basics of parsing an environment variable as a list into a separate utility class, since it doesn't need access to any of the internals of a `Parameter`.  Other than that change, I didn't work too hard to avoid duplicate code for the different `-ListParameter` types -- there's probably more that could be DRY'd up at some point, maybe if additional List types are added in the future.

I followed the lead of the `StringList` type and did not allow `defaultValue` in the definitions of these new types, but I'm not sure I agree with this decision (I think there's no reason you can't have a default value, and if the arg is never set on the command line, then `values = [defaultValue]`.)  I can push for that change in a follow-up PR for all ListParameter types.

## How it was tested

 - Added `ChoiceList` and `IntegerList` to the existing unit test snapshots.
 - Added some tests to verify the different error messages that can be produced by the `ChoiceList` type (this being the most complicated one).
 - Tested the changes on our local monorepo, swapping a known StringList for a ChoiceList and confirming the CLI tool behaved as expected.
