### PR TITLE
[ts-command-line] Allow space-separated parameters for ListParameter types

### DIFF
--- a/common/changes/@rushstack/ts-command-line/greedy-list-params_2021-07-01-13-55.json
+++ b/common/changes/@rushstack/ts-command-line/greedy-list-params_2021-07-01-13-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Allow space-separated parameters passed to ListParameter types",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "elliot-nelson@users.noreply.github.com"
+}

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
@@ -43,17 +43,20 @@ export class CommandLineChoiceListParameter extends CommandLineParameter {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public _setValue(data: any): void {
-    // If argparse passed us a value, confirm it is valid
+    // If argparse passed us a value, confirm it is valid. Note that argparse
+    // may pass an array of arrays of args, so we flatten it before validating
+    // each entry.
     if (data !== null && data !== undefined) {
       if (!Array.isArray(data)) {
         this.reportInvalidData(data);
       }
-      for (const arrayItem of data) {
-        if (typeof arrayItem !== 'string') {
+      const values: unknown[] = data.reduce((list, item) => list.concat(item), []);
+      for (const item of values) {
+        if (typeof item !== 'string') {
           this.reportInvalidData(data);
         }
       }
-      this._values = data;
+      this._values = values as string[];
       return;
     }
 

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
@@ -28,17 +28,20 @@ export class CommandLineIntegerListParameter extends CommandLineParameterWithArg
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public _setValue(data: any): void {
-    // If argparse passed us a value, confirm it is valid
+    // If argparse passed us a value, confirm it is valid. Note that argparse
+    // may pass an array of arrays of args, so we flatten it before validating
+    // each entry.
     if (data !== null && data !== undefined) {
       if (!Array.isArray(data)) {
         this.reportInvalidData(data);
       }
-      for (const arrayItem of data) {
-        if (typeof arrayItem !== 'number') {
+      const values: unknown[] = data.reduce((list, item) => list.concat(item), []);
+      for (const item of values) {
+        if (typeof item !== 'number') {
           this.reportInvalidData(data);
         }
       }
-      this._values = data;
+      this._values = values as number[];
       return;
     }
 

--- a/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
@@ -28,17 +28,20 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public _setValue(data: any): void {
-    // If argparse passed us a value, confirm it is valid
+    // If argparse passed us a value, confirm it is valid. Note that argparse
+    // may pass an array of arrays of args, so we flatten it before validating
+    // each entry.
     if (data !== null && data !== undefined) {
       if (!Array.isArray(data)) {
         this.reportInvalidData(data);
       }
-      for (const arrayItem of data) {
-        if (typeof arrayItem !== 'string') {
+      const values: unknown[] = data.reduce((list, item) => list.concat(item), []);
+      for (const item of values) {
+        if (typeof item !== 'string') {
           this.reportInvalidData(data);
         }
       }
-      this._values = data;
+      this._values = values as string[];
       return;
     }
 

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -383,6 +383,7 @@ export abstract class CommandLineParameterProvider {
         const choiceParameter: CommandLineChoiceListParameter = parameter as CommandLineChoiceListParameter;
         argparseOptions.choices = choiceParameter.alternatives as string[];
         argparseOptions.action = 'append';
+        argparseOptions.nargs = '+';
         break;
       }
       case CommandLineParameterKind.Flag:
@@ -394,11 +395,13 @@ export abstract class CommandLineParameterProvider {
       case CommandLineParameterKind.IntegerList:
         argparseOptions.type = 'int';
         argparseOptions.action = 'append';
+        argparseOptions.nargs = '+';
         break;
       case CommandLineParameterKind.String:
         break;
       case CommandLineParameterKind.StringList:
         argparseOptions.action = 'append';
+        argparseOptions.nargs = '+';
         break;
     }
 

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -333,6 +333,33 @@ describe('CommandLineParameter', () => {
     expect(copiedArgs).toMatchSnapshot();
   });
 
+  it('supports both single and greedy args for list parameters', async () => {
+    const commandLineParser: CommandLineParser = createParser();
+    const action: CommandLineAction = commandLineParser.getAction('do:the-job');
+
+    const args: string[] = [
+      'do:the-job',
+      '--integer-required',
+      '6',
+      '--string-list',
+      'cat',
+      '--string-list',
+      'dog',
+      'pig',
+      '--string-list',
+      'cow'
+    ];
+
+    await commandLineParser.execute(args);
+
+    const copiedArgs: string[] = [];
+    for (const parameter of action.parameters) {
+      copiedArgs.push(`### ${parameter.longName} output: ###`);
+      parameter.appendToArgList(copiedArgs);
+    }
+    expect(copiedArgs).toMatchSnapshot();
+  });
+
   describe('choice list', () => {
     function createHelloWorldParser(): CommandLineParser {
       const commandLineParser: CommandLineParser = new DynamicCommandLineParser({

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -544,12 +544,13 @@ Array [
 exports[`CommandLineParameter prints the action help 1`] = `
 "usage: example do:the-job [-h] [-c {one,two,three,default}]
                           [--choice-with-default {one,two,three,default}]
-                          [-C {red,green,blue}] [-f] [-i NUMBER]
-                          [--integer-with-default NUMBER] --integer-required
-                          NUMBER [-I LIST_ITEM] [-s TEXT]
+                          [-C {red,green,blue} [{red,green,blue} ...]] [-f]
+                          [-i NUMBER] [--integer-with-default NUMBER]
+                          --integer-required NUMBER
+                          [-I LIST_ITEM [LIST_ITEM ...]] [-s TEXT]
                           [--string-with-default TEXT]
                           [--string-with-undocumented-synonym TEXT]
-                          [-l LIST_ITEM]
+                          [-l LIST_ITEM [LIST_ITEM ...]]
                           
 
 a longer description
@@ -564,7 +565,7 @@ Optional arguments:
                         \\"quoted word\\". This parameter may alternatively be 
                         specified via the ENV_CHOICE2 environment variable. 
                         The default value is \\"default\\".
-  -C {red,green,blue}, --choice-list {red,green,blue}
+  -C {red,green,blue} [{red,green,blue} ...], --choice-list {red,green,blue} [{red,green,blue} ...]
                         This parameter may be specified multiple times to 
                         make a list of choices. This parameter may 
                         alternatively be specified via the ENV_CHOICE_LIST 
@@ -580,7 +581,7 @@ Optional arguments:
                         environment variable. The default value is 123.
   --integer-required NUMBER
                         An integer
-  -I LIST_ITEM, --integer-list LIST_ITEM
+  -I LIST_ITEM [LIST_ITEM ...], --integer-list LIST_ITEM [LIST_ITEM ...]
                         This parameter may be specified multiple times to 
                         make a list of integers. This parameter may 
                         alternatively be specified via the ENV_INTEGER_LIST 
@@ -594,7 +595,7 @@ Optional arguments:
                         environment variable. The default value is \\"123\\".
   --string-with-undocumented-synonym TEXT
                         A string with an undocumented synonym
-  -l LIST_ITEM, --string-list LIST_ITEM
+  -l LIST_ITEM [LIST_ITEM ...], --string-list LIST_ITEM [LIST_ITEM ...]
                         This parameter may be specified multiple times to 
                         make a list of strings. This parameter may 
                         alternatively be specified via the ENV_STRING_LIST 
@@ -617,4 +618,54 @@ Optional arguments:
 
 For detailed help about a specific command, use: example <command> -h
 "
+`;
+
+exports[`CommandLineParameter supports both single and greedy args for list parameters 1`] = `
+Array [
+  "### --choice output: ###",
+  "--choice",
+  "one",
+  "### --choice-with-default output: ###",
+  "--choice-with-default",
+  "two",
+  "### --choice-list output: ###",
+  "--choice-list",
+  "red",
+  "--choice-list",
+  "green",
+  "### --flag output: ###",
+  "--flag",
+  "### --integer output: ###",
+  "--integer",
+  "111",
+  "### --integer-with-default output: ###",
+  "--integer-with-default",
+  "222",
+  "### --integer-required output: ###",
+  "--integer-required",
+  "6",
+  "### --integer-list output: ###",
+  "--integer-list",
+  "1",
+  "--integer-list",
+  "2",
+  "--integer-list",
+  "3",
+  "### --string output: ###",
+  "--string",
+  "Hello, world!",
+  "### --string-with-default output: ###",
+  "--string-with-default",
+  "Hello, world!",
+  "### --string-with-undocumented-synonym output: ###",
+  "### --string-list output: ###",
+  "--string-list",
+  "cat",
+  "--string-list",
+  "dog",
+  "--string-list",
+  "pig",
+  "--string-list",
+  "cow",
+]
 `;


### PR DESCRIPTION
## Summary

Allow users to pass space-separated parameters to ListParameter types.  For example, these command lines are now all equivalent:

```console
bin/my-program --color red --color green --color blue
bin/my-program --color red green blue
bin/my-program --color red --color green blue
```

On MacOS/Linux, this allows you to take advantage of normal shell expansion for file parameters, e.g.:

```console
bin/my-program --files *.json
```

(CLI authors writing programs compatible with all operating systems still need to build in glob support for Windows, where this command will pass the literal `"*.json"` instead of individual strings `["a.json", "b.json", "c.json"]`.  However, now users of your program on MacOS/Linux won't need to wrap the wildcard in single quotes to avoid getting an error with your program.)

Fixes #2741.

## Details

Relatively simple implementation.  `argparse` works in a way very familiar to users of `yargs` and other popular frameworks (additional arguments will be consumed until an argument that appears to be a flag is encountered).

When you enable multiple argument consumption `argparse` returns slightly different values; for example, the command line `--color red --color blue green` becomes the values array `[["red"], ["blue", "green"]]`.  To support this, minor tweaks were made to the existing `*ListParameter` parameter types.

## How it was tested

 - Additional unit test added
 - Confirmed in one of our own CLI programs that the basic functionality works (including that failing to pass a value still generates an error).
 - Confirmed that argparse gets the same arguments for basic quoted strings in Windows and MacOS (e.g. `bin/my-program -p "string 1" "string 2"`).
