### PR TITLE
[heft-config-file] Fix issue preventing replacement of configuration properties using falsey values

### DIFF
--- a/common/changes/@rushstack/heft-config-file/user-danade-FixFalsyConfig_2021-09-08-08-02.json
+++ b/common/changes/@rushstack/heft-config-file/user-danade-FixFalsyConfig_2021-09-08-08-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Fix issue with overwriting configuration properties using falsey values",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "3473356+D4N14L@users.noreply.github.com"
+}

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -471,9 +471,9 @@ export class ConfigurationFile<TConfigurationFile> {
         newValue = parentPropertyValue;
       };
 
-      if (propertyValue && !parentPropertyValue) {
+      if (propertyValue !== undefined && parentPropertyValue === undefined) {
         usePropertyValue();
-      } else if (parentPropertyValue && !propertyValue) {
+      } else if (parentPropertyValue !== undefined && propertyValue === undefined) {
         useParentPropertyValue();
       } else {
         switch (propertyInheritance.inheritanceType) {

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -133,24 +133,28 @@ describe('ConfigurationFile', () => {
 
     interface ISimpleConfigFile {
       things: string[];
+      booleanProp: boolean;
     }
 
     it('Correctly loads the config file', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
-        { projectRelativeFilePath: projectRelativeFilePath, jsonSchemaPath: schemaPath }
+        {
+          projectRelativeFilePath,
+          jsonSchemaPath: schemaPath
+        }
       );
       const loadedConfigFile: ISimpleConfigFile = await configFileLoader.loadConfigurationFileForProjectAsync(
         terminal,
         __dirname
       );
-      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C'] };
+      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C'], booleanProp: true };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
 
     it('Correctly resolves paths relative to the config file', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           jsonPathMetadata: {
             '$.things.*': {
@@ -168,7 +172,8 @@ describe('ConfigurationFile', () => {
           nodeJsPath.resolve(__dirname, configFileFolderName, 'A'),
           nodeJsPath.resolve(__dirname, configFileFolderName, 'B'),
           nodeJsPath.resolve(__dirname, configFileFolderName, 'C')
-        ]
+        ],
+        booleanProp: true
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -176,7 +181,7 @@ describe('ConfigurationFile', () => {
     it('Correctly resolves paths relative to the project root', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           jsonPathMetadata: {
             '$.things.*': {
@@ -194,7 +199,8 @@ describe('ConfigurationFile', () => {
           nodeJsPath.resolve(projectRoot, 'A'),
           nodeJsPath.resolve(projectRoot, 'B'),
           nodeJsPath.resolve(projectRoot, 'C')
-        ]
+        ],
+        booleanProp: true
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -211,24 +217,28 @@ describe('ConfigurationFile', () => {
 
     interface ISimpleConfigFile {
       things: string[];
+      booleanProp: boolean;
     }
 
     it('Correctly loads the config file with default config meta', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
-        { projectRelativeFilePath: projectRelativeFilePath, jsonSchemaPath: schemaPath }
+        {
+          projectRelativeFilePath,
+          jsonSchemaPath: schemaPath
+        }
       );
       const loadedConfigFile: ISimpleConfigFile = await configFileLoader.loadConfigurationFileForProjectAsync(
         terminal,
         __dirname
       );
-      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C', 'D', 'E'] };
+      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C', 'D', 'E'], booleanProp: false };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
 
     it('Correctly loads the config file with "append" in config meta', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           propertyInheritance: {
             things: {
@@ -241,14 +251,14 @@ describe('ConfigurationFile', () => {
         terminal,
         __dirname
       );
-      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C', 'D', 'E'] };
+      const expectedConfigFile: ISimpleConfigFile = { things: ['A', 'B', 'C', 'D', 'E'], booleanProp: false };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
 
     it('Correctly loads the config file with "replace" in config meta', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           propertyInheritance: {
             things: {
@@ -261,14 +271,14 @@ describe('ConfigurationFile', () => {
         terminal,
         __dirname
       );
-      const expectedConfigFile: ISimpleConfigFile = { things: ['D', 'E'] };
+      const expectedConfigFile: ISimpleConfigFile = { things: ['D', 'E'], booleanProp: false };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
 
     it('Correctly loads the config file with "custom" in config meta', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           propertyInheritance: {
             things: {
@@ -282,14 +292,14 @@ describe('ConfigurationFile', () => {
         terminal,
         __dirname
       );
-      const expectedConfigFile: ISimpleConfigFile = { things: ['X', 'Y', 'Z'] };
+      const expectedConfigFile: ISimpleConfigFile = { things: ['X', 'Y', 'Z'], booleanProp: false };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
 
     it('Correctly resolves paths relative to the config file', async () => {
       const configFileLoader: ConfigurationFile<ISimpleConfigFile> = new ConfigurationFile<ISimpleConfigFile>(
         {
-          projectRelativeFilePath: projectRelativeFilePath,
+          projectRelativeFilePath,
           jsonSchemaPath: schemaPath,
           jsonPathMetadata: {
             '$.things.*': {
@@ -316,7 +326,8 @@ describe('ConfigurationFile', () => {
           nodeJsPath.resolve(parentConfigFileFolder, 'C'),
           nodeJsPath.resolve(__dirname, configFileFolderName, 'D'),
           nodeJsPath.resolve(__dirname, configFileFolderName, 'E')
-        ]
+        ],
+        booleanProp: false
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });

--- a/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.json
@@ -1,4 +1,5 @@
 {
   "$schema": "http://schema.net/",
-  "things": ["A", "B", "C"]
+  "things": ["A", "B", "C"],
+  "booleanProp": true
 }

--- a/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.schema.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.schema.json
@@ -15,6 +15,10 @@
       "items": {
         "type": "string"
       }
+    },
+
+    "booleanProp": {
+      "type": "boolean"
     }
   }
 }

--- a/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://schema.net/",
   "extends": "../simpleConfigFile/simpleConfigFile.json",
-  "things": ["D", "E"]
+  "things": ["D", "E"],
+  "booleanProp": false
 }

--- a/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.schema.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.schema.json
@@ -19,6 +19,10 @@
       "items": {
         "type": "string"
       }
+    },
+
+    "booleanProp": {
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix issue overwriting/replacing configuration properties using falsey values

## Details

While working in our Rush repo using Jest configuration files, I found that a boolean property was not being respected. Further investigation led to the cause being that a check was incorrectly equating falsey values with `undefined`. This bug leads to the inability to set a truthy value to a falsey value in an extending configuration file (ex, the inability to overwrite and set a value to `false` after previously being `true`).

## How it was tested

Added a test first to validate that the issue was reproducible outside of our Rush repo, then made the fix to validate that the change resolves the issue.
