### PR TITLE
[heft] Fix an issue where setting the emitMjsExtensionForESModule typescript.json option in a project whose tsconfig emits CommonJS will only emit .mjs files.

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -853,7 +853,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         reason: 'emitMjsExtensionForESModule'
       };
 
-      specifiedKinds.set(ts.ModuleKind.CommonJS, mjsReason);
+      specifiedKinds.set(ts.ModuleKind.ESNext, mjsReason);
       specifiedOutDirs.set(`${tsconfig.options.outDir!}:.mjs`, mjsReason);
     }
 

--- a/common/changes/@rushstack/heft/user-ianc-fix-mjs-extension_2021-09-18-02-47.json
+++ b/common/changes/@rushstack/heft/user-ianc-fix-mjs-extension_2021-09-18-02-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where setting the emitMjsExtensionForESModule typescript.json option in a project whose tsconfig emits CommonJS will only emit .mjs files.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

The TypeScriptBuilder has an issue where setting the `emitMjsExtensionForESModule` option in `config/typescript.json` in a project whose `tsconfig.json` is configured to emit CommonJS will only emit `.mjs`.

## Details

There's a typo in `TypeScriptBuilder` that incorrectly marks `ESNext` as `CommonJS`, which ignores the option in `tsconfig.json`.

## How it was tested

Tested on a project with `emitMjsExtensionForESModule` set to `true`.