### PR TITLE
Streamline rushx startup output

### DIFF
--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -99,7 +99,7 @@ export class Rush {
   public static earlyVerboseFlag(): boolean {
     const args = process.argv.slice(2);
     const cmdIndex = args.findIndex((arg) => !arg.startsWith('-'));
-    const flags = args.slice(0, cmdIndex);
+    const flags = cmdIndex < 0 ? args : args.slice(0, cmdIndex);
 
     return flags.includes('-v') || flags.includes('--verbose');
   }

--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -167,10 +167,11 @@ export class RushXCommandLine {
 
   private static _showUsage(packageJson: IPackageJson, projectCommandSet: ProjectCommandSet): void {
     console.log('usage: rushx [-h]');
-    console.log('       rushx <command> ...' + os.EOL);
+    console.log('       rushx [-v] <command> ...' + os.EOL);
 
     console.log('Optional arguments:');
-    console.log('  -h, --help            Show this help message and exit.' + os.EOL);
+    console.log('  -h, --help            Show this help message and exit.');
+    console.log('  -v, --verbose         Show more detailed information while starting.' + os.EOL);
 
     if (projectCommandSet.commandNames.length > 0) {
       console.log(`Project commands for ${colors.cyan(packageJson.name)}:`);


### PR DESCRIPTION
## Summary

This is a strawman PR for ticket #2815 ( Fixes #2815 ).

Open to feedback on the desired output level (and ideas on the best way to retrieve the flags).

## Details

I think the information `rushx` prints (Rush version, node.js version, etc.) is useful even if you don't want verbose info, so I've proposed a "compact" version of the startup banner that keeps it but shortens it to one line.

The information about finding the `rush.json` configuration file, and the details of the exact command being executed, I think can be jettisoned if you aren't running verbose.  (The command listed in the ticket above is a good example -- if you've hidden the complexity of a command like `node lib/blah/blah/blah.js --arg1 --arg2` inside an npm script, the last thing you want is to have to see that complexity every time you run rushx.)

#### Example: `rushx build`

```console
> rushx build
Rush 5.51.1 (unmanaged) - https://rushjs.io (Node.js 12.17.0 LTS)

Using local Heft from /[.................]/node_modules/@rushstack/heft

Project build folder is "/[..............]"
Using rig configuration from ./[..............]
Starting test
 ---- Clean started ---- 
```

#### Example: `rushx -v build`

```console
> rushx -v build

Rush Multi-Project Build Tool 5.51.1 (unmanaged) - https://rushjs.io
Node.js version is 12.17.0 (LTS)

Found configuration in /[............]/rush.json

Executing: "heft test --clean"

Using local Heft from /[.................]/node_modules/@rushstack/heft

Project build folder is "/[..............]"
Using rig configuration from ./[..............]
Starting test
 ---- Clean started ---- 
```

#### Example: `rushx -h`

```console
> rushx -h      
Rush 5.51.1 (unmanaged) - https://rushjs.io (Node.js 12.17.0 LTS)

usage: rushx [-h]
       rushx [-v] <command> ...

Optional arguments:
  -h, --help            Show this help message and exit.
  -v, --verbose         Show more detailed information while starting.

Project commands for [......]:
  build: "heft test --clean"
  dev:   "heft build --watch"
  start: "heft start"
  test:  "heft test --clean"
```

#### Example: `rushx -v -h`

```console
> rushx -v -h

Rush Multi-Project Build Tool 5.51.1 (unmanaged) - https://rushjs.io
Node.js version is 12.17.0 (LTS)

Found configuration in /[............]/rush.json

usage: rushx [-h]
       rushx [-v] <command> ...

Optional arguments:
  -h, --help            Show this help message and exit.
  -v, --verbose         Show more detailed information while starting.

Project commands for [.....]:
  build: "heft test --clean"
  dev:   "heft build --watch"
  start: "heft start"
  test:  "heft test --clean"
```

## How it was tested

 - Tested locally on our monorepo.
 - Will update unit tests, run rush change, etc., if given tentative approval.
