### PR TITLE
[rush] Allow selection parameters to select 0 projects

### DIFF
--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -150,6 +150,23 @@ export class SelectionParameterSet {
    * If no parameters are specified, returns all projects in the Rush config file.
    */
   public getSelectedProjects(): Set<RushConfigurationProject> {
+    // Check if any of the selection parameters have a value specified on the command line
+    const isSelectionSpecified: boolean = [
+      this._onlyProject,
+      this._fromProject,
+      this._fromVersionPolicy,
+      this._toProject,
+      this._toVersionPolicy,
+      this._toExceptProject,
+      this._impactedByProject,
+      this._impactedByExceptProject
+    ].some((param: CommandLineStringListParameter) => param.values.length > 0);
+
+    // If no selection parameters are specified, return everything
+    if (!isSelectionSpecified) {
+      return new Set(this._rushConfiguration.projects);
+    }
+
     // Include exactly these projects (--only)
     const onlyProjects: Iterable<RushConfigurationProject> = this._evaluateProjectParameter(
       this._onlyProject
@@ -189,13 +206,6 @@ export class SelectionParameterSet {
       // Only dependents of these projects, not dependencies
       Selection.expandAllConsumers(impactedByProjects)
     );
-
-    // If no projects selected, select everything.
-    if (selection.size === 0) {
-      for (const project of this._rushConfiguration.projects) {
-        selection.add(project);
-      }
-    }
 
     return selection;
   }

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -132,6 +132,11 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const selection: Set<RushConfigurationProject> = this._selectionParameters.getSelectedProjects();
 
+    if (!selection.size) {
+      terminal.writeLine(colors.yellow(`The command line selection parameters did not match any projects.`));
+      return;
+    }
+
     const taskSelectorOptions: ITaskSelectorConstructor = {
       rushConfiguration: this.rushConfiguration,
       buildCacheConfiguration,

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -61,23 +61,7 @@ export class TaskSelector {
   }
 
   public registerTasks(): TaskCollection {
-    const selectedProjects: ReadonlySet<RushConfigurationProject> = this._computeSelectedProjects();
-
-    return this._createTaskCollection(selectedProjects);
-  }
-
-  private _computeSelectedProjects(): ReadonlySet<RushConfigurationProject> {
-    const { selection } = this._options;
-
-    if (selection.size) {
-      return selection;
-    }
-
-    // Default to all projects
-    return new Set(this._options.rushConfiguration.projects);
-  }
-
-  private _createTaskCollection(projects: ReadonlySet<RushConfigurationProject>): TaskCollection {
+    const projects: ReadonlySet<RushConfigurationProject> = this._options.selection;
     const taskCollection: TaskCollection = new TaskCollection();
 
     // Register all tasks

--- a/common/changes/@microsoft/rush/fix-empty-selection_2021-06-24-23-05.json
+++ b/common/changes/@microsoft/rush/fix-empty-selection_2021-06-24-23-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "When selection CLI parameters are specified and applying them does not select any projects, log that the selection is empty and immediately exit.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

If one or more selection parameters are specified, allow the set of matched projects to be empty.

Fixes #2756

## Details
Checks to see if any selection parameters are specified, and either return the full project set if none are specified, or the exact selection if one or more are specified.

Added a message when 0 projects are selected by the parameters.

## How it was tested
Verified that running `rush build --to-except tree-pattern` selects 0 projects and does no work.
```
PS D:\rushstack> node .\apps\rush-lib\lib\start.js build -v --to-except tree-pattern

Rush Multi-Project Build Tool 5.47.0 (unmanaged) - https://rushjs.io
Node.js version is 12.22.1 (LTS)


Starting "rush build"

The command line selection parameters did not match any projects.
```

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
