### PR TITLE
[heft-jest-plugin] Set Jest `displayName` to the package name by default and log test duration

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-JestDisplayName_2021-09-01-00-38.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-JestDisplayName_2021-09-01-00-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Use package name as Jest 'displayName' by default",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-JestDisplayName_2021-09-01-00-38.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-JestDisplayName_2021-09-01-00-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "Use package name as Jest 'displayName' by default",
+      "comment": "Use package name as Jest 'displayName' by default and always log a test duration.",
       "type": "patch"
     }
   ],

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -65,9 +65,9 @@ export default class HeftJestReporter implements Reporter {
       this._terminal.write(Colors.greenBackground(Colors.black('PASS')));
     }
 
-    // Calculate the suite duration time from the test result if the duration isn't provided.
-    // This is necessary because Jest doesn't provide the duration for each test (at least not
-    // as of Jest 25), and other reporters (ex. jest-junit) only use perfStats:
+    // Calculate the suite duration time from the test result. This is necessary because Jest doesn't
+    // provide the duration on the 'test' object (at least not as of Jest 25), and other reporters
+    // (ex. jest-junit) only use perfStats:
     // https://github.com/jest-community/jest-junit/blob/12da1a20217a9b6f30858013175319c1256f5b15/utils/buildJsonResults.js#L112
     const duration: string = perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
     this._terminal.writeLine(

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -69,8 +69,7 @@ export default class HeftJestReporter implements Reporter {
     // This is necessary because Jest doesn't provide the duration for each test (at least not
     // as of Jest 25), and other reporters (ex. jest-junit) only use perfStats:
     // https://github.com/jest-community/jest-junit/blob/12da1a20217a9b6f30858013175319c1256f5b15/utils/buildJsonResults.js#L112
-    const duration: string =
-      test.duration ?? perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
+    const duration: string = perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
     this._terminal.writeLine(
       ` ${this._getTestPath(
         test.path

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -66,6 +66,9 @@ export default class HeftJestReporter implements Reporter {
     }
 
     // Calculate the suite duration time from the test result if the duration isn't provided.
+    // This is necessary because Jest doesn't provide the duration for each test (at least not
+    // as of Jest 25), and other reporters (ex. jest-junit) only use perfStats:
+    // https://github.com/jest-community/jest-junit/blob/12da1a20217a9b6f30858013175319c1256f5b15/utils/buildJsonResults.js#L112
     const duration: string =
       test.duration ?? perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
     this._terminal.writeLine(

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -65,8 +65,9 @@ export default class HeftJestReporter implements Reporter {
       this._terminal.write(Colors.greenBackground(Colors.black('PASS')));
     }
 
-    // Calculate the suite duration time from the test result
-    const duration: string = perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
+    // Calculate the suite duration time from the test result if the duration isn't provided.
+    const duration: string =
+      test.duration ?? perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
     this._terminal.writeLine(
       ` ${this._getTestPath(
         test.path

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -69,11 +69,11 @@ export default class HeftJestReporter implements Reporter {
     // provide the duration on the 'test' object (at least not as of Jest 25), and other reporters
     // (ex. jest-junit) only use perfStats:
     // https://github.com/jest-community/jest-junit/blob/12da1a20217a9b6f30858013175319c1256f5b15/utils/buildJsonResults.js#L112
-    const duration: string = perfStats ? ((perfStats.end - perfStats.start) / 1000).toFixed(3) : '?';
+    const duration: string = perfStats ? `${((perfStats.end - perfStats.start) / 1000).toFixed(3)}s` : '?';
     this._terminal.writeLine(
       ` ${this._getTestPath(
         test.path
-      )} (duration: ${duration}s, ${numPassingTests} passed, ${numFailingTests} failed)`
+      )} (duration: ${duration}, ${numPassingTests} passed, ${numFailingTests} failed)`
     );
 
     if (failureMessage) {

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -160,6 +160,13 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       }
     }
 
+    // If no displayName is provided, use the package name. This field is used by Jest to
+    // differentiate in multi-project repositories, and since we have the context, we may
+    // as well provide it.
+    if (!jestConfig.displayName) {
+      jestConfig.displayName = heftConfiguration.projectPackageJson.name;
+    }
+
     const jestArgv: Config.Argv = {
       watch: testStageProperties.watchMode,
 


### PR DESCRIPTION
## Summary

Set the Jest `displayName` to the package name that contains the tests being run by default, instead of requiring it to be specified in each `jest.config.json`.

Additionally, this PR adds fallback logic for calculating the test duration in the reporter if the Jest-provided value is not available.

Fixes #2848

## Details

The `displayName` field is intended to help differentiate between projects in Jest. While we use our own reporter instead of the built-in reporter and therefore do not use the displayName, it can be used in other reporters such as `jest-junit` to provide more context.

Additionally, the test duration value is not always available/provided by Jest, so we can perform a lightweight tracking of start and end times to provide our own duration.

## How it was tested

Running a build and outputting the displayName manually in the HeftJestReporter to confirm the value was set correctly.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
