### PR TITLE
[heft-jest-plugin] Improve module resolution for Jest configuration files

### DIFF
--- a/common/changes/@rushstack/heft-config-file/user-danade-ImprovedJestResolve_2021-06-25-21-53.json
+++ b/common/changes/@rushstack/heft-config-file/user-danade-ImprovedJestResolve_2021-06-25-21-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Allow for specifying a custom resolver when resolving paths with heft-config-file. This change removes \"preresolve\" property for JsonPath module resolution options and replaces it with a more flexible \"customResolver\" property",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-ImprovedJestResolve_2021-06-25-21-53.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-ImprovedJestResolve_2021-06-25-21-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Improve resolution logic to match closer to default Jest functionality and add \"<configDir>\" and \"<packageDir:...>\" tokens to improve flexibility when using extended configuration files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -327,6 +327,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "jest-environment-node",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "jest-snapshot",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -327,6 +327,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "jest-config",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "jest-environment-node",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -992,6 +992,7 @@ importers:
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
       eslint: ~7.12.1
+      jest-config: ~25.4.0
       jest-environment-node: ~25.4.0
       jest-snapshot: ~25.4.0
       lodash: ~4.17.15
@@ -1002,6 +1003,7 @@ importers:
       '@jest/transform': 25.4.0
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/node-core-library': link:../../libraries/node-core-library
+      jest-config: 25.4.0
       jest-snapshot: 25.4.0
       lodash: 4.17.21
     devDependencies:
@@ -2159,7 +2161,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.6
       jest-changed-files: 25.5.0
-      jest-config: 25.5.4
+      jest-config: 25.4.0
       jest-haste-map: 25.5.1
       jest-message-util: 25.5.0
       jest-regex-util: 25.2.6
@@ -6950,6 +6952,34 @@ packages:
       - utf-8-validate
     dev: true
 
+  /jest-config/25.4.0:
+    resolution: {integrity: sha512-egT9aKYxMyMSQV1aqTgam0SkI5/I2P9qrKexN5r2uuM2+68ypnc+zPGmfUxK7p1UhE7dYH9SLBS7yb+TtmT1AA==}
+    engines: {node: '>= 8.3'}
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/test-sequencer': 25.5.4
+      '@jest/types': 25.4.0
+      babel-jest: 25.5.1_@babel+core@7.14.6
+      chalk: 3.0.0
+      deepmerge: 4.2.2
+      glob: 7.1.7
+      jest-environment-jsdom: 25.5.0
+      jest-environment-node: 25.4.0
+      jest-get-type: 25.2.6
+      jest-jasmine2: 25.5.4
+      jest-regex-util: 25.2.6
+      jest-resolve: 25.5.1
+      jest-util: 25.5.0
+      jest-validate: 25.5.0
+      micromatch: 4.0.4
+      pretty-format: 25.5.0
+      realpath-native: 2.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   /jest-config/25.5.4:
     resolution: {integrity: sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==}
     engines: {node: '>= 8.3'}
@@ -7029,7 +7059,6 @@ packages:
       jest-mock: 25.5.0
       jest-util: 25.5.0
       semver: 6.3.0
