### PR TITLE
[rush] Clean up and expose ProjectChangeAnalyzer from rush-lib.

### DIFF
--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -85,7 +85,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
     });
 
     const trackedFiles: string[] = Array.from(
-      (await projectChangeAnalyzer.tryGetProjectDependenciesAsync(project.packageName, terminal))!.keys()
+      (await projectChangeAnalyzer._tryGetProjectDependenciesAsync(project.packageName, terminal))!.keys()
     );
     const commandLineConfigFilePath: string = path.join(
       this.rushConfiguration.commonRushConfigFolder,

--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -11,7 +11,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { ProjectBuilder } from '../../logic/taskRunner/ProjectBuilder';
-import { PackageChangeAnalyzer } from '../../logic/PackageChangeAnalyzer';
+import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
 import { Utilities } from '../../utilities/Utilities';
 import { TaskSelector } from '../../logic/TaskSelector';
 import { RushConstants } from '../../logic/RushConstants';
@@ -72,7 +72,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
     const command: string = this._command.value!;
     const commandToRun: string | undefined = TaskSelector.getScriptToRun(project, command, []);
 
-    const packageChangeAnalyzer: PackageChangeAnalyzer = new PackageChangeAnalyzer(this.rushConfiguration);
+    const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const projectBuilder: ProjectBuilder = new ProjectBuilder({
       rushProject: project,
       rushConfiguration: this.rushConfiguration,
@@ -80,12 +80,12 @@ export class WriteBuildCacheAction extends BaseRushAction {
       commandName: command,
       commandToRun: commandToRun || '',
       isIncrementalBuildAllowed: false,
-      packageChangeAnalyzer,
+      projectChangeAnalyzer,
       packageDepsFilename: Utilities.getPackageDepsFilenameForCommand(command)
     });
 
     const trackedFiles: string[] = Array.from(
-      (await packageChangeAnalyzer.getPackageDeps(project.packageName, terminal))!.keys()
+      (await projectChangeAnalyzer.getPackageDeps(project.packageName, terminal))!.keys()
     );
     const commandLineConfigFilePath: string = path.join(
       this.rushConfiguration.commonRushConfigFolder,

--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -85,7 +85,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
     });
 
     const trackedFiles: string[] = Array.from(
-      (await projectChangeAnalyzer.getPackageDeps(project.packageName, terminal))!.keys()
+      (await projectChangeAnalyzer.tryGetProjectDependenciesAsync(project.packageName, terminal))!.keys()
     );
     const commandLineConfigFilePath: string = path.join(
       this.rushConfiguration.commonRushConfigFolder,

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -237,8 +237,8 @@ export class BulkScriptAction extends BaseScriptAction {
           ...options.taskSelectorOptions,
           // Revise down the set of projects to execute the command on
           selection,
-          // Pass the PackageChangeAnalyzer from the state differ to save a bit of overhead
-          packageChangeAnalyzer: state
+          // Pass the ProjectChangeAnalyzer from the state differ to save a bit of overhead
+          projectChangeAnalyzer: state
         },
         taskRunnerOptions: options.taskRunnerOptions,
         stopwatch,

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -59,3 +59,5 @@ export { VersionPolicyConfiguration } from './api/VersionPolicyConfiguration';
 export { ILaunchOptions, Rush } from './api/Rush';
 
 export { ExperimentsConfiguration, IExperimentsJson } from './api/ExperimentsConfiguration';
+
+export { ProjectChangeAnalyzer } from './logic/ProjectChangeAnalyzer';

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -60,4 +60,4 @@ export { ILaunchOptions, Rush } from './api/Rush';
 
 export { ExperimentsConfiguration, IExperimentsJson } from './api/ExperimentsConfiguration';
 
-export { ProjectChangeAnalyzer } from './logic/ProjectChangeAnalyzer';
+export { ProjectChangeAnalyzer, IGetChangedProjectsOptions } from './logic/ProjectChangeAnalyzer';

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as url from 'url';
 import colors from 'colors/safe';
-import { Executable, AlreadyReportedError, Path } from '@rushstack/node-core-library';
+import { Executable, AlreadyReportedError, Path, Terminal } from '@rushstack/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';
 import { GitEmailPolicy } from './policy/GitEmailPolicy';
@@ -176,9 +176,13 @@ export class Git {
     }
   }
 
-  public getChangedFolders(targetBranch: string, shouldFetch: boolean = false): string[] | undefined {
+  public getChangedFolders(
+    targetBranch: string,
+    terminal: Terminal,
+    shouldFetch: boolean = false
+  ): string[] | undefined {
     if (shouldFetch) {
-      this._fetchRemoteBranch(targetBranch);
+      this._fetchRemoteBranch(targetBranch, terminal);
     }
 
     const gitPath: string = this.getGitPathOrThrow();
@@ -208,9 +212,14 @@ export class Git {
    * those in the provided {@param targetBranch}. If a {@param pathPrefix} is provided,
    * this function only returns results under the that path.
    */
-  public getChangedFiles(targetBranch: string, skipFetch: boolean = false, pathPrefix?: string): string[] {
+  public getChangedFiles(
+    targetBranch: string,
+    terminal: Terminal,
+    skipFetch: boolean = false,
+    pathPrefix?: string
+  ): string[] {
     if (!skipFetch) {
-      this._fetchRemoteBranch(targetBranch);
+      this._fetchRemoteBranch(targetBranch, terminal);
     }
 
     const gitPath: string = this.getGitPathOrThrow();
@@ -458,14 +467,12 @@ export class Git {
     return spawnResult.status === 0;
   }
 
-  private _fetchRemoteBranch(remoteBranchName: string): void {
+  private _fetchRemoteBranch(remoteBranchName: string, terminal: Terminal): void {
     console.log(`Checking for updates to ${remoteBranchName}...`);
     const fetchResult: boolean = this._tryFetchRemoteBranch(remoteBranchName);
     if (!fetchResult) {
-      console.log(
-        colors.yellow(
-          `Error fetching git remote branch ${remoteBranchName}. Detected changed files may be incorrect.`
-        )
+      terminal.writeWarningLine(
+        `Error fetching git remote branch ${remoteBranchName}. Detected changed files may be incorrect.`
       );
     }
   }

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -118,10 +118,10 @@ export class ProjectChangeAnalyzer {
    * Gets a list of projects that have changed in the current state of the repo
    * when compared to the specified branch.
    */
-  public *getChangedProjects(
+  public async *getChangedProjectsAsync(
     targetBranch: string,
     shouldFetch: boolean = false
-  ): Iterable<RushConfigurationProject> {
+  ): AsyncIterable<RushConfigurationProject> {
     const changedFolders: string[] | undefined = this._git.getChangedFolders(targetBranch, shouldFetch);
 
     if (changedFolders) {

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -16,7 +16,7 @@ import { BaseProjectShrinkwrapFile } from './base/BaseProjectShrinkwrapFile';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { RushConstants } from './RushConstants';
 
-export class PackageChangeAnalyzer {
+export class ProjectChangeAnalyzer {
   /**
    * null === we haven't looked
    * undefined === data isn't available (i.e. - git isn't present)
@@ -44,7 +44,7 @@ export class PackageChangeAnalyzer {
 
   /**
    * The project state hash is calculated in the following way:
-   * - Project dependencies are collected (see PackageChangeAnalyzer.getPackageDeps)
+   * - Project dependencies are collected (see ProjectChangeAnalyzer.getPackageDeps)
    *   - If project dependencies cannot be collected (i.e. - if Git isn't available),
    *     this function returns `undefined`
    * - The (path separator normalized) repo-root-relative dependencies' file paths are sorted

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -36,34 +36,13 @@ export class ProjectChangeAnalyzer {
 
   /**
    * Try to get a list of the specified project's dependencies and their hashes.
-   */
-  public async getProjectDependenciesAsync(
-    projectName: string,
-    terminal: Terminal
-  ): Promise<Map<string, string>> {
-    if (this._data === null) {
-      this._data = await this._getDataAsync(terminal);
-    }
-
-    if (this._data === undefined) {
-      throw new Error('Unable to get current repo state.');
-    } else {
-      const result: Map<string, string> | undefined = this._data.get(projectName);
-      if (!result) {
-        throw new Error(`Project "${projectName}" does not exist in the current Rush configuration.`);
-      } else {
-        return result;
-      }
-    }
-  }
-
-  /**
-   * Try to get a list of the specified project's dependencies and their hashes.
    *
    * @remarks
    * If the data can't be generated (i.e. - if Git is not present) this returns undefined.
+   *
+   * @internal
    */
-  public async tryGetProjectDependenciesAsync(
+  public async _tryGetProjectDependenciesAsync(
     projectName: string,
     terminal: Terminal
   ): Promise<Map<string, string> | undefined> {
@@ -92,14 +71,16 @@ export class ProjectChangeAnalyzer {
    * - A SHA1 hash is created and each (sorted) file path is fed into the hash and then its
    *   Git SHA is fed into the hash
    * - A hex digest of the hash is returned
+   *
+   * @internal
    */
-  public async tryGetProjectStateHashAsync(
+  public async _tryGetProjectStateHashAsync(
     projectName: string,
     terminal: Terminal
   ): Promise<string | undefined> {
     let projectState: string | undefined = this._projectStateCache.get(projectName);
     if (!projectState) {
-      const packageDeps: Map<string, string> | undefined = await this.tryGetProjectDependenciesAsync(
+      const packageDeps: Map<string, string> | undefined = await this._tryGetProjectDependenciesAsync(
         projectName,
         terminal
       );

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -36,15 +36,11 @@ export class ProjectChangeAnalyzer {
 
   /**
    * Try to get a list of the specified project's dependencies and their hashes.
-   *
-   * @remarks
-   * If the data can't be generated (i.e. - if Git is not present), this throws an Error.
-   * If the project name is invalid, this returns undefined.
    */
   public async getProjectDependenciesAsync(
     projectName: string,
     terminal: Terminal
-  ): Promise<Map<string, string> | undefined> {
+  ): Promise<Map<string, string>> {
     if (this._data === null) {
       this._data = await this._getDataAsync(terminal);
     }
@@ -52,7 +48,12 @@ export class ProjectChangeAnalyzer {
     if (this._data === undefined) {
       throw new Error('Unable to get current repo state.');
     } else {
-      return this._data.get(projectName);
+      const result: Map<string, string> | undefined = this._data.get(projectName);
+      if (!result) {
+        throw new Error(`Project "${projectName}" does not exist in the current Rush configuration.`);
+      } else {
+        return result;
+      }
     }
   }
 
@@ -60,8 +61,7 @@ export class ProjectChangeAnalyzer {
    * Try to get a list of the specified project's dependencies and their hashes.
    *
    * @remarks
-   * If the data can't be generated (i.e. - if Git is not present), or if the project name
-   * is invalid, this returns undefined.
+   * If the data can't be generated (i.e. - if Git is not present) this returns undefined.
    */
   public async tryGetProjectDependenciesAsync(
     projectName: string,
@@ -71,7 +71,16 @@ export class ProjectChangeAnalyzer {
       this._data = await this._getDataAsync(terminal);
     }
 
-    return this._data?.get(projectName);
+    if (this._data === undefined) {
+      return undefined;
+    } else {
+      const result: Map<string, string> | undefined = this._data.get(projectName);
+      if (!result) {
+        throw new Error(`Project "${projectName}" does not exist in the current Rush configuration.`);
+      } else {
+        return result;
+      }
+    }
   }
 
   /**

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -15,16 +15,17 @@ import { Git } from './Git';
 import { BaseProjectShrinkwrapFile } from './base/BaseProjectShrinkwrapFile';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { RushConstants } from './RushConstants';
+import { UNINITIALIZED } from '../utilities/Utilities';
 
 /**
  * @beta
  */
 export class ProjectChangeAnalyzer {
   /**
-   * null === we haven't looked
+   * UNINITIALIZED === we haven't looked
    * undefined === data isn't available (i.e. - git isn't present)
    */
-  private _data: Map<string, Map<string, string>> | undefined | null = null;
+  private _data: Map<string, Map<string, string>> | undefined | UNINITIALIZED = UNINITIALIZED;
   private _projectStateCache: Map<string, string> = new Map<string, string>();
   private _rushConfiguration: RushConfiguration;
   private readonly _git: Git;
@@ -46,7 +47,7 @@ export class ProjectChangeAnalyzer {
     projectName: string,
     terminal: Terminal
   ): Promise<Map<string, string> | undefined> {
-    if (this._data === null) {
+    if (this._data === UNINITIALIZED) {
       this._data = await this._getDataAsync(terminal);
     }
 

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -79,7 +79,7 @@ export class ProjectWatcher {
     const useNativeRecursiveWatch: boolean = os.platform() === 'win32' || os.platform() === 'darwin';
 
     for (const project of this._projectsToWatch) {
-      const projectState: Map<string, string> = (await previousState.getPackageDeps(
+      const projectState: Map<string, string> = (await previousState.tryGetProjectDependenciesAsync(
         project.packageName,
         this._terminal
       ))!;
@@ -244,8 +244,8 @@ export class ProjectWatcher {
 
       if (
         ProjectWatcher._haveProjectDepsChanged(
-          (await previousState.getPackageDeps(packageName, this._terminal))!,
-          (await state.getPackageDeps(packageName, this._terminal))!
+          (await previousState.tryGetProjectDependenciesAsync(packageName, this._terminal))!,
+          (await state.tryGetProjectDependenciesAsync(packageName, this._terminal))!
         )
       ) {
         // May need to detect if the nature of the change will break the process, e.g. changes to package.json

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -79,7 +79,7 @@ export class ProjectWatcher {
     const useNativeRecursiveWatch: boolean = os.platform() === 'win32' || os.platform() === 'darwin';
 
     for (const project of this._projectsToWatch) {
-      const projectState: Map<string, string> = (await previousState.tryGetProjectDependenciesAsync(
+      const projectState: Map<string, string> = (await previousState._tryGetProjectDependenciesAsync(
         project.packageName,
         this._terminal
       ))!;
@@ -244,8 +244,8 @@ export class ProjectWatcher {
 
       if (
         ProjectWatcher._haveProjectDepsChanged(
-          (await previousState.tryGetProjectDependenciesAsync(packageName, this._terminal))!,
-          (await state.tryGetProjectDependenciesAsync(packageName, this._terminal))!
+          (await previousState._tryGetProjectDependenciesAsync(packageName, this._terminal))!,
+          (await state._tryGetProjectDependenciesAsync(packageName, this._terminal))!
         )
       ) {
         // May need to detect if the nature of the change will break the process, e.g. changes to package.json

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -5,7 +5,7 @@ import { BuildCacheConfiguration } from '../api/BuildCacheConfiguration';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { ProjectBuilder, convertSlashesForWindows } from '../logic/taskRunner/ProjectBuilder';
-import { PackageChangeAnalyzer } from './PackageChangeAnalyzer';
+import { ProjectChangeAnalyzer } from './ProjectChangeAnalyzer';
 import { TaskCollection } from './taskRunner/TaskCollection';
 
 export interface ITaskSelectorConstructor {
@@ -20,7 +20,7 @@ export interface ITaskSelectorConstructor {
   ignoreMissingScript: boolean;
   ignoreDependencyOrder: boolean;
   packageDepsFilename: string;
-  packageChangeAnalyzer?: PackageChangeAnalyzer;
+  projectChangeAnalyzer?: ProjectChangeAnalyzer;
 }
 
 /**
@@ -31,14 +31,14 @@ export interface ITaskSelectorConstructor {
  */
 export class TaskSelector {
   private _options: ITaskSelectorConstructor;
-  private _packageChangeAnalyzer: PackageChangeAnalyzer;
+  private _projectChangeAnalyzer: ProjectChangeAnalyzer;
 
   public constructor(options: ITaskSelectorConstructor) {
     this._options = options;
 
-    const { packageChangeAnalyzer = new PackageChangeAnalyzer(options.rushConfiguration) } = options;
+    const { projectChangeAnalyzer = new ProjectChangeAnalyzer(options.rushConfiguration) } = options;
 
-    this._packageChangeAnalyzer = packageChangeAnalyzer;
+    this._projectChangeAnalyzer = projectChangeAnalyzer;
   }
 
   public static getScriptToRun(
@@ -130,7 +130,7 @@ export class TaskSelector {
         commandToRun: commandToRun || '',
         commandName: this._options.commandName,
         isIncrementalBuildAllowed: this._options.isIncrementalBuildAllowed,
-        packageChangeAnalyzer: this._packageChangeAnalyzer,
+        projectChangeAnalyzer: this._projectChangeAnalyzer,
         packageDepsFilename: this._options.packageDepsFilename
       })
     );

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -448,7 +448,7 @@ export class ProjectBuildCache {
       for (const projectToProcess of projectsToProcess) {
         projectsThatHaveBeenProcessed.add(projectToProcess);
 
-        const projectState: string | undefined = await projectChangeAnalyzer.getProjectStateHash(
+        const projectState: string | undefined = await projectChangeAnalyzer.tryGetProjectStateHashAsync(
           projectToProcess.packageName,
           options.terminal
         );

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -10,7 +10,7 @@ import { FileSystem, LegacyAdapters, Path, Terminal } from '@rushstack/node-core
 import * as fs from 'fs';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
+import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { RushConstants } from '../RushConstants';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
@@ -24,7 +24,7 @@ interface IProjectBuildCacheOptions {
   projectConfiguration: RushProjectConfiguration;
   command: string;
   trackedProjectFiles: string[] | undefined;
-  packageChangeAnalyzer: PackageChangeAnalyzer;
+  projectChangeAnalyzer: ProjectChangeAnalyzer;
   terminal: Terminal;
 }
 
@@ -426,7 +426,7 @@ export class ProjectBuildCache {
 
   private static async _getCacheId(options: IProjectBuildCacheOptions): Promise<string | undefined> {
     // The project state hash is calculated in the following method:
-    // - The current project's hash (see PackageChangeAnalyzer.getProjectStateHash) is
+    // - The current project's hash (see ProjectChangeAnalyzer.getProjectStateHash) is
     //   calculated and appended to an array
     // - The current project's recursive dependency projects' hashes are calculated
     //   and appended to the array
@@ -437,7 +437,7 @@ export class ProjectBuildCache {
     //   3. Each dependency project hash (from the array constructed in previous steps),
     //      in sorted alphanumerical-sorted order
     // - A hex digest of the hash is returned
-    const packageChangeAnalyzer: PackageChangeAnalyzer = options.packageChangeAnalyzer;
+    const projectChangeAnalyzer: ProjectChangeAnalyzer = options.projectChangeAnalyzer;
     const projectStates: string[] = [];
     const projectsThatHaveBeenProcessed: Set<RushConfigurationProject> = new Set<RushConfigurationProject>();
     let projectsToProcess: Set<RushConfigurationProject> = new Set<RushConfigurationProject>();
@@ -448,7 +448,7 @@ export class ProjectBuildCache {
       for (const projectToProcess of projectsToProcess) {
         projectsThatHaveBeenProcessed.add(projectToProcess);
 
-        const projectState: string | undefined = await packageChangeAnalyzer.getProjectStateHash(
+        const projectState: string | undefined = await projectChangeAnalyzer.getProjectStateHash(
           projectToProcess.packageName,
           options.terminal
         );

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -448,7 +448,7 @@ export class ProjectBuildCache {
       for (const projectToProcess of projectsToProcess) {
         projectsThatHaveBeenProcessed.add(projectToProcess);
 
-        const projectState: string | undefined = await projectChangeAnalyzer.tryGetProjectStateHashAsync(
+        const projectState: string | undefined = await projectChangeAnalyzer._tryGetProjectStateHashAsync(
           projectToProcess.packageName,
           options.terminal
         );

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -20,7 +20,7 @@ describe('ProjectBuildCache', () => {
   async function prepareSubject(options: Partial<ITestOptions>): Promise<ProjectBuildCache | undefined> {
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
     const projectChangeAnalyzer = {
-      [ProjectChangeAnalyzer.prototype.tryGetProjectStateHashAsync.name]: async () => {
+      [ProjectChangeAnalyzer.prototype._tryGetProjectStateHashAsync.name]: async () => {
         return 'state_hash';
       }
     } as unknown as ProjectChangeAnalyzer;

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -4,7 +4,7 @@
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 import { BuildCacheConfiguration } from '../../../api/BuildCacheConfiguration';
 import { RushProjectConfiguration } from '../../../api/RushProjectConfiguration';
-import { PackageChangeAnalyzer } from '../../../logic/PackageChangeAnalyzer';
+import { ProjectChangeAnalyzer } from '../../ProjectChangeAnalyzer';
 import { IGenerateCacheEntryIdOptions } from '../CacheEntryId';
 import { FileSystemBuildCacheProvider } from '../FileSystemBuildCacheProvider';
 
@@ -19,11 +19,11 @@ interface ITestOptions {
 describe('ProjectBuildCache', () => {
   async function prepareSubject(options: Partial<ITestOptions>): Promise<ProjectBuildCache | undefined> {
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
-    const packageChangeAnalyzer = {
+    const projectChangeAnalyzer = {
       getProjectStateHash: () => {
         return 'state_hash';
       }
-    } as unknown as PackageChangeAnalyzer;
+    } as unknown as ProjectChangeAnalyzer;
 
     const subject: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCache({
       buildCacheConfiguration: {
@@ -45,7 +45,7 @@ describe('ProjectBuildCache', () => {
       } as unknown as RushProjectConfiguration,
       command: 'build',
       trackedProjectFiles: options.hasOwnProperty('trackedProjectFiles') ? options.trackedProjectFiles : [],
-      packageChangeAnalyzer,
+      projectChangeAnalyzer,
       terminal
     });
 

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -20,7 +20,7 @@ describe('ProjectBuildCache', () => {
   async function prepareSubject(options: Partial<ITestOptions>): Promise<ProjectBuildCache | undefined> {
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
     const projectChangeAnalyzer = {
-      getProjectStateHash: () => {
+      [ProjectChangeAnalyzer.prototype.tryGetProjectStateHashAsync.name]: async () => {
         return 'state_hash';
       }
     } as unknown as ProjectChangeAnalyzer;

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -211,7 +211,7 @@ export class ProjectBuilder extends BaseBuilder {
       let trackedFiles: string[] | undefined;
       try {
         const fileHashes: Map<string, string> | undefined =
-          await this._projectChangeAnalyzer.tryGetProjectDependenciesAsync(
+          await this._projectChangeAnalyzer._tryGetProjectDependenciesAsync(
             this._rushProject.packageName,
             terminal
           );

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -210,10 +210,11 @@ export class ProjectBuilder extends BaseBuilder {
       let projectBuildDeps: IProjectBuildDeps | undefined;
       let trackedFiles: string[] | undefined;
       try {
-        const fileHashes: Map<string, string> | undefined = await this._projectChangeAnalyzer.getPackageDeps(
-          this._rushProject.packageName,
-          terminal
-        );
+        const fileHashes: Map<string, string> | undefined =
+          await this._projectChangeAnalyzer.tryGetProjectDependenciesAsync(
+            this._rushProject.packageName,
+            terminal
+          );
 
         if (fileHashes) {
           const files: { [filePath: string]: string } = {};

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -23,7 +23,7 @@ import { CollatedTerminal } from '@rushstack/stream-collator';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import { Utilities } from '../../utilities/Utilities';
+import { Utilities, UNINITIALIZED } from '../../utilities/Utilities';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
 import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
@@ -65,9 +65,6 @@ function _areShallowEqual(object1: JsonObject, object2: JsonObject): boolean {
   }
   return true;
 }
-
-const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
-type UNINITIALIZED = 'UNINITIALIZED';
 
 /**
  * A `BaseBuilder` subclass that builds a Rush project and updates its package-deps-hash

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -26,7 +26,7 @@ import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { Utilities } from '../../utilities/Utilities';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
-import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
+import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
 import { BaseBuilder, IBuilderContext } from './BaseBuilder';
 import { ProjectLogWritable } from './ProjectLogWritable';
 import { ProjectBuildCache } from '../buildCache/ProjectBuildCache';
@@ -48,7 +48,7 @@ export interface IProjectBuilderOptions {
   commandToRun: string;
   commandName: string;
   isIncrementalBuildAllowed: boolean;
-  packageChangeAnalyzer: PackageChangeAnalyzer;
+  projectChangeAnalyzer: ProjectChangeAnalyzer;
   packageDepsFilename: string;
 }
 
@@ -86,7 +86,7 @@ export class ProjectBuilder extends BaseBuilder {
   private readonly _buildCacheConfiguration: BuildCacheConfiguration | undefined;
   private readonly _commandName: string;
   private readonly _commandToRun: string;
-  private readonly _packageChangeAnalyzer: PackageChangeAnalyzer;
+  private readonly _projectChangeAnalyzer: ProjectChangeAnalyzer;
   private readonly _packageDepsFilename: string;
 
   /**
@@ -103,7 +103,7 @@ export class ProjectBuilder extends BaseBuilder {
     this._commandName = options.commandName;
     this._commandToRun = options.commandToRun;
     this.isIncrementalBuildAllowed = options.isIncrementalBuildAllowed;
-    this._packageChangeAnalyzer = options.packageChangeAnalyzer;
+    this._projectChangeAnalyzer = options.projectChangeAnalyzer;
     this._packageDepsFilename = options.packageDepsFilename;
   }
 
@@ -210,7 +210,7 @@ export class ProjectBuilder extends BaseBuilder {
       let projectBuildDeps: IProjectBuildDeps | undefined;
       let trackedFiles: string[] | undefined;
       try {
-        const fileHashes: Map<string, string> | undefined = await this._packageChangeAnalyzer.getPackageDeps(
+        const fileHashes: Map<string, string> | undefined = await this._projectChangeAnalyzer.getPackageDeps(
           this._rushProject.packageName,
           terminal
         );
@@ -396,7 +396,7 @@ export class ProjectBuilder extends BaseBuilder {
                 terminal,
                 command: this._commandToRun,
                 trackedProjectFiles: trackedProjectFiles,
-                packageChangeAnalyzer: this._packageChangeAnalyzer
+                projectChangeAnalyzer: this._projectChangeAnalyzer
               });
             }
           }

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -44,7 +44,7 @@ describe(ProjectChangeAnalyzer.name, () => {
     return subject;
   }
 
-  describe(ProjectChangeAnalyzer.prototype.tryGetProjectDependenciesAsync.name, () => {
+  describe(ProjectChangeAnalyzer.prototype._tryGetProjectDependenciesAsync.name, () => {
     it('returns the files for the specified project', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -65,10 +65,10 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
-      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([['apps/banana/peel.js', 'b201']])
       );
     });
@@ -104,13 +104,13 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/core.js', 'a101'],
           ['apps/apple/assets/one.jpg', 'a103']
         ])
       );
-      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([
           ['apps/banana/peel.js', 'b201'],
           ['apps/banana/peel.js.map', 'b202']
@@ -145,7 +145,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       // In a dot-ignore file, the later rule '!assets/important/**' should override the previous
       // rule of '*.png'. This unit test verifies that this behavior doesn't change later if
       // we modify the implementation.
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/assets/important/four.png', 'a104'],
           ['apps/apple/assets/important/five.psd', 'a105'],
@@ -176,13 +176,13 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/core.js', 'a101'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
         ])
       );
-      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([
           ['apps/banana/peel.js', 'b201'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
@@ -203,7 +203,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       try {
-        await subject.tryGetProjectDependenciesAsync('carrot', terminal);
+        await subject._tryGetProjectDependenciesAsync('carrot', terminal);
         fail('Should have thrown error');
       } catch (e) {
         expect(e).toMatchSnapshot();
@@ -227,18 +227,18 @@ describe(ProjectChangeAnalyzer.name, () => {
       // this test makes that expectation explicit.
 
       expect(subject['_data']).toBeNull();
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
       expect(subject['_data']).toBeDefined();
-      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
+      expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
       expect(subject['_getRepoDeps']).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe(ProjectChangeAnalyzer.prototype.tryGetProjectStateHashAsync.name, () => {
+  describe(ProjectChangeAnalyzer.prototype._tryGetProjectStateHashAsync.name, () => {
     it('returns a fixed hash snapshot for a set of project deps', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -255,7 +255,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.tryGetProjectStateHashAsync('apple', terminal)).toMatchInlineSnapshot(
+      expect(await subject._tryGetProjectStateHashAsync('apple', terminal)).toMatchInlineSnapshot(
         `"265536e325cdfac3fa806a51873d927a712fc6c9"`
       );
     });
@@ -290,8 +290,8 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subjectB: ProjectChangeAnalyzer = createTestSubject(projectsB, filesB);
 
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
-      expect(await subjectA.tryGetProjectStateHashAsync('apple', terminal)).toEqual(
-        await subjectB.tryGetProjectStateHashAsync('apple', terminal)
+      expect(await subjectA._tryGetProjectStateHashAsync('apple', terminal)).toEqual(
+        await subjectB._tryGetProjectStateHashAsync('apple', terminal)
       );
     });
   });

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -44,7 +44,7 @@ describe(ProjectChangeAnalyzer.name, () => {
     return subject;
   }
 
-  describe(ProjectChangeAnalyzer.prototype.getPackageDeps.name, () => {
+  describe(ProjectChangeAnalyzer.prototype.tryGetProjectDependenciesAsync.name, () => {
     it('returns the files for the specified project', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -65,10 +65,10 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
-      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([['apps/banana/peel.js', 'b201']])
       );
     });
@@ -104,13 +104,13 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/core.js', 'a101'],
           ['apps/apple/assets/one.jpg', 'a103']
         ])
       );
-      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([
           ['apps/banana/peel.js', 'b201'],
           ['apps/banana/peel.js.map', 'b202']
@@ -145,7 +145,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       // In a dot-ignore file, the later rule '!assets/important/**' should override the previous
       // rule of '*.png'. This unit test verifies that this behavior doesn't change later if
       // we modify the implementation.
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/assets/important/four.png', 'a104'],
           ['apps/apple/assets/important/five.psd', 'a105'],
@@ -176,13 +176,13 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([
           ['apps/apple/core.js', 'a101'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
         ])
       );
-      expect(await subject.getPackageDeps('banana', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('banana', terminal)).toEqual(
         new Map([
           ['apps/banana/peel.js', 'b201'],
           ['common/config/rush/pnpm-lock.yaml', 'ffff']
@@ -202,7 +202,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.getPackageDeps('carrot', terminal)).toBeUndefined();
+      expect(await subject.tryGetProjectDependenciesAsync('carrot', terminal)).toBeUndefined();
     });
 
     it('lazy-loads project data and caches it for future calls', async () => {
@@ -222,18 +222,18 @@ describe(ProjectChangeAnalyzer.name, () => {
       // this test makes that expectation explicit.
 
       expect(subject['_data']).toBeNull();
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
       expect(subject['_data']).toBeDefined();
-      expect(await subject.getPackageDeps('apple', terminal)).toEqual(
+      expect(await subject.tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
       expect(subject['_getRepoDeps']).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe(ProjectChangeAnalyzer.prototype.getProjectStateHash.name, () => {
+  describe(ProjectChangeAnalyzer.prototype.tryGetProjectStateHashAsync.name, () => {
     it('returns a fixed hash snapshot for a set of project deps', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -250,7 +250,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.getProjectStateHash('apple', terminal)).toMatchInlineSnapshot(
+      expect(await subject.tryGetProjectStateHashAsync('apple', terminal)).toMatchInlineSnapshot(
         `"265536e325cdfac3fa806a51873d927a712fc6c9"`
       );
     });
@@ -285,8 +285,8 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subjectB: ProjectChangeAnalyzer = createTestSubject(projectsB, filesB);
 
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
-      expect(await subjectA.getProjectStateHash('apple', terminal)).toEqual(
-        await subjectB.getProjectStateHash('apple', terminal)
+      expect(await subjectA.tryGetProjectStateHashAsync('apple', terminal)).toEqual(
+        await subjectB.tryGetProjectStateHashAsync('apple', terminal)
       );
     });
   });

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -2,13 +2,14 @@
 // See LICENSE in the project root for license information.
 
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
-import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
+
+import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 
-describe('PackageChangeAnalyzer', () => {
+describe(ProjectChangeAnalyzer.name, () => {
   beforeEach(() => {
     jest.spyOn(EnvironmentConfiguration, 'gitBinaryPath', 'get').mockReturnValue(undefined);
     jest.spyOn(RushProjectConfiguration, 'tryLoadForProjectAsync').mockResolvedValue(undefined);
@@ -21,7 +22,7 @@ describe('PackageChangeAnalyzer', () => {
   function createTestSubject(
     projects: RushConfigurationProject[],
     files: Map<string, string>
-  ): PackageChangeAnalyzer {
+  ): ProjectChangeAnalyzer {
     const rushConfiguration: RushConfiguration = {
       commonRushConfigFolder: '',
       projects,
@@ -34,7 +35,7 @@ describe('PackageChangeAnalyzer', () => {
       }
     } as RushConfiguration;
 
-    const subject: PackageChangeAnalyzer = new PackageChangeAnalyzer(rushConfiguration);
+    const subject: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
     subject['_getRepoDeps'] = jest.fn(() => {
       return files;
@@ -43,7 +44,7 @@ describe('PackageChangeAnalyzer', () => {
     return subject;
   }
 
-  describe('getPackageDeps', () => {
+  describe(ProjectChangeAnalyzer.prototype.getPackageDeps.name, () => {
     it('returns the files for the specified project', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -61,7 +62,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/core.js', 'a101'],
         ['apps/banana/peel.js', 'b201']
       ]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       expect(await subject.getPackageDeps('apple', terminal)).toEqual(
@@ -100,7 +101,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/banana/peel.js', 'b201'],
         ['apps/banana/peel.js.map', 'b202']
       ]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       expect(await subject.getPackageDeps('apple', terminal)).toEqual(
@@ -138,7 +139,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/assets/important/five.psd', 'a105'],
         ['apps/apple/src/index.ts', 'a106']
       ]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       // In a dot-ignore file, the later rule '!assets/important/**' should override the previous
@@ -172,7 +173,7 @@ describe('PackageChangeAnalyzer', () => {
         ['common/config/rush/pnpm-lock.yaml', 'ffff'],
         ['tools/random-file.js', 'e00e']
       ]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       expect(await subject.getPackageDeps('apple', terminal)).toEqual(
@@ -198,7 +199,7 @@ describe('PackageChangeAnalyzer', () => {
         } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       expect(await subject.getPackageDeps('carrot', terminal)).toBeUndefined();
@@ -213,11 +214,11 @@ describe('PackageChangeAnalyzer', () => {
         } as RushConfigurationProject
       ];
       const files: Map<string, string> = new Map([['apps/apple/core.js', 'a101']]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       // Because other unit tests rely on the fact that a freshly instantiated
-      // PackageChangeAnalyzer is inert until someone actually requests project data,
+      // ProjectChangeAnalyzer is inert until someone actually requests project data,
       // this test makes that expectation explicit.
 
       expect(subject['_data']).toBeNull();
@@ -232,7 +233,7 @@ describe('PackageChangeAnalyzer', () => {
     });
   });
 
-  describe('getProjectStateHash', () => {
+  describe(ProjectChangeAnalyzer.prototype.getProjectStateHash.name, () => {
     it('returns a fixed hash snapshot for a set of project deps', async () => {
       const projects: RushConfigurationProject[] = [
         {
@@ -246,7 +247,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/juice.js', 'e333'],
         ['apps/apple/slices.js', 'a102']
       ]);
-      const subject: PackageChangeAnalyzer = createTestSubject(projects, files);
+      const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
       expect(await subject.getProjectStateHash('apple', terminal)).toMatchInlineSnapshot(
@@ -267,7 +268,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/juice.js', 'e333'],
         ['apps/apple/slices.js', 'a102']
       ]);
-      const subjectA: PackageChangeAnalyzer = createTestSubject(projectsA, filesA);
+      const subjectA: ProjectChangeAnalyzer = createTestSubject(projectsA, filesA);
 
       const projectsB: RushConfigurationProject[] = [
         {
@@ -281,7 +282,7 @@ describe('PackageChangeAnalyzer', () => {
         ['apps/apple/core.js', 'a101'],
         ['apps/apple/juice.js', 'e333']
       ]);
-      const subjectB: PackageChangeAnalyzer = createTestSubject(projectsB, filesB);
+      const subjectB: ProjectChangeAnalyzer = createTestSubject(projectsB, filesB);
 
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
       expect(await subjectA.getProjectStateHash('apple', terminal)).toEqual(

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -8,6 +8,7 @@ import { RushConfiguration } from '../../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import { UNINITIALIZED } from '../../utilities/Utilities';
 
 describe(ProjectChangeAnalyzer.name, () => {
   beforeEach(() => {
@@ -226,7 +227,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       // ProjectChangeAnalyzer is inert until someone actually requests project data,
       // this test makes that expectation explicit.
 
-      expect(subject['_data']).toBeNull();
+      expect(subject['_data']).toEqual(UNINITIALIZED);
       expect(await subject._tryGetProjectDependenciesAsync('apple', terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -190,7 +190,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       );
     });
 
-    it('returns undefined if the specified project does not exist', async () => {
+    it('throws an exception if the specified project does not exist', async () => {
       const projects: RushConfigurationProject[] = [
         {
           packageName: 'apple',
@@ -202,7 +202,12 @@ describe(ProjectChangeAnalyzer.name, () => {
       const subject: ProjectChangeAnalyzer = createTestSubject(projects, files);
       const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
 
-      expect(await subject.tryGetProjectDependenciesAsync('carrot', terminal)).toBeUndefined();
+      try {
+        await subject.tryGetProjectDependenciesAsync('carrot', terminal);
+        fail('Should have thrown error');
+      } catch (e) {
+        expect(e).toMatchSnapshot();
+      }
     });
 
     it('lazy-loads project data and caches it for future calls', async () => {

--- a/apps/rush-lib/src/logic/test/__snapshots__/ProjectChangeAnalyzer.test.ts.snap
+++ b/apps/rush-lib/src/logic/test/__snapshots__/ProjectChangeAnalyzer.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectChangeAnalyzer tryGetProjectDependenciesAsync throws an exception if the specified project does not exist 1`] = `[Error: Project "carrot" does not exist in the current Rush configuration.]`;

--- a/apps/rush-lib/src/logic/test/__snapshots__/ProjectChangeAnalyzer.test.ts.snap
+++ b/apps/rush-lib/src/logic/test/__snapshots__/ProjectChangeAnalyzer.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProjectChangeAnalyzer tryGetProjectDependenciesAsync throws an exception if the specified project does not exist 1`] = `[Error: Project "carrot" does not exist in the current Rush configuration.]`;
+exports[`ProjectChangeAnalyzer _tryGetProjectDependenciesAsync throws an exception if the specified project does not exist 1`] = `[Error: Project "carrot" does not exist in the current Rush configuration.]`;

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -11,6 +11,9 @@ import { CommandLineHelper } from '@rushstack/ts-command-line';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 
+export type UNINITIALIZED = 'UNINITIALIZED';
+export const UNINITIALIZED: UNINITIALIZED = 'UNINITIALIZED';
+
 export interface IEnvironment {
   // NOTE: the process.env doesn't actually support "undefined" as a value.
   // If you try to assign it, it will be converted to the text string "undefined".

--- a/build-tests/rush-project-change-analyzer-test/.eslintrc.js
+++ b/build-tests/rush-project-change-analyzer-test/.eslintrc.js
@@ -1,0 +1,10 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname }
+};

--- a/build-tests/rush-project-change-analyzer-test/config/rig.json
+++ b/build-tests/rush-project-change-analyzer-test/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "@rushstack/heft-node-rig"
+}

--- a/build-tests/rush-project-change-analyzer-test/package.json
+++ b/build-tests/rush-project-change-analyzer-test/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rush-project-change-analyzer-test",
+  "description": "This is an example project that uses rush-lib's ProjectChangeAnalyzer to ",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "heft build --clean",
+    "start": "heft start"
+  },
+  "dependencies": {
+    "@microsoft/rush-lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@rushstack/eslint-config": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@types/node": "10.17.13",
+    "@rushstack/heft-node-rig": "workspace:*"
+  }
+}

--- a/build-tests/rush-project-change-analyzer-test/package.json
+++ b/build-tests/rush-project-change-analyzer-test/package.json
@@ -8,7 +8,8 @@
     "start": "heft start"
   },
   "dependencies": {
-    "@microsoft/rush-lib": "workspace:*"
+    "@microsoft/rush-lib": "workspace:*",
+    "@rushstack/node-core-library": "workspace:*"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -1,6 +1,8 @@
 import { RushConfiguration, ProjectChangeAnalyzer, RushConfigurationProject } from '@microsoft/rush-lib';
+import { Terminal, ConsoleTerminalProvider } from '@rushstack/node-core-library';
 
 async function runAsync(): Promise<void> {
+  const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
   const rushConfiguration: RushConfiguration = RushConfiguration.loadFromDefaultLocation({
     startingFolder: process.cwd()
   });
@@ -22,7 +24,10 @@ async function runAsync(): Promise<void> {
   const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
   const changedProjects: AsyncIterable<RushConfigurationProject> =
-    projectChangeAnalyzer.getChangedProjectsAsync(rushConfiguration.repositoryDefaultBranch, false);
+    projectChangeAnalyzer.getChangedProjectsAsync({
+      targetBranchName: rushConfiguration.repositoryDefaultBranch,
+      terminal
+    });
   const projectsNeedingValidation: Set<RushConfigurationProject> = new Set<RushConfigurationProject>();
   function addProject(project: RushConfigurationProject): void {
     if (!projectsNeedingValidation.has(project)) {
@@ -37,12 +42,12 @@ async function runAsync(): Promise<void> {
     addProject(project);
   }
 
-  console.log('Projects needing validation due to changes: ');
+  terminal.writeLine('Projects needing validation due to changes: ');
   const namesOfProjectsNeedingValidation: string[] = Array.from(projectsNeedingValidation)
     .map((project) => project.packageName)
     .sort();
   for (const nameOfProjectsNeedingValidation of namesOfProjectsNeedingValidation) {
-    console.log(` - ${nameOfProjectsNeedingValidation}`);
+    terminal.writeLine(` - ${nameOfProjectsNeedingValidation}`);
   }
 }
 

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -1,0 +1,52 @@
+import { RushConfiguration, ProjectChangeAnalyzer, RushConfigurationProject } from '@microsoft/rush-lib';
+
+async function runAsync(): Promise<void> {
+  const rushConfiguration: RushConfiguration = RushConfiguration.loadFromDefaultLocation({
+    startingFolder: process.cwd()
+  });
+
+  const projectDiretDependentsMap: Map<RushConfigurationProject, Set<RushConfigurationProject>> = new Map<
+    RushConfigurationProject,
+    Set<RushConfigurationProject>
+  >();
+  for (const project of rushConfiguration.projects) {
+    projectDiretDependentsMap.set(project, new Set<RushConfigurationProject>());
+  }
+
+  for (const project of rushConfiguration.projects) {
+    for (const dependencyProject of project.dependencyProjects) {
+      projectDiretDependentsMap.get(dependencyProject)!.add(project);
+    }
+  }
+
+  const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
+
+  const changedProjects: AsyncIterable<RushConfigurationProject> =
+    projectChangeAnalyzer.getChangedProjectsAsync(rushConfiguration.repositoryDefaultBranch, false);
+  const projectsNeedingValidation: Set<RushConfigurationProject> = new Set<RushConfigurationProject>();
+  function addProject(project: RushConfigurationProject): void {
+    if (!projectsNeedingValidation.has(project)) {
+      projectsNeedingValidation.add(project);
+
+      for (const projectDiretDependent of projectDiretDependentsMap.get(project)!) {
+        addProject(projectDiretDependent);
+      }
+    }
+  }
+  for await (const project of changedProjects) {
+    addProject(project);
+  }
+
+  console.log('Projects needing validation due to changes: ');
+  const namesOfProjectsNeedingValidation: string[] = Array.from(projectsNeedingValidation)
+    .map((project) => project.packageName)
+    .sort();
+  for (const nameOfProjectsNeedingValidation of namesOfProjectsNeedingValidation) {
+    console.log(` - ${nameOfProjectsNeedingValidation}`);
+  }
+}
+
+runAsync().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/build-tests/rush-project-change-analyzer-test/tsconfig.json
+++ b/build-tests/rush-project-change-analyzer-test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/common/changes/@microsoft/rush/ianc-expose-project-change-analyzer_2021-07-07-22-22.json
+++ b/common/changes/@microsoft/rush/ianc-expose-project-change-analyzer_2021-07-07-22-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Expose APIs useful for determining which projects have changed on the current branch compared to another branch.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -963,6 +963,21 @@ importers:
       webpack-cli: 3.3.12_webpack@4.44.2
       webpack-dev-server: 3.11.2_93ca2875a658e9d1552850624e6b91c7
 
+  ../../build-tests/rush-project-change-analyzer-test:
+    specifiers:
+      '@microsoft/rush-lib': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@types/node': 10.17.13
+    dependencies:
+      '@microsoft/rush-lib': link:../../apps/rush-lib
+    devDependencies:
+      '@rushstack/eslint-config': link:../../stack/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@types/node': 10.17.13
+
   ../../build-tests/ts-command-line-test:
     specifiers:
       '@rushstack/ts-command-line': workspace:*

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -969,9 +969,11 @@ importers:
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
     dependencies:
       '@microsoft/rush-lib': link:../../apps/rush-lib
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "120bef2afb29b7e9a261d84a6a2211c1239e2286",
+  "pnpmShrinkwrapHash": "8b1fa96df822226d9144c4fb2dad2c5854c64475",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "74b5d235fc2b00836bbaf6517f6840aa205bafa5",
+  "pnpmShrinkwrapHash": "120bef2afb29b7e9a261d84a6a2211c1239e2286",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -155,6 +155,16 @@ export interface IExperimentsJson {
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 }
 
+// @beta (undocumented)
+export interface IGetChangedProjectsOptions {
+    // (undocumented)
+    shouldFetch?: boolean;
+    // (undocumented)
+    targetBranchName: string;
+    // (undocumented)
+    terminal: Terminal;
+}
+
 // @public
 export interface ILaunchOptions {
     alreadyReportedNodeTooNewError?: boolean;
@@ -314,7 +324,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
-    getChangedProjectsAsync(targetBranch: string, shouldFetch?: boolean): AsyncIterable<RushConfigurationProject>;
+    getChangedProjectsAsync(options: IGetChangedProjectsOptions): AsyncIterable<RushConfigurationProject>;
     // @internal
     _tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     // @internal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -315,9 +315,10 @@ export type PnpmStoreOptions = 'local' | 'global';
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
     getChangedProjectsAsync(targetBranch: string, shouldFetch?: boolean): AsyncIterable<RushConfigurationProject>;
-    getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string>>;
-    tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
-    tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;
+    // @internal
+    _tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
+    // @internal
+    _tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;
 }
 
 // @public

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -7,6 +7,7 @@
 import { IPackageJson } from '@rushstack/node-core-library';
 import { JsonObject } from '@rushstack/node-core-library';
 import { PackageNameParser } from '@rushstack/node-core-library';
+import { Terminal } from '@rushstack/node-core-library';
 
 // @public
 export class ApprovedPackagesConfiguration {
@@ -309,6 +310,14 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
 
 // @public
 export type PnpmStoreOptions = 'local' | 'global';
+
+// @beta (undocumented)
+export class ProjectChangeAnalyzer {
+    constructor(rushConfiguration: RushConfiguration);
+    getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
+    tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
+    tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;
+}
 
 // @public
 export class RepoStateFile {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -314,7 +314,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
-    getChangedProjects(targetBranch: string, shouldFetch?: boolean): Iterable<RushConfigurationProject>;
+    getChangedProjectsAsync(targetBranch: string, shouldFetch?: boolean): AsyncIterable<RushConfigurationProject>;
     getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -315,7 +315,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
     getChangedProjectsAsync(targetBranch: string, shouldFetch?: boolean): AsyncIterable<RushConfigurationProject>;
-    getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
+    getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string>>;
     tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -314,6 +314,7 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
+    getChangedProjects(targetBranch: string, shouldFetch?: boolean): Iterable<RushConfigurationProject>;
     getProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     tryGetProjectDependenciesAsync(projectName: string, terminal: Terminal): Promise<Map<string, string> | undefined>;
     tryGetProjectStateHashAsync(projectName: string, terminal: Terminal): Promise<string | undefined>;

--- a/rush.json
+++ b/rush.json
@@ -673,7 +673,12 @@
       "reviewCategory": "tests",
       "shouldPublish": false
     },
-
+    {
+      "packageName": "rush-project-change-analyzer-test",
+      "projectFolder": "build-tests/rush-project-change-analyzer-test",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
     {
       "packageName": "ts-command-line-test",
       "projectFolder": "build-tests/ts-command-line-test",


### PR DESCRIPTION
## Summary

This change cleans up the API of `ProjectChangeAnalyzer` and exposes it from `@microsoft/rush-lib`. It also moves the changed project detection from `ChangeAction` to `ProjectChangeAnalyzer`.

## Details

This is useful code for working with a Rush repo, so instead of having API users reinvent it, it's useful to just provide it. For example, I'm working on a project to filter integration tests that are run by a service external to the build by the set of projects that are changed in a PR. The code that `rush change` uses to determine which projects where changed is ideal for this.

## How it was tested

Tested the `rush change`, `rush change --verify`, and `rush build` actions locally to ensure they still work.