### PR TITLE
Benpapp/add params to heft telemetry

### DIFF
--- a/apps/heft/src/cli/actions/HeftActionBase.ts
+++ b/apps/heft/src/cli/actions/HeftActionBase.ts
@@ -108,7 +108,7 @@ export abstract class HeftActionBase extends CommandLineAction {
   }
 
   public recordMetrics(): void {
-    this.metricsCollector.record(this.actionName, this.getParameterStringMap());
+    this.metricsCollector.record(this.actionName, undefined, this.getParameterStringMap());
   }
 
   public async onExecute(): Promise<void> {

--- a/apps/heft/src/cli/actions/HeftActionBase.ts
+++ b/apps/heft/src/cli/actions/HeftActionBase.ts
@@ -108,7 +108,7 @@ export abstract class HeftActionBase extends CommandLineAction {
   }
 
   public recordMetrics(): void {
-    this.metricsCollector.record(this.actionName);
+    this.metricsCollector.record(this.actionName, this.getParameterStringMap());
   }
 
   public async onExecute(): Promise<void> {

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -108,8 +108,8 @@ export class MetricsCollector {
    */
   public record(
     command: string,
-    parameterMap: Record<string, string>,
-    performanceData?: Partial<IPerformanceData>
+    performanceData?: Partial<IPerformanceData>,
+    parameters?: Record<string, string>
   ): void {
     if (this._startTimeMs === undefined) {
       throw new InternalError('MetricsCollector has not been initialized with setStartTime() yet');
@@ -136,7 +136,7 @@ export class MetricsCollector {
       machineCores: os.cpus().length,
       machineProcessor: os.cpus()[0].model,
       machineTotalMemoryMB: os.totalmem(),
-      commandParameters: parameterMap
+      commandParameters: parameters || {}
     };
 
     this.hooks.recordMetric.call('inner_loop_heft', metricsData);

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -44,6 +44,11 @@ export interface IMetricsData {
    * The total amount of memory the machine has, in megabytes.
    */
   machineTotalMemoryMB: number;
+
+  /**
+   * A map of commandline parameter names to their effective values
+   */
+  commandParameters?: Record<string, string>;
 }
 
 /**
@@ -98,9 +103,14 @@ export class MetricsCollector {
    * Record metrics to the installed plugin(s).
    *
    * @param command - Describe the user command, e.g. `start` or `build`
-   * @param params - Optional parameters
+   * @param parameterMap - Optional map of parameters to their values
+   * @param performanceData - Optional performance data
    */
-  public record(command: string, performanceData?: Partial<IPerformanceData>): void {
+  public record(
+    command: string,
+    parameterMap?: Record<string, string>,
+    performanceData?: Partial<IPerformanceData>
+  ): void {
     if (this._startTimeMs === undefined) {
       throw new InternalError('MetricsCollector has not been initialized with setStartTime() yet');
     }
@@ -125,7 +135,8 @@ export class MetricsCollector {
       machineArch: process.arch,
       machineCores: os.cpus().length,
       machineProcessor: os.cpus()[0].model,
-      machineTotalMemoryMB: os.totalmem()
+      machineTotalMemoryMB: os.totalmem(),
+      commandParameters: parameterMap
     };
 
     this.hooks.recordMetric.call('inner_loop_heft', metricsData);

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -48,7 +48,7 @@ export interface IMetricsData {
   /**
    * A map of commandline parameter names to their effective values
    */
-  commandParameters?: Record<string, string>;
+  commandParameters: Record<string, string>;
 }
 
 /**
@@ -108,7 +108,7 @@ export class MetricsCollector {
    */
   public record(
     command: string,
-    parameterMap?: Record<string, string>,
+    parameterMap: Record<string, string>,
     performanceData?: Partial<IPerformanceData>
   ): void {
     if (this._startTimeMs === undefined) {

--- a/common/changes/@rushstack/heft/benpapp-AddParamsToHeftTelemetry_2021-08-24-23-48.json
+++ b/common/changes/@rushstack/heft/benpapp-AddParamsToHeftTelemetry_2021-08-24-23-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add commandParameters to IMetricsData for recording parameter usage",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "BPapp-MS@users.noreply.github.com"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -274,7 +274,7 @@ export interface IHeftSessionHooks {
 // @public (undocumented)
 export interface IMetricsData {
     command: string;
-    commandParameters?: Record<string, string>;
+    commandParameters: Record<string, string>;
     machineArch: string;
     machineCores: number;
     machineOs: string;
@@ -363,7 +363,7 @@ export class _MetricsCollector {
     flushAsync(): Promise<void>;
     // (undocumented)
     readonly hooks: MetricsCollectorHooks;
-    record(command: string, parameterMap?: Record<string, string>, performanceData?: Partial<_IPerformanceData>): void;
+    record(command: string, parameterMap: Record<string, string>, performanceData?: Partial<_IPerformanceData>): void;
     setStartTime(): void;
 }
 

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -363,7 +363,7 @@ export class _MetricsCollector {
     flushAsync(): Promise<void>;
     // (undocumented)
     readonly hooks: MetricsCollectorHooks;
-    record(command: string, parameterMap: Record<string, string>, performanceData?: Partial<_IPerformanceData>): void;
+    record(command: string, performanceData?: Partial<_IPerformanceData>, parameters?: Record<string, string>): void;
     setStartTime(): void;
 }
 

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -274,6 +274,7 @@ export interface IHeftSessionHooks {
 // @public (undocumented)
 export interface IMetricsData {
     command: string;
+    commandParameters?: Record<string, string>;
     machineArch: string;
     machineCores: number;
     machineOs: string;
@@ -362,7 +363,7 @@ export class _MetricsCollector {
     flushAsync(): Promise<void>;
     // (undocumented)
     readonly hooks: MetricsCollectorHooks;
-    record(command: string, performanceData?: Partial<_IPerformanceData>): void;
+    record(command: string, parameterMap?: Record<string, string>, performanceData?: Partial<_IPerformanceData>): void;
     setStartTime(): void;
 }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->


<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Similar to the recent PR adding commandline parameters to the output of the rush telemetry file, this PR adds the same structure into the metrics collector data for the purpose of being read by a heft plugin.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
The change is pretty straightforward, it re-uses the function for getting the stringified parameters and values that I used for the telemetry in BaseInstallAction and BulkScriptAction

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Testing by installing this version of heft on a local repository and logging the telemetry results pulled from the metrics collector

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
