### PR TITLE
[eslint-plugin-packlets] fix link in README.md

### DIFF
--- a/common/changes/@rushstack/eslint-plugin-packlets/patch-1_2021-06-21-23-56.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/patch-1_2021-06-21-23-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/stack/eslint-plugin-packlets/README.md
+++ b/stack/eslint-plugin-packlets/README.md
@@ -33,7 +33,7 @@ With packlets, our folders would be reorganized as follows:
 - `src/packlets/reports/*.ts` - the report engine
 - `src/*.ts` - other arbitrary files such as startup code and the main application
 
-The [packlets-tutorial](https://github.com/microsoft/rushstack/tree/master/tutorials/packlets-tutorial) sample project illustrates this layout in full detail.
+The [packlets-tutorial](https://github.com/microsoft/rushstack-samples/tree/main/other/packlets-tutorial) sample project illustrates this layout in full detail.
 
 The basic design can be summarized in 5 rules:
 


### PR DESCRIPTION
## Summary

Update `packlets-tutorial` after being moved to `rushstack-samples`

The link to `packlets-tutorial` was outdated.

**Old link:** https://github.com/microsoft/rushstack/tree/master/tutorials/packlets-tutorial
**New link:** https://github.com/microsoft/rushstack-samples/tree/main/other/packlets-tutorial