### PR TITLE
[api-extractor] Fix "indentDocComment cannot be nested" error

### DIFF
--- a/apps/api-extractor/.vscode/launch.json
+++ b/apps/api-extractor/.vscode/launch.json
@@ -79,7 +79,7 @@
         "run",
         "--local",
         "--config",
-        "./temp/configs/api-extractor-exportImportStarAs2.json"
+        "./temp/configs/api-extractor-spanSorting.json"
       ],
       "sourceMaps": true
     }

--- a/apps/api-extractor/src/analyzer/Span.ts
+++ b/apps/api-extractor/src/analyzer/Span.ts
@@ -80,10 +80,15 @@ export class SpanModification {
   public sortKey: string | undefined;
 
   /**
-   * If true, then getModifiedText() will search for a "/*" doc comment in this span and indent it.
+   * Optionally configures getModifiedText() to search for a "/*" doc comment and indent it.
+   * At most one comment is detected.
    *
    * @remarks
-   * This feature is selectively enabled because (1) we do not want to accidentally match `/*` appearing
+   * The indentation can be applied to the `Span.modifier.prefix` only, or it can be applied to the
+   * full subtree of nodes (as needed for `ts.SyntaxKind.JSDocComment` trees).  However the enabled
+   * scopes must not overlap.
+   *
+   * This feature is enabled selectively because (1) we do not want to accidentally match `/*` appearing
    * in a string literal or other expression that is not a comment, and (2) parsing comments is relatively
    * expensive.
    */

--- a/apps/api-extractor/src/analyzer/Span.ts
+++ b/apps/api-extractor/src/analyzer/Span.ts
@@ -83,8 +83,8 @@ export class SpanModification {
    * If true, then getModifiedText() will search for a "/*" doc comment in this span and indent it.
    *
    * @remarks
-   * This feature is selectively enabled because (1) we do not want to accidentally `/*` appearing
-   * in a string literal or other expression that is not a comment, and (2) parsing comments is potentially
+   * This feature is selectively enabled because (1) we do not want to accidentally match `/*` appearing
+   * in a string literal or other expression that is not a comment, and (2) parsing comments is relatively
    * expensive.
    */
   public indentDocComment: IndentDocCommentScope = IndentDocCommentScope.None;

--- a/apps/api-extractor/src/analyzer/Span.ts
+++ b/apps/api-extractor/src/analyzer/Span.ts
@@ -404,6 +404,49 @@ export class Span {
   }
 
   /**
+   * Returns a diagnostic dump of the tree, showing the SpanModification settings for each nodde.
+   */
+  public getModifiedDump(indent: string = ''): string {
+    let result: string = indent + ts.SyntaxKind[this.node.kind] + ': ';
+
+    if (this.prefix) {
+      result += ' pre=[' + this._getTrimmed(this.modification.prefix) + ']';
+    }
+    if (this.suffix) {
+      result += ' suf=[' + this._getTrimmed(this.modification.suffix) + ']';
+    }
+    if (this.separator) {
+      result += ' sep=[' + this._getTrimmed(this.separator) + ']';
+    }
+    if (this.modification.indentDocComment !== IndentDocCommentScope.None) {
+      result += ' indentDocComment=' + IndentDocCommentScope[this.modification.indentDocComment];
+    }
+    if (this.modification.omitChildren) {
+      result += ' omitChildren';
+    }
+    if (this.modification.omitSeparatorAfter) {
+      result += ' omitSeparatorAfter';
+    }
+    if (this.modification.sortChildren) {
+      result += ' sortChildren';
+    }
+    if (this.modification.sortKey !== undefined) {
+      result += ` sortKey="${this.modification.sortKey}"`;
+    }
+    result += '\n';
+
+    if (!this.modification.omitChildren) {
+      for (const child of this.children) {
+        result += child.getModifiedDump(indent + '  ');
+      }
+    } else {
+      result += `${indent}  (${this.children.length} children)\n`;
+    }
+
+    return result;
+  }
+
+  /**
    * Recursive implementation of `getModifiedText()` and `writeModifiedText()`.
    */
   private _writeModifiedText(options: IWriteModifiedTextOptions): void {

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -9,7 +9,7 @@ import { ReleaseTag } from '@microsoft/api-extractor-model';
 
 import { Collector } from '../collector/Collector';
 import { TypeScriptHelpers } from '../analyzer/TypeScriptHelpers';
-import { Span, SpanModification } from '../analyzer/Span';
+import { IndentDocCommentScope, Span, SpanModification } from '../analyzer/Span';
 import { AstImport } from '../analyzer/AstImport';
 import { CollectorEntity } from '../collector/CollectorEntity';
 import { AstDeclaration } from '../analyzer/AstDeclaration';
@@ -333,7 +333,7 @@ export class DtsRollupGenerator {
             if (!/\r?\n\s*$/.test(originalComment)) {
               originalComment += '\n';
             }
-            span.modification.indentDocComment = true;
+            span.modification.indentDocComment = IndentDocCommentScope.PrefixOnly;
             span.modification.prefix = originalComment + span.modification.prefix;
           }
         }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
@@ -355,7 +355,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "api-extractor-scenarios!exampleD:var",
-          "docComment": "/**\n * Outer description\n */\n",
+          "docComment": "/**\n * Outer description\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
@@ -351,6 +351,27 @@
             }
           ],
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Variable",
+          "canonicalReference": "api-extractor-scenarios!exampleD:var",
+          "docComment": "/**\n * Outer description\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "exampleD: "
+            },
+            {
+              "kind": "Content",
+              "text": "(o: {\n    a: number;\n    b(): string;\n}) => void"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "exampleD",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
         }
       ]
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.md
@@ -22,6 +22,12 @@ export class ExampleC {
     member1(): void;
 }
 
+// @public
+export const exampleD: (o: {
+    a: number;
+    b(): string;
+}) => void;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/rollup.d.ts
@@ -35,4 +35,19 @@ export declare class ExampleC {
     member1(): void;
 }
 
+/**
+ * Outer description
+ */
+export declare const exampleD: (o: {
+    /**
+     * Inner description
+     */
+    a: number;
+    /**
+     * @returns a string
+     * {@link http://example.com}
+     */
+    b(): string;
+}) => void;
+
 export { }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/rollup.d.ts
@@ -37,6 +37,7 @@ export declare class ExampleC {
 
 /**
  * Outer description
+ * @public
  */
 export declare const exampleD: (o: {
     /**

--- a/build-tests/api-extractor-scenarios/src/spanSorting/index.ts
+++ b/build-tests/api-extractor-scenarios/src/spanSorting/index.ts
@@ -39,3 +39,19 @@ export class ExampleC {
      */
   public member1(): void {}
 }
+
+/**
+ * Outer description
+ */
+export const exampleD = (o: {
+  /**
+   * Inner description
+   */
+  a: number;
+
+  /**
+   * @returns a string
+   * {@link http://example.com}
+   */
+  b(): string;
+}) => {};

--- a/build-tests/api-extractor-scenarios/src/spanSorting/index.ts
+++ b/build-tests/api-extractor-scenarios/src/spanSorting/index.ts
@@ -42,6 +42,7 @@ export class ExampleC {
 
 /**
  * Outer description
+ * @public
  */
 export const exampleD = (o: {
   /**

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-2797_2021-07-08-23-17.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-2797_2021-07-08-23-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix a recent regression that reported \"Internal Error: indentDocComment cannot be nested\" (GitHub #2797)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Fixes https://github.com/microsoft/rushstack/issues/2797

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

 

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
This syntax did not occur in any of the projects that I tested for PR #2796.  

I've added a build test to cover this case.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
