### PR TITLE
[module-minifier-plugin] Fix compatibility issue with mini-css-extract-plugin

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/module-minifier-mini-css-compat_2021-08-17-21-01.json
+++ b/common/changes/@rushstack/module-minifier-plugin/module-minifier-mini-css-compat_2021-08-17-21-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Fix compatibility issue with mini-css-extract-plugin and other plugins that introduce non-JavaScript modules and asset types.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -226,7 +226,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
          */
         function dehydrateAsset(modules: Source, chunk: webpack.compilation.Chunk): Source {
           for (const mod of chunk.modulesIterable) {
-            if (mod.id === null || !submittedModules.has(mod.id)) {
+            // If the id is null, it won't be part of the chunk
+            if (mod.id !== null && !submittedModules.has(mod.id)) {
               console.error(
                 `Chunk ${chunk.id} failed to render module ${mod.id} for ${(mod as IExtendedModule).resource}`
               );

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -493,6 +493,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
           }
         );
 
+        // This function is written twice because the parameter order is not the same between the two hooks
         (compilation.chunkTemplate as unknown as IExtendedChunkTemplate).hooks.modules.tap(
           TAP_AFTER,
           (source: Source, chunk: webpack.compilation.Chunk, moduleTemplate: unknown) => {

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -451,7 +451,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
                     }
                   );
                 } else {
-                  // Skip minification for all other assets, though the modules still might be
+                  // This isn't a JS asset. Don't try to minify the asset wrapper, though if it contains modules, those might still get replaced with minified versions.
                   minifiedAssets.set(assetName, {
                     // Still need to restore ids
                     source: postProcessCode(new ReplaceSource(asset), assetName),


### PR DESCRIPTION
## Summary
Configures the ModuleMinifierPlugin to ignore non-JavaScript modules/assets as appropriate.

## Details
If the asset being rendered does not use the JavaScript module template, leaves the rendered modules in place instead of replacing the content with a marker.

## How it was tested
Used built version against a separate project with mini-css-extract-plugin in use.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