-    dev: true
 
   /jest-environment-node/25.5.0:
     resolution: {integrity: sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -992,6 +992,7 @@ importers:
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
       eslint: ~7.12.1
+      jest-environment-node: ~25.4.0
       jest-snapshot: ~25.4.0
       lodash: ~4.17.15
       typescript: ~3.9.7
@@ -1012,6 +1013,7 @@ importers:
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
       eslint: 7.12.1
+      jest-environment-node: 25.4.0
       typescript: 3.9.10
 
   ../../heft-plugins/heft-webpack4-plugin:
@@ -7016,6 +7018,18 @@ packages:
       - bufferutil
       - canvas
       - utf-8-validate
+
+  /jest-environment-node/25.4.0:
+    resolution: {integrity: sha512-wryZ18vsxEAKFH7Z74zi/y/SyI1j6UkVZ6QsllBuT/bWlahNfQjLNwFsgh/5u7O957dYFoXj4yfma4n4X6kU9A==}
+    engines: {node: '>= 8.3'}
+    dependencies:
+      '@jest/environment': 25.5.0
+      '@jest/fake-timers': 25.5.0
+      '@jest/types': 25.4.0
+      jest-mock: 25.5.0
+      jest-util: 25.5.0
+      semver: 6.3.0
+    dev: true
 
   /jest-environment-node/25.5.0:
     resolution: {integrity: sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a16a53136dc3c864253a843f43c84762cd43b808",
+  "pnpmShrinkwrapHash": "9d6a20010da561140bdaffde212ec32b22ce34d4",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9d6a20010da561140bdaffde212ec32b22ce34d4",
+  "pnpmShrinkwrapHash": "ae73867dac98f9b3dd014c707ff81563d0924c93",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -34,7 +34,7 @@ export interface ICustomPropertyInheritance<TObject> extends IPropertyInheritanc
 
 // @beta
 export interface IJsonPathMetadata {
-    customResolver?: (configurationFilePath: string, value: string) => string;
+    customResolver?: (configurationFilePath: string, propertyName: string, propertyValue: string) => string;
     pathResolutionMethod?: PathResolutionMethod;
 }
 

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -34,8 +34,8 @@ export interface ICustomPropertyInheritance<TObject> extends IPropertyInheritanc
 
 // @beta
 export interface IJsonPathMetadata {
+    customResolver?: (configurationFilePath: string, value: string) => string;
     pathResolutionMethod?: PathResolutionMethod;
-    preresolve?: (path: string) => string;
 }
 
 // @beta
@@ -72,6 +72,7 @@ export interface IPropertyInheritance<TInheritanceType extends InheritanceType> 
 
 // @beta (undocumented)
 export enum PathResolutionMethod {
+    custom = 3,
     NodeResolve = 2,
     resolvePathRelativeToConfigurationFile = 0,
     resolvePathRelativeToProjectRoot = 1

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -24,6 +24,7 @@
     "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "lodash": "~4.17.15",
+    "jest-config": "~25.4.0",
     "jest-snapshot": "~25.4.0"
   },
   "devDependencies": {

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -35,6 +35,7 @@
     "@types/lodash": "4.14.116",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
+    "jest-environment-node": "~25.4.0",
     "typescript": "~3.9.7"
   }
 }

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -431,8 +431,9 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
                 `in "${configurationFilePath}".`
             );
           }
