### PR TITLE
[module-minifier-plugin] Separate comment extraction from minification

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/module-minifier-enhancements_2021-07-02-00-30.json
+++ b/common/changes/@rushstack/module-minifier-plugin/module-minifier-enhancements_2021-07-02-00-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Separate comment extraction from minification.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -24,7 +24,6 @@ export function generateLicenseFileForAsset(compilation: webpack.compilation.Com
 export interface IAssetInfo {
     chunk: webpack.compilation.Chunk;
     externalNames: Map<string, string>;
-    extractedComments: string[];
     fileName: string;
     modules: (string | number)[];
     source: Source;
@@ -50,14 +49,13 @@ export interface IExtendedModule extends webpack.compilation.Module {
     external?: boolean;
     id: string | number | null;
     identifier(): string;
+    modules?: IExtendedModule[];
     readableIdentifier(requestShortener: unknown): string;
     resource?: string;
-    skipMinification?: boolean;
 }
 
 // @public
 export interface IModuleInfo {
-    extractedComments: string[];
     module: IExtendedModule;
     source: Source;
 }
@@ -75,7 +73,6 @@ export interface IModuleMinificationCallback {
 export interface IModuleMinificationErrorResult {
     code?: undefined;
     error: Error;
-    extractedComments?: undefined;
     hash: string;
     map?: undefined;
 }
@@ -95,7 +92,6 @@ export type IModuleMinificationResult = IModuleMinificationErrorResult | IModule
 export interface IModuleMinificationSuccessResult {
     code: string;
     error: undefined;
-    extractedComments: string[];
     hash: string;
     map?: RawSourceMap;
 }
@@ -144,6 +140,12 @@ export interface _INormalModuleFactoryModuleData {
 export interface ISynchronousMinifierOptions {
     // (undocumented)
     terserOptions?: MinifyOptions;
+}
+
+// @internal
+export interface _IWebpackCompilationData {
+    // (undocumented)
+    normalModuleFactory: webpack.compilation.NormalModuleFactory;
 }
 
 // @public

--- a/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
+++ b/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
@@ -4,7 +4,25 @@
 import * as path from 'path';
 import * as webpack from 'webpack';
 import { ConcatSource } from 'webpack-sources';
-import { IAssetInfo, IModuleMap, IModuleInfo } from './ModuleMinifierPlugin.types';
+import { IAssetInfo, IModuleMap, IModuleInfo, IExtendedModule } from './ModuleMinifierPlugin.types';
+
+function* iterateAllComments(moduleIds: (string | number)[], minifiedModules: IModuleMap): Iterable<string> {
+  for (const moduleId of moduleIds) {
+    const mod: IModuleInfo | undefined = minifiedModules.get(moduleId);
+    if (!mod) {
+      continue;
+    }
+
+    const { module: webpackModule } = mod;
+    const modules: IExtendedModule[] = webpackModule.modules || [webpackModule];
+    for (const submodule of modules) {
+      const { comments: subModuleComments } = submodule.factoryMeta;
+      if (subModuleComments) {
+        yield* subModuleComments;
+      }
+    }
+  }
+}
 
 /**
  * Generates a companion asset containing all extracted comments. If it is non-empty, returns a banner comment directing users to said companion asset.
@@ -22,15 +40,7 @@ export function generateLicenseFileForAsset(
 ): string {
   // Extracted comments from the minified asset and from the modules.
   // The former generally will be nonexistent (since it contains only the runtime), but the modules may have some.
-  const comments: Set<string> = new Set(asset.extractedComments);
-  for (const moduleId of asset.modules) {
-    const mod: IModuleInfo | undefined = minifiedModules.get(moduleId);
-    if (mod) {
-      for (const comment of mod.extractedComments) {
-        comments.add(comment);
-      }
-    }
-  }
+  const comments: Set<string> = new Set(iterateAllComments(asset.modules, minifiedModules));
 
   const assetName: string = asset.fileName;
 

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -28,7 +28,8 @@ import {
   IAssetMap,
   IExtendedModule,
   IModuleMinifierPluginHooks,
-  IDehydratedAssets
+  IDehydratedAssets,
+  _IWebpackCompilationData
 } from './ModuleMinifierPlugin.types';
 import { generateLicenseFileForAsset } from './GenerateLicenseFileForAsset';
 import { rehydrateAsset } from './RehydrateAsset';
@@ -50,6 +51,19 @@ const TAP_AFTER: TapOptions<'sync'> = {
 interface IExtendedChunkTemplate {
   hooks: {
     modules: SyncWaterfallHook<Source, webpack.compilation.Chunk>;
+  };
+}
+
+interface IAcornComment {
+  type: 'Line' | 'Block';
+  value: string;
+  start: number;
+  end: number;
+}
+
+interface IExtendedParser extends webpack.compilation.normalModuleFactory.Parser {
+  state: {
+    module: IExtendedModule;
   };
 }
 
@@ -102,6 +116,10 @@ function isMinificationResultError(
   return !!result.error;
 }
 
+function defaultLicenseCommentTest(comment: IAcornComment): boolean {
+  return /@preserve|@lic|@cc_on|^\**!/i.test(comment.value);
+}
+
 /**
  * Webpack plugin that minifies code on a per-module basis rather than per-asset. The actual minification is handled by the input `minifier` object.
  * @public
@@ -152,329 +170,352 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
       stableIdsPlugin.apply(compiler);
     }
 
-    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation: webpack.compilation.Compilation) => {
-      /**
-       * Set of local module ids that have been processed.
-       */
-      const submittedModules: Set<string | number> = new Set();
+    compiler.hooks.thisCompilation.tap(
+      PLUGIN_NAME,
+      (compilation: webpack.compilation.Compilation, compilationData: _IWebpackCompilationData) => {
+        const { normalModuleFactory } = compilationData;
 
-      /**
-       * The text and comments of all minified modules.
-       */
-      const minifiedModules: IModuleMap = new Map();
-
-      /**
-       * The text and comments of all minified chunks. Most of these are trivial, but the runtime chunk is a bit larger.
-       */
-      const minifiedAssets: IAssetMap = new Map();
-
-      let pendingMinificationRequests: number = 0;
-      /**
-       * Indicates that all files have been sent to the minifier and therefore that when pending hits 0, assets can be rehydrated.
-       */
-      let allRequestsIssued: boolean = false;
-
-      let resolveMinifyPromise: () => void;
-
-      const getRealId: (id: number | string) => number | string | undefined = (id: number | string) =>
-        this.hooks.finalModuleId.call(id);
-
-      const postProcessCode: (code: ReplaceSource, context: string) => ReplaceSource = (
-        code: ReplaceSource,
-        context: string
-      ) => this.hooks.postProcessCodeFragment.call(code, context);
-
-      /**
-       * Callback to invoke when a file has finished minifying.
-       */
-      function onFileMinified(): void {
-        if (--pendingMinificationRequests === 0 && allRequestsIssued) {
-          resolveMinifyPromise();
+        function addCommentExtraction(parser: webpack.compilation.normalModuleFactory.Parser): void {
+          parser.hooks.program.tap(PLUGIN_NAME, (program: unknown, comments: IAcornComment[]) => {
+            (parser as IExtendedParser).state.module.factoryMeta.comments =
+              comments.filter(defaultLicenseCommentTest);
+          });
         }
-      }
 
-      /**
-       * Callback to invoke for a chunk during render to replace the modules with CHUNK_MODULES_TOKEN
-       */
-      function dehydrateAsset(modules: Source, chunk: webpack.compilation.Chunk): Source {
-        for (const mod of chunk.modulesIterable) {
-          if (mod.id === null || !submittedModules.has(mod.id)) {
-            console.error(
-              `Chunk ${chunk.id} failed to render module ${mod.id} for ${(mod as IExtendedModule).resource}`
-            );
+        normalModuleFactory.hooks.parser.for('javascript/auto').tap(PLUGIN_NAME, addCommentExtraction);
+        normalModuleFactory.hooks.parser.for('javascript/dynamic').tap(PLUGIN_NAME, addCommentExtraction);
+        normalModuleFactory.hooks.parser.for('javascript/esm').tap(PLUGIN_NAME, addCommentExtraction);
+
+        /**
+         * Set of local module ids that have been processed.
+         */
+        const submittedModules: Set<string | number> = new Set();
+
+        /**
+         * The text and comments of all minified modules.
+         */
+        const minifiedModules: IModuleMap = new Map();
+
+        /**
+         * The text and comments of all minified chunks. Most of these are trivial, but the runtime chunk is a bit larger.
+         */
+        const minifiedAssets: IAssetMap = new Map();
+
+        let pendingMinificationRequests: number = 0;
+        /**
+         * Indicates that all files have been sent to the minifier and therefore that when pending hits 0, assets can be rehydrated.
+         */
+        let allRequestsIssued: boolean = false;
+
+        let resolveMinifyPromise: () => void;
+
+        const getRealId: (id: number | string) => number | string | undefined = (id: number | string) =>
+          this.hooks.finalModuleId.call(id);
+
+        const postProcessCode: (code: ReplaceSource, context: string) => ReplaceSource = (
+          code: ReplaceSource,
+          context: string
+        ) => this.hooks.postProcessCodeFragment.call(code, context);
+
+        /**
+         * Callback to invoke when a file has finished minifying.
+         */
+        function onFileMinified(): void {
+          if (--pendingMinificationRequests === 0 && allRequestsIssued) {
+            resolveMinifyPromise();
           }
         }
 
-        // Discard the rendered modules
-        return new RawSource(CHUNK_MODULES_TOKEN);
-      }
-
-      const { minifier } = this;
-
-      const cleanupMinifier: (() => Promise<void>) | undefined = minifier.ref && minifier.ref();
-
-      const requestShortener: webpack.compilation.RequestShortener =
-        compilation.runtimeTemplate.requestShortener;
-
-      /**
-       * Extracts the code for the module and sends it to be minified.
-       * Currently source maps are explicitly not supported.
-       * @param {Source} source
-       * @param {Module} mod
-       */
-      function minifyModule(source: Source, mod: IExtendedModule): Source {
-        const id: string | number | null = mod.id;
-
-        if (id !== null && !submittedModules.has(id)) {
-          // options.chunk contains the current chunk, if needed
-          // Render the source, then hash, then persist hash -> module, return a placeholder
-
-          // Initially populate the map with unminified version; replace during callback
-          submittedModules.add(id);
-
-          const realId: string | number | undefined = getRealId(id);
-
-          if (realId !== undefined && !mod.skipMinification) {
-            const wrapped: ConcatSource = new ConcatSource(
-              MODULE_WRAPPER_PREFIX + '\n',
-              source,
-              '\n' + MODULE_WRAPPER_SUFFIX
-            );
-
-            const nameForMap: string = `(modules)/${realId}`;
-
-            const { source: wrappedCode, map } = useSourceMaps
-              ? wrapped.sourceAndMap()
-              : {
-                  source: wrapped.source(),
-                  map: undefined
-                };
-
-            const hash: string = hashCodeFragment(wrappedCode);
-
-            ++pendingMinificationRequests;
-
-            minifier.minify(
-              {
-                hash,
-                code: wrappedCode,
-                nameForMap: useSourceMaps ? nameForMap : undefined,
-                externals: undefined
-              },
-              (result: IModuleMinificationResult) => {
-                if (isMinificationResultError(result)) {
-                  compilation.errors.push(result.error);
-                } else {
-                  try {
-                    // Have the source map display the module id instead of the minifier boilerplate
-                    const sourceForMap: string = `// ${mod.readableIdentifier(
-                      requestShortener
-                    )}${wrappedCode.slice(MODULE_WRAPPER_PREFIX.length, -MODULE_WRAPPER_SUFFIX.length)}`;
-
-                    const { code: minified, map: minifierMap, extractedComments } = result;
-
-                    const rawOutput: Source = useSourceMaps
-                      ? new SourceMapSource(
-                          minified, // Code
-                          nameForMap, // File
-                          minifierMap!, // Base source map
-                          sourceForMap, // Source from before transform
-                          map!, // Source Map from before transform
-                          false // Remove original source
-                        )
-                      : new RawSource(minified);
-
-                    const unwrapped: ReplaceSource = new ReplaceSource(rawOutput);
-                    const len: number = minified.length;
-
-                    unwrapped.replace(0, MODULE_WRAPPER_PREFIX.length - 1, '');
-                    unwrapped.replace(len - MODULE_WRAPPER_SUFFIX.length, len - 1, '');
-
-                    const withIds: Source = postProcessCode(unwrapped, mod.identifier());
-
-                    minifiedModules.set(realId, {
-                      source: new CachedSource(withIds),
-                      extractedComments,
-                      module: mod
-                    });
-                  } catch (err) {
-                    compilation.errors.push(err);
-                  }
-                }
-
-                onFileMinified();
-              }
-            );
-          } else {
-            // Route any other modules straight through
-            minifiedModules.set(realId !== undefined ? realId : id, {
-              source: new CachedSource(postProcessCode(new ReplaceSource(source), mod.identifier())),
-              extractedComments: [],
-              module: mod
-            });
-          }
-        }
-
-        // Return something so that this stage still produces valid ECMAScript
-        return new RawSource('(function(){})');
-      }
-
-      // During code generation, send the generated code to the minifier and replace with a placeholder
-      compilation.moduleTemplates.javascript.hooks.package.tap(TAP_AFTER, minifyModule);
-
-      // This should happen before any other tasks that operate during optimizeChunkAssets
-      compilation.hooks.optimizeChunkAssets.tapPromise(
-        TAP_BEFORE,
-        async (chunks: webpack.compilation.Chunk[]): Promise<void> => {
-          // Still need to minify the rendered assets
-          for (const chunk of chunks) {
-            const externals: string[] = [];
-            const externalNames: Map<string, string> = new Map();
-
-            const chunkModuleSet: Set<string | number> = new Set();
-            const allChunkModules: Iterable<IExtendedModule> =
-              chunk.modulesIterable as Iterable<IExtendedModule>;
-            let hasNonNumber: boolean = false;
-            for (const mod of allChunkModules) {
-              if (mod.id !== null) {
-                if (typeof mod.id !== 'number') {
-                  hasNonNumber = true;
-                }
-                chunkModuleSet.add(mod.id);
-
-                if (mod.external) {
-                  const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
-                    `${mod.id}`
-                  )}__`;
-                  // The first two identifiers are used for function (module, exports) at the module site
-                  const ordinal: number = 2 + externals.length;
-                  const miniId: string = getIdentifier(ordinal);
-                  externals.push(key);
-                  externalNames.set(key, miniId);
-                }
-              }
+        /**
+         * Callback to invoke for a chunk during render to replace the modules with CHUNK_MODULES_TOKEN
+         */
+        function dehydrateAsset(modules: Source, chunk: webpack.compilation.Chunk): Source {
+          for (const mod of chunk.modulesIterable) {
+            if (mod.id === null || !submittedModules.has(mod.id)) {
+              console.error(
+                `Chunk ${chunk.id} failed to render module ${mod.id} for ${(mod as IExtendedModule).resource}`
+              );
             }
+          }
 
-            const chunkModules: (string | number)[] = Array.from(chunkModuleSet);
-            // Sort by id before rehydration in case we rehydrate a given chunk multiple times
-            chunkModules.sort(
-              hasNonNumber
-                ? stringifyIdSortPredicate
-                : (x: string | number, y: string | number) => (x as number) - (y as number)
-            );
+          // Discard the rendered modules
+          return new RawSource(CHUNK_MODULES_TOKEN);
+        }
 
-            for (const assetName of chunk.files) {
-              const asset: Source = compilation.assets[assetName];
+        const { minifier } = this;
 
-              // Verify that this is a JS asset
-              if (/\.m?js(\?.+)?$/.test(assetName)) {
-                ++pendingMinificationRequests;
+        const cleanupMinifier: (() => Promise<void>) | undefined = minifier.ref && minifier.ref();
 
-                const rawCode: string = asset.source() as string;
-                const nameForMap: string = `(chunks)/${assetName}`;
+        const requestShortener: webpack.compilation.RequestShortener =
+          compilation.runtimeTemplate.requestShortener;
 
-                const hash: string = hashCodeFragment(rawCode);
+        /**
+         * Extracts the code for the module and sends it to be minified.
+         * Currently source maps are explicitly not supported.
+         * @param {Source} source
+         * @param {Module} mod
+         */
+        function minifyModule(source: Source, mod: IExtendedModule): Source {
+          const id: string | number | null = mod.id;
 
-                minifier.minify(
-                  {
-                    hash,
-                    code: rawCode,
-                    nameForMap: useSourceMaps ? nameForMap : undefined,
-                    externals
-                  },
-                  (result: IModuleMinificationResult) => {
-                    if (isMinificationResultError(result)) {
-                      compilation.errors.push(result.error);
-                      console.error(result.error);
-                    } else {
-                      try {
-                        const { code: minified, map: minifierMap, extractedComments } = result;
+          if (id !== null && !submittedModules.has(id)) {
+            // options.chunk contains the current chunk, if needed
+            // Render the source, then hash, then persist hash -> module, return a placeholder
 
-                        let codeForMap: string = rawCode;
-                        if (useSourceMaps) {
-                          // Pretend the __WEBPACK_CHUNK_MODULES__ token is an array of module ids, so that the source map contains information about the module ids in the chunk
-                          codeForMap = codeForMap.replace(
-                            CHUNK_MODULES_TOKEN,
-                            JSON.stringify(chunkModules, undefined, 2)
-                          );
-                        }
+            // Initially populate the map with unminified version; replace during callback
+            submittedModules.add(id);
 
-                        const rawOutput: Source = useSourceMaps
-                          ? new SourceMapSource(
-                              minified, // Code
-                              nameForMap, // File
-                              minifierMap!, // Base source map
-                              codeForMap, // Source from before transform
-                              undefined, // Source Map from before transform
-                              false // Remove original source
-                            )
-                          : new RawSource(minified);
+            const realId: string | number | undefined = getRealId(id);
 
-                        const withIds: Source = postProcessCode(new ReplaceSource(rawOutput), assetName);
+            if (realId !== undefined && !mod.factoryMeta.skipMinification) {
+              const wrapped: ConcatSource = new ConcatSource(
+                MODULE_WRAPPER_PREFIX + '\n',
+                source,
+                '\n' + MODULE_WRAPPER_SUFFIX
+              );
 
-                        minifiedAssets.set(assetName, {
-                          source: new CachedSource(withIds),
-                          extractedComments,
-                          modules: chunkModules,
-                          chunk,
-                          fileName: assetName,
-                          externalNames
-                        });
-                      } catch (err) {
-                        compilation.errors.push(err);
-                      }
+              const nameForMap: string = `(modules)/${realId}`;
+
+              const { source: wrappedCode, map } = useSourceMaps
+                ? wrapped.sourceAndMap()
+                : {
+                    source: wrapped.source(),
+                    map: undefined
+                  };
+
+              const hash: string = hashCodeFragment(wrappedCode);
+
+              ++pendingMinificationRequests;
+
+              minifier.minify(
+                {
+                  hash,
+                  code: wrappedCode,
+                  nameForMap: useSourceMaps ? nameForMap : undefined,
+                  externals: undefined
+                },
+                (result: IModuleMinificationResult) => {
+                  if (isMinificationResultError(result)) {
+                    compilation.errors.push(result.error);
+                  } else {
+                    try {
+                      // Have the source map display the module id instead of the minifier boilerplate
+                      const sourceForMap: string = `// ${mod.readableIdentifier(
+                        requestShortener
+                      )}${wrappedCode.slice(MODULE_WRAPPER_PREFIX.length, -MODULE_WRAPPER_SUFFIX.length)}`;
+
+                      const { code: minified, map: minifierMap } = result;
+
+                      const rawOutput: Source = useSourceMaps
+                        ? new SourceMapSource(
+                            minified, // Code
+                            nameForMap, // File
+                            minifierMap!, // Base source map
+                            sourceForMap, // Source from before transform
+                            map!, // Source Map from before transform
+                            false // Remove original source
+                          )
+                        : new RawSource(minified);
+
+                      const unwrapped: ReplaceSource = new ReplaceSource(rawOutput);
+                      const len: number = minified.length;
+
+                      unwrapped.replace(0, MODULE_WRAPPER_PREFIX.length - 1, '');
+                      unwrapped.replace(len - MODULE_WRAPPER_SUFFIX.length, len - 1, '');
+
+                      const withIds: Source = postProcessCode(unwrapped, mod.identifier());
+                      const cached: CachedSource = new CachedSource(withIds);
+
+                      const minifiedSize: number = Buffer.byteLength(cached.source(), 'utf-8');
+                      mod.factoryMeta.minifiedSize = minifiedSize;
+
+                      minifiedModules.set(realId, {
+                        source: cached,
+                        module: mod
+                      });
+                    } catch (err) {
+                      compilation.errors.push(err);
                     }
-
-                    onFileMinified();
                   }
-                );
-              } else {
-                // Skip minification for all other assets, though the modules still are
-                minifiedAssets.set(assetName, {
-                  // Still need to restore ids
-                  source: postProcessCode(new ReplaceSource(asset), assetName),
-                  extractedComments: [],
-                  modules: chunkModules,
-                  chunk,
-                  fileName: assetName,
-                  externalNames
-                });
-              }
+
+                  onFileMinified();
+                }
+              );
+            } else {
+              // Route any other modules straight through
+              const cached: CachedSource = new CachedSource(
+                postProcessCode(new ReplaceSource(source), mod.identifier())
+              );
+
+              const minifiedSize: number = Buffer.byteLength(cached.source(), 'utf-8');
+              mod.factoryMeta.minifiedSize = minifiedSize;
+
+              minifiedModules.set(realId !== undefined ? realId : id, {
+                source: cached,
+                module: mod
+              });
             }
           }
 
-          allRequestsIssued = true;
-
-          if (pendingMinificationRequests) {
-            await new Promise<void>((resolve) => {
-              resolveMinifyPromise = resolve;
-            });
-          }
-
-          // Handle any error from the minifier.
-          if (cleanupMinifier) {
-            await cleanupMinifier();
-          }
-
-          // All assets and modules have been minified, hand them off to be rehydrated
-
-          // Clone the maps for safety, even though we won't be using them in the plugin anymore
-          const assets: IAssetMap = new Map(minifiedAssets);
-          const modules: IModuleMap = new Map(minifiedModules);
-
-          await this.hooks.rehydrateAssets.promise(
-            {
-              assets,
-              modules
-            },
-            compilation
-          );
+          // Return something so that this stage still produces valid ECMAScript
+          return new RawSource('(function(){})');
         }
-      );
 
-      for (const template of [compilation.chunkTemplate, compilation.mainTemplate]) {
-        (template as unknown as IExtendedChunkTemplate).hooks.modules.tap(TAP_AFTER, dehydrateAsset);
+        // During code generation, send the generated code to the minifier and replace with a placeholder
+        compilation.moduleTemplates.javascript.hooks.package.tap(TAP_AFTER, minifyModule);
+
+        // This should happen before any other tasks that operate during optimizeChunkAssets
+        compilation.hooks.optimizeChunkAssets.tapPromise(
+          TAP_BEFORE,
+          async (chunks: webpack.compilation.Chunk[]): Promise<void> => {
+            // Still need to minify the rendered assets
+            for (const chunk of chunks) {
+              const externals: string[] = [];
+              const externalNames: Map<string, string> = new Map();
+
+              const chunkModuleSet: Set<string | number> = new Set();
+              const allChunkModules: Iterable<IExtendedModule> =
+                chunk.modulesIterable as Iterable<IExtendedModule>;
+              let hasNonNumber: boolean = false;
+              for (const mod of allChunkModules) {
+                if (mod.id !== null) {
+                  if (typeof mod.id !== 'number') {
+                    hasNonNumber = true;
+                  }
+                  chunkModuleSet.add(mod.id);
+
+                  if (mod.external) {
+                    const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
+                      `${mod.id}`
+                    )}__`;
+                    // The first two identifiers are used for function (module, exports) at the module site
+                    const ordinal: number = 2 + externals.length;
+                    const miniId: string = getIdentifier(ordinal);
+                    externals.push(key);
+                    externalNames.set(key, miniId);
+                  }
+                }
+              }
+
+              const chunkModules: (string | number)[] = Array.from(chunkModuleSet);
+              // Sort by id before rehydration in case we rehydrate a given chunk multiple times
+              chunkModules.sort(
+                hasNonNumber
+                  ? stringifyIdSortPredicate
+                  : (x: string | number, y: string | number) => (x as number) - (y as number)
+              );
+
+              for (const assetName of chunk.files) {
+                const asset: Source = compilation.assets[assetName];
+
+                // Verify that this is a JS asset
+                if (/\.m?js(\?.+)?$/.test(assetName)) {
+                  ++pendingMinificationRequests;
+
+                  const rawCode: string = asset.source() as string;
+                  const nameForMap: string = `(chunks)/${assetName}`;
+
+                  const hash: string = hashCodeFragment(rawCode);
+
+                  minifier.minify(
+                    {
+                      hash,
+                      code: rawCode,
+                      nameForMap: useSourceMaps ? nameForMap : undefined,
+                      externals
+                    },
+                    (result: IModuleMinificationResult) => {
+                      if (isMinificationResultError(result)) {
+                        compilation.errors.push(result.error);
+                        console.error(result.error);
+                      } else {
+                        try {
+                          const { code: minified, map: minifierMap } = result;
+
+                          let codeForMap: string = rawCode;
+                          if (useSourceMaps) {
+                            // Pretend the __WEBPACK_CHUNK_MODULES__ token is an array of module ids, so that the source map contains information about the module ids in the chunk
+                            codeForMap = codeForMap.replace(
+                              CHUNK_MODULES_TOKEN,
+                              JSON.stringify(chunkModules, undefined, 2)
+                            );
+                          }
+
+                          const rawOutput: Source = useSourceMaps
+                            ? new SourceMapSource(
+                                minified, // Code
+                                nameForMap, // File
+                                minifierMap!, // Base source map
+                                codeForMap, // Source from before transform
+                                undefined, // Source Map from before transform
+                                false // Remove original source
+                              )
+                            : new RawSource(minified);
+
+                          const withIds: Source = postProcessCode(new ReplaceSource(rawOutput), assetName);
+
+                          minifiedAssets.set(assetName, {
+                            source: new CachedSource(withIds),
+                            modules: chunkModules,
+                            chunk,
+                            fileName: assetName,
+                            externalNames
+                          });
+                        } catch (err) {
+                          compilation.errors.push(err);
+                        }
+                      }
+
+                      onFileMinified();
+                    }
+                  );
+                } else {
+                  // Skip minification for all other assets, though the modules still are
+                  minifiedAssets.set(assetName, {
+                    // Still need to restore ids
+                    source: postProcessCode(new ReplaceSource(asset), assetName),
+                    modules: chunkModules,
+                    chunk,
+                    fileName: assetName,
+                    externalNames
+                  });
+                }
+              }
+            }
+
+            allRequestsIssued = true;
+
+            if (pendingMinificationRequests) {
+              await new Promise<void>((resolve) => {
+                resolveMinifyPromise = resolve;
+              });
+            }
+
+            // Handle any error from the minifier.
+            if (cleanupMinifier) {
+              await cleanupMinifier();
+            }
+
+            // All assets and modules have been minified, hand them off to be rehydrated
+
+            // Clone the maps for safety, even though we won't be using them in the plugin anymore
+            const assets: IAssetMap = new Map(minifiedAssets);
+            const modules: IModuleMap = new Map(minifiedModules);
+
+            await this.hooks.rehydrateAssets.promise(
+              {
+                assets,
+                modules
+              },
+              compilation
+            );
+          }
+        );
+
+        for (const template of [compilation.chunkTemplate, compilation.mainTemplate]) {
+          (template as unknown as IExtendedChunkTemplate).hooks.modules.tap(TAP_AFTER, dehydrateAsset);
+        }
       }
-    });
+    );
   }
 }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -245,7 +245,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
 
         const { minifier } = this;
 
-        const cleanupMinifier: (() => Promise<void>) | undefined = minifier.ref && minifier.ref();
+        const cleanupMinifier: (() => Promise<void>) | undefined = minifier.ref?.();
 
         const requestShortener: webpack.compilation.RequestShortener =
           compilation.runtimeTemplate.requestShortener;
@@ -386,6 +386,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                   chunkModuleSet.add(mod.id);
 
                   if (mod.external) {
+                    // Match the identifiers generated in the AmdMainTemplatePlugin
+                    // https://github.com/webpack/webpack/blob/444e59f8a427f94f0064cae6765e5a3c4b78596d/lib/AmdMainTemplatePlugin.js#L49
                     const key: string = `__WEBPACK_EXTERNAL_MODULE_${webpack.Template.toIdentifier(
                       `${mod.id}`
                     )}__`;

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -116,7 +116,9 @@ function isMinificationResultError(
   return !!result.error;
 }
 
-function defaultLicenseCommentTest(comment: IAcornComment): boolean {
+// Matche behavior of terser's "some" option
+function isLicenseComment(comment: IAcornComment): boolean {
+  // https://github.com/terser/terser/blob/d3d924fa9e4c57bbe286b811c6068bcc7026e902/lib/output.js#L175
   return /@preserve|@lic|@cc_on|^\**!/i.test(comment.value);
 }
 
@@ -177,8 +179,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
 
         function addCommentExtraction(parser: webpack.compilation.normalModuleFactory.Parser): void {
           parser.hooks.program.tap(PLUGIN_NAME, (program: unknown, comments: IAcornComment[]) => {
-            (parser as IExtendedParser).state.module.factoryMeta.comments =
-              comments.filter(defaultLicenseCommentTest);
+            (parser as IExtendedParser).state.module.factoryMeta.comments = comments.filter(isLicenseComment);
           });
         }
 

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -50,10 +50,6 @@ export interface IModuleMinificationErrorResult {
    * Marker property to always return the same result shape.
    */
   map?: undefined;
-  /**
-   * Marker property to always return the same result shape.
-   */
-  extractedComments?: undefined;
 }
 
 /**
@@ -77,10 +73,6 @@ export interface IModuleMinificationSuccessResult {
    * Marker property to always return the same result shape.
    */
   map?: RawSourceMap;
-  /**
-   * The array of extracted comments, usually these are license information for 3rd party libraries.
-   */
-  extractedComments: string[];
 }
 
 /**
@@ -113,11 +105,6 @@ export interface IAssetInfo {
   fileName: string;
 
   /**
-   * The extracted comments from the boilerplate. Will usually be empty unless the minifier configuration and a plugin inject a comment that needs extraction in the runtime.
-   */
-  extractedComments: string[];
-
-  /**
    * The ids of the modules that are part of the chunk corresponding to this asset
    */
   modules: (string | number)[];
@@ -144,11 +131,6 @@ export interface IModuleInfo {
   source: Source;
 
   /**
-   * The extracted comments from this module, e.g. license information for a 3rd party library.
-   */
-  extractedComments: string[];
-
-  /**
    * The raw module object from Webpack, in case information from it is necessary for reconstruction
    */
   module: IExtendedModule;
@@ -163,6 +145,10 @@ export interface IExtendedModule extends webpack.compilation.Module {
    * Is this module external?
    */
   external?: boolean;
+  /**
+   * Concatenated modules
+   */
+  modules?: IExtendedModule[];
   /**
    * Id for the module
    */
@@ -180,10 +166,6 @@ export interface IExtendedModule extends webpack.compilation.Module {
    * Path to the physical file this module represents
    */
   resource?: string;
-  /**
-   * If set, bypass the minifier for this module. Useful if the code is known to already be minified.
-   */
-  skipMinification?: boolean;
 }
 
 declare module 'webpack' {
@@ -197,6 +179,15 @@ declare module 'webpack' {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     interface RequestShortener {}
   }
+}
+
+/**
+ * This is the second parameter to the thisCompilation and compilation webpack.Compiler hooks.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface _IWebpackCompilationData {
+  normalModuleFactory: webpack.compilation.NormalModuleFactory;
 }
 
 /**

--- a/webpack/module-minifier-plugin/src/NoopMinifier.ts
+++ b/webpack/module-minifier-plugin/src/NoopMinifier.ts
@@ -24,8 +24,7 @@ export class NoopMinifier implements IModuleMinifier {
       hash,
       error: undefined,
       code,
-      map: undefined,
-      extractedComments: []
+      map: undefined
     });
   }
 }

--- a/webpack/module-minifier-plugin/src/ParallelCompiler.ts
+++ b/webpack/module-minifier-plugin/src/ParallelCompiler.ts
@@ -16,27 +16,30 @@ export interface IParallelWebpackOptions {
   usePortableModules?: boolean;
 }
 
+const ZERO: bigint = BigInt(0);
+const THOUSAND: bigint = BigInt(1e3);
+
 /**
  * Formats a delta of `process.hrtime.bigint()` values as a string
  * @param timeNs
  */
 function formatTime(timeNs: bigint): string {
   let unit: string = 'ns';
-  let fraction: bigint = 0n;
-  if (timeNs > 1e3) {
+  let fraction: bigint = ZERO;
+  if (timeNs > THOUSAND) {
     unit = 'us';
-    fraction = timeNs % 1000n;
-    timeNs /= 1000n;
+    fraction = timeNs % THOUSAND;
+    timeNs /= THOUSAND;
   }
-  if (timeNs > 1e3) {
+  if (timeNs > THOUSAND) {
     unit = 'ms';
-    fraction = timeNs % 1000n;
-    timeNs /= 1000n;
+    fraction = timeNs % THOUSAND;
+    timeNs /= THOUSAND;
   }
-  if (timeNs > 1e3) {
+  if (timeNs > THOUSAND) {
     unit = 's';
-    fraction = timeNs % 1000n;
-    timeNs /= 1000n;
+    fraction = timeNs % THOUSAND;
+    timeNs /= THOUSAND;
   }
 
   return `${timeNs}.${('000' + fraction).slice(-3, -1)} ${unit}`;

--- a/webpack/module-minifier-plugin/src/terser/MinifySingleFile.ts
+++ b/webpack/module-minifier-plugin/src/terser/MinifySingleFile.ts
@@ -12,31 +12,7 @@ declare module 'terser' {
   }
 }
 
-import {
-  IModuleMinificationRequest,
-  IModuleMinificationResult,
-  IModuleMinificationErrorResult
-} from '../ModuleMinifierPlugin.types';
-
-interface IComment {
-  value: string;
-  type: 'comment1' | 'comment2' | 'comment3' | 'comment4';
-  pos: number;
-  line: number;
-  col: number;
-}
-
-/**
- * The logic for Terser's default "some" comments setting for preservation
- * @see https://github.com/terser/terser/blob/8d8200c2331c695d37f139b5850b10b595bce1d8/lib/output.js#L164-170
- */
-function isSomeComments(comment: IComment): boolean {
-  // multiline comment
-  return (
-    (comment.type === 'comment2' || comment.type === 'comment1') &&
-    /@preserve|@lic|@cc_on|^\**!/i.test(comment.value)
-  );
-}
+import { IModuleMinificationRequest, IModuleMinificationResult } from '../ModuleMinifierPlugin.types';
 
 /**
  * Minifies a single chunk of code. Factored out for reuse between ThreadPoolMinifier and SynchronousMinifier
@@ -47,7 +23,6 @@ export function minifySingleFile(
   request: IModuleMinificationRequest,
   terserOptions: MinifyOptions
 ): IModuleMinificationResult {
-  const extractedComments: string[] = [];
   const output: MinifyOptions['output'] = terserOptions.output || {};
   const { mangle: originalMangle } = terserOptions;
 
@@ -59,22 +34,7 @@ export function minifySingleFile(
     output,
     mangle
   };
-
-  if (output.comments !== false) {
-    /**
-     * Comment extraction as performed by terser-webpack-plugin to ensure output parity in default configuration
-     * @see https://github.com/webpack-contrib/terser-webpack-plugin/blob/master/src/minify.js#L129-142
-     */
-    output.comments = (astNode: unknown, comment: IComment) => {
-      if (isSomeComments(comment)) {
-        const commentText: string =
-          comment.type === 'comment2' ? `/*${comment.value}*/\n` : `//${comment.value}\n`;
-        extractedComments.push(commentText);
-      }
-
-      return false;
-    };
-  }
+  output.comments = false;
 
   const { code, nameForMap, hash, externals } = request;
 
@@ -100,16 +60,14 @@ export function minifySingleFile(
       error: minified.error,
       code: undefined,
       map: undefined,
-      hash,
-      extractedComments: undefined
-    } as IModuleMinificationErrorResult;
+      hash
+    };
   }
 
   return {
     error: undefined,
     code: minified.code!,
     map: minified.map as unknown as RawSourceMap,
-    hash,
-    extractedComments
+    hash
   };
 }

--- a/webpack/module-minifier-plugin/src/test/MinifySingleFile.test.ts
+++ b/webpack/module-minifier-plugin/src/test/MinifySingleFile.test.ts
@@ -1,0 +1,21 @@
+import { minifySingleFile } from '../terser/MinifySingleFile';
+
+describe('minifySingleFile', () => {
+  it('uses consistent identifiers for webpack vars', () => {
+    const code: string = `__MINIFY_MODULE__(function (module, __webpack_exports__, __webpack_require__) {});`;
+
+    const minifierResult = minifySingleFile(
+      {
+        hash: 'foo',
+        code,
+        nameForMap: undefined,
+        externals: undefined
+      },
+      {
+        mangle: true
+      }
+    );
+
+    expect(minifierResult).toMatchSnapshot();
+  });
+});

--- a/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
+++ b/webpack/module-minifier-plugin/src/test/RehydrateAsset.test.ts
@@ -6,62 +6,51 @@ import { IAssetInfo, IModuleMap } from '../ModuleMinifierPlugin.types';
 const modules: IModuleMap = new Map();
 modules.set('a', {
   source: new RawSource('foo'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set('b', {
   source: new RawSource('bar'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set('0b', {
   source: new RawSource('baz'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set('=', {
   source: new RawSource('bak'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set('a0', {
   source: new RawSource('bal'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set(0, {
   source: new RawSource('fizz'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set(2, {
   source: new RawSource('buzz'),
-  extractedComments: [],
   module: undefined!
 });
 modules.set(255, {
   source: new RawSource('__WEBPACK_EXTERNAL_MODULE_fizz__'),
-  extractedComments: [],
   module: undefined!
 });
 for (let i: number = 14; i < 30; i++) {
   if (i !== 25) {
     modules.set(i, {
       source: new RawSource('bozz'),
-      extractedComments: [],
       module: undefined!
     });
   }
 }
 modules.set(25, {
   source: new RawSource('bang'),
-  extractedComments: [],
   module: undefined!
 });
 for (let i: number = 1000; i < 1010; i++) {
   modules.set(i, {
     source: new RawSource(`b${i}`),
-    extractedComments: [],
     module: undefined!
   });
 }
@@ -73,7 +62,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: ['a', 'b', '0b', '=', 'a0'],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -91,7 +79,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [0, 25],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -109,7 +96,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [2],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -127,7 +113,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -145,7 +130,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -163,7 +147,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [0, 2, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -181,7 +164,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [2, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map()
@@ -199,7 +181,6 @@ describe('rehydrateAsset', () => {
     const asset: IAssetInfo = {
       source: new RawSource(`<before>${CHUNK_MODULES_TOKEN}<after>`),
       modules: [255],
-      extractedComments: [],
       fileName: 'test',
       chunk: undefined!,
       externalNames: new Map([['__WEBPACK_EXTERNAL_MODULE_fizz__', 'TREBLE']])

--- a/webpack/module-minifier-plugin/src/test/__snapshots__/MinifySingleFile.test.ts.snap
+++ b/webpack/module-minifier-plugin/src/test/__snapshots__/MinifySingleFile.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`minifySingleFile uses consistent identifiers for webpack vars 1`] = `
+Object {
+  "code": "__MINIFY_MODULE__((function(e,t,n){}));",
+  "error": undefined,
+  "hash": "foo",
+  "map": undefined,
+}
+`;

--- a/webpack/module-minifier-plugin/src/workerPool/WorkerPool.ts
+++ b/webpack/module-minifier-plugin/src/workerPool/WorkerPool.ts
@@ -244,7 +244,7 @@ export class WorkerPool {
     }
 
     if (!this._alive.length && !this._error) {
-      for (const [resolve] of this._onComplete) {
+      for (const [resolve] of this._onComplete.splice(0)) {
         resolve();
       }
     }

--- a/webpack/module-minifier-plugin/tsconfig.json
+++ b/webpack/module-minifier-plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2019",
     "types": ["heft-jest", "node"],
     "noImplicitAny": false // Some typings are missing
   }

--- a/webpack/module-minifier-plugin/tsconfig.json
+++ b/webpack/module-minifier-plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2018",
     "types": ["heft-jest", "node"],
     "noImplicitAny": false // Some typings are missing
   }


### PR DESCRIPTION
## Summary
Separates responsibility for comment extraction from minification. This allows minifier implementations to be more flexible, as they can freely discard comments in all cases.

## Details
Added metadata for minified module sizes.
Removed comment extraction from the minifier and moved it to the initial parse phase.

## How it was tested
Local build validation, unit tests.
