### PR TITLE
[rush] Fix the --no-fetch parameter

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -332,7 +332,7 @@ export class ChangeAction extends BaseRushAction {
       projectChangeAnalyzer.getChangedProjectsAsync({
         targetBranchName: this._targetBranch,
         terminal: this._terminal,
-        shouldFetch: this._noFetchParameter.value
+        shouldFetch: !this._noFetchParameter.value
       });
     const projectHostMap: Map<string, string> = this._generateHostMap();
 

--- a/common/changes/@microsoft/rush/ianc-fix-no-fetch_2021-07-13-22-37.json
+++ b/common/changes/@microsoft/rush/ianc-fix-no-fetch_2021-07-13-22-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the \"--no-fetch\" \"rush change\" parameter would cause a \"git fetch\" and absence of that parameter wouldn't fetch.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

https://github.com/microsoft/rushstack/pull/2795 caused a regression where the `rush change` `--no-fetch` parameter causes a `git fetch`, and absence of that parameter doesn't fetch.

## How it was tested

Tested `rush change` and `rush change -v` locally with and without the `--no-fetch` parameter.