### PR TITLE
[heft] Fix building with Typescript 4.4 due to changed internal interface

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -995,7 +995,8 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
             currentFolder,
             depth,
             this._cachedFileSystem.readFolderFilesAndDirectories.bind(this._cachedFileSystem),
-            this._cachedFileSystem.getRealPath.bind(this._cachedFileSystem)
+            this._cachedFileSystem.getRealPath.bind(this._cachedFileSystem),
+            this._cachedFileSystem.directoryExists.bind(this._cachedFileSystem)
           ),
         useCaseSensitiveFileNames: true
       },

--- a/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
@@ -85,7 +85,7 @@ export interface IExtendedTypeScript {
   readJson(filePath: string): object;
 
   /**
-   * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/utilities.ts#L5848-L5907
+   * https://github.com/microsoft/TypeScript/blob/782c09d783e006a697b4ba6d1e7ec2f718ce8393/src/compiler/utilities.ts#L6540
    */
   matchFiles(
     path: string,
@@ -99,7 +99,8 @@ export interface IExtendedTypeScript {
       readonly files: ReadonlyArray<string>;
       readonly directories: ReadonlyArray<string>;
     },
-    realpath: (path: string) => string
+    realpath: (path: string) => string,
+    directoryExists: (path: string) => boolean
   ): string[];
 
   /**

--- a/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
+++ b/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
@@ -51,6 +51,19 @@ export class TypeScriptCachedFileSystem {
     }
   };
 
+  public directoryExists: (path: string) => boolean = (path: string) => {
+    try {
+      const stats: FileSystemStats = this.getStatistics(path);
+      return stats.isDirectory();
+    } catch (e) {
+      if (FileSystem.isNotExistError(e)) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  };
+
   public getStatistics: (path: string) => FileSystemStats = (path: string) => {
     return this._withCaching(path, FileSystem.getStatistics, this._statsCache);
   };

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,27 +5,27 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.4.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.36.3.tgz
+      '@rushstack/heft': file:rushstack-heft-0.37.0.tgz
       eslint: ~7.30.0
       tslint: ~5.20.1
-      typescript: ~4.3.5
+      typescript: ~4.4.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.3.5
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.36.3.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.4.2
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.37.0.tgz
       eslint: 7.30.0
-      tslint: 5.20.1_typescript@4.3.5
-      typescript: 4.3.5
+      tslint: 5.20.1_typescript@4.4.2
+      typescript: 4.4.2
 
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.4.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.36.3.tgz
+      '@rushstack/heft': file:rushstack-heft-0.37.0.tgz
       eslint: ~7.30.0
       tslint: ~5.20.1
       typescript: ~3.9.7
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.36.3.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.37.0.tgz
       eslint: 7.30.0
       tslint: 5.20.1_typescript@3.9.10
       typescript: 3.9.10
@@ -138,31 +138,6 @@ packages:
     resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.28.3_8da3816a7c3fb8ebc9f4c4b3e4b2e38f:
-    resolution: {integrity: sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.3.5
-      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@4.3.5
-      '@typescript-eslint/scope-manager': 4.28.3
-      debug: 4.3.1
-      eslint: 7.30.0
-      functional-red-black-tree: 1.0.1
-      regexpp: 3.1.0
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/4.28.3_c791be63d80b830096132a88d884d3c6:
     resolution: {integrity: sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -188,6 +163,31 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin/4.28.3_dea3c07b05ffc5d33aadcc92b8a0deed:
+    resolution: {integrity: sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^4.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
+      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@4.4.2
+      '@typescript-eslint/scope-manager': 4.28.3
+      debug: 4.3.1
+      eslint: 7.30.0
+      functional-red-black-tree: 1.0.1
+      regexpp: 3.1.0
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.4.2
+      typescript: 4.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/experimental-utils/4.28.3_eslint@7.30.0+typescript@3.9.10:
     resolution: {integrity: sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -206,7 +206,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.28.3_eslint@7.30.0+typescript@4.3.5:
+  /@typescript-eslint/experimental-utils/4.28.3_eslint@7.30.0+typescript@4.4.2:
     resolution: {integrity: sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -215,7 +215,7 @@ packages:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/scope-manager': 4.28.3
       '@typescript-eslint/types': 4.28.3
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.4.2
       eslint: 7.30.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.30.0
@@ -244,7 +244,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.28.3_eslint@7.30.0+typescript@4.3.5:
+  /@typescript-eslint/parser/4.28.3_eslint@7.30.0+typescript@4.4.2:
     resolution: {integrity: sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -256,10 +256,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.28.3
       '@typescript-eslint/types': 4.28.3
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.4.2
       debug: 4.3.1
       eslint: 7.30.0
-      typescript: 4.3.5
+      typescript: 4.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -298,7 +298,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/4.28.3_typescript@4.3.5:
+  /@typescript-eslint/typescript-estree/4.28.3_typescript@4.4.2:
     resolution: {integrity: sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -313,8 +313,8 @@ packages:
       globby: 11.0.4
       is-glob: 4.0.1
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.4.2
+      typescript: 4.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1637,7 +1637,7 @@ packages:
       typescript: 3.9.10
     dev: true
 
-  /tslint/5.20.1_typescript@4.3.5:
+  /tslint/5.20.1_typescript@4.4.2:
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
     engines: {node: '>=4.8.0'}
     hasBin: true
@@ -1656,8 +1656,8 @@ packages:
       resolve: 1.20.0
       semver: 5.7.1
       tslib: 1.14.1
-      tsutils: 2.29.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 2.29.0_typescript@4.4.2
+      typescript: 4.4.2
     dev: true
 
   /tsutils/2.29.0_typescript@3.9.10:
@@ -1669,13 +1669,13 @@ packages:
       typescript: 3.9.10
     dev: true
 
-  /tsutils/2.29.0_typescript@4.3.5:
+  /tsutils/2.29.0_typescript@4.4.2:
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.3.5
+      typescript: 4.4.2
     dev: true
 
   /tsutils/3.21.0_typescript@3.9.10:
@@ -1688,14 +1688,14 @@ packages:
       typescript: 3.9.10
     dev: true
 
-  /tsutils/3.21.0_typescript@4.3.5:
+  /tsutils/3.21.0_typescript@4.4.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.3.5
+      typescript: 4.4.2
     dev: true
 
   /type-check/0.4.0:
@@ -1716,8 +1716,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript/4.3.5:
-    resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
+  /typescript/4.4.2:
+    resolution: {integrity: sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -1819,7 +1819,7 @@ packages:
       - supports-color
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.3.5:
+  file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz
     name: '@rushstack/eslint-config'
@@ -1829,18 +1829,18 @@ packages:
       typescript: '>=3.0.0'
     dependencies:
       '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.0.6.tgz
-      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@4.3.5
-      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@4.3.5
-      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@4.3.5
-      '@typescript-eslint/eslint-plugin': 4.28.3_8da3816a7c3fb8ebc9f4c4b3e4b2e38f
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.3.5
-      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@4.3.5
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.3.5
+      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@4.4.2
+      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@4.4.2
+      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@4.4.2
+      '@typescript-eslint/eslint-plugin': 4.28.3_dea3c07b05ffc5d33aadcc92b8a0deed
+      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
+      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@4.4.2
+      '@typescript-eslint/typescript-estree': 4.28.3_typescript@4.4.2
       eslint: 7.30.0
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.20.6_eslint@7.30.0
       eslint-plugin-tsdoc: 0.2.14
-      typescript: 4.3.5
+      typescript: 4.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1867,7 +1867,7 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@4.3.5:
+  file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz
     name: '@rushstack/eslint-plugin'
@@ -1876,7 +1876,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -1899,7 +1899,7 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@4.3.5:
+  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz
     name: '@rushstack/eslint-plugin-packlets'
@@ -1908,7 +1908,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -1931,7 +1931,7 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@4.3.5:
+  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz
     name: '@rushstack/eslint-plugin-security'
@@ -1940,23 +1940,23 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.36.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.36.3.tgz}
+  file:../temp/tarballs/rushstack-heft-0.37.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.37.0.tgz}
     name: '@rushstack/heft'
-    version: 0.36.3
+    version: 0.37.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.6.2.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.6.3.tgz
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.0.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.2.13.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.9.0.tgz
       '@rushstack/typings-generator': file:../temp/tarballs/rushstack-typings-generator-0.3.9.tgz
       '@types/tapable': 1.0.6
@@ -1971,14 +1971,14 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.6.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.6.2.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.6.3.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.6.3.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.6.2
+    version: 0.6.3
     engines: {node: '>=10.13.0'}
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.0.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.2.13.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
@@ -1998,10 +1998,10 @@ packages:
       z-schema: 3.18.4
     dev: true
 
-  file:../temp/tarballs/rushstack-rig-package-0.2.13.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.2.13.tgz}
+  file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz}
     name: '@rushstack/rig-package'
-    version: 0.2.13
+    version: 0.3.0
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1

--- a/build-tests/install-test-workspace/workspace/typescript-newest-test/package.json
+++ b/build-tests/install-test-workspace/workspace/typescript-newest-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rushstack/eslint-config": "*",
     "@rushstack/heft": "*",
-    "typescript": "~4.3.5",
+    "typescript": "~4.4.2",
     "tslint": "~5.20.1",
     "eslint": "~7.30.0"
   }

--- a/common/changes/@rushstack/heft/master_2021-09-03-21-45.json
+++ b/common/changes/@rushstack/heft/master_2021-09-03-21-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix building for Typescript 4.4 (Error: directoryExists is not a function)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "jonasb@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

When building a project with Typescript 4.4 the typescript Heft plugin would fail with "Error: directoryExists is not a function". This PR fixes it by adding a missing directoryExists argument to the call to the Typescript internal `matchFiles` method.

Fixes https://github.com/microsoft/rushstack/issues/2878.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->



## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

* Upgraded typescript-newest-test to Typescript 4.4.2. `install-test-workspace` was failing before this change
* Upgraded heft-node-everything-test to Typescript 4.4.2 locally. Had to remove `tslint-microsoft-contrib` from that project since it wasn't compatible with Typescript 4.4. After disabling tslint for that project it built fine.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
