### PR TITLE
[heft-sass-plugin] Support emitting the compiled CSS to disk

### DIFF
--- a/build-tests/heft-sass-test/config/sass.json
+++ b/build-tests/heft-sass-test/config/sass.json
@@ -1,0 +1,3 @@
+{
+  "cssOutputFolders": ["lib"]
+}

--- a/build-tests/heft-sass-test/config/typescript.json
+++ b/build-tests/heft-sass-test/config/typescript.json
@@ -52,7 +52,7 @@
     /**
      * File extensions that should be copied from the src folder to the destination folder(s).
      */
-    "fileExtensions": [".sass", ".scss", ".css"]
+    "fileExtensions": []
 
     /**
      * Glob patterns that should be explicitly included.

--- a/build-tests/heft-sass-test/src/_stylesImport.sass
+++ b/build-tests/heft-sass-test/src/_stylesImport.sass
@@ -1,6 +1,5 @@
 /**
- * This file gets copied to the "lib" folder because its extension is registered in copy-static-assets.json
- * Then Webpack uses sass-loader to transpile, css-loader to embed, and finally style-loader to apply it to the DOM.
+ * This file is a SASS partial and therefore has no direct output file, but gets embedded into other files.
  */
 
 // This will be imported by styles.sass

--- a/build-tests/heft-sass-test/src/styles.sass
+++ b/build-tests/heft-sass-test/src/styles.sass
@@ -1,8 +1,8 @@
 /**
- * This file gets copied to the "lib" folder because its extension is registered in copy-static-assets.json
- * Then Webpack uses sass-loader to transpile, css-loader to embed, and finally style-loader to apply it to the DOM.
+ * This file gets transpiled by the heft-sass-plugin and output to the lib/ folder.
+ * Then Webpack uses css-loader to embed, and finally style-loader to apply it to the DOM.
  */
- 
+
 // Testing Sass imports
 @import 'stylesImport'
 
@@ -22,7 +22,7 @@ html, body
   padding: 20px
   border-radius: 5px
   width: 400px
-  
+
 .exampleButton
   @include buttono-block()
   @include buttono-style-modifier($background-color: mediumorchid)

--- a/build-tests/heft-sass-test/src/stylesAltSyntax.scss
+++ b/build-tests/heft-sass-test/src/stylesAltSyntax.scss
@@ -1,6 +1,6 @@
 /**
- * This file gets copied to the "lib" folder because its extension is registered in copy-static-assets.json
- * Then Webpack uses sass-loader to transpile, css-loader to embed, and finally style-loader to apply it to the DOM.
+ * This file gets transpiled by the heft-sass-plugin and output to the lib/ folder.
+ * Then Webpack uses css-loader to embed, and finally style-loader to apply it to the DOM.
  */
 
 // Testing SCSS syntax

--- a/build-tests/heft-sass-test/src/stylesCSS.css
+++ b/build-tests/heft-sass-test/src/stylesCSS.css
@@ -1,6 +1,6 @@
 /**
- * This file gets copied to the "lib" folder because its extension is registered in copy-static-assets.json
- * Then Webpack uses sass-loader to transpile, css-loader to embed, and finally style-loader to apply it to the DOM.
+ * This file gets picked up by the heft-sass-plugin and output to the lib/ folder.
+ * Then Webpack uses css-loader to embed, and finally style-loader to apply it to the DOM.
  */
 
 /* Testing CSS styles */

