### PR TITLE
[debug-certificate-manager] Update node-forge.

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/ianc-update-node-forge_2021-07-27-21-50.json
+++ b/common/changes/@rushstack/debug-certificate-manager/ianc-update-node-forge_2021-07-27-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Update node-forge to version ~0.10.0.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1085,12 +1085,12 @@ importers:
       '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
-      '@types/node-forge': 0.9.1
-      node-forge: ~0.7.1
+      '@types/node-forge': 0.10.2
+      node-forge: ~0.10.0
       sudo: ~1.0.3
     dependencies:
       '@rushstack/node-core-library': link:../node-core-library
-      node-forge: 0.7.6
+      node-forge: 0.10.0
       sudo: 1.0.3
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -1098,7 +1098,7 @@ importers:
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
-      '@types/node-forge': 0.9.1
+      '@types/node-forge': 0.10.2
 
   ../../libraries/heft-config-file:
     specifiers:
@@ -3165,8 +3165,8 @@ packages:
       form-data: 3.0.1
     dev: false
 
-  /@types/node-forge/0.9.1:
-    resolution: {integrity: sha512-xNO6BfB4Du8DSChdbqyTf488gQwCEUjkxVQq8CeigoG6N7INc8TTRHJK+88IcrnJ0Q8HWPLK4X8pwC8Rcx+sYg==}
+  /@types/node-forge/0.10.2:
+    resolution: {integrity: sha512-nEWO3mkJ1j7eGxGUu32jaGFJj+YSvUt/zG4sEAXbUDbjkQMf9u98Bf3peC4oGFR3zA1n3M3KaXcw6xQyZpl5jg==}
     dependencies:
       '@types/node': 10.17.13
     dev: true
@@ -8475,10 +8475,6 @@ packages:
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
     engines: {node: '>= 6.0.0'}
-    dev: false
-
-  /node-forge/0.7.6:
-    resolution: {integrity: sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==}
     dev: false
 
   /node-gyp/7.1.2:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f45464cdd2ef1f79ab3446b3edd2384175b1e967",
+  "pnpmShrinkwrapHash": "803697b395109817287ec4be1099c161ddb1fd09",
   "preferredVersionsHash": "1fbc26d2c5b3248616b9edccd6bef064075243bc"
 }

--- a/libraries/debug-certificate-manager/package.json
+++ b/libraries/debug-certificate-manager/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
-    "node-forge": "~0.7.1",
+    "node-forge": "~0.10.0",
     "sudo": "~1.0.3"
   },
   "devDependencies": {
@@ -22,6 +22,6 @@
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
-    "@types/node-forge": "0.9.1"
+    "@types/node-forge": "0.10.2"
   }
 }

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as forge from 'node-forge';
+import type { pki } from 'node-forge';
 import * as path from 'path';
 import * as child_process from 'child_process';
 import { EOL } from 'os';
-import { FileSystem, Terminal } from '@rushstack/node-core-library';
+import { FileSystem, Terminal, Import } from '@rushstack/node-core-library';
 
 import { runSudoAsync, IRunResult, runAsync } from './exec';
 import { CertificateStore } from './CertificateStore';
+
+const forge: typeof import('node-forge') = Import.lazy('node-forge', require);
 
 const SERIAL_NUMBER: string = '731c321744e34650a202e3ef91c3c1b0';
 const FRIENDLY_NAME: string = 'debug-certificate-manager Development Certificate';
@@ -39,7 +41,6 @@ export interface ICertificate {
  */
 export class CertificateManager {
   private _certificateStore: CertificateStore;
-  private _getCertUtilPathPromise: Promise<string | undefined> | undefined;
 
   public constructor() {
     this._certificateStore = new CertificateStore();
@@ -171,8 +172,8 @@ export class CertificateManager {
   }
 
   private _createDevelopmentCertificate(): ICertificate {
-    const keys: forge.pki.KeyPair = forge.pki.rsa.generateKeyPair(2048);
-    const certificate: forge.pki.Certificate = forge.pki.createCertificate();
+    const keys: pki.KeyPair = forge.pki.rsa.generateKeyPair(2048);
+    const certificate: pki.Certificate = forge.pki.createCertificate();
     certificate.publicKey = keys.publicKey;
 
     certificate.serialNumber = SERIAL_NUMBER;
@@ -182,7 +183,7 @@ export class CertificateManager {
     // Valid for 3 years
     certificate.validity.notAfter.setFullYear(certificate.validity.notBefore.getFullYear() + 3);
 
-    const attrs: forge.pki.CertificateField[] = [
+    const attrs: pki.CertificateField[] = [
       {
         name: 'commonName',
         value: 'localhost'
@@ -400,7 +401,7 @@ export class CertificateManager {
     if (!certificateData) {
       return false;
     }
-    const certificate: forge.pki.Certificate = forge.pki.certificateFromPem(certificateData);
+    const certificate: pki.Certificate = forge.pki.certificateFromPem(certificateData);
     return !!certificate.getExtension('subjectAltName');
   }
 }

--- a/libraries/debug-certificate-manager/src/exec.ts
+++ b/libraries/debug-certificate-manager/src/exec.ts
@@ -3,8 +3,6 @@
 
 import { Executable } from '@rushstack/node-core-library';
 import * as child_process from 'child_process';
-// eslint-disable-next-line
-const sudo: (args: string[], options: any) => child_process.ChildProcess = require('sudo');
 
 export interface IRunResult {
   stdout: string[];
@@ -13,6 +11,8 @@ export interface IRunResult {
 }
 
 export async function runSudoAsync(command: string, params: string[]): Promise<IRunResult> {
+  // eslint-disable-next-line
+  const sudo: (args: string[], options: any) => child_process.ChildProcess = require('sudo');
   const result: child_process.ChildProcess = sudo([command, ...params], {
     cachePassword: false,
     prompt: 'Enter your password: '


### PR DESCRIPTION
## Summary

There is a vulnerability flagged in `node-forge` versions before 0.10.0. This PR updates `node-forge` to `~0.10.0`. This change also updates `debug-certificate-manager` to lazy-load `node-forge`.

## How it was tested

Tested by creating certificates in a heft project in another repo.