### PR TITLE
Turn on noUnusedLocals in heft-node-rig and heft-web-rig.

### DIFF
--- a/common/changes/@rushstack/heft-node-rig/ianc-noUnusedLocals-for-tools_2021-09-07-22-03.json
+++ b/common/changes/@rushstack/heft-node-rig/ianc-noUnusedLocals-for-tools_2021-09-07-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Turn on the \"noUnusedLocals\" compiler option.",
+      "type": "minor",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/ianc-noUnusedLocals-for-tools_2021-09-07-22-03.json
+++ b/common/changes/@rushstack/heft-web-rig/ianc-noUnusedLocals-for-tools_2021-09-07-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Turn on the \"noUnusedLocals\" compiler option.",
+      "type": "minor",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/rigs/heft-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/heft-node-rig/profiles/default/tsconfig-base.json
@@ -16,6 +16,7 @@
     "esModuleInterop": true,
     "noEmitOnError": false,
     "allowUnreachableCode": false,
+    "noUnusedLocals": true,
 
     "types": [],
 

--- a/rigs/heft-web-rig/profiles/library/tsconfig-base.json
+++ b/rigs/heft-web-rig/profiles/library/tsconfig-base.json
@@ -17,6 +17,7 @@
     "esModuleInterop": true,
     "noEmitOnError": false,
     "allowUnreachableCode": false,
+    "noUnusedLocals": true,
 
     "types": [],
 


### PR DESCRIPTION
## Summary

Turns on the "noUnusedLocals" compiler option in the rigs.

## How it was tested

Built the repo.