### PR TITLE
[heft] Ensure the CWD is set correctly for subprocesses.

### DIFF
--- a/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
+++ b/apps/heft/src/plugins/ApiExtractorPlugin/ApiExtractorRunner.ts
@@ -6,10 +6,13 @@ import * as path from 'path';
 import { Terminal, Path } from '@rushstack/node-core-library';
 import type * as TApiExtractor from '@microsoft/api-extractor';
 
-import { SubprocessRunnerBase } from '../../utilities/subprocess/SubprocessRunnerBase';
+import {
+  ISubprocessRunnerBaseConfiguration,
+  SubprocessRunnerBase
+} from '../../utilities/subprocess/SubprocessRunnerBase';
 import { IScopedLogger } from '../../pluginFramework/logging/ScopedLogger';
 
-export interface IApiExtractorRunnerConfiguration {
+export interface IApiExtractorRunnerConfiguration extends ISubprocessRunnerBaseConfiguration {
   /**
    * The path to the Extractor's config file ("api-extractor.json")
    *
@@ -30,13 +33,6 @@ export interface IApiExtractorRunnerConfiguration {
    * For example, /home/username/code/repo/project/node_modules/typescript
    */
   typescriptPackagePath: string | undefined;
-
-  /**
-   * The folder of the project being built
-   *
-   * For example, /home/username/code/repo/project
-   */
-  buildFolder: string;
 
   /**
    * If set to true, run API Extractor in production mode

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -20,7 +20,10 @@ import {
   IExtendedSourceFile
 } from './internalTypings/TypeScriptInternals';
 
-import { SubprocessRunnerBase } from '../../utilities/subprocess/SubprocessRunnerBase';
+import {
+  ISubprocessRunnerBaseConfiguration,
+  SubprocessRunnerBase
+} from '../../utilities/subprocess/SubprocessRunnerBase';
 import { Async } from '../../utilities/Async';
 import { PerformanceMeasurer, PerformanceMeasurerAsync } from '../../utilities/Performance';
 import { Tslint } from './Tslint';
@@ -41,8 +44,9 @@ interface ILinterWrapper {
   measureTsPerformance: PerformanceMeasurer;
 }
 
-export interface ITypeScriptBuilderConfiguration extends ISharedTypeScriptConfiguration {
-  buildFolder: string;
+export interface ITypeScriptBuilderConfiguration
+  extends ISharedTypeScriptConfiguration,
+    ISubprocessRunnerBaseConfiguration {
   /**
    * The folder to write build metadata.
    */

--- a/apps/heft/src/utilities/subprocess/SubprocessRunnerBase.ts
+++ b/apps/heft/src/utilities/subprocess/SubprocessRunnerBase.ts
@@ -33,6 +33,15 @@ export interface ISubprocessInnerConfiguration {
 export const SUBPROCESS_RUNNER_CLASS_LABEL: unique symbol = Symbol('IsSubprocessModule');
 export const SUBPROCESS_RUNNER_INNER_INVOKE: unique symbol = Symbol('SubprocessInnerInvoke');
 
+export interface ISubprocessRunnerBaseConfiguration {
+  /**
+   * The folder of the project being built
+   *
+   * For example, /home/username/code/repo/project
+   */
+  buildFolder: string;
+}
+
 interface ISubprocessExitMessage extends ISubprocessMessageBase {
   type: 'exit';
   error: ISubprocessApiCallArg;
@@ -45,7 +54,9 @@ interface ISubprocessExitMessage extends ISubprocessMessageBase {
  * The subprocess can be provided with a configuration, which must be JSON-serializable,
  * and the subprocess can log data via a Terminal object.
  */
-export abstract class SubprocessRunnerBase<TSubprocessConfiguration> {
+export abstract class SubprocessRunnerBase<
+  TSubprocessConfiguration extends ISubprocessRunnerBaseConfiguration
+> {
   public static [SUBPROCESS_RUNNER_CLASS_LABEL]: boolean = true;
   private static _subprocessInspectorPort: number = 9229 + 1; // 9229 is the default port
 
@@ -105,7 +116,7 @@ export abstract class SubprocessRunnerBase<TSubprocessConfiguration> {
     }
   }
 
-  public static initializeSubprocess<TSubprocessConfiguration>(
+  public static initializeSubprocess<TSubprocessConfiguration extends ISubprocessRunnerBaseConfiguration>(
     thisType: new (
       parentGlobalTerminalProvider: ITerminalProvider,
       configuration: TSubprocessConfiguration,
@@ -148,6 +159,7 @@ export abstract class SubprocessRunnerBase<TSubprocessConfiguration> {
         [this.filename, JSON.stringify(this._innerConfiguration), JSON.stringify(this._configuration)],
         {
           execArgv: this._processNodeArgsForSubprocess(this._globalTerminal, process.execArgv),
+          cwd: this._configuration.buildFolder,
           ...SubprocessTerminator.RECOMMENDED_OPTIONS
         }
       );

--- a/apps/heft/src/utilities/subprocess/startSubprocess.ts
+++ b/apps/heft/src/utilities/subprocess/startSubprocess.ts
@@ -5,7 +5,8 @@ import {
   SubprocessRunnerBase,
   ISubprocessInnerConfiguration,
   SUBPROCESS_RUNNER_CLASS_LABEL,
-  SUBPROCESS_RUNNER_INNER_INVOKE
+  SUBPROCESS_RUNNER_INNER_INVOKE,
+  ISubprocessRunnerBaseConfiguration
 } from './SubprocessRunnerBase';
 
 const [, , subprocessModulePath, serializedInnerConfiguration, serializedSubprocessConfiguration] =
@@ -22,7 +23,7 @@ if (subprocessRunnerModuleExports.length !== 1) {
   );
 }
 
-declare class SubprocessRunnerSubclass extends SubprocessRunnerBase<object> {
+declare class SubprocessRunnerSubclass extends SubprocessRunnerBase<ISubprocessRunnerBaseConfiguration> {
   public filename: string;
   public invokeAsync(): Promise<void>;
 }
@@ -37,7 +38,9 @@ if (!SubprocessRunnerClass[SUBPROCESS_RUNNER_CLASS_LABEL]) {
 }
 
 const innerConfiguration: ISubprocessInnerConfiguration = JSON.parse(serializedInnerConfiguration);
-const subprocessConfiguration: object = JSON.parse(serializedSubprocessConfiguration);
+const subprocessConfiguration: ISubprocessRunnerBaseConfiguration = JSON.parse(
+  serializedSubprocessConfiguration
+);
 
 const subprocessRunner: SubprocessRunnerSubclass = SubprocessRunnerClass.initializeSubprocess(
   SubprocessRunnerClass,

--- a/common/changes/@rushstack/heft/ianc-fix-subprocess-cwd_2021-08-12-06-51.json
+++ b/common/changes/@rushstack/heft/ianc-fix-subprocess-cwd_2021-08-12-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue with the TypeScript compilation when Heft is invoked in a terminal with incorrect casing in the CWD.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

There is currently an issue where if Heft is invoked in a console with incorrect casing in the CWD (for example, `c:\code\projectfolder` instead of `C:\code\projectfolder`), modules with incorrect properties will be passed to TSLint.

## Details

This change fixes the issue by explicitly setting the `cwd` property in the subprocess runner.

## How it was tested

Tested with a console with an incorrectly-cased working directory.