### PR TITLE
[rush-lib] fix cacheEntryNamePattern description of [normalized] token should be [normalize]

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/build-cache.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/build-cache.json
@@ -21,9 +21,9 @@
 
   /**
    * Setting this property overrides the cache entry ID.  If this property is set, it must contain
-   * a [hash] token. It may also contain a [projectName] or a [projectName:normalized] token.
+   * a [hash] token. It may also contain a [projectName] or a [projectName:normalize] token.
    */
-  // "cacheEntryNamePattern": "[projectName:normalized]-[hash]"
+  // "cacheEntryNamePattern": "[projectName:normalize]-[hash]"
 
   /**
    * Use this configuration with "cacheProvider"="azure-blob-storage"

--- a/apps/rush-lib/src/schemas/build-cache.schema.json
+++ b/apps/rush-lib/src/schemas/build-cache.schema.json
@@ -37,7 +37,7 @@
 
         "cacheEntryNamePattern": {
           "type": "string",
-          "description": "Setting this property overrides the cache entry ID. If this property is set, it must contain a [hash] token. It may also contain a [projectName] or a [projectName:normalized] token."
+          "description": "Setting this property overrides the cache entry ID. If this property is set, it must contain a [hash] token. It may also contain a [projectName] or a [projectName:normalize] token."
         },
 
         "azureBlobStorageConfiguration": {

--- a/common/changes/@microsoft/rush/fix-build-cache-schema_2021-06-30-13-59.json
+++ b/common/changes/@microsoft/rush/fix-build-cache-schema_2021-06-30-13-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix rush-lib build-cache cacheEntryNamePattern description of [normalize] token",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "lpegasus@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/fix-build-cache-schema_2021-06-30-13-59.json
+++ b/common/changes/@microsoft/rush/fix-build-cache-schema_2021-06-30-13-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix rush-lib build-cache cacheEntryNamePattern description of [normalize] token",
+      "comment": "Fix the build-cache.json cacheEntryNamePattern description of the [normalize] token.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary

When using build-cache feature and set cacheEntryNamePattern with [normalized] token as comments, error occurred.

https://github.com/microsoft/rushstack/blob/448854a414f1402f221cbd01e26fbbdcb89f5a31/apps/rush-lib/src/logic/buildCache/CacheEntryId.ts#L77

It's seemed to be a spell mistake.

