### PR TITLE
[rush] Feat rush install check only

### DIFF
--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -5,8 +5,11 @@ import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { SelectionParameterSet } from '../SelectionParameterSet';
+import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 export class InstallAction extends BaseInstallAction {
+  private _checkOnlyParameter!: CommandLineFlagParameter;
+
   public constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'install',
@@ -33,6 +36,11 @@ export class InstallAction extends BaseInstallAction {
     super.onDefineParameters();
 
     this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this);
+
+    this._checkOnlyParameter = this.defineFlagParameter({
+      parameterLongName: '--check-only',
+      description: `Check only the validation before install, not actually install anything.`
+    });
   }
 
   protected buildInstallOptions(): IInstallManagerOptions {
@@ -50,7 +58,8 @@ export class InstallAction extends BaseInstallAction {
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
       // These are derived independently of the selection for command line brevity
-      pnpmFilterArguments: this._selectionParameters!.getPnpmFilterArguments()
+      pnpmFilterArguments: this._selectionParameters!.getPnpmFilterArguments(),
+      checkOnly: this._checkOnlyParameter.value
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { SelectionParameterSet } from '../SelectionParameterSet';
-import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 export class InstallAction extends BaseInstallAction {
   private _checkOnlyParameter!: CommandLineFlagParameter;
@@ -39,7 +40,7 @@ export class InstallAction extends BaseInstallAction {
 
     this._checkOnlyParameter = this.defineFlagParameter({
       parameterLongName: '--check-only',
-      description: `Check only the validation before install, not actually install anything.`
+      description: `Only check the validity of the shrinkwrap file without performing an install.`
     });
   }
 

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -70,7 +70,8 @@ export class UpdateAction extends BaseInstallAction {
       // Because the 'defaultValue' option on the _maxInstallAttempts parameter is set,
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
-      pnpmFilterArguments: []
+      pnpmFilterArguments: [],
+      checkOnly: false
     };
   }
 }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -656,8 +656,8 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  --check-only          Check only the validation before install, not 
-                        actually install anything.
+  --check-only          Only check the validity of the shrinkwrap file 
+                        without performing an install.
 "
 `;
 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -535,7 +535,7 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
                     [--variant VARIANT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME]
+                    [--from-version-policy VERSION_POLICY_NAME] [--check-only]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -656,6 +656,8 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --check-only          Check only the validation before install, not 
+                        actually install anything.
 "
 `;
 

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -138,7 +138,8 @@ export class PackageJsonUpdater {
       collectLogFile: false,
       variant: variant,
       maxInstallAttempts: RushConstants.defaultMaxInstallAttempts,
-      pnpmFilterArguments: []
+      pnpmFilterArguments: [],
+      checkOnly: false
     };
     const installManager: BaseInstallManager = InstallManagerFactory.getInstallManager(
       this._rushConfiguration,

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -50,6 +50,11 @@ export interface IInstallManagerOptions {
   allowShrinkwrapUpdates: boolean;
 
   /**
+   * Whether to check the validation before install only, without actually installing anything.
+   */
+  checkOnly: boolean;
+
+  /**
    * Whether to skip policy checks.
    */
   bypassPolicy: boolean;
@@ -179,6 +184,10 @@ export abstract class BaseInstallManager {
     }
 
     const { shrinkwrapIsUpToDate, variantIsUpToDate } = await this.prepareAsync();
+
+    if (this.options.checkOnly) {
+      return;
+    }
 
     console.log(
       os.EOL + colors.bold(`Checking installation in "${this.rushConfiguration.commonTempFolder}"`)

--- a/common/changes/@microsoft/rush/feat-rush-install-check-only_2021-09-11-02-21.json
+++ b/common/changes/@microsoft/rush/feat-rush-install-check-only_2021-09-11-02-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add check-only to rush install",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chengcyber@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/feat-rush-install-check-only_2021-09-11-02-21.json
+++ b/common/changes/@microsoft/rush/feat-rush-install-check-only_2021-09-11-02-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add check-only to rush install",
+      "comment": "Add a \"--check-only\" parameter to \"rush install\" to check the validity of the shrinkwrap without performing a full install.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary

Add `--check-only` parameter to `rush install`

which fixes https://github.com/microsoft/rushstack/issues/2570

## Details

As per pete (https://github.com/microsoft/rushstack/issues/2570#issuecomment-809866637), a new flag parameter is added to `InstallAction`, it helps to only check the validatation before install, without install anything actually. Targeting the situation when user only want to check whether shrinkwrap file is update to date.

## How it was tested

Local
