### PR TITLE
[rush] readable cache hash

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -23,6 +23,7 @@ interface IProjectBuildCacheOptions {
   buildCacheConfiguration: BuildCacheConfiguration;
   projectConfiguration: RushProjectConfiguration;
   command: string;
+  commandName: string;
   trackedProjectFiles: string[] | undefined;
   projectChangeAnalyzer: ProjectChangeAnalyzer;
   terminal: Terminal;
@@ -424,6 +425,7 @@ export class ProjectBuildCache {
     return path.join(this._project.projectRushTempFolder, 'build-cache-tar.log');
   }
 
+  // todo: mess about with this to get restore-keys style functionality
   private static async _getCacheId(options: IProjectBuildCacheOptions): Promise<string | undefined> {
     // The project state hash is calculated in the following method:
     // - The current project's hash (see ProjectChangeAnalyzer.getProjectStateHash) is
@@ -482,7 +484,8 @@ export class ProjectBuildCache {
       hash.update(RushConstants.hashDelimiter);
     }
 
-    const projectStateHash: string = hash.digest('hex');
+    const projectStateHash: string =
+      options.projectConfiguration.project.packageName + '/' + options.commandName + '/' + hash.digest('hex') + '.tgz';
 
     return options.buildCacheConfiguration.getCacheEntryId({
       projectName: options.projectConfiguration.project.packageName,

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -425,7 +425,6 @@ export class ProjectBuildCache {
     return path.join(this._project.projectRushTempFolder, 'build-cache-tar.log');
   }
 
-  // todo: mess about with this to get restore-keys style functionality
   private static async _getCacheId(options: IProjectBuildCacheOptions): Promise<string | undefined> {
     // The project state hash is calculated in the following method:
     // - The current project's hash (see ProjectChangeAnalyzer.getProjectStateHash) is

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -483,8 +483,15 @@ export class ProjectBuildCache {
       hash.update(RushConstants.hashDelimiter);
     }
 
+    // The rebuild command is a special-case, and can use a cache from the build command.
+    const cacheableCommandName: string = options.commandName === 'rebuild' ? 'build' : options.commandName;
     const projectStateHash: string =
-      options.projectConfiguration.project.packageName + '/' + options.commandName + '/' + hash.digest('hex') + '.tgz';
+      options.projectConfiguration.project.packageName +
+      '/' +
+      cacheableCommandName +
+      '/' +
+      hash.digest('hex') +
+      '.tgz';
 
     return options.buildCacheConfiguration.getCacheEntryId({
       projectName: options.projectConfiguration.project.packageName,

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -28,8 +28,7 @@ describe('ProjectBuildCache', () => {
     const subject: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCache({
       buildCacheConfiguration: {
         buildCacheEnabled: options.hasOwnProperty('enabled') ? options.enabled : true,
-        getCacheEntryId: (options: IGenerateCacheEntryIdOptions) =>
-          `${options.projectName}/${options.projectStateHash}`,
+        getCacheEntryId: (options: IGenerateCacheEntryIdOptions) => options.projectStateHash,
         localCacheProvider: undefined as unknown as FileSystemBuildCacheProvider,
         cloudCacheProvider: {
           isCacheWriteAllowed: options.hasOwnProperty('writeAllowed') ? options.writeAllowed : false
@@ -44,6 +43,7 @@ describe('ProjectBuildCache', () => {
         }
       } as unknown as RushProjectConfiguration,
       command: 'build',
+      commandName: 'build',
       trackedProjectFiles: options.hasOwnProperty('trackedProjectFiles') ? options.trackedProjectFiles : [],
       projectChangeAnalyzer,
       terminal
@@ -56,7 +56,7 @@ describe('ProjectBuildCache', () => {
     it('returns a ProjectBuildCache with a calculated cacheId value', async () => {
       const subject: ProjectBuildCache = (await prepareSubject({}))!;
       expect(subject['_cacheId']).toMatchInlineSnapshot(
-        `"acme-wizard/e229f8765b7d450a8a84f711a81c21e37935d661"`
+        `"acme-wizard/build/e229f8765b7d450a8a84f711a81c21e37935d661.tgz"`
       );
     });
 

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -14,6 +14,7 @@ interface ITestOptions {
   enabled: boolean;
   writeAllowed: boolean;
   trackedProjectFiles: string[] | undefined;
+  commandName: string;
 }
 
 describe('ProjectBuildCache', () => {
@@ -43,7 +44,7 @@ describe('ProjectBuildCache', () => {
         }
       } as unknown as RushProjectConfiguration,
       command: 'build',
-      commandName: 'build',
+      commandName: options.commandName ?? 'build',
       trackedProjectFiles: options.hasOwnProperty('trackedProjectFiles') ? options.trackedProjectFiles : [],
       projectChangeAnalyzer,
       terminal
@@ -55,6 +56,15 @@ describe('ProjectBuildCache', () => {
   describe('tryGetProjectBuildCache', () => {
     it('returns a ProjectBuildCache with a calculated cacheId value', async () => {
       const subject: ProjectBuildCache = (await prepareSubject({}))!;
+      expect(subject['_cacheId']).toMatchInlineSnapshot(
+        `"acme-wizard/build/e229f8765b7d450a8a84f711a81c21e37935d661.tgz"`
+      );
+    });
+
+    it('returns a ProjectBuildCache with a calculated cacheId value for "build" when commandName is "rebuild"', async () => {
+      const subject: ProjectBuildCache = (await prepareSubject({
+        commandName: 'rebuild'
+      }))!;
       expect(subject['_cacheId']).toMatchInlineSnapshot(
         `"acme-wizard/build/e229f8765b7d450a8a84f711a81c21e37935d661.tgz"`
       );

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -412,6 +412,7 @@ export class ProjectBuilder extends BaseBuilder {
                 buildCacheConfiguration: this._buildCacheConfiguration,
                 terminal,
                 command: this._commandToRun,
+                commandName: this._commandName,
                 trackedProjectFiles: trackedProjectFiles,
                 projectChangeAnalyzer: this._projectChangeAnalyzer
               });

--- a/common/changes/@microsoft/rush/readable-cache-hash_2021-08-04-16-53.json
+++ b/common/changes/@microsoft/rush/readable-cache-hash_2021-08-04-16-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add project, command name, and file extension to build-cache files",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "misha.kaletsky@gmail.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Originally discussed in [this zulip thread](https://rushstack.zulipchat.com/#narrow/stream/262513-general/topic/Add.20package.2Fcommand.20name.20to.20cache.20filepath) - make the tgz cache files created more easily viewable by humans and machines.

## Details

Previously, all cache files were unintelligible hashes with no extension. I wasn't sure how rush distinguishes between, say a "build" cache and a "lint" cache. This adds the project name, the command, and a `.tgz` file extension to cache file paths:

`common/temp/build-cache` contents before:

```
- 7283bf05f138a224db53daeee9b41d77
- a14fa2b12d0551162f6a868f5e03d32a
- 163a27b8bceb5a280b028e3f777a173b
- 1a2d69996d9810e69047d2737c8d9b21
- e5599f888975bf70ad3402356f06ba35
```

`common/temp/build-cache` contents after:

```
- @mycompany/
  - package-a/
    - build/
      - 7283bf05f138a224db53daeee9b41d77.tgz
      - a14fa2b12d0551162f6a868f5e03d32a.tgz
    - lint/
      - 163a27b8bceb5a280b028e3f777a173b.tgz
  - package-b/
    - build/
      - 1a2d69996d9810e69047d2737c8d9b21.tgz
    - lint/
      - e5599f888975bf70ad3402356f06ba35.tgz
```

This change lets users:

- see which packages, and which commands are taking up the most cache space
- inspect the actual contents of the caches without having to randomly guess which is which
- use native tools in Finder/Explorer to unpack `.tgz` files because of the extension
- (maybe) do more customized build cache tricks like restoring the most recent one on cache miss
- delete all the caches for the package-a's `lint` command, but leave alone the `build` command and all the caches for package-b

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I made the same changes to my local rush installation, and saw that it wrote the files successfully. Then I modified source files in some projects, and saw that those projects and its downstream dependents were rebuilt as expected, the rest were restored from their caches.

___

- [x] `rush change`
- [x] update unit tests

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

Note: @iclanton suggested making this configurable, but since that requires somewhat more careful design I'm proposing this as a new "default" behavior first. Configurability can always be added later, as needed.