### PR TITLE
[heft] Restore generation of tsbuildinfo path to compensate for improper resolution semantics

### DIFF
--- a/common/changes/@rushstack/heft-node-rig/lock-tsbuildinfo-path_2021-08-12-00-43.json
+++ b/common/changes/@rushstack/heft-node-rig/lock-tsbuildinfo-path_2021-08-12-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restore automatic generation of tsBuildInfo.json file path to work around odd path resolution behavior.",
+      "type": "patch",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/lock-tsbuildinfo-path_2021-08-12-00-43.json
+++ b/common/changes/@rushstack/heft-web-rig/lock-tsbuildinfo-path_2021-08-12-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restore automatic generation of tsBuildInfo.json file path to work around odd path resolution behavior.",
+      "type": "patch",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/lock-tsbuildinfo-path_2021-08-12-00-43.json
+++ b/common/changes/@rushstack/heft/lock-tsbuildinfo-path_2021-08-12-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Restore automatic generation of tsBuildInfo.json file path to work around odd path resolution behavior.",
+      "type": "patch",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/rigs/heft-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/heft-node-rig/profiles/default/tsconfig-base.json
@@ -18,7 +18,6 @@
     "allowUnreachableCode": false,
 
     "incremental": true,
-    "tsBuildInfoFile": "../../../../../temp/_tsBuildInfo.json",
 
     "types": [],
 

--- a/rigs/heft-web-rig/profiles/library/tsconfig-base.json
+++ b/rigs/heft-web-rig/profiles/library/tsconfig-base.json
@@ -19,7 +19,6 @@
     "allowUnreachableCode": false,
 
     "incremental": true,
-    "tsBuildInfoFile": "../../../../../temp/_tsBuildInfo.json",
 
     "types": [],
 


### PR DESCRIPTION
## Summary
Using the `tsBuildInfoFile` in tsconfig-base.json in rigs was resolving incorrectly. This PR restores it to being auto-generated inside of the Heft TypeScriptPlugin.

## Details
Uses the same algorithm as previously, but routed into the `temp/` folder instead of `.heft/build-cache`.

## How it was tested
Local `rush build`, verified that projects have a build info file in the expected location.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
