### PR TITLE
[api-extractor] Don't export trimmed namespace members during rollup

### DIFF
--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -203,6 +203,15 @@ export class DtsRollupGenerator {
             );
           }
 
+          // If the entity's declaration won't be included, then neither should the namespace export it
+          // This fixes the issue encountered here: https://github.com/microsoft/rushstack/issues/2791
+          const symbolMetadata: SymbolMetadata | undefined =
+            collector.tryFetchMetadataForAstEntity(exportedEntity);
+          const maxEffectiveReleaseTag: ReleaseTag = symbolMetadata
+            ? symbolMetadata.maxEffectiveReleaseTag
+            : ReleaseTag.None;
+          if (!this._shouldIncludeReleaseTag(maxEffectiveReleaseTag, dtsKind)) continue;
+
           if (collectorEntity.nameForEmit === exportedName) {
             exportClauses.push(collectorEntity.nameForEmit);
           } else {

--- a/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
+++ b/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
@@ -61,14 +61,14 @@ export namespace EntangledNamespace {
 export type ExportedAlias = AlphaClass;
 
 // Warning: (ae-internal-missing-underscore) The name "InternalClass" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal
 export class InternalClass {
     undecoratedMember(): void;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "IPublicClassInternalParameters" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal
 export interface IPublicClassInternalParameters {
 }
@@ -82,6 +82,24 @@ export interface IPublicComplexInterface {
 }
 
 export { Lib1Interface }
+
+declare namespace NS {
+  export {
+    NS_PUBLIC,
+    NS_BETA,
+    NS_INTERNAL
+  }
+}
+export { NS }
+
+// @beta (undocumented)
+const NS_BETA = "BETA";
+
+// @internal (undocumented)
+const NS_INTERNAL = "INTERNAL";
+
+// @public (undocumented)
+const NS_PUBLIC = "PUBLIC";
 
 // @public
 export class PublicClass {

--- a/build-tests/api-extractor-test-04/src/NamespaceWithTrimming.ts
+++ b/build-tests/api-extractor-test-04/src/NamespaceWithTrimming.ts
@@ -1,0 +1,8 @@
+/** @public */
+export const NS_PUBLIC = 'PUBLIC';
+
+/** @beta */
+export const NS_BETA = 'BETA';
+
+/** @internal */
+export const NS_INTERNAL = 'INTERNAL';

--- a/build-tests/api-extractor-test-04/src/index.ts
+++ b/build-tests/api-extractor-test-04/src/index.ts
@@ -36,3 +36,10 @@ export type ExportedAlias = AlphaClass;
 export { IPublicComplexInterface } from './IPublicComplexInterface';
 
 export { Lib1Interface } from 'api-extractor-lib1-test';
+
+/**
+ * Test that when exporting namespaces, we don't export members that got trimmed.
+ * See this issue: https://github.com/microsoft/rushstack/issues/2791
+ */
+import * as NS from './NamespaceWithTrimming';
+export { NS };

--- a/common/changes/@microsoft/api-extractor/master_2021-07-07-00-32.json
+++ b/common/changes/@microsoft/api-extractor/master_2021-07-07-00-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Don't export trimmed namespace members during rollup (#2791)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "14597409+SchoofsKelvin@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes #2791.

## Details

Adds a check to `_generateTypingsFileContent` when emitting namespaces that skips over trimmed members.

## How it was tested

Added a `NamespaceWithTrimming` module to `api-extractor-test-04` which gets imported/exported like this:
```ts
import * as NS from './NamespaceWithTrimming';
export { NS };
```

The module itself contains 3 definitions:
```ts
/** @public */
export const NS_PUBLIC = 'PUBLIC';

/** @beta */
export const NS_BETA = 'BETA';

/** @internal */
export const NS_INTERNAL = 'INTERNAL';
```

Before the fix, the rollup would generate an invalid beta (and public) rollup, which would cause the test's `beta-consumer` to fail due to the `.d.ts` trying to export `INTERNAL` which wasn't emitted, like this:

```ts
declare namespace NS {
  export {
    NS_PUBLIC,
    NS_BETA,
    NS_INTERNAL
  }
}
export { NS }

// @beta (undocumented)
const NS_BETA = "BETA";

// @public (undocumented)
const NS_PUBLIC = "PUBLIC";

// NS_INTERNAL is trimmed
```

With this fix, the namespace won't export its members which get trimmed:

```ts
declare namespace NS {
  export {
    NS_PUBLIC,
    NS_BETA
  }
}
export { NS }

// @beta (undocumented)
const NS_BETA = "BETA";

// @public (undocumented)
const NS_PUBLIC = "PUBLIC";

// NS_INTERNAL is trimmed
```

In the public rollup, it would also omit `NS_PUBLIC`, which isn't automatically tested but is practically the identical use case covered by `beta-consumer` validating whether `NS_INTERNAL` is properly trimmed.
