### PR TITLE
[heft-jest-plugin] Fix merge pattern used to combine moduleNameMappers and transforms

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-FixJestTransformMerge_2021-06-30-18-55.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-FixJestTransformMerge_2021-06-30-18-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Fix Jest configuration merging of \"transform\" and \"moduleNameMapper\" fields",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -253,10 +253,11 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       parentObject: T
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) => T = <T extends { [key: string]: any }>(currentObject: T, parentObject: T): T => {
-      // Done in this order to ensure that the currentObject properties take priority in order-of-declaration,
-      // since Jest cares about this internally. For example, if the extended Jest configuration contains a
-      // "\\.(css|sass|scss)$" transform but the extending Jest configuration contains a "\\.(css)$" override
-      // transform merging like this will ensure that the returned transforms are executed in the correct order:
+      // Merged in this order to ensure that the currentObject properties take priority in order-of-definition,
+      // since Jest executes them in this order. For example, if the extended Jest configuration contains a
+      // "\\.(css|sass|scss)$" transform but the extending Jest configuration contains a "\\.(css)$" transform,
+      // merging like this will ensure that the returned transforms are executed in the correct order, stopping
+      // after hitting the first pattern that applies:
       // {
       //   "\\.(css)$": "..."
       //   "\\.(css|sass|scss)$": "..."

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -259,7 +259,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       // merging like this will ensure that the returned transforms are executed in the correct order, stopping
       // after hitting the first pattern that applies:
       // {
-      //   "\\.(css)$": "..."
+      //   "\\.(css)$": "...",
       //   "\\.(css|sass|scss)$": "..."
       // }
       // https://github.com/facebook/jest/blob/0a902e10e0a5550b114340b87bd31764a7638729/packages/jest-config/src/normalize.ts#L102

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -253,7 +253,16 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       parentObject: T
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) => T = <T extends { [key: string]: any }>(currentObject: T, parentObject: T): T => {
-      return { ...(parentObject || {}), ...(currentObject || {}) };
+      // Done in this order to ensure that the currentObject properties take priority in order-of-declaration,
+      // since Jest cares about this internally. For example, if the extended Jest configuration contains a
+      // "\\.(css|sass|scss)$" transform but the extending Jest configuration contains a "\\.(css)$" override
+      // transform merging like this will ensure that the returned transforms are executed in the correct order:
+      // {
+      //   "\\.(css)$": "..."
+      //   "\\.(css|sass|scss)$": "..."
+      // }
+      // https://github.com/facebook/jest/blob/0a902e10e0a5550b114340b87bd31764a7638729/packages/jest-config/src/normalize.ts#L102
+      return { ...(currentObject || {}), ...(parentObject || {}), ...(currentObject || {}) };
     };
     const deepObjectInheritanceFunc: <T>(
       currentObject: T,


### PR DESCRIPTION
## Summary

Fix the pattern used to combine `moduleNameMapper` and `transform` Jest configuration fields and add documentation on why it was done this way.

## Details

When creating the Jest configuration from presets internally, Jest cares about the order of definition of the object properties for the `moduleNameMapper` and `transform` fields since it will execute them in the order they were defined, stopping after hitting the first applicable pattern. This change is done in this order to ensure that the extending properties are defined first.

For example, if the _extended_ Jest configuration contains a `"\\.(css|sass|scss)$"` transform but the _extending_ Jest configuration contains a `"\\.(css)$"` override transform, merging like this will ensure that the returned transforms are executed in the correct order:
```json
{
  "\\.(css)$": "...",
  "\\.(css|sass|scss)$": "..."
}
```
See: https://github.com/facebook/jest/blob/0a902e10e0a5550b114340b87bd31764a7638729/packages/jest-config/src/normalize.ts#L102

## How it was tested

Made the change and consumed it locally to confirm that it fixed the issue in my repo.
