### PR TITLE
[api-documenter] Delete redundant newline from fenced code

### DIFF
--- a/apps/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -162,7 +162,7 @@ export class MarkdownEmitter {
         writer.write(docFencedCode.language);
         writer.writeLine();
         writer.write(docFencedCode.code);
-        writer.writeLine();
+        writer.ensureNewLine();
         writer.writeLine('```');
         break;
       }

--- a/common/changes/@microsoft/api-documenter/redundant-newline-in-fenced-code_2021-08-15-05-01.json
+++ b/common/changes/@microsoft/api-documenter/redundant-newline-in-fenced-code_2021-08-15-05-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "7571111+autopp@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-documenter/redundant-newline-in-fenced-code_2021-08-15-05-01.json
+++ b/common/changes/@microsoft/api-documenter/redundant-newline-in-fenced-code_2021-08-15-05-01.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/api-documenter",
-      "comment": "",
-      "type": "none"
+      "comment": "Remove redundant newline in fenced code blocks",
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/api-documenter",


### PR DESCRIPTION
## Summary

Fixes #2857

This PR delete redundant newline at end of fenced code in output of `api-documenter markdown`.

## Details

Use `writer.ensureNewLine()` instead of `writer.writeLine()` for write end of fenced code.

At first I simply removed the call of `writer.writeLine()`, but it affected the Signature section.

## How it was tested

Prepare `.d.ts` which contains fenced code in doc comment.

E.g.
```typescript
/**
 * @example
 * ```typescript
 * console.log(add(40, 2)) // => 42
 * ```
 */
export function add(x: number, y: number): number;
```

Generate the markdown document for it.

The output changes from
<pre>
```typescript
console.log(add(40, 2)) // => 42

```
</pre>
to
<pre>
```typescript
console.log(add(40, 2)) // => 42
```
</pre>
