### PR TITLE
[rush] Allow build cache reads downstream of built projects during `rush build`

### DIFF
--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -27,9 +27,9 @@ export abstract class BaseBuilder {
   abstract readonly name: string;
 
   /**
-   * This flag determines if an incremental build is allowed for the task.
+   * This flag determines if an the task is allowed to be skipped if up to date.
    */
-  abstract isIncrementalBuildAllowed: boolean;
+  abstract isSkipAllowed: boolean;
 
   /**
    * Assigned by execute().  True if the build script was an empty string.  Operationally an empty string is

--- a/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/BaseBuilder.ts
@@ -27,7 +27,7 @@ export abstract class BaseBuilder {
   abstract readonly name: string;
 
   /**
-   * This flag determines if an the task is allowed to be skipped if up to date.
+   * This flag determines if the task is allowed to be skipped if up to date.
    */
   abstract isSkipAllowed: boolean;
 

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -338,7 +338,7 @@ export class TaskRunner {
 
     task.dependents.forEach((dependent: Task) => {
       if (!this._changedProjectsOnly) {
-        dependent.builder.isIncrementalBuildAllowed = false;
+        dependent.builder.isSkipAllowed = false;
       }
       dependent.dependencies.delete(task);
     });
@@ -355,7 +355,7 @@ export class TaskRunner {
     task.status = TaskStatus.SuccessWithWarning;
     task.dependents.forEach((dependent: Task) => {
       if (!this._changedProjectsOnly) {
-        dependent.builder.isIncrementalBuildAllowed = false;
+        dependent.builder.isSkipAllowed = false;
       }
       dependent.dependencies.delete(task);
     });

--- a/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/MockBuilder.ts
@@ -10,7 +10,7 @@ export class MockBuilder extends BaseBuilder {
   private readonly _action: ((terminal: CollatedTerminal) => Promise<TaskStatus>) | undefined;
   public readonly name: string;
   public readonly hadEmptyScript: boolean = false;
-  public readonly isIncrementalBuildAllowed: boolean = false;
+  public readonly isSkipAllowed: boolean = false;
 
   public constructor(name: string, action?: (terminal: CollatedTerminal) => Promise<TaskStatus>) {
     super();

--- a/common/changes/@microsoft/rush/fix-rush-build-cache_2021-08-13-22-04.json
+++ b/common/changes/@microsoft/rush/fix-rush-build-cache_2021-08-13-22-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "When build cache is enabled in `rush build`, allow projects downstream to be satisfied from the cache if applicable. Cache reads will still be disabled for `rush rebuild`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
Partially undoes behavior changes of #2802. Allows `rush build` to read from the build cache for projects for which dependencies have been rebuilt, if applicable. Still ensures that `rush rebuild` does not read from the build cache.

## Details
Separates the `isIncrementalBuildAllowed` option in `ProjectBuilder` into two separate flags for the desired behaviors:
- `_isCacheReadAllowed` is set by being the command-level `isIncrementalBuildAllowed` flag, and controls if read from cache is permitted if a match is found.
- `isSkipAllowed` is initialized by the command-level `isIncrementalBuildAllowed` flag, but updated by `TaskRunner` in response to upstream projects being built, and controls if the project may be skipped if current package-deps match the most recent execution.

## How it was tested
Ran local `node ./apps/rush-lib/lib/start.js build` and verified that projects downstream of skipped projects (e.g. `@rushstack/heft-node-rig`) pulled from the local build cache.
