### PR TITLE
[rush] Update JSZip.

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -39,7 +39,7 @@
     "ignore": "~5.1.6",
     "inquirer": "~7.3.3",
     "js-yaml": "~3.13.1",
-    "jszip": "~3.5.0",
+    "jszip": "~3.7.1",
     "lodash": "~4.17.15",
     "minimatch": "~3.0.2",
     "node-fetch": "~2.6.1",

--- a/common/changes/@microsoft/rush/ianc-update-jszip_2021-08-10-22-48.json
+++ b/common/changes/@microsoft/rush/ianc-update-jszip_2021-08-10-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update JSZip dependency.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -258,7 +258,7 @@ importers:
       inquirer: ~7.3.3
       jest: ~25.4.0
       js-yaml: ~3.13.1
-      jszip: ~3.5.0
+      jszip: ~3.7.1
       lodash: ~4.17.15
       minimatch: ~3.0.2
       node-fetch: ~2.6.1
@@ -295,7 +295,7 @@ importers:
       ignore: 5.1.8
       inquirer: 7.3.3
       js-yaml: 3.13.1
-      jszip: 3.5.0
+      jszip: 3.7.1
       lodash: 4.17.21
       minimatch: 3.0.4
       node-fetch: 2.6.1
@@ -7969,8 +7969,8 @@ packages:
       array-includes: 3.1.3
       object.assign: 4.1.2
 
-  /jszip/3.5.0:
-    resolution: {integrity: sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==}
+  /jszip/3.7.1:
+    resolution: {integrity: sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==}
     dependencies:
       lie: 3.3.0
       pako: 1.0.11

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a87ca42757369632b3dcacc39399f26fa591a4ea",
+  "pnpmShrinkwrapHash": "30dd6f0cf630dc4fa0c66b73735436b4e05b43c6",
   "preferredVersionsHash": "1fbc26d2c5b3248616b9edccd6bef064075243bc"
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/2836.

Tested by running `rush deploy` in another repo.