### PR TITLE
[rush] build-cache respects allowWarningsInSuccessfulBuild

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -28,5 +28,11 @@
    * If true, the chmod field in temporary project tar headers will not be normalized.
    * This normalization can help ensure consistent tarball integrity across platforms.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "noChmodFieldInTarHeaderNormalization": true
+  /*[LINE "HYPOTHETICAL"]*/ "noChmodFieldInTarHeaderNormalization": true,
+
+  /**
+   * If true, build caching will respect the allowWarningsInSuccessfulBuild flag and cache builds with warnings.
+   * This will not replay warnings from the cached build.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "buildCacheWithAllowWarningsInSuccessfulBuild": true
 }

--- a/apps/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/apps/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -34,6 +34,12 @@ export interface IExperimentsJson {
    * This normalization can help ensure consistent tarball integrity across platforms.
    */
   noChmodFieldInTarHeaderNormalization?: boolean;
+
+  /**
+   * If true, build caching will respect the allowWarningsInSuccessfulBuild flag and cache builds with warnings.
+   * This will not replay warnings from the cached build.
+   */
+  buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -145,6 +145,7 @@ export class BulkScriptAction extends BaseScriptAction {
       isIncrementalBuildAllowed: this._isIncrementalBuildAllowed,
       ignoreMissingScript: this._ignoreMissingScript,
       ignoreDependencyOrder: this._ignoreDependencyOrder,
+      allowWarningsInSuccessfulBuild: this._allowWarningsInSuccessfulBuild,
       packageDepsFilename: Utilities.getPackageDepsFilenameForCommand(this._commandToRun)
     };
 

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -22,6 +22,7 @@ export interface ITaskSelectorConstructor {
   ignoreDependencyOrder: boolean;
   packageDepsFilename: string;
   projectChangeAnalyzer?: ProjectChangeAnalyzer;
+  allowWarningsInSuccessfulBuild?: boolean;
 }
 
 /**
@@ -132,7 +133,8 @@ export class TaskSelector {
         commandName: this._options.commandName,
         isIncrementalBuildAllowed: this._options.isIncrementalBuildAllowed,
         projectChangeAnalyzer: this._projectChangeAnalyzer,
-        packageDepsFilename: this._options.packageDepsFilename
+        packageDepsFilename: this._options.packageDepsFilename,
+        allowWarningsInSuccessfulBuild: this._options.allowWarningsInSuccessfulBuild
       })
     );
   }

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -354,7 +354,10 @@ export class ProjectBuilder extends BaseBuilder {
 
       const taskIsSuccessful: boolean =
         status === TaskStatus.Success ||
-        (status === TaskStatus.SuccessWithWarning && this._allowWarningsInSuccessfulBuild);
+        (status === TaskStatus.SuccessWithWarning &&
+          this._allowWarningsInSuccessfulBuild &&
+          !!this._rushConfiguration.experimentsConfiguration.configuration
+            .buildCacheWithAllowWarningsInSuccessfulBuild);
 
       if (taskIsSuccessful && projectBuildDeps) {
         // Write deps on success.

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -181,7 +181,7 @@ describe('TaskRunner', () => {
         };
       });
 
-      it.only('Logs warnings correctly', async () => {
+      it('Logs warnings correctly', async () => {
         taskRunner = createTaskRunner(
           taskRunnerOptions,
           new MockBuilder('success with warnings (success)', async (terminal: CollatedTerminal) => {

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -181,7 +181,7 @@ describe('TaskRunner', () => {
         };
       });
 
-      it('Logs warnings correctly', async () => {
+      it.only('Logs warnings correctly', async () => {
         taskRunner = createTaskRunner(
           taskRunnerOptions,
           new MockBuilder('success with warnings (success)', async (terminal: CollatedTerminal) => {

--- a/apps/rush-lib/src/schemas/experiments.schema.json
+++ b/apps/rush-lib/src/schemas/experiments.schema.json
@@ -25,6 +25,10 @@
     "noChmodFieldInTarHeaderNormalization": {
       "description": "If true, the chmod field in temporary project tar headers will not be normalized. This normalization can help ensure consistent tarball integrity across platforms.",
       "type": "boolean"
+    },
+    "buildCacheWithAllowWarningsInSuccessfulBuild": {
+      "description": "If true, build caching will respect the allowWarningsInSuccessfulBuild flag and cache builds with warnings. This will not replay warnings from the cached build.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/common/changes/@microsoft/rush/relm-cache_with_warnings_2021-07-31-18-49.json
+++ b/common/changes/@microsoft/rush/relm-cache_with_warnings_2021-07-31-18-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Writing to build-cache should respect allowWarningsInSuccessfulBuild",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "relm923@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/relm-cache_with_warnings_2021-08-22-20-34.json
+++ b/common/changes/@microsoft/rush/relm-cache_with_warnings_2021-08-22-20-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Experiment to enable build caching with warnings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "relm923@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -150,6 +150,7 @@ export interface IConfigurationEnvironmentVariable {
 
 // @beta
 export interface IExperimentsJson {
+    buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #2803

Update ProjectBuilder to persist `build-cache` when task status `SuccessWithWarning` and `allowWarningsInSuccessfulBuild: true` is set for the command

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Now passing `allowWarningsInSuccessfulBuild` flag from `BulkScriptAction` down to `ProjectBuilder` and conditionally persisting the cache if enabled

## How it was tested

Tested locally as there is limited test coverage around `ProjectBuilder` currently

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
