### PR TITLE
[rush] Support project paths outside the rush.json parent folder

### DIFF
--- a/common/changes/@microsoft/rush/support-outer-paths_2021-09-06-15-36.json
+++ b/common/changes/@microsoft/rush/support-outer-paths_2021-09-06-15-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support project paths outside the rush.json parent folder.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "elliot-nelson@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/package-deps-hash/support-outer-paths_2021-09-06-15-36.json
+++ b/common/changes/@rushstack/package-deps-hash/support-outer-paths_2021-09-06-15-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "getPackageDeps now takes an options hash instead of individual parameters.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "elliot-nelson@users.noreply.github.com"
+}

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -8,6 +8,13 @@
 export function getGitHashForFiles(filesToHash: string[], packagePath: string, gitPath?: string): Map<string, string>;
 
 // @public
-export function getPackageDeps(packagePath?: string, excludedPaths?: string[], gitPath?: string): Map<string, string>;
+export function getPackageDeps(packagePath?: string, options?: IGetPackageDepsOptions): Map<string, string>;
+
+// @public
+export interface IGetPackageDepsOptions {
+    excludedPaths?: string[];
+    gitPath?: string;
+    relativeToPath?: string;
+}
 
 ```

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -13,4 +13,4 @@
  * @packageDocumentation
  */
 
-export { getPackageDeps, getGitHashForFiles } from './getPackageDeps';
+export { IGetPackageDepsOptions, getPackageDeps, getGitHashForFiles } from './getPackageDeps';

--- a/libraries/package-deps-hash/src/test/getPackageDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getPackageDeps.test.ts
@@ -235,11 +235,9 @@ describe('getPackageDeps', () => {
   });
 
   it('can exclude a committed file', (done) => {
-    const results: Map<string, string> = getPackageDeps(TEST_PROJECT_PATH, [
-      'file1.txt',
-      'file  2.txt',
-      'file蝴蝶.txt'
-    ]);
+    const results: Map<string, string> = getPackageDeps(TEST_PROJECT_PATH, {
+      excludedPaths: ['file1.txt', 'file  2.txt', 'file蝴蝶.txt']
+    });
     try {
       const expectedFiles: { [key: string]: string } = {
         [FileConstants.PackageJson]: '18a1e415e56220fa5122428a4ef8eb8874756576'
@@ -264,7 +262,9 @@ describe('getPackageDeps', () => {
       done(e);
     }
 
-    const results: Map<string, string> = getPackageDeps(TEST_PROJECT_PATH, ['a.txt']);
+    const results: Map<string, string> = getPackageDeps(TEST_PROJECT_PATH, {
+      excludedPaths: ['a.txt']
+    });
     try {
       const expectedFiles: { [key: string]: string } = {
         'file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -406,5 +406,26 @@ describe('getPackageDeps', () => {
     }
 
     _done();
+  });
+
+  it('can return results relative to a specified root', (done) => {
+    const results: Map<string, string> = getPackageDeps(TEST_PROJECT_PATH, {
+      relativeToPath: path.join(TEST_PROJECT_PATH, 'inner/inner')
+    });
+    try {
+      const expectedFiles: { [key: string]: string } = {
+        '../../file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+        '../../file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+        '../../file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+        ['../../' + FileConstants.PackageJson]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+      };
+      const filePaths: string[] = Array.from(results.keys()).sort();
+
+      filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
+    } catch (e) {
+      return done(e);
+    }
+
+    done();
   });
 });


### PR DESCRIPTION
## Summary

This PR is a potential approach for solving the issue described in #2874 by @davidabap.

The goal is to correctly support incremental builds (both build skipping and build caching) for projects that live _inside the git repo_ but _outside the rush.json parent folder_. Where possible, supporting this edge case shouldn't impact the performance for standard setups where all project folders are inside the rush.json parent folder.

## Details

 - For the most common use case, where all project folders are under the `rush.json` parent folder, there should be no changes at all to existing functionality.

 - If one or more project folders are not under the `rush.json` parent folder, find a new root folder that contains all of the project folders. All files inside this new root folder will be considered for incremental change analysis (but will be described relative to the `rush.json` parent folder, as normal).

 - With this change, it's possible to point at a relative folder path that ends up _outside_ the git repo, causing the new root folder not to be tracked by git. This is a user error that results in no change detection at all, and will likely print:

 ```console
Error calculating the state of the repo. (inner error: Error: git ls-tree exited with status 128: fatal: not a git repository (or any of the parent directories): .git
). Continuing without diffing files.

This workspace does not appear to be tracked by Git. Rush will proceed without incremental build, caching, and change detection.
```

(Overall, I feel like this would be the correct behavior in that scenario.)

 - ⚠️ This PR contains a breaking change for `package-deps-hash` (not strictly required I suppose, but 3 optional trailing parameters is beginning to stretch the bounds of a reasonable public API anyway).

## How it was tested

 - Added a couple unit tests describing the new functionality to avoid future regressions.
 - Tested before/after behavior on @davidabap's example repo.