--- a/build-tests/heft-sass-test/webpack.config.js
+++ b/build-tests/heft-sass-test/webpack.config.js
@@ -14,12 +14,12 @@ function createWebpackConfig({ production }) {
     // Documentation: https://webpack.js.org/configuration/mode/
     mode: production ? 'production' : 'development',
     resolve: {
-      extensions: ['.js', '.jsx', '.json']
+      extensions: ['.js', '.jsx', '.json', '.css']
     },
     module: {
       rules: [
         {
-          test: /\.(scss|sass|css)$/,
+          test: /\.css$/,
           exclude: /node_modules/,
           use: [
             // Creates `style` nodes from JS strings
@@ -38,16 +38,6 @@ function createWebpackConfig({ production }) {
               options: {
                 postcssOptions: {
                   plugins: [new Autoprefixer()]
-                }
-              }
-            },
-            // Compiles Sass to CSS
-            {
-              loader: 'sass-loader',
-              options: {
-                implementation: sass,
-                sassOptions: {
-                  includePaths: [path.resolve(__dirname, 'node_modules')]
                 }
               }
             }

--- a/common/changes/@rushstack/heft-sass-plugin/sass-plugin-emit_2021-08-26-00-29.json
+++ b/common/changes/@rushstack/heft-sass-plugin/sass-plugin-emit_2021-08-26-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Add a \"cssOuputFolders\" option to \"config/sass.json\" to emit compiled CSS.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/typings-generator/sass-plugin-emit_2021-08-26-00-29.json
+++ b/common/changes/@rushstack/typings-generator/sass-plugin-emit_2021-08-26-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "Support additional output files beyond the typings files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -35,9 +35,11 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> {
     // (undocumented)
     generatedTsFolder: string;
     // (undocumented)
+    getAdditionalOutputFiles?: (relativePath: string) => string[];
+    // (undocumented)
     globsToIgnore?: string[];
     // (undocumented)
-    parseAndGenerateTypings: (fileContents: string, filePath: string) => TTypingsResult | Promise<TTypingsResult>;
+    parseAndGenerateTypings: (fileContents: string, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
     // (undocumented)
     srcFolder: string;
     // (undocumented)
@@ -55,8 +57,10 @@ export class TypingsGenerator {
     // (undocumented)
     generateTypingsAsync(): Promise<void>;
     // (undocumented)
+    getOutputFilePaths(relativePath: string): string[];
+    // (undocumented)
     protected _options: ITypingsGeneratorOptions;
-    registerDependency(target: string, dependency: string): void;
+    registerDependency(consumer: string, rawDependency: string): void;
     // (undocumented)
     runWatcherAsync(): Promise<void>;
 }

--- a/heft-plugins/heft-sass-plugin/src/SassTypingsGenerator.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassTypingsGenerator.ts
@@ -2,10 +2,10 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { render, Result } from 'node-sass';
+import { render, Result, SassError } from 'node-sass';
 import postcss from 'postcss';
 import cssModules from 'postcss-modules';
-import { LegacyAdapters } from '@rushstack/node-core-library';
+import { FileSystem } from '@rushstack/node-core-library';
 import { IStringValueTypings, StringValuesTypingsGenerator } from '@rushstack/typings-generator';
 
 /**
@@ -23,6 +23,11 @@ export interface ISassConfiguration {
    * Defaults to "temp/sass-ts/".
    */
   generatedTsFolder?: string;
+
+  /**
+   * Output directories for compiled CSS
+   */
+  cssOutputFolders?: string[] | undefined;
 
   /**
    * Determines if export values are wrapped in a default property, or not.
@@ -87,6 +92,17 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
       sassConfiguration.exportAsDefault === undefined ? true : sassConfiguration.exportAsDefault;
     const exportAsDefaultInterfaceName: string = 'IExportStyles';
     const fileExtensions: string[] = sassConfiguration.fileExtensions || ['.sass', '.scss', '.css'];
+    const { cssOutputFolders } = sassConfiguration;
+
+    const getCssPaths: ((relativePath: string) => string[]) | undefined = cssOutputFolders
+      ? (relativePath: string): string[] => {
+          return cssOutputFolders.map(
+            (folder: string) =>
+              `${folder}/${relativePath.endsWith('.css') ? relativePath : `${relativePath}.css`}`
+          );
+        }
+      : undefined;
+
     super({
       srcFolder,
       generatedTsFolder,
@@ -95,24 +111,55 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
       fileExtensions,
       filesToIgnore: sassConfiguration.excludeFiles,
 
+      getAdditionalOutputFiles: getCssPaths,
+
       // Generate typings function
-      parseAndGenerateTypings: async (fileContents: string, filePath: string) => {
+      parseAndGenerateTypings: async (fileContents: string, filePath: string, relativePath: string) => {
         if (this._isSassPartial(filePath)) {
           // Do not generate typings for Sass partials.
           return;
         }
+
         const css: string = await this._transpileSassAsync(
           fileContents,
           filePath,
           buildFolder,
           sassConfiguration.importIncludePaths
         );
-        const classNames: string[] = await this._getClassNamesFromCSSAsync(css, filePath);
-        const sortedClassNames: string[] = classNames.sort((a, b) => a.localeCompare(b));
-        const sassTypings: IStringValueTypings = { typings: [] };
-        for (const exportName of sortedClassNames) {
-          sassTypings.typings.push({ exportName });
+
+        let classMap: IClassMap = {};
+        const cssModulesClassMapPlugin: postcss.Plugin<TCssModules> = cssModules({
+          getJSON: (cssFileName: string, json: IClassMap) => {
+            // This callback will be invoked durint the promise evaluation of the postcss process() function.
+            classMap = json;
+          },
+          // Avoid unnecessary name hashing.
+          generateScopedName: (name: string) => name
+        });
+
+        await postcss([cssModulesClassMapPlugin]).process(css, { from: filePath });
+
+        if (getCssPaths) {
+          await Promise.all(
+            getCssPaths(relativePath).map(async (cssFile: string) => {
+              // The typings generator processes files serially and the number of output folders is expected to be small,
+              // thus throttling here is not currently a concern.
+              await FileSystem.writeFileAsync(cssFile, css, {
+                ensureFolderExists: true
+              });
+            })
+          );
         }
+
+        const sortedClassNames: string[] = Object.keys(classMap).sort();
+
+        const sassTypings: IStringValueTypings = {
+          typings: sortedClassNames.map((exportName: string) => {
+            return {
+              exportName
+            };
+          })
+        };
 
         return sassTypings;
       }
@@ -133,20 +180,33 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
     buildFolder: string,
     importIncludePaths: string[] | undefined
   ): Promise<string> {
-    const result: Result = await LegacyAdapters.convertCallbackToPromise(render, {
-      data: fileContents,
-      file: filePath,
-      importer: (url: string) => ({ file: this._patchSassUrl(url) }),
-      includePaths: importIncludePaths
-        ? importIncludePaths
-        : [path.join(buildFolder, 'node_modules'), path.join(buildFolder, 'src')],
-      indentedSyntax: path.extname(filePath).toLowerCase() === '.sass'
-    });
+    const result: Result = await new Promise(
+      (resolve: (result: Result) => void, reject: (err: Error) => void) => {
+        render(
+          {
+            data: fileContents,
+            file: filePath,
+            importer: (url: string) => ({ file: this._patchSassUrl(url) }),
+            includePaths: importIncludePaths
+              ? importIncludePaths
+              : [path.join(buildFolder, 'node_modules'), path.join(buildFolder, 'src')],
+            indentedSyntax: path.extname(filePath).toLowerCase() === '.sass'
+          },
+          (err: SassError, result: Result) => {
+            if (err) {
+              // Extract location information and format into the error message until we have a concept
+              // of location-aware diagnostics in Heft.
+              return reject(new Error(`${err.file}(${err.column},${err.line}): ${err.message}`));
+            }
+            resolve(result);
+          }
+        );
+      }
+    );
 
     // Register any @import files as dependencies.
-    const target: string = result.stats.entry;
     for (const dependency of result.stats.includedFiles) {
-      this.registerDependency(target, dependency);
+      this.registerDependency(filePath, dependency);
     }
 
     return result.css.toString();
@@ -154,24 +214,9 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
 
   private _patchSassUrl(url: string): string {
     if (url[0] === '~') {
-      return 'node_modules/' + url.substr(1);
+      return 'node_modules/' + url.slice(1);
     }
 
     return url;
-  }
-
-  private async _getClassNamesFromCSSAsync(css: string, filePath: string): Promise<string[]> {
-    let classMap: IClassMap = {};
-    const cssModulesClassMapPlugin: postcss.Plugin<TCssModules> = cssModules({
-      getJSON: (cssFileName: string, json: IClassMap) => {
-        classMap = json;
-      },
-      // Avoid unnecessary name hashing.
-      generateScopedName: (name: string) => name
-    });
-    await postcss([cssModulesClassMapPlugin]).process(css, { from: filePath });
-    const classNames: string[] = Object.keys(classMap);
-
-    return classNames;
   }
 }

--- a/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
@@ -95,6 +95,9 @@ export class SassTypingsPlugin implements IHeftPlugin {
           },
           '$.srcFolder.*': {
             pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToProjectRoot
+          },
+          '$.cssOutputFolders.*': {
+            pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToProjectRoot
           }
         }
       });

--- a/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
@@ -32,6 +32,15 @@
       "description": "Determines if export values are wrapped in a default property, or not."
     },
 
+    "cssOutputFolders": {
+      "type": "array",
+      "description": "If specified, folders where compiled CSS files will be emitted to. They will be named by appending \".css\" to the source file name for ease of reference translation.",
+      "items": {
+        "type": "string",
+        "pattern": "[^\\\\]"
+      }
+    },
+
     "fileExtensions": {
       "type": "array",
       "description": "Files with these extensions will pass through the Sass transpiler for typings generation.",

--- a/libraries/typings-generator/src/StringValuesTypingsGenerator.ts
+++ b/libraries/typings-generator/src/StringValuesTypingsGenerator.ts
@@ -49,10 +49,11 @@ export class StringValuesTypingsGenerator extends TypingsGenerator {
   public constructor(options: IStringValuesTypingsGeneratorOptions) {
     super({
       ...options,
-      parseAndGenerateTypings: async (fileContents: string, filePath: string) => {
+      parseAndGenerateTypings: async (fileContents: string, filePath: string, relativePath: string) => {
         const stringValueTypings: IStringValueTypings | undefined = await options.parseAndGenerateTypings(
           fileContents,
-          filePath
+          filePath,
+          relativePath
         );
 
         if (stringValueTypings === undefined) {

--- a/libraries/typings-generator/src/TypingsGenerator.ts
+++ b/libraries/typings-generator/src/TypingsGenerator.ts
@@ -25,8 +25,10 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> {
   fileExtensions: string[];
   parseAndGenerateTypings: (
     fileContents: string,
-    filePath: string
+    filePath: string,
+    relativePath: string
   ) => TTypingsResult | Promise<TTypingsResult>;
+  getAdditionalOutputFiles?: (relativePath: string) => string[];
   terminal?: ITerminal;
   globsToIgnore?: string[];
   /**
@@ -43,13 +45,18 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> {
  * @public
  */
 export class TypingsGenerator {
-  // Map of target file path -> Set<dependency file path>
-  private _targetMap: Map<string, Set<string>>;
+  // Map of resolved consumer file path -> Set<resolved dependency file path>
+  private readonly _dependenciesOfFile: Map<string, Set<string>>;
 
-  // Map of dependency file path -> Set<target file path>
-  private _dependencyMap: Map<string, Set<string>>;
+  // Map of resolved dependency file path -> Set<resolved consumer file path>
+  private readonly _consumersOfFile: Map<string, Set<string>>;
+
+  // Map of resolved file path -> relative file path
+  private readonly _relativePaths: Map<string, string>;
 
   protected _options: ITypingsGeneratorOptions;
+
+  private readonly _fileGlob: string;
 
   public constructor(options: ITypingsGeneratorOptions) {
     this._options = {
@@ -90,9 +97,11 @@ export class TypingsGenerator {
 
     this._options.fileExtensions = this._normalizeFileExtensions(this._options.fileExtensions);
 
-    this._targetMap = new Map();
+    this._dependenciesOfFile = new Map();
+    this._consumersOfFile = new Map();
+    this._relativePaths = new Map();
 
-    this._dependencyMap = new Map();
+    this._fileGlob = `**/*+(${this._options.fileExtensions.join('|')})`;
   }
 
   public async generateTypingsAsync(): Promise<void> {
@@ -100,7 +109,7 @@ export class TypingsGenerator {
 
     const filePaths: string[] = await LegacyAdapters.convertCallbackToPromise(
       glob,
-      `**/*+(${this._options.fileExtensions.join('|')})`,
+      this._fileGlob,
       {
         cwd: this._options.srcFolder,
         absolute: true,
@@ -110,78 +119,153 @@ export class TypingsGenerator {
       }
     );
 
-    await Async.forEachAsync(
-      filePaths,
-      async (filePath: string) => {
-        filePath = `${this._options.srcFolder}/${filePath}`;
-        await this._parseFileAndGenerateTypingsAsync(filePath);
-      },
-      { concurrency: 50 }
-    );
+    await this._reprocessFiles(filePaths);
   }
 
   public async runWatcherAsync(): Promise<void> {
     await FileSystem.ensureFolderAsync(this._options.generatedTsFolder);
 
-    const globBase: string = `${this._options.srcFolder}/**`;
-
     await new Promise((resolve, reject): void => {
       const watcher: chokidar.FSWatcher = chokidar.watch(
-        this._options.fileExtensions.map((fileExtension) => `${globBase}/*${fileExtension}`),
+        this._fileGlob,
         {
+          cwd: this._options.srcFolder,
           ignored: this._options.globsToIgnore
         }
       );
-      const boundGenerateTypingsFunction: (filePath: string) => Promise<void> =
-        this._parseFileAndGenerateTypingsAsync.bind(this);
-      watcher.on('add', boundGenerateTypingsFunction);
-      watcher.on('change', boundGenerateTypingsFunction);
-      watcher.on('unlink', async (filePath) => {
-        const generatedTsFilePath: string = this._getTypingsFilePath(filePath);
-        await FileSystem.deleteFileAsync(generatedTsFilePath);
+
+      const queue: Set<string> = new Set();
+      let timeout: NodeJS.Timeout | undefined;
+      let processing: boolean = false;
+      let flushAfterCompletion: boolean = false;
+
+      const flushInternal: () => void = () => {
+        processing = true;
+
+        const toProcess: string[] = Array.from(queue);
+        queue.clear();
+        this._reprocessFiles(toProcess)
+          .then(() => {
+            processing = false;
+            // If the timeout was invoked again, immediately reexecute with the changed files.
+            if (flushAfterCompletion) {
+              flushAfterCompletion = false;
+              flushInternal();
+            }
+          })
+          .catch(reject);
+      };
+
+      const debouncedFlush: () => void = () => {
+        timeout = undefined;
+        if (processing) {
+          // If the callback was invoked while processing is ongoing, indicate that we should flush immediately
+          // upon completion of the current change batch.
+          flushAfterCompletion = true;
+          return;
+        }
+
+        flushInternal();
+      };
+
+      const onChange: (relativePath: string) => void = (relativePath: string) => {
+        queue.add(relativePath);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        setTimeout(debouncedFlush, 100);
+      };
+
+      watcher.on('add', onChange);
+      watcher.on('change', onChange);
+      watcher.on('unlink', async (relativePath) => {
+        await Promise.all(
+          this.getOutputFilePaths(relativePath).map(async (outputFile: string) => {
+            await FileSystem.deleteFileAsync(outputFile);
+          })
+        );
       });
       watcher.on('error', reject);
     });
   }
 
   /**
-   * Register file dependencies that may effect the typings of a target file.
+   * Register file dependencies that may effect the typings of a consumer file.
    * Note: This feature is only useful in watch mode.
    * The registerDependency method must be called in the body of parseAndGenerateTypings every
    * time because the registry for a file is cleared at the beginning of processing.
    */
-  public registerDependency(target: string, dependency: string): void {
-    let targetDependencySet: Set<string> | undefined = this._targetMap.get(target);
-    if (!targetDependencySet) {
-      targetDependencySet = new Set();
-      this._targetMap.set(target, targetDependencySet);
-    }
-    targetDependencySet.add(dependency);
+  public registerDependency(consumer: string, rawDependency: string): void {
+    // Need to normalize slashes in the dependency path
+    const dependency: string = path.resolve(this._options.srcFolder, rawDependency);
 
-    let dependencyTargetSet: Set<string> | undefined = this._dependencyMap.get(dependency);
-    if (!dependencyTargetSet) {
-      dependencyTargetSet = new Set();
-      this._dependencyMap.set(dependency, dependencyTargetSet);
+    let dependencies: Set<string> | undefined = this._dependenciesOfFile.get(consumer);
+    if (!dependencies) {
+      dependencies = new Set();
+      this._dependenciesOfFile.set(consumer, dependencies);
     }
-    dependencyTargetSet.add(target);
+    dependencies.add(dependency);
+
+    let consumers: Set<string> | undefined = this._consumersOfFile.get(dependency);
+    if (!consumers) {
+      consumers = new Set();
+      this._consumersOfFile.set(dependency, consumers);
+    }
+    consumers.add(consumer);
   }
 
-  private async _parseFileAndGenerateTypingsAsync(filePath: string): Promise<void> {
-    // Clear registered dependencies prior to reprocessing.
-    this._clearDependencies(filePath);
+  public getOutputFilePaths(relativePath: string): string[] {
+    const typingsFile: string = this._getTypingsFilePath(relativePath);
+    const additionalPaths: string[] | undefined = this._options.getAdditionalOutputFiles?.(relativePath);
+    return additionalPaths ? [typingsFile, ...additionalPaths] : [typingsFile];
+  }
 
-    // Check for targets that register this file as a dependency, and reprocess them too.
-    for (const target of this._getDependencyTargets(filePath)) {
-      await this._parseFileAndGenerateTypingsAsync(target);
+  private async _reprocessFiles(relativePaths: Iterable<string>): Promise<void> {
+    // Build a queue of resolved paths
+    const toProcess: Set<string> = new Set();
+    for (const rawPath of relativePaths) {
+      const relativePath: string = Path.convertToSlashes(rawPath);
+      const resolvedPath: string = path.resolve(this._options.srcFolder, rawPath);
+      this._relativePaths.set(resolvedPath, relativePath);
+      toProcess.add(resolvedPath);
     }
 
+    // Expand out all registered consumers, according to the current dependency graph
+    for (const file of toProcess) {
+      const consumers: Set<string> | undefined = this._consumersOfFile.get(file);
+      if (consumers) {
+        for (const consumer of consumers) {
+          toProcess.add(consumer);
+        }
+      }
+    }
+
+    // Map back to the relative paths so that the information is available
+    await Async.forEachAsync(
+      toProcess,
+      async (resolvedPath: string) => {
+        const relativePath: string | undefined = this._relativePaths.get(resolvedPath);
+        if (!relativePath) {
+          throw new Error(`Missing relative path for file ${resolvedPath}`);
+        }
+        await this._parseFileAndGenerateTypingsAsync(relativePath, resolvedPath);
+      },
+      { concurrency: 20 }
+    );
+  }
+
+  private async _parseFileAndGenerateTypingsAsync(relativePath: string, resolvedPath: string): Promise<void> {
+    // Clear registered dependencies prior to reprocessing.
+    this._clearDependencies(resolvedPath);
+
     try {
-      const fileContents: string = await FileSystem.readFileAsync(filePath);
+      const fileContents: string = await FileSystem.readFileAsync(resolvedPath);
       const typingsData: string | undefined = await this._options.parseAndGenerateTypings(
         fileContents,
-        filePath
+        resolvedPath,
+        relativePath
       );
-      const generatedTsFilePath: string = this._getTypingsFilePath(filePath);
 
       // Typings data will be undefined when no types should be generated for the parsed file.
       if (typingsData === undefined) {
@@ -194,46 +278,46 @@ export class TypingsGenerator {
         typingsData
       ].join(EOL);
 
+      const generatedTsFilePath: string = this._getTypingsFilePath(relativePath);
+
       await FileSystem.writeFileAsync(generatedTsFilePath, prefixedTypingsData, {
         ensureFolderExists: true,
         convertLineEndings: NewlineKind.OsDefault
       });
     } catch (e) {
       this._options.terminal!.writeError(
-        `Error occurred parsing and generating typings for file "${filePath}": ${e}`
+        `Error occurred parsing and generating typings for file "${resolvedPath}": ${e}`
       );
     }
   }
 
-  private _clearDependencies(target: string): void {
-    const targetDependencySet: Set<string> | undefined = this._targetMap.get(target);
-    if (targetDependencySet) {
-      for (const dependency of targetDependencySet) {
-        this._dependencyMap.get(dependency)!.delete(target);
+  /**
+   * Removes the consumer from all extant dependencies
+   */
+  private _clearDependencies(consumer: string): void {
+    const dependencies: Set<string> | undefined = this._dependenciesOfFile.get(consumer);
+    if (dependencies) {
+      for (const dependency of dependencies) {
+        this._consumersOfFile.get(dependency)!.delete(consumer);
       }
-      targetDependencySet.clear();
+      dependencies.clear();
     }
   }
 
-  private _getDependencyTargets(dependency: string): string[] {
-    return [...(this._dependencyMap.get(dependency)?.keys() || [])];
-  }
-
-  private _getTypingsFilePath(filePath: string): string {
-    const relativeSourceFilePath: string = path.relative(this._options.srcFolder, `${filePath}.d.ts`);
-    return `${this._options.generatedTsFolder}/${relativeSourceFilePath}`;
+  private _getTypingsFilePath(relativePath: string): string {
+    return path.resolve(this._options.generatedTsFolder, `${relativePath}.d.ts`);
   }
 
   private _normalizeFileExtensions(fileExtensions: string[]): string[] {
-    const result: string[] = [];
+    const result: Set<string> = new Set();
     for (const fileExtension of fileExtensions) {
       if (!fileExtension.startsWith('.')) {
-        result.push(`.${fileExtension}`);
+        result.add(`.${fileExtension}`);
       } else {
-        result.push(fileExtension);
+        result.add(fileExtension);
       }
     }
 
-    return result;
+    return Array.from(result);
   }
 }


### PR DESCRIPTION
## Summary
Adds an option `cssOuputFolder` to sass.json, which, if specified, will cause the Heft SASS plugin to emit the compiled CSS into said folder, preserving folder structure. If the source file name does not exactly end in `.css`, the `.css` extension will be appended to keep resolution simple (e.g. `.scss.css`).

The intended use is for consuming projects to not need to recompile the SASS of packages they import, while still being able to control how it is packaged for the final application. SASS is an implementation detail, but making the CSS available improves flexibility (e.g. to use css-in-js or to extract it into a concatenated stylesheet with the mini-css-extract-plugin)

## Details
Modifies the `typings-generator` infrastructure to understand the concept of producing multiple output files for a give input.
Modifies the `heft-sass-plugin` to have a config option `cssOutputFolder` that resolves relative to the project build folder. After the SASS compiler runs, the output CSS (before module CSS parsing) will be emitted to disk at this location, if specified.

## How it was tested
Used the `heft-sass-test` project, which has been modified to emit compiled SASS into `lib/`, no longer directly copy the `.sass`, `.scss`, or `.css` files from the source tree, and skip the `sass-loader` in the webpack config.
Dependency watching for the sass files is handled within the sass plugin.