### PR TITLE
[heft] Revert setting incremental: true in tsconfig-base.json

### DIFF
--- a/common/changes/@rushstack/heft-node-rig/rig-revert-incremental_2021-08-12-18-47.json
+++ b/common/changes/@rushstack/heft-node-rig/rig-revert-incremental_2021-08-12-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove default use of incremental: true in tsconfig-base.json",
+      "type": "patch",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/rig-revert-incremental_2021-08-12-18-47.json
+++ b/common/changes/@rushstack/heft-web-rig/rig-revert-incremental_2021-08-12-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove default use of incremental: true in tsconfig-base.json",
+      "type": "patch",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/rigs/heft-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/heft-node-rig/profiles/default/tsconfig-base.json
@@ -17,8 +17,6 @@
     "noEmitOnError": false,
     "allowUnreachableCode": false,
 
-    "incremental": true,
-
     "types": [],
 
     "module": "commonjs",

--- a/rigs/heft-web-rig/profiles/library/tsconfig-base.json
+++ b/rigs/heft-web-rig/profiles/library/tsconfig-base.json
@@ -18,8 +18,6 @@
     "noEmitOnError": false,
     "allowUnreachableCode": false,
 
-    "incremental": true,
-
     "types": [],
 
     "module": "esnext",


### PR DESCRIPTION
## Summary
Setting "incremental: true" in tsconfig requires setting `tsBuildInfoFile` in the config as well, but Heft is rewriting the value thereof. This PR removes the setting from the rig to ensure that the config is compatible with other tools that might read tsconfig.json.

## Details
An alternative would be to set the `tsBuildInfoFile` property, but we previously encountered issues with how the path resolves when this is specified in a rig.

## How it was tested
Regular build of rushstack repo, since most projects in the repo use the rigs.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
