### PR TITLE
[heft] Fix an issue where a misleading error is thrown when a subprocess requesting a ScopedLogger throws.

### DIFF
--- a/apps/heft/src/utilities/subprocess/SubprocessLoggerManager.ts
+++ b/apps/heft/src/utilities/subprocess/SubprocessLoggerManager.ts
@@ -122,7 +122,7 @@ export class SubprocessLoggerManager extends SubprocessCommunicationManagerBase 
           };
         } catch (error) {
           responseMessage = {
-            type: SUBPROCESS_LOGGER_MANAGER_REQUEST_LOGGER_MESSAGE_TYPE,
+            type: SUBPROCESS_LOGGER_MANAGER_PROVIDE_LOGGER_MESSAGE_TYPE,
             loggerName: typedMessage.loggerName,
             error: SubprocessRunnerBase.serializeForIpcMessage(
               error

--- a/common/changes/@rushstack/heft/ianc-fix-error-case_2021-08-05-02-15.json
+++ b/common/changes/@rushstack/heft/ianc-fix-error-case_2021-08-05-02-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

There is a bug (that should never be exposed to users) where a misleading error is thrown when a subprocess requesting a `ScopedLogger` throws an error.

## How it was tested

Created an error condition and ensured the thrown error is correct.