### PR TITLE
[rush] Add ability to customize tag separator

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -75,6 +75,7 @@ export interface IRushGitPolicyJson {
   sampleEmail?: string;
   versionBumpCommitMessage?: string;
   changeLogUpdateCommitMessage?: string;
+  tagSeparator?: string;
 }
 
 /**
@@ -446,6 +447,7 @@ export class RushConfiguration {
   private _gitSampleEmail: string;
   private _gitVersionBumpCommitMessage: string | undefined;
   private _gitChangeLogUpdateCommitMessage: string | undefined;
+  private _gitTagSeparator: string | undefined;
 
   // "hotfixChangeEnabled" feature
   private _hotfixChangeEnabled: boolean;
@@ -666,6 +668,10 @@ export class RushConfiguration {
 
       if (rushConfigurationJson.gitPolicy.changeLogUpdateCommitMessage) {
         this._gitChangeLogUpdateCommitMessage = rushConfigurationJson.gitPolicy.changeLogUpdateCommitMessage;
+      }
+
+      if (rushConfigurationJson.gitPolicy.tagSeparator) {
+        this._gitTagSeparator = rushConfigurationJson.gitPolicy.tagSeparator;
       }
     }
 
@@ -1292,6 +1298,14 @@ export class RushConfiguration {
    */
   public get gitChangeLogUpdateCommitMessage(): string | undefined {
     return this._gitChangeLogUpdateCommitMessage;
+  }
+
+  /**
+   * [Part of the "gitPolicy" feature.]
+   * The separator between package name and version in git tag.
+   */
+  public get gitTagSeparator(): string | undefined {
+    return this._gitTagSeparator;
   }
 
   /**

--- a/apps/rush-lib/src/logic/ChangelogGenerator.ts
+++ b/apps/rush-lib/src/logic/ChangelogGenerator.ts
@@ -102,7 +102,11 @@ export class ChangelogGenerator {
     if (!changelog.entries.some((entry) => entry.version === change.newVersion)) {
       const changelogEntry: IChangeLogEntry = {
         version: change.newVersion!,
-        tag: PublishUtilities.createTagname(change.packageName, change.newVersion!),
+        tag: PublishUtilities.createTagname(
+          change.packageName,
+          change.newVersion!,
+          rushConfiguration.gitTagSeparator
+        ),
         date: new Date().toUTCString(),
         comments: {}
       };

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -14,6 +14,8 @@ import { GitEmailPolicy } from './policy/GitEmailPolicy';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../api/EnvironmentConfiguration';
 
+export const DEFAULT_GIT_TAG_SEPARATOR: string = '_';
+
 interface IResultOrError<TResult> {
   error?: Error;
   result?: TResult;
@@ -332,6 +334,10 @@ export class Git {
     return changes.filter((change) => {
       return change.trim().length > 0;
     });
+  }
+
+  public getTagSeparator(): string {
+    return this._rushConfiguration.gitTagSeparator || DEFAULT_GIT_TAG_SEPARATOR;
   }
 
   /**

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -11,10 +11,12 @@ const DUMMY_BRANCH_NAME: string = '-branch-name-';
 export class PublishGit {
   private readonly _targetBranch: string | undefined;
   private readonly _gitPath: string;
+  private readonly _gitTagSeparator: string;
 
   public constructor(git: Git, targetBranch: string | undefined) {
     this._targetBranch = targetBranch;
     this._gitPath = git.getGitPathOrThrow();
+    this._gitTagSeparator = git.getTagSeparator();
   }
 
   public checkout(branchName: string | undefined, createBranch: boolean = false): void {
@@ -91,7 +93,11 @@ export class PublishGit {
     commitId: string | undefined
   ): void {
     // Tagging only happens if we're publishing to real NPM and committing to git.
-    const tagName: string = PublishUtilities.createTagname(packageName, packageVersion);
+    const tagName: string = PublishUtilities.createTagname(
+      packageName,
+      packageVersion,
+      this._gitTagSeparator
+    );
     PublishUtilities.execCommand(!!this._targetBranch && shouldExecute, this._gitPath, [
       'tag',
       '-a',
@@ -105,7 +111,8 @@ export class PublishGit {
   public hasTag(packageConfig: RushConfigurationProject): boolean {
     const tagName: string = PublishUtilities.createTagname(
       packageConfig.packageName,
-      packageConfig.packageJson.version
+      packageConfig.packageJson.version,
+      this._gitTagSeparator
     );
     const tagOutput: string = Utilities.executeCommandAndCaptureOutput(
       this._gitPath,

--- a/apps/rush-lib/src/logic/PublishUtilities.ts
+++ b/apps/rush-lib/src/logic/PublishUtilities.ts
@@ -19,7 +19,7 @@ import { PrereleaseToken } from './PrereleaseToken';
 import { ChangeFiles } from './ChangeFiles';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { DependencySpecifier, DependencySpecifierType } from './DependencySpecifier';
-import { Git } from './Git';
+import { Git, DEFAULT_GIT_TAG_SEPARATOR } from './Git';
 
 export interface IChangeInfoHash {
   [key: string]: IChangeInfo;
@@ -165,8 +165,12 @@ export class PublishUtilities {
   /**
    * Returns the generated tagname to use for a published commit, given package name and version.
    */
-  public static createTagname(packageName: string, version: string): string {
-    return packageName + '_v' + version;
+  public static createTagname(
+    packageName: string,
+    version: string,
+    separator: string = DEFAULT_GIT_TAG_SEPARATOR
+  ): string {
+    return packageName + `${separator}v` + version;
   }
 
   public static isRangeDependency(version: string): boolean {

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -180,6 +180,10 @@
         "changeLogUpdateCommitMessage": {
           "description": "The commit message to use when committing change log files \"rush version\". Defaults to \"Deleting change files and updating change logs for package updates.\"",
           "type": "string"
+        },
+        "tagSeparator": {
+          "description": "The separator between package name and version in git tag. Defaults to \"_\"",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/common/changes/@microsoft/rush/feature-issue-2654_2021-09-02-15-24.json
+++ b/common/changes/@microsoft/rush/feature-issue-2654_2021-09-02-15-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add ability to customize tag separator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "ziofat@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -385,6 +385,7 @@ export class RushConfiguration {
     get gitAllowedEmailRegExps(): string[];
     get gitChangeLogUpdateCommitMessage(): string | undefined;
     get gitSampleEmail(): string;
+    get gitTagSeparator(): string | undefined;
     get gitVersionBumpCommitMessage(): string | undefined;
     get hotfixChangeEnabled(): boolean;
     static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Add a new gitPolicy configuration to customize git tag separator.

Fixes #2654

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

`rush publish` using package name and version as tag name, which is fair enough. However, as we want to manage tags in a more visual way, the current separator `_` is not good for us to keep things organized.

If we use separator `/` between package name and version, we may have ability to keep all related tags in one directory for specific package.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Manually run `rush publish -a` in a rush managed repo which have open changes. And check the log to see if `gitPolicy.tagSeparator` in `rush.json` has effect on the tag names.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
