### PR TITLE
[rush] Do not apply build caching and skipping to the same project

### DIFF
--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -258,13 +258,31 @@ export class ProjectBuilder extends BaseBuilder {
         });
       }
 
-      // If allowed to read from the build cache, try retrieving the cache entry.
+      // If possible, we want to skip this build -- either by restoring it from the
+      // build cache, if build caching is enabled, or determining that the project
+      // is unchanged (using the older incremental build logic). These two approaches,
+      // "caching" and "skipping", are incompatible, so only one applies.
+      //
+      // Note that "build caching" and "build skipping" take two different approaches
+      // to tracking dependents:
+      //
+      //   - For build caching, "isCacheReadAllowed" is set if a project supports
+      //     incremental builds, and determining whether this project or a dependent
+      //     has changed happens inside the hashing logic.
+      //
+      //   - For build skipping, "isSkipAllowed" is set to true initially, and during
+      //     the process of building dependents, it will be changed by TaskRunner to
+      //     false if a dependency wasn't able to be skipped.
+      //
+      let buildCacheReadAttempted: boolean = false;
       if (this._isCacheReadAllowed) {
         const projectBuildCache: ProjectBuildCache | undefined = await this._getProjectBuildCacheAsync(
           terminal,
           trackedFiles,
           context.repoCommandLineConfiguration
         );
+
+        buildCacheReadAttempted = !!projectBuildCache;
         const restoreFromCacheSuccess: boolean | undefined =
           await projectBuildCache?.tryRestoreFromCacheAsync(terminal);
 
@@ -272,9 +290,7 @@ export class ProjectBuilder extends BaseBuilder {
           return TaskStatus.FromCache;
         }
       }
-
-      // If allowed, attempt to skip building.
-      if (this.isSkipAllowed) {
+      if (this.isSkipAllowed && !buildCacheReadAttempted) {
         const isPackageUnchanged: boolean = !!(
           lastProjectBuildDeps &&
           projectBuildDeps &&

--- a/common/changes/@microsoft/rush/build-cache-skip_2021-09-05-16-40.json
+++ b/common/changes/@microsoft/rush/build-cache-skip_2021-09-05-16-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Incremental build should use caching or skipping, but not both.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "elliot-nelson@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

In order to better position _build caching_ as a new replacement for _build skipping_, this PR tweaks the project builder so that projects which can use the build cache do not also attempt to skip the build.  Once a Rush monorepo makes the jump to build caching, we can consider the whole monorepo "in cache mode" (with a few caveats).

Projects that disable build caching in their `rush-project.json`, or that haven't yet configured their output folders, can continue to use the "build skip" incremental build logic.

This change does prevent some unfortunate corner cases -- for example, if you attempt to restore from build cache and there's a corrupted cache entry, you end up with a deleted `lib` folder but nothing unpacked; then you delete the offending cache entry, but now it skips the build entirely because the incremental build logic thinks nothing has changed.  Interactions between "build caching" and "build skipping" can be avoided if a project only uses one or the other.

> Accompanying docs change: https://github.com/microsoft/rushjs.io-website/pull/100

## Details

If we can retrieve a ProjectBuildCache, it means that caching is enabled, configured for this project, and that the project itself has not disabled it -- so that's a good stand-in for "this project is in caching mode", and we will ignore build skipping in that case.

This change was originally suggested by @iclanton in https://github.com/microsoft/rushstack/pull/2802#issuecomment-879471868. I think clarifying this now is good because some of the new features we'll be designing (like multi-phase builds and eventually builds split across multiple machines) may end up making extensive use of build caching.

(It may eventually make sense to get even _more_ strict than this PR does, and make enabling build cache a global flag that disables build skipping altogether, even for projects that haven't configured build caching.  We will need to see how build skips interact with the new features coming up.)

## How it was tested

Existing tests pass, behavior as expected in local monorepo.
