### PR TITLE
[rush-lib] Fix the issue where update-autoinstaller does not use .npmrc

### DIFF
--- a/apps/rush-lib/src/logic/Autoinstaller.ts
+++ b/apps/rush-lib/src/logic/Autoinstaller.ts
@@ -80,6 +80,8 @@ export class Autoinstaller {
 
     console.log();
 
+    Utilities.syncNpmrc(this._rushConfiguration.commonRushConfigFolder, this.folderFullPath);
+
     Utilities.executeCommand({
       command: this._rushConfiguration.packageManagerToolFilename,
       args: ['install'],

--- a/apps/rush/bin/rushx
+++ b/apps/rush/bin/rushx
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../lib/start.js')
+require('../lib/start.js');

--- a/common/changes/@microsoft/rush/fix-autoinstaller-update_2021-09-14-17-35.json
+++ b/common/changes/@microsoft/rush/fix-autoinstaller-update_2021-09-14-17-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix the issue where update-autoinstaller does not use .npmrc",
+      "comment": "Fix an issue where `rush update-autoinstaller` does not use the repo's .npmrc",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-autoinstaller-update_2021-09-14-17-35.json
+++ b/common/changes/@microsoft/rush/fix-autoinstaller-update_2021-09-14-17-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix the issue where update-autoinstaller does not use .npmrc",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "h-a-n-a@users.noreply.github.com"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #2905 

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Copy `.npmrc` to the current working autoinstaller
## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Reinvoked `rush update-autoinstaller --name xxx` and all the dependencies installed correctly that private registry provides.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