-          const slashCount: number = (packageName.match(/\//g) || []).length;
-          if (slashCount > 1 || (slashCount === 0 && !packageName.startsWith('@'))) {
+
+          // Prevent module paths from being specified by limiting the number of '/' characters present
+          if (packageName.match(/^((@[^\/]+\/)|([^@]))[^\/]+\/.*$/)) {
             throw new Error(
               `Module paths are not supported when using the "packageDir" token ` +
                 (propertyName ? `of property "${propertyName}" ` : '') +

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -399,8 +399,13 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
     ];
   }
 
-  // Resolve all specified properties using Node resolution, and replace <rootDir> with the same rootDir
-  // that we provide to Jest. Resolve if we modified since paths containing <rootDir> should be absolute.
+  /**
+   * Resolve all specified properties to an absolute path using Jest resolution. In addition, the following
+   * transforms will be applied to the provided propertyValue before resolution:
+   *   - replace <rootDir> with the same rootDir
+   *   - replace <configDir> with the directory containing the current configuration file
+   *   - replace <packageDir:...> with the path to the resolved package (NOT module)
+   */
   private static _getJsonPathMetadata(options: IJsonPathMetadataOptions): IJsonPathMetadata {
     return {
       customResolver: (configurationFilePath: string, propertyName: string, propertyValue: string) => {

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -442,7 +442,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
             throw new Error(
               `Module paths are not supported when using the "packageDir" token ` +
                 (propertyName ? `of property "${propertyName}" ` : '') +
-                `in "${configurationFilePath}".`
+                `in "${configurationFilePath}". Only a package name is allowed.`
             );
           }
 

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -433,7 +433,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
           }
 
           // Prevent module paths from being specified by limiting the number of '/' characters present
-          if (packageName.match(/^((@[^\/]+\/)|([^@]))[^\/]+\/.*$/)) {
+          if (packageName.match(/^((@[^\/]+\/)|[^@])[^\/]+\/.*$/)) {
             throw new Error(
               `Module paths are not supported when using the "packageDir" token ` +
                 (propertyName ? `of property "${propertyName}" ` : '') +

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -438,7 +438,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
             );
           }
           const slashCount: number = (packageName.match(/\//g) || []).length;
-          if (slashCount > 2 || (slashCount > 1 && !packageName.startsWith('@'))) {
+          if (slashCount > 1 || (slashCount === 0 && !packageName.startsWith('@'))) {
             throw new Error(
               `Module paths are not supported when using the "packageDir" token ` +
                 (propertyName ? `of property "${propertyName}" ` : '') +

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -42,7 +42,8 @@ import { HeftJestDataFile } from './HeftJestDataFile';
 type JestReporterConfig = string | Config.ReporterConfig;
 
 /**
- *
+ * Options to use when performing resolution for paths and modules specified in the Jest
+ * configuration.
  */
 interface IJestResolutionOptions {
   /**
@@ -66,17 +67,6 @@ interface IJestResolutionOptions {
   ignoreMissingModule?: boolean;
 }
 
-/**
- *
- */
-interface IExtendedJestResolutionOptions extends IJestResolutionOptions {
-  /**
-   * The value that will be substituted for <configDir> tokens. It is also the directory that will be
-   * used as the base directory during module resolution.
-   */
-  configDir: string;
-}
-
 export interface IJestPluginOptions {
   disableConfigurationModuleResolution?: boolean;
   configurationPath?: string;
@@ -87,7 +77,7 @@ export interface IHeftJestConfiguration extends Config.InitialOptions {}
 const PLUGIN_NAME: string = 'JestPlugin';
 const PLUGIN_PACKAGE_NAME: string = '@rushstack/heft-jest-plugin';
 const PLUGIN_PACKAGE_FOLDER: string = path.resolve(__dirname, '..');
-const PLUGIN_SCHEMA_PATH: string = `${path.dirname()}/schemas/heft-jest-plugin.schema.json`;
+const PLUGIN_SCHEMA_PATH: string = path.resolve(__dirname, 'schemas', 'heft-jest-plugin.schema.json');
 const JEST_CONFIGURATION_LOCATION: string = `config/jest.config.json`;
 
 const ROOTDIR_TOKEN: string = '<rootDir>';

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -249,6 +249,12 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       buildFolder,
       resolveAsModule: true
     });
+    const watchPluginsJestResolveMetadata: IJsonPathMetadata = JestPlugin._getJsonPathMetadata({
+      buildFolder,
+      resolveAsModule: true,
+      modulePrefix: 'jest-watch-',
+      ignoreMissingModule: true
+    });
 
     return new ConfigurationFile<IHeftJestConfiguration>({
       projectRelativeFilePath: projectRelativeFilePath,
@@ -316,20 +322,8 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         '$.transform.*@string()': jestResolveMetadata, // string path
         '$.transform.*[?(@property == 0)]': jestResolveMetadata, // First entry in [ path, options ]
         // watchPlugins: (path | [ path, options ])[]
-        '$.watchPlugins.*@string()': JestPlugin._getJsonPathMetadata({
-          // string path
-          buildFolder,
-          resolveAsModule: true,
-          modulePrefix: 'jest-watch-',
-          ignoreMissingModule: true
-        }),
-        '$.watchPlugins.*[?(@property == 0)]': JestPlugin._getJsonPathMetadata({
-          // First entry in [ path, options ]
-          buildFolder,
-          resolveAsModule: true,
-          modulePrefix: 'jest-watch-',
-          ignoreMissingModule: true
-        })
+        '$.watchPlugins.*@string()': watchPluginsJestResolveMetadata, // string path
+        '$.watchPlugins.*[?(@property == 0)]': watchPluginsJestResolveMetadata // First entry in [ path, options ]
       }
     });
   }

--- a/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
+++ b/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
@@ -36,6 +36,9 @@ describe('JestConfigLoader', () => {
     expect(loadedConfig.setupFiles![0]).toBe(path.join(rootDir, 'a', 'b', 'setupFile2.js'));
     expect(loadedConfig.setupFiles![1]).toBe(path.join(rootDir, 'a', 'b', 'setupFile1.js'));
 
+    // Validate testEnvironment
+    expect(loadedConfig.testEnvironment).toBe(require.resolve('jest-environment-node'));
+
     // Validate reporters
     expect(loadedConfig.reporters?.length).toBe(3);
     expect(loadedConfig.reporters![0]).toBe('default');
@@ -107,5 +110,9 @@ describe('JestConfigLoader', () => {
 
     expect(loadedConfig.setupFiles?.length).toBe(1);
     expect(loadedConfig.setupFiles![0]).toBe(require.resolve('@jest/core'));
+
+    // Also validate that a test environment that we specified did not resolve. Done intentionally to ensure that
+    // Jest itself can attempt to satisfy certain fields
+    expect(loadedConfig.testEnvironment).toBe('jsdom');
   });
 });

--- a/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
+++ b/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
@@ -18,14 +18,16 @@ describe('JestConfigLoader', () => {
   });
 
   it('resolves extended config modules', async () => {
-    const rootDir: string = path.join(__dirname, 'project1');
+    // Because we require the built modules, we need to set our rootDir to be in the 'lib' folder, since transpilation
+    // means that we don't run on the built test assets directly
+    const rootDir: string = path.resolve(__dirname, '..', '..', 'lib', 'test', 'project1');
     const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,
       'config/jest.config.json'
     );
     const loadedConfig: IHeftJestConfiguration = await loader.loadConfigurationFileForProjectAsync(
       terminal,
-      path.join(__dirname, 'project1')
+      path.join(__dirname, '..', '..', 'lib', 'test', 'project1')
     );
 
     expect(loadedConfig.preset).toBe(undefined);
@@ -98,21 +100,24 @@ describe('JestConfigLoader', () => {
   });
 
   it('resolves extended package modules', async () => {
-    const rootDir: string = path.join(__dirname, 'project1');
+    // Because we require the built modules, we need to set our rootDir to be in the 'lib' folder, since transpilation
+    // means that we don't run on the built test assets directly
+    const rootDir: string = path.resolve(__dirname, '..', '..', 'lib', 'test', 'project1');
     const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,
       'config/jest.config.json'
     );
     const loadedConfig: IHeftJestConfiguration = await loader.loadConfigurationFileForProjectAsync(
       terminal,
-      path.join(__dirname, 'project2')
+      path.resolve(__dirname, '..', '..', 'lib', 'test', 'project2')
     );
 
     expect(loadedConfig.setupFiles?.length).toBe(1);
     expect(loadedConfig.setupFiles![0]).toBe(require.resolve('@jest/core'));
 
-    // Also validate that a test environment that we specified did not resolve. Done intentionally to ensure that
-    // Jest itself can attempt to satisfy certain fields
-    expect(loadedConfig.testEnvironment).toBe('jsdom');
+    // Also validate that a test environment that we specified as 'jsdom' (but have not added as a dependency)
+    // is resolved, implying it came from Jest directly
+    expect(loadedConfig.testEnvironment).toContain('jest-environment-jsdom');
+    expect(loadedConfig.testEnvironment).toMatch(/index.js$/);
   });
 });

--- a/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
+++ b/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import type { Config } from '@jest/types';
 import { ConfigurationFile } from '@rushstack/heft-config-file';
-import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
+import { Import, StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 
 import { IHeftJestConfiguration, JestPlugin } from '../JestPlugin';
 
@@ -17,7 +17,7 @@ describe('JestConfigLoader', () => {
     terminal = new Terminal(terminalProvider);
   });
 
-  it('resolves preset config modules', async () => {
+  it('resolves extended config modules', async () => {
     const rootDir: string = path.join(__dirname, 'project1');
     const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,
@@ -53,6 +53,31 @@ describe('JestConfigLoader', () => {
       path.join(rootDir, 'a', 'c', 'mockTransformModule3.js')
     );
 
+    // Validate moduleNameMapper
+    expect(Object.keys(loadedConfig.moduleNameMapper || {}).length).toBe(4);
+    expect(loadedConfig.moduleNameMapper!['\\.resx$']).toBe(
+      // Test overrides
+      path.join(rootDir, 'a', 'some', 'path', 'to', 'overridden', 'module.js')
+    );
+    expect(loadedConfig.moduleNameMapper!['\\.jpg$']).toBe(
+      // Test <configDir>
+      path.join(rootDir, 'a', 'c', 'some', 'path', 'to', 'module.js')
+    );
+    expect(loadedConfig.moduleNameMapper!['^!!file-loader']).toBe(
+      // Test <packageDir:...>
+      path.join(
+        Import.resolvePackage({ packageName: '@rushstack/heft', baseFolderPath: __dirname }),
+        'some',
+        'path',
+        'to',
+        'module.js'
+      )
+    );
+    expect(loadedConfig.moduleNameMapper!['^@1js/search-dispatcher/lib/(.+)']).toBe(
+      // Test unmodified
+      '@1js/search-dispatcher/lib-commonjs/$1'
+    );
+
     // Validate globals
     expect(Object.keys(loadedConfig.globals || {}).length).toBe(4);
     expect(loadedConfig.globals!.key1).toBe('value5');
@@ -69,7 +94,7 @@ describe('JestConfigLoader', () => {
     expect(loadedConfig.globals!.key7).toBe('value9');
   });
 
-  it('resolves preset package modules', async () => {
+  it('resolves extended package modules', async () => {
     const rootDir: string = path.join(__dirname, 'project1');
     const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,

--- a/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
@@ -5,6 +5,8 @@
 
   "reporters": ["default", "./mockReporter1.js", ["./d/mockReporter2.js", { "key": "value" }]],
 
+  "testEnvironment": "node",
+
   "transform": {
     "\\.(xxx)$": ["../b/mockTransformModule1.js", { "key": "value" }],
     "\\.(yyy)$": ["./mockTransformModule3.js", { "key": "value" }]

--- a/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
@@ -10,6 +10,12 @@
     "\\.(yyy)$": ["./mockTransformModule3.js", { "key": "value" }]
   },
 
+  "moduleNameMapper": {
+    "\\.resx$": "<configDir>/some/path/to/module.js",
+    "\\.jpg$": "<configDir>/some/path/to/module.js",
+    "^!!file-loader": "<packageDir:@rushstack/heft>/some/path/to/module.js"
+  },
+
   "globals": {
     "key1": "value1",
     "key2": ["value2", "value3"],

--- a/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
@@ -15,7 +15,7 @@
   "moduleNameMapper": {
     "\\.resx$": "<configDir>/some/path/to/module.js",
     "\\.jpg$": "<configDir>/some/path/to/module.js",
-    "^!!file-loader": "<packageDir:@rushstack/heft>/some/path/to/module.js"
+    "^!!file-loader": "<packageDir:@rushstack/heft/lib>/some/path/to/module.js"
   },
 
   "globals": {

--- a/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project1/a/c/jest.config.json
@@ -15,7 +15,7 @@
   "moduleNameMapper": {
     "\\.resx$": "<configDir>/some/path/to/module.js",
     "\\.jpg$": "<configDir>/some/path/to/module.js",
-    "^!!file-loader": "<packageDir:@rushstack/heft/lib>/some/path/to/module.js"
+    "^!!file-loader": "<packageDir:@rushstack/heft>/some/path/to/module.js"
   },
 
   "globals": {

--- a/heft-plugins/heft-jest-plugin/src/test/project1/a/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project1/a/jest.config.json
@@ -5,5 +5,10 @@
 
   "transform": {
     "\\.(xxx)$": "./b/mockTransformModule2.js"
+  },
+
+  "moduleNameMapper": {
+    "\\.resx$": "<configDir>/some/path/to/overridden/module.js",
+    "^@1js/search-dispatcher/lib/(.+)": "@1js/search-dispatcher/lib-commonjs/$1"
   }
 }

--- a/heft-plugins/heft-jest-plugin/src/test/project2/a/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project2/a/jest.config.json
@@ -1,3 +1,5 @@
 {
-  "setupFiles": ["@jest/core"]
+  "setupFiles": ["@jest/core"],
+
+  "testEnvironment": "jsdom"
 }

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -84,7 +84,7 @@ export interface IJsonPathMetadata {
    * If `IJsonPathMetadata.pathResolutionMethod` is set to `PathResolutionMethod.custom`,
    * this property be used to resolve the path.
    */
-  customResolver?: (configurationFilePath: string, value: string) => string;
+  customResolver?: (configurationFilePath: string, propertyName: string, propertyValue: string) => string;
 
   /**
    * If this property describes a filesystem path, use this property to describe
@@ -382,6 +382,7 @@ export class ConfigurationFile<TConfigurationFile> {
         callback: (payload: unknown, payloadType: string, fullPayload: IJsonPathCallbackObject) => {
           const resolvedPath: string = this._resolvePathProperty(
             resolvedConfigurationFilePath,
+            fullPayload.path,
             fullPayload.value,
             metadata
           );
@@ -614,6 +615,7 @@ export class ConfigurationFile<TConfigurationFile> {
 
   private _resolvePathProperty(
     configurationFilePath: string,
+    propertyName: string,
     propertyValue: string,
     metadata: IJsonPathMetadata
   ): string {
@@ -655,7 +657,7 @@ export class ConfigurationFile<TConfigurationFile> {
               'resolver was not provided.'
           );
         }
-        return metadata.customResolver(configurationFilePath, propertyValue);
+        return metadata.customResolver(configurationFilePath, propertyName, propertyValue);
       }
 
       default: {

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -55,7 +55,12 @@ export enum PathResolutionMethod {
    * Treat the property as a NodeJS-style require/import reference and resolve using standard
    * NodeJS filesystem resolution
    */
-  NodeResolve
+  NodeResolve,
+
+  /**
+   * Resolve the property using a custom resolver.
+   */
+  custom
 }
 
 const CONFIGURATION_FILE_FIELD_ANNOTATION: unique symbol = Symbol('configuration-file-field-annotation');
@@ -76,10 +81,10 @@ interface IConfigurationFileFieldAnnotation<TField> {
  */
 export interface IJsonPathMetadata {
   /**
-   * If this property is set, it will be used for manual path modification before the
-   * specified `IJsonPathMetadata.pathResolutionMethod` is executed.
+   * If `IJsonPathMetadata.pathResolutionMethod` is set to `PathResolutionMethod.custom`,
+   * this property be used to resolve the path.
    */
-  preresolve?: (path: string) => string;
+  customResolver?: (configurationFilePath: string, value: string) => string;
 
   /**
    * If this property describes a filesystem path, use this property to describe
@@ -375,18 +380,11 @@ export class ConfigurationFile<TConfigurationFile> {
         path: jsonPath,
         json: configurationJson,
         callback: (payload: unknown, payloadType: string, fullPayload: IJsonPathCallbackObject) => {
-          let resolvedPath: string = fullPayload.value;
-          if (metadata.preresolve) {
-            resolvedPath = metadata.preresolve(resolvedPath);
-          }
-          if (metadata.pathResolutionMethod !== undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            resolvedPath = this._resolvePathProperty(
-              resolvedConfigurationFilePath,
-              resolvedPath,
-              metadata.pathResolutionMethod
-            );
-          }
+          const resolvedPath: string = this._resolvePathProperty(
+            resolvedConfigurationFilePath,
+            fullPayload.value,
+            metadata
+          );
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (fullPayload.parent as any)[fullPayload.parentProperty] = resolvedPath;
         },
@@ -617,9 +615,14 @@ export class ConfigurationFile<TConfigurationFile> {
   private _resolvePathProperty(
     configurationFilePath: string,
     propertyValue: string,
-    resolutionMethod: PathResolutionMethod | undefined
+    metadata: IJsonPathMetadata
   ): string {
-    switch (resolutionMethod) {
+    const resolutionMethod: PathResolutionMethod | undefined = metadata.pathResolutionMethod;
+    if (resolutionMethod === undefined) {
+      return propertyValue;
+    }
+
+    switch (metadata.pathResolutionMethod) {
       case PathResolutionMethod.resolvePathRelativeToConfigurationFile: {
         return nodeJsPath.resolve(nodeJsPath.dirname(configurationFilePath), propertyValue);
       }
@@ -645,8 +648,20 @@ export class ConfigurationFile<TConfigurationFile> {
         });
       }
 
+      case PathResolutionMethod.custom: {
+        if (!metadata.customResolver) {
+          throw new Error(
+            `PathResolutionMethod "${PathResolutionMethod[resolutionMethod]}" was provided, but no custom ` +
+              'resolver was found.'
+          );
+        }
+        return metadata.customResolver(configurationFilePath, propertyValue);
+      }
+
       default: {
-        return propertyValue;
+        throw new Error(
+          `Unsupported PathResolutionMethod: ${PathResolutionMethod[resolutionMethod]} (${resolutionMethod})`
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2745

- Improve module resolution for Jest configuration files loaded using `heft-jest-plugin` such that it more closely resembles how default Jest functions
- Add tokens to allow for referencing special directories in non-path (but still 'pathy') fields like `moduleNameMapper`


## Details

In using JSON configuration files that were resolved fully before passing to Jest, we introduced a few limitations. Namely:
- All modules being referenced _must_ be available in the package the configuration file is sourced from
- No auto-prefixing for certain Jest fields
- No runtime resolution of paths in non-module fields

Unfortunately, this meant that we had introduced a few regressions in comparison with default Jest that we do not want to get rid of. Specifically, a few features that are being added back are:
- Allowing certain fields to resolve to a prefixed package name (ex. `jest-environment-` prefix for `testEnvironment` option)
- Allowing certain fields to silently fail module resolution and pass the value through to Jest when a module isn't directly resolvable from the package containing the configuration file (ex. `jest-environment-node` or `node` are resolved from Jest for `testEnvironment` option)

Additionally, by restricting ourselves to JSON files (instead of JSON and .js, as is true with default Jest), we removed the ability to run JavaScript code to resolve paths relative to the configuration file in non-path (but still pathy) fields. For example, the ability to create `moduleNameMappers` that map to modules within the project containing the configuration file was lost. To work around this, two new tokens were added which will be mapped/replaced during resolution:
- `<configDir>` to reference paths relative to the directory that the config file is in. This will always refer to the configuration file that contains the `<configDir>` tag, unlike `<rootDir>` which will always reference the build folder
- `<packageDir:...>` token to reference a path relative to the root of a dependency package, where `...` is the package name. This package is resolved using Node module resolution relative to the directory that the config file is in

## How it was tested
- Added more unit tests to cover these cases
- Rebuilt projects that are using the `heft-jest-plugin` and confirmed that their tests did not fail

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
