### PR TITLE
[rush-lib] Fix incremental build state calculation during filtered installs

### DIFF
--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -33,6 +33,9 @@ describe(ProjectChangeAnalyzer.name, () => {
       },
       findProjectForPosixRelativePath(path: string): object | undefined {
         return projects.find((project) => path.startsWith(project.projectRelativeFolder));
+      },
+      getProjectByName(name: string): object | undefined {
+        return projects.find((project) => project.packageName === name);
       }
     } as RushConfiguration;
 

--- a/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -31,10 +31,10 @@ describe(ProjectChangeAnalyzer.name, () => {
       getCommittedShrinkwrapFilename(): string {
         return 'common/config/rush/pnpm-lock.yaml';
       },
-      findProjectForPosixRelativePath(path: string): object | undefined {
+      findProjectForPosixRelativePath(path: string): RushConfigurationProject | undefined {
         return projects.find((project) => path.startsWith(project.projectRelativeFolder));
       },
-      getProjectByName(name: string): object | undefined {
+      getProjectByName(name: string): RushConfigurationProject | undefined {
         return projects.find((project) => project.packageName === name);
       }
     } as RushConfiguration;

--- a/common/changes/@microsoft/rush/user-danade-FixFilteredInstalls_2021-07-15-00-36.json
+++ b/common/changes/@microsoft/rush/user-danade-FixFilteredInstalls_2021-07-15-00-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix incremental build state calculation when using filtered installs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Filtered installs were broken due to attempting to load config files in dependencies while calculating incremental build state.

## Details
Calculating incremental build state is done by analyzing the world in the repo during initialization, and then proceeding only with the required data. This is done (partially) in an attempt to preserve perf when calculating this state. However, recent changes in #2643 caused this calculation to fail for filtered installs with the error message:
```
Error calculating incremental build state. Instead running full rebuild. Error: Cannot find module '<package A>' from '<path to some project>'
```

This is because it introduced loading of a config file in a project that has not been included in the filtered install. This change makes it so that the config file is only ever loaded when encountering the project during a build, thus making it fail only when attempting to build a package that wasn't installed.

## How it was tested

Unit tests + own repo which had issues with this.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
