### PR TITLE
[Rush] Allow commands to have fallbacks for build cache read

### DIFF
--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -28,6 +28,8 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   allowWarningsInSuccessfulBuild?: boolean;
   watchForChanges?: boolean;
   disableBuildCache?: boolean;
+
+  fallbackCommandsForCacheRead?: string[];
 }
 
 /**
@@ -50,6 +52,8 @@ export interface IBaseParameterJson {
   description: string;
   associatedCommands: string[];
   required?: boolean;
+
+  ignoreForCacheRead?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -26,6 +26,7 @@ export interface IBaseScriptActionOptions extends IBaseRushActionOptions {
 export abstract class BaseScriptAction extends BaseRushAction {
   protected readonly _commandLineConfiguration: CommandLineConfiguration | undefined;
   protected readonly customParameters: CommandLineParameter[] = [];
+  protected readonly cacheReadCustomParameters: CommandLineParameter[] = [];
 
   public constructor(options: IBaseScriptActionOptions) {
     super(options);
@@ -86,6 +87,9 @@ export abstract class BaseScriptAction extends BaseRushAction {
 
         if (customParameter) {
           this.customParameters.push(customParameter);
+          if (!parameterJson.ignoreForCacheRead) {
+            this.cacheReadCustomParameters.push(customParameter);
+          }
         }
       }
     }

--- a/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -43,7 +43,7 @@ describe('ProjectBuildCache', () => {
           dependencyProjects: []
         }
       } as unknown as RushProjectConfiguration,
-      command: 'build',
+      cacheKeys: ['build-incremental', 'build'],
       trackedProjectFiles: options.hasOwnProperty('trackedProjectFiles') ? options.trackedProjectFiles : [],
       projectChangeAnalyzer,
       terminal
@@ -55,9 +55,12 @@ describe('ProjectBuildCache', () => {
   describe('tryGetProjectBuildCache', () => {
     it('returns a ProjectBuildCache with a calculated cacheId value', async () => {
       const subject: ProjectBuildCache = (await prepareSubject({}))!;
-      expect(subject['_cacheId']).toMatchInlineSnapshot(
-        `"acme-wizard/e229f8765b7d450a8a84f711a81c21e37935d661"`
-      );
+      expect(subject['_cacheIds']).toMatchInlineSnapshot(`
+        Array [
+          "acme-wizard/1a5e13b20ee911a4e5b5a0a0fb38b01e7edb8246",
+          "acme-wizard/e229f8765b7d450a8a84f711a81c21e37935d661",
+        ]
+      `);
     });
 
     it('returns undefined if the tracked file list is undefined', async () => {

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -47,6 +47,10 @@ export interface IProjectBuilderOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration: BuildCacheConfiguration | undefined;
+  /**
+   * Primary and fallback command text for the build cache.
+   */
+  cacheKeys?: ReadonlyArray<string> | undefined;
   commandToRun: string;
   commandName: string;
   isIncrementalBuildAllowed: boolean;
@@ -89,6 +93,7 @@ export class ProjectBuilder extends BaseBuilder {
   private readonly _buildCacheConfiguration: BuildCacheConfiguration | undefined;
   private readonly _commandName: string;
   private readonly _commandToRun: string;
+  private readonly _cacheKeys: ReadonlyArray<string>;
   private readonly _isCacheReadAllowed: boolean;
   private readonly _projectChangeAnalyzer: ProjectChangeAnalyzer;
   private readonly _packageDepsFilename: string;
@@ -107,6 +112,7 @@ export class ProjectBuilder extends BaseBuilder {
     this._buildCacheConfiguration = options.buildCacheConfiguration;
     this._commandName = options.commandName;
     this._commandToRun = options.commandToRun;
+    this._cacheKeys = options.cacheKeys || [options.commandToRun];
     this._isCacheReadAllowed = options.isIncrementalBuildAllowed;
     this.isSkipAllowed = options.isIncrementalBuildAllowed;
     this._projectChangeAnalyzer = options.projectChangeAnalyzer;
@@ -430,7 +436,7 @@ export class ProjectBuilder extends BaseBuilder {
                 projectConfiguration,
                 buildCacheConfiguration: this._buildCacheConfiguration,
                 terminal,
-                command: this._commandToRun,
+                cacheKeys: this._cacheKeys,
                 trackedProjectFiles: trackedProjectFiles,
                 projectChangeAnalyzer: this._projectChangeAnalyzer
               });

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -90,6 +90,11 @@
               "title": "Disable build cache.",
               "description": "Disable build cache for this action. This may be useful if this command affects state outside of projects' own folders.",
               "type": "boolean"
+            },
+            "fallbackCommandsForCacheRead": {
+              "title": "Fallback Commands for Cache Read",
+              "description": "Series of command names to test when trying to restore outputs from the cache.",
+              "type": "boolean"
             }
           }
         },
@@ -199,6 +204,11 @@
           "title": "Required",
           "description": "If true, then this parameter must be included on the command line",
           "type": "boolean"
+        },
+        "ignoreForCacheRead": {
+          "title": "Ignore for Cache Read",
+          "description": "If true, then the build cache will discard this parameter value when looking for cache matches.",
+          "type": "boolean"
         }
       }
     },
@@ -226,7 +236,8 @@
             "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "associatedCommands": { "$ref": "#/definitions/anything" },
-            "required": { "$ref": "#/definitions/anything" }
+            "required": { "$ref": "#/definitions/anything" },
+            "ignoreForCacheRead": { "$ref": "#/definitions/anything" }
           }
         }
       ]
@@ -262,6 +273,7 @@
             "description": { "$ref": "#/definitions/anything" },
             "associatedCommands": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
+            "ignoreForCacheRead": { "$ref": "#/definitions/anything" },
 
             "argumentName": { "$ref": "#/definitions/anything" }
           }
@@ -322,6 +334,7 @@
             "description": { "$ref": "#/definitions/anything" },
             "associatedCommands": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
+            "ignoreForCacheRead": { "$ref": "#/definitions/anything" },
 
             "alternatives": { "$ref": "#/definitions/anything" },
             "defaultValue": { "$ref": "#/definitions/anything" }


### PR DESCRIPTION
## Summary
Allows custom bulk script commands to specify fallback alternatives for build cache reads.
For example a command "build-incremental" might fall back to "build".

Allows custom parameters to specify that they can be ignored when reading from the build cache.
For example a parameter "--no-test" could be ignored when restoring from cache.

## Details
Couples the command schemas somewhat more strongly with the concept of the build cache, in order to allow for fallback keys for cache reads.

## How it was tested
Modified the local command-line.json to have a command `build-incremental` that falls back to `build`, and make the `--no-color` flag have `ignoreForCacheRead: true`. Verified that `rush build-incremental --no-color` could be satisifed by the cache entry created by `rush build`.
