### PR TITLE
[module-minifier-plugin] Fix comment file generation, WorkerPoolMinifier

### DIFF
--- a/build-tests/localization-plugin-test-02/src/indexA.ts
+++ b/build-tests/localization-plugin-test-02/src/indexA.ts
@@ -5,6 +5,14 @@ import * as strings5 from './strings5.resx';
 console.log(string1);
 
 console.log(strings3.string2);
+/*! Preserved comment */
+//@preserve Another comment
+// Blah @lic Foo
+// Foo @cc_on bar
+/**
+ * Stuff
+ * @lic Blah
+ */
 
 import(/* webpackChunkName: 'chunk-with-strings' */ './chunks/chunkWithStrings').then(
   ({ ChunkWithStringsClass }) => {

--- a/build-tests/localization-plugin-test-02/webpack.config.js
+++ b/build-tests/localization-plugin-test-02/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 const { LocalizationPlugin } = require('@rushstack/localization-plugin');
-const { ModuleMinifierPlugin, SynchronousMinifier } = require('@rushstack/module-minifier-plugin');
+const { ModuleMinifierPlugin, WorkerPoolMinifier } = require('@rushstack/module-minifier-plugin');
 const { SetPublicPathPlugin } = require('@rushstack/set-webpack-public-path-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -42,7 +42,9 @@ function generateConfiguration(mode, outputFolderName) {
     optimization: {
       minimizer: [
         new ModuleMinifierPlugin({
-          minifier: new SynchronousMinifier(),
+          minifier: new WorkerPoolMinifier({
+            verbose: true
+          }),
           sourceMap: true,
           usePortableModules: true
         })

--- a/common/changes/@rushstack/module-minifier-plugin/fix-minifier-comment-extraction_2021-07-22-21-47.json
+++ b/common/changes/@rushstack/module-minifier-plugin/fix-minifier-comment-extraction_2021-07-22-21-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Fix comment file generation logic. Add to build test.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/module-minifier-plugin/fix-minifier-comment-extraction_2021-07-22-21-47.json
+++ b/common/changes/@rushstack/module-minifier-plugin/fix-minifier-comment-extraction_2021-07-22-21-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/module-minifier-plugin",
-      "comment": "Fix comment file generation logic. Add to build test.",
+      "comment": "Fix comment file generation logic. Fix WorkerPoolMinifier hanging the process.",
       "type": "patch"
     }
   ],

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -20,6 +20,18 @@ export const CHUNK_MODULES_TOKEN: '__WEBPACK_CHUNK_MODULES__';
 // @public
 export function generateLicenseFileForAsset(compilation: webpack.compilation.Compilation, asset: IAssetInfo, minifiedModules: IModuleMap): string;
 
+// @internal
+export interface _IAcornComment {
+    // (undocumented)
+    end: number;
+    // (undocumented)
+    start: number;
+    // (undocumented)
+    type: 'Line' | 'Block';
+    // (undocumented)
+    value: string;
+}
+
 // @public
 export interface IAssetInfo {
     chunk: webpack.compilation.Chunk;

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -164,6 +164,7 @@ export interface _IWebpackCompilationData {
 export interface IWorkerPoolMinifierOptions {
     maxThreads?: number;
     terserOptions?: MinifyOptions;
+    verbose?: boolean;
 }
 
 // @public

--- a/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
+++ b/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
@@ -29,7 +29,8 @@ function getAllComments(moduleIds: (string | number)[], minifiedModules: IModule
       };
       if (subModuleComments) {
         for (const comment of subModuleComments) {
-          allComments.add(comment.value);
+          const value: string = comment.type === 'Line' ? `//${comment.value}\n` : `/*${comment.value}*/\n`;
+          allComments.add(value);
         }
       }
     }

--- a/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
+++ b/webpack/module-minifier-plugin/src/GenerateLicenseFileForAsset.ts
@@ -4,7 +4,13 @@
 import * as path from 'path';
 import * as webpack from 'webpack';
 import { ConcatSource } from 'webpack-sources';
-import { IAssetInfo, IModuleMap, IModuleInfo, IExtendedModule } from './ModuleMinifierPlugin.types';
+import {
+  IAssetInfo,
+  IModuleMap,
+  IModuleInfo,
+  IExtendedModule,
+  _IAcornComment
+} from './ModuleMinifierPlugin.types';
 
 function getAllComments(moduleIds: (string | number)[], minifiedModules: IModuleMap): Set<string> {
   const allComments: Set<string> = new Set();
@@ -18,10 +24,12 @@ function getAllComments(moduleIds: (string | number)[], minifiedModules: IModule
     const { module: webpackModule } = mod;
     const modules: IExtendedModule[] = webpackModule.modules || [webpackModule];
     for (const submodule of modules) {
-      const { comments: subModuleComments } = submodule.factoryMeta;
+      const { comments: subModuleComments } = submodule.factoryMeta as {
+        comments?: Set<_IAcornComment>;
+      };
       if (subModuleComments) {
         for (const comment of subModuleComments) {
-          allComments.add(comment);
+          allComments.add(comment.value);
         }
       }
     }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -29,7 +29,8 @@ import {
   IExtendedModule,
   IModuleMinifierPluginHooks,
   IDehydratedAssets,
-  _IWebpackCompilationData
+  _IWebpackCompilationData,
+  _IAcornComment
 } from './ModuleMinifierPlugin.types';
 import { generateLicenseFileForAsset } from './GenerateLicenseFileForAsset';
 import { rehydrateAsset } from './RehydrateAsset';
@@ -52,13 +53,6 @@ interface IExtendedChunkTemplate {
   hooks: {
     modules: SyncWaterfallHook<Source, webpack.compilation.Chunk>;
   };
-}
-
-interface IAcornComment {
-  type: 'Line' | 'Block';
-  value: string;
-  start: number;
-  end: number;
 }
 
 interface IExtendedParser extends webpack.compilation.normalModuleFactory.Parser {
@@ -117,7 +111,7 @@ function isMinificationResultError(
 }
 
 // Matche behavior of terser's "some" option
-function isLicenseComment(comment: IAcornComment): boolean {
+function isLicenseComment(comment: _IAcornComment): boolean {
   // https://github.com/terser/terser/blob/d3d924fa9e4c57bbe286b811c6068bcc7026e902/lib/output.js#L175
   return /@preserve|@lic|@cc_on|^\**!/i.test(comment.value);
 }
@@ -178,7 +172,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
         const { normalModuleFactory } = compilationData;
 
         function addCommentExtraction(parser: webpack.compilation.normalModuleFactory.Parser): void {
-          parser.hooks.program.tap(PLUGIN_NAME, (program: unknown, comments: IAcornComment[]) => {
+          parser.hooks.program.tap(PLUGIN_NAME, (program: unknown, comments: _IAcornComment[]) => {
             (parser as IExtendedParser).state.module.factoryMeta.comments = comments.filter(isLicenseComment);
           });
         }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -318,6 +318,7 @@ export interface IModuleMinifierPluginHooks {
  * The comment objects from the Acorn parser inside of webpack
  * @internal
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface _IAcornComment {
   type: 'Line' | 'Block';
   value: string;

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -313,3 +313,14 @@ export interface IModuleMinifierPluginHooks {
    */
   postProcessCodeFragment: SyncWaterfallHook<ReplaceSource, string>;
 }
+
+/**
+ * The comment objects from the Acorn parser inside of webpack
+ * @internal
+ */
+export interface _IAcornComment {
+  type: 'Line' | 'Block';
+  value: string;
+  start: number;
+  end: number;
+}

--- a/webpack/module-minifier-plugin/src/WorkerPoolMinifier.ts
+++ b/webpack/module-minifier-plugin/src/WorkerPoolMinifier.ts
@@ -8,7 +8,6 @@ import {
   IModuleMinifier
 } from './ModuleMinifierPlugin.types';
 import { MinifyOptions } from 'terser';
-import { Worker } from 'worker_threads';
 import { WorkerPool } from './workerPool/WorkerPool';
 import { cpus } from 'os';
 
@@ -29,6 +28,11 @@ export interface IWorkerPoolMinifierOptions {
    * `output.comments` is currently not configurable and will always extract license comments to a separate file.
    */
   terserOptions?: MinifyOptions;
+
+  /**
+   * If true, log to the console about the minification results.
+   */
+  verbose?: boolean;
 }
 
 /**
@@ -37,37 +41,23 @@ export interface IWorkerPoolMinifierOptions {
  */
 export class WorkerPoolMinifier implements IModuleMinifier {
   private readonly _pool: WorkerPool;
+  private readonly _verbose: boolean;
 
   private _refCount: number;
   private _deduped: number;
   private _minified: number;
+
   private readonly _resultCache: Map<string, IModuleMinificationResult>;
   private readonly _activeRequests: Map<string, IModuleMinificationCallback[]>;
 
   public constructor(options: IWorkerPoolMinifierOptions) {
-    const { maxThreads = cpus().length, terserOptions = {} } = options || {};
+    const { maxThreads = cpus().length, terserOptions = {}, verbose = false } = options || {};
 
     const activeRequests: Map<string, IModuleMinificationCallback[]> = new Map();
     const resultCache: Map<string, IModuleMinificationResult> = new Map();
     const terserPool: WorkerPool = new WorkerPool({
       id: 'Minifier',
       maxWorkers: maxThreads,
-      prepareWorker: (worker: Worker) => {
-        const cb: (message: IModuleMinificationResult) => void = (
-          message: IModuleMinificationResult
-        ): void => {
-          const callbacks: IModuleMinificationCallback[] | undefined = activeRequests.get(message.hash)!;
-          activeRequests.delete(message.hash);
-          resultCache.set(message.hash, message);
-          for (const callback of callbacks) {
-            callback(message);
-          }
-          terserPool.checkinWorker(worker);
-          worker.off('message', cb);
-        };
-
-        worker.on('message', cb);
-      },
       workerData: terserOptions,
       workerScriptPath: require.resolve('./workerPool/MinifierWorker')
     });
@@ -76,6 +66,7 @@ export class WorkerPoolMinifier implements IModuleMinifier {
     this._refCount = 0;
     this._resultCache = resultCache;
     this._pool = terserPool;
+    this._verbose = verbose;
 
     this._deduped = 0;
     this._minified = 0;
@@ -117,6 +108,21 @@ export class WorkerPoolMinifier implements IModuleMinifier {
     this._pool
       .checkoutWorkerAsync(true)
       .then((worker) => {
+        const cb: (message: IModuleMinificationResult) => void = (
+          message: IModuleMinificationResult
+        ): void => {
+          worker.off('message', cb);
+          const callbacks: IModuleMinificationCallback[] | undefined = activeRequests.get(message.hash)!;
+          activeRequests.delete(message.hash);
+          this._resultCache.set(message.hash, message);
+          for (const callback of callbacks) {
+            callback(message);
+          }
+          // This should always be the last thing done with the worker
+          this._pool.checkinWorker(worker);
+        };
+
+        worker.on('message', cb);
         worker.postMessage(request);
       })
       .catch((error: Error) => {
@@ -139,10 +145,15 @@ export class WorkerPoolMinifier implements IModuleMinifier {
 
     return async () => {
       if (--this._refCount === 0) {
+        if (this._verbose) {
+          console.log(`Shutting down minifier worker pool`);
+        }
         await this._pool.finishAsync();
         this._resultCache.clear();
         this._activeRequests.clear();
-        console.log(`Module minification: ${this._deduped} Deduped, ${this._minified} Processed`);
+        if (this._verbose) {
+          console.log(`Module minification: ${this._deduped} Deduped, ${this._minified} Processed`);
+        }
       }
     };
   }


### PR DESCRIPTION
## Summary
Fixes faulty code in the license file generator that was causing a crash.

## Details
Comments were being stored as objects but expected to be strings, and was not caught during the build due to an `any` on the typings of the `factoryMeta` fields. Was not caught during the build tests because none of them had preserved comments in the source text.
Updated the code to unpack the objects back into the raw string form.

Added license comments to the localization-plugin-test-02 build test suite to validate that comment extraction works as expected. Updated the same test to leverage `WorkerPoolMinifier` instead of `SynchronousMinifier`.

Fixed incorrect configuration of the `WorkerPool` instance inside of `WorkerPoolMinifier` that resulted in use of it hanging the process.

## How it was tested
Ran the new localization-plugin-test-02 build and verified the generated license.txt file in the dist-prod output.