### PR TITLE
Update to TypeScript 4.4

### DIFF
--- a/apps/api-documenter/src/plugin/PluginLoader.ts
+++ b/apps/api-documenter/src/plugin/PluginLoader.ts
@@ -87,7 +87,7 @@ export class PluginLoader {
             try {
               markdownDocumenterFeature = new featureDefinition.subclass(initialization);
             } catch (e) {
-              throw new Error(`Failed to construct feature subclass:\n` + e.toString());
+              throw new Error(`Failed to construct feature subclass:\n` + (e as Error).toString());
             }
             if (!(markdownDocumenterFeature instanceof MarkdownDocumenterFeature)) {
               throw new Error('The constructed subclass was not an instance of MarkdownDocumenterFeature');
@@ -96,7 +96,7 @@ export class PluginLoader {
             try {
               markdownDocumenterFeature.onInitialized();
             } catch (e) {
-              throw new Error('Error occurred during the onInitialized() event: ' + e.toString());
+              throw new Error('Error occurred during the onInitialized() event: ' + (e as Error).toString());
             }
 
             this.markdownDocumenterFeature = markdownDocumenterFeature;
@@ -105,7 +105,7 @@ export class PluginLoader {
           }
         }
       } catch (e) {
-        throw new Error(`Error loading plugin ${configPlugin.packageName}: ` + e.message);
+        throw new Error(`Error loading plugin ${configPlugin.packageName}: ` + (e as Error).message);
       }
     }
   }

--- a/apps/api-extractor-model/package.json
+++ b/apps/api-extractor-model/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13"
   }

--- a/apps/api-extractor-model/src/items/ApiItem.ts
+++ b/apps/api-extractor-model/src/items/ApiItem.ts
@@ -114,7 +114,7 @@ export class ApiItem {
         this._canonicalReference = this.buildCanonicalReference();
       } catch (e) {
         const name: string = this.getScopedNameWithinPackage() || this.displayName;
-        throw new InternalError(`Error building canonical reference for ${name}:\n` + e.message);
+        throw new InternalError(`Error building canonical reference for ${name}:\n` + (e as Error).message);
       }
     }
     return this._canonicalReference;

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -45,12 +45,12 @@
     "resolve": "~1.17.0",
     "semver": "~7.3.0",
     "source-map": "~0.6.1",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.2"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",
     "@types/node": "10.17.13",

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -518,7 +518,7 @@ export class ExtractorConfig {
                 basedir: currentConfigFolderPath
               });
             } catch (e) {
-              throw new Error(`Error resolving NodeJS path "${extendsField}": ${e.message}`);
+              throw new Error(`Error resolving NodeJS path "${extendsField}": ${(e as Error).message}`);
             }
           }
         }
@@ -534,7 +534,7 @@ export class ExtractorConfig {
         currentConfigFilePath = extendsField;
       } while (currentConfigFilePath);
     } catch (e) {
-      throw new Error(`Error loading ${currentConfigFilePath}:\n` + e.message);
+      throw new Error(`Error loading ${currentConfigFilePath}:\n` + (e as Error).message);
     }
 
     // Lastly, apply the defaults
@@ -973,7 +973,7 @@ export class ExtractorConfig {
         testMode: !!configObject.testMode
       };
     } catch (e) {
-      throw new Error(`Error parsing ${filenameForErrors}:\n` + e.message);
+      throw new Error(`Error parsing ${filenameForErrors}:\n` + (e as Error).message);
     }
 
     let tsdocConfigFile: TSDocConfigFile | undefined = options.tsdocConfigFile;

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/argparse": "1.0.38",
     "@types/eslint": "7.2.0",
     "@types/glob": "7.1.1",
@@ -60,6 +60,6 @@
     "@types/semver": "7.3.5",
     "colors": "~1.2.1",
     "tslint": "~5.20.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/apps/heft/src/cli/HeftToolsCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftToolsCommandLineParser.ts
@@ -191,7 +191,7 @@ export class HeftToolsCommandLineParser extends CommandLineParser {
 
       return await super.execute(args);
     } catch (e) {
-      await this._reportErrorAndSetExitCode(e);
+      await this._reportErrorAndSetExitCode(e as Error);
       return false;
     }
   }
@@ -215,7 +215,7 @@ export class HeftToolsCommandLineParser extends CommandLineParser {
       await super.onExecute();
       await this._metricsCollector.flushAndTeardownAsync();
     } catch (e) {
-      await this._reportErrorAndSetExitCode(e);
+      await this._reportErrorAndSetExitCode(e as Error);
     }
 
     // If we make it here, things are fine and reset the exit code back to 0

--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -432,7 +432,7 @@ export class NodeServicePlugin implements IHeftPlugin {
     try {
       action();
     } catch (error) {
-      this._logger.emitError(error);
+      this._logger.emitError(error as Error);
       this._logger.terminal.writeErrorLine('An unexpected error occurred');
 
       // TODO: Provide a Heft facility for this

--- a/apps/heft/src/plugins/ProjectValidatorPlugin.ts
+++ b/apps/heft/src/plugins/ProjectValidatorPlugin.ts
@@ -111,7 +111,7 @@ export class ProjectValidatorPlugin implements IHeftPlugin {
         }
       );
     } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
+      if (!FileSystem.isNotExistError(e as Error)) {
         throw e;
       } else {
         return;

--- a/apps/heft/src/plugins/TypeScriptPlugin/LinterBase.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/LinterBase.ts
@@ -114,7 +114,7 @@ export abstract class LinterBase<TLintResult> {
     try {
       tslintCacheData = await JsonFile.loadAsync(cacheFilePath);
     } catch (e) {
-      if (FileSystem.isNotExistError(e)) {
+      if (FileSystem.isNotExistError(e as Error)) {
         tslintCacheData = undefined;
       } else {
         throw e;

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -1070,7 +1070,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
           const stats: FileSystemStats = this._cachedFileSystem.getStatistics(directoryPath);
           return stats.isDirectory() || stats.isSymbolicLink();
         } catch (error) {
-          if (FileSystem.isNotExistError(error)) {
+          if (FileSystem.isNotExistError(error as Error)) {
             return false;
           } else {
             throw error;
@@ -1083,7 +1083,7 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
           const stats: FileSystemStats = this._cachedFileSystem.getStatistics(filePath);
           return stats.isFile();
         } catch (error) {
-          if (FileSystem.isNotExistError(error)) {
+          if (FileSystem.isNotExistError(error as Error)) {
             return false;
           } else {
             throw error;

--- a/apps/heft/src/startWithVersionSelector.ts
+++ b/apps/heft/src/startWithVersionSelector.ts
@@ -68,7 +68,7 @@ function tryStartLocalHeft(): boolean {
       try {
         packageJson = JSON.parse(packageJsonContent);
       } catch (error) {
-        throw new Error(`Error parsing ${packageJsonPath}:` + error.message);
+        throw new Error(`Error parsing ${packageJsonPath}:` + (error as Error).message);
       }
 
       // Does package.json have a dependency on Heft?
@@ -91,7 +91,7 @@ function tryStartLocalHeft(): boolean {
       console.log(`Using local Heft from ${heftFolder}`);
       console.log();
     } catch (error) {
-      throw new Error('Error probing for local Heft version: ' + error.message);
+      throw new Error('Error probing for local Heft version: ' + (error as Error).message);
     }
 
     require(heftEntryPoint);

--- a/apps/heft/src/utilities/Async.ts
+++ b/apps/heft/src/utilities/Async.ts
@@ -18,7 +18,7 @@ export class Async {
     try {
       fn().catch((e) => scopedLogger.emitError(e));
     } catch (e) {
-      scopedLogger.emitError(e);
+      scopedLogger.emitError(e as Error);
     }
   }
 }

--- a/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
+++ b/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
@@ -43,7 +43,7 @@ export class TypeScriptCachedFileSystem {
       this.getStatistics(path);
       return true;
     } catch (e) {
-      if (FileSystem.isNotExistError(e)) {
+      if (FileSystem.isNotExistError(e as Error)) {
         return false;
       } else {
         throw e;
@@ -56,7 +56,7 @@ export class TypeScriptCachedFileSystem {
       const stats: FileSystemStats = this.getStatistics(path);
       return stats.isDirectory();
     } catch (e) {
-      if (FileSystem.isNotExistError(e)) {
+      if (FileSystem.isNotExistError(e as Error)) {
         return false;
       } else {
         throw e;
@@ -184,7 +184,7 @@ export class TypeScriptCachedFileSystem {
       try {
         cacheEntry = { entry: fn(path) };
       } catch (e) {
-        cacheEntry = { error: e, entry: undefined };
+        cacheEntry = { error: e as Error, entry: undefined };
       }
 
       cache.set(path, cacheEntry);

--- a/apps/heft/src/utilities/subprocess/SubprocessRunnerBase.ts
+++ b/apps/heft/src/utilities/subprocess/SubprocessRunnerBase.ts
@@ -226,7 +226,7 @@ export abstract class SubprocessRunnerBase<
     try {
       await this.invokeAsync();
     } catch (e) {
-      error = e;
+      error = e as Error;
     } finally {
       process.removeAllListeners();
 

--- a/apps/heft/src/utilities/subprocess/SubprocessTerminator.ts
+++ b/apps/heft/src/utilities/subprocess/SubprocessTerminator.ts
@@ -173,7 +173,7 @@ export class SubprocessTerminator {
           SubprocessTerminator.killProcessTree(trackedSubprocess.subprocess, { detached: true });
         } catch (error) {
           if (firstError === undefined) {
-            firstError = error;
+            firstError = error as Error;
           }
         }
       }

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -77,6 +77,6 @@
     "@types/tar": "4.0.3",
     "@types/z-schema": "3.16.31",
     "jest": "~25.4.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
+++ b/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
@@ -102,7 +102,7 @@ export class CommonVersionsConfiguration {
           commonVersionsJson.allowedAlternativeVersions
         );
       } catch (e) {
-        throw new Error(`Error loading "${path.basename(filePath)}": ${e.message}`);
+        throw new Error(`Error loading "${path.basename(filePath)}": ${(e as Error).message}`);
       }
     }
     this._filePath = filePath;

--- a/apps/rush-lib/src/api/PackageJsonEditor.ts
+++ b/apps/rush-lib/src/api/PackageJsonEditor.ts
@@ -163,7 +163,7 @@ export class PackageJsonEditor {
       Sort.sortMapKeys(this._dependencies);
       Sort.sortMapKeys(this._devDependencies);
     } catch (e) {
-      throw new Error(`Error loading "${filepath}": ${e.message}`);
+      throw new Error(`Error loading "${filepath}": ${(e as Error).message}`);
     }
   }
 

--- a/apps/rush-lib/src/api/RushUserConfiguration.ts
+++ b/apps/rush-lib/src/api/RushUserConfiguration.ts
@@ -43,7 +43,7 @@ export class RushUserConfiguration {
         RushUserConfiguration._schema
       );
     } catch (e) {
-      if (!FileSystem.isNotExistError(e)) {
+      if (!FileSystem.isNotExistError(e as Error)) {
         throw e;
       }
     }

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -87,7 +87,7 @@ export class RushCommandLineParser extends CommandLineParser {
         this.rushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFilename);
       }
     } catch (error) {
-      this._reportErrorAndSetExitCode(error);
+      this._reportErrorAndSetExitCode(error as Error);
     }
 
     NodeJsCompatibility.warnAboutCompatibilityIssues({
@@ -134,7 +134,7 @@ export class RushCommandLineParser extends CommandLineParser {
       // If we make it here, everything went fine, so reset the exit code back to 0
       process.exitCode = 0;
     } catch (error) {
-      this._reportErrorAndSetExitCode(error);
+      this._reportErrorAndSetExitCode(error as Error);
     }
   }
 
@@ -184,7 +184,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
       this._populateScriptActions();
     } catch (error) {
-      this._reportErrorAndSetExitCode(error);
+      this._reportErrorAndSetExitCode(error as Error);
     }
   }
 
@@ -300,8 +300,8 @@ export class RushCommandLineParser extends CommandLineParser {
         break;
       default:
         throw new Error(
-          `${RushConstants.commandLineFilename} defines a command "${command!.name}"` +
-            ` using an unsupported command kind "${command!.commandKind}"`
+          `${RushConstants.commandLineFilename} defines a command "${(command as CommandJson).name}"` +
+            ` using an unsupported command kind "${(command as CommandJson).commandKind}"`
         );
     }
   }

--- a/apps/rush-lib/src/cli/RushXCommandLine.ts
+++ b/apps/rush-lib/src/cli/RushXCommandLine.ts
@@ -150,7 +150,7 @@ export class RushXCommandLine {
 
       process.exitCode = exitCode;
     } catch (error) {
-      console.log(colors.red('Error: ' + error.message));
+      console.log(colors.red('Error: ' + (error as Error).message));
     }
   }
 

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -290,7 +290,7 @@ export class ChangeAction extends BaseRushAction {
         interactiveMode
       );
     } catch (error) {
-      throw new Error(`There was an error creating a change file: ${error.toString()}`);
+      throw new Error(`There was an error creating a change file: ${(error as Error).toString()}`);
     }
   }
 

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -5,6 +5,7 @@ import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { BaseRushAction, IBaseRushActionOptions } from '../actions/BaseRushAction';
 import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 import { RushConstants } from '../../logic/RushConstants';
+import type { ParameterJson } from '../../api/CommandLineJson';
 
 /**
  * Constructor parameters for BaseScriptAction
@@ -79,8 +80,8 @@ export abstract class BaseScriptAction extends BaseRushAction {
             break;
           default:
             throw new Error(
-              `${RushConstants.commandLineFilename} defines a parameter "${parameterJson!.longName}"` +
-                ` using an unsupported parameter kind "${parameterJson!.parameterKind}"`
+              `${RushConstants.commandLineFilename} defines a parameter "${(parameterJson as ParameterJson).longName}"` +
+                ` using an unsupported parameter kind "${(parameterJson as ParameterJson).parameterKind}"`
             );
         }
 

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -332,11 +332,11 @@ export class BulkScriptAction extends BaseScriptAction {
       if (error instanceof AlreadyReportedError) {
         console.log(`rush ${this.actionName} (${stopwatch.toString()})`);
       } else {
-        if (error && error.message) {
+        if (error && (error as Error).message) {
           if (this.parser.isDebug) {
-            console.log('Error: ' + error.stack);
+            console.log('Error: ' + (error as Error).stack);
           } else {
-            console.log('Error: ' + error.message);
+            console.log('Error: ' + (error as Error).message);
           }
         }
 

--- a/apps/rush-lib/src/logic/CredentialCache.ts
+++ b/apps/rush-lib/src/logic/CredentialCache.ts
@@ -68,7 +68,7 @@ export class CredentialCache implements IDisposable {
     try {
       loadedJson = await JsonFile.loadAndValidateAsync(cacheFilePath, jsonSchema);
     } catch (e) {
-      if (!FileSystem.isErrnoException(e)) {
+      if (!FileSystem.isErrnoException(e as Error)) {
         throw e;
       }
     }

--- a/apps/rush-lib/src/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/logic/EventHooksManager.ts
@@ -55,7 +55,7 @@ export class EventHooksManager {
               )
           );
           if (isDebug) {
-            console.error(os.EOL + error.message);
+            console.error(os.EOL + (error as Error).message);
           }
         }
       });

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -416,7 +416,7 @@ export class Git {
         };
       } catch (e) {
         this._gitEmailResult = {
-          error: e
+          error: e as Error
         };
       }
     }

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -129,7 +129,7 @@ export class ProjectWatcher {
           } catch (err) {
             // eslint-disable-next-line require-atomic-updates
             terminated = true;
-            reject(err);
+            reject(err as NodeJS.ErrnoException);
           }
         };
 
@@ -179,7 +179,9 @@ export class ProjectWatcher {
                     addWatcher(normalizedName, changeListener);
                   }
                 } catch (err) {
-                  if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+                  const code: string | undefined = (err as NodeJS.ErrnoException).code;
+
+                  if (code !== 'ENOENT' && code !== 'ENOTDIR') {
                     throw err;
                   }
                 }
@@ -194,7 +196,7 @@ export class ProjectWatcher {
             timeout = setTimeout(resolveIfChanged, this._debounceMilliseconds);
           } catch (err) {
             terminated = true;
-            reject(err);
+            reject(err as NodeJS.ErrnoException);
           }
         };
 

--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -101,7 +101,7 @@ export class RepoStateFile {
     try {
       fileContents = FileSystem.readFile(jsonFilename);
     } catch (error) {
-      if (!FileSystem.isNotExistError(error)) {
+      if (!FileSystem.isNotExistError(error as Error)) {
         throw error;
       }
     }

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -374,7 +374,7 @@ export abstract class BaseInstallManager {
         );
       } catch (ex) {
         console.log();
-        console.log(`Unable to load the ${this._rushConfiguration.shrinkwrapFilePhrase}: ${ex.message}`);
+        console.log(`Unable to load the ${this._rushConfiguration.shrinkwrapFilePhrase}: ${(ex as Error).message}`);
 
         if (!this.options.allowShrinkwrapUpdates) {
           console.log();

--- a/apps/rush-lib/src/logic/buildCache/AmazonS3/test/AmazonS3Client.test.ts
+++ b/apps/rush-lib/src/logic/buildCache/AmazonS3/test/AmazonS3Client.test.ts
@@ -130,7 +130,7 @@ describe('AmazonS3Client', () => {
       try {
         result = await request(s3Client);
       } catch (e) {
-        error = e;
+        error = e as Error;
       }
 
       expect(spy).toHaveBeenCalledTimes(1);

--- a/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
+++ b/apps/rush-lib/src/logic/buildCache/AzureStorageBuildCacheProvider.ts
@@ -43,6 +43,17 @@ export interface IAzureStorageBuildCacheProviderOptions {
 
 const SAS_TTL_MILLISECONDS: number = 7 * 24 * 60 * 60 * 1000; // Seven days
 
+interface IBlobError extends Error {
+  statusCode: number;
+  code: string;
+  response?: {
+    status: string;
+    parsedHeaders?: {
+      errorCode: string;
+    }
+  }
+}
+
 export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase {
   private readonly _storageAccountName: string;
   private readonly _storageContainerName: string;
@@ -110,7 +121,8 @@ export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase 
       } else {
         return undefined;
       }
-    } catch (e) {
+    } catch (err) {
+      const e: IBlobError = err as IBlobError;
       const errorMessage: string =
         'Error getting cache entry from Azure Storage: ' +
         [e.name, e.message, e.response?.status, e.response?.parsedHeaders?.errorCode]
@@ -174,7 +186,9 @@ export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase 
 
     try {
       blobAlreadyExists = await blockBlobClient.exists();
-    } catch (e) {
+    } catch (err) {
+      const e: IBlobError = err as IBlobError;
+
       // If RUSH_BUILD_CACHE_CREDENTIAL is set but is corrupted or has been rotated
       // in Azure Portal, or the user's own cached credentials have been corrupted or
       // invalidated, we'll print the error and continue (this way we don't fail the
@@ -196,13 +210,13 @@ export class AzureStorageBuildCacheProvider extends CloudBuildCacheProviderBase 
         await blockBlobClient.upload(entryStream, entryStream.length);
         return true;
       } catch (e) {
-        if (e.statusCode === 409 /* conflict */) {
+        if ((e as IBlobError).statusCode === 409 /* conflict */) {
           // If something else has written to the blob at the same time,
           // it's probably a concurrent process that is attempting to write
           // the same cache entry. That is an effective success.
           terminal.writeVerboseLine(
             'Azure Storage returned status 409 (conflict). The cache entry has ' +
-              `probably already been set by another builder. Code: "${e.code}".`
+              `probably already been set by another builder. Code: "${(e as IBlobError).code}".`
           );
           return true;
         } else {

--- a/apps/rush-lib/src/logic/deploy/DeployManager.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployManager.ts
@@ -205,7 +205,7 @@ export class DeployManager {
       try {
         this._traceResolveDependency(dependencyPackageName, packageJsonRealFolderPath, deployState);
       } catch (resolveErr) {
-        if (resolveErr.code === 'MODULE_NOT_FOUND' && optionalDependencyNames.has(dependencyPackageName)) {
+        if ((resolveErr as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND' && optionalDependencyNames.has(dependencyPackageName)) {
           // Ignore missing optional dependency
           continue;
         }
@@ -237,7 +237,7 @@ export class DeployManager {
           // }
           this._traceResolveDependency(packageJson.name, pnpmDotFolderPath, deployState);
         } catch (resolveErr) {
-          if (resolveErr.code === 'MODULE_NOT_FOUND') {
+          if ((resolveErr as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
             // The workaround link isn't guaranteed to exist, so ignore if it's missing
             // NOTE: If you encounter this warning a lot, please report it to the Rush maintainers.
             console.log('Ignoring missing PNPM workaround link for ' + packageJsonFolderPath);
@@ -313,7 +313,7 @@ export class DeployManager {
           deployState.symlinkAnalyzer.analyzePath(filePath);
           return resolvedPath;
         } catch (realpathErr) {
-          if (realpathErr.code !== 'ENOENT') {
+          if ((realpathErr as NodeJS.ErrnoException).code !== 'ENOENT') {
             throw realpathErr;
           }
         }

--- a/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/apps/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -144,7 +144,7 @@ export class InstallHelpers {
     try {
       FileSystem.deleteFolder(localPackageManagerToolFolder);
     } catch (error) {
-      if (error.code !== 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw error;
       }
     }

--- a/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -305,7 +305,7 @@ export class RushInstallManager extends BaseInstallManager {
 
           console.log(`Updating ${tarballFile}`);
         } catch (error) {
-          console.log(colors.yellow(error));
+          console.log(colors.yellow(error as string));
           // delete everything in case of any error
           FileSystem.deleteFile(tarballFile);
           FileSystem.deleteFile(tempPackageJsonFilename);
@@ -352,7 +352,7 @@ export class RushInstallManager extends BaseInstallManager {
       try {
         await FileSystem.deleteFileAsync(workspaceFilePath);
       } catch (e) {
-        if (!FileSystem.isNotExistError(e)) {
+        if (!FileSystem.isNotExistError(e as Error)) {
           throw e;
         }
       }

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -63,7 +63,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
 
       return new NpmShrinkwrapFile(JSON.parse(data));
     } catch (error) {
-      throw new Error(`Error reading "${shrinkwrapJsonFilename}":` + os.EOL + `  ${error.message}`);
+      throw new Error(`Error reading "${shrinkwrapJsonFilename}":` + os.EOL + `  ${(error as Error).message}`);
     }
   }
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -237,7 +237,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       const parsedData: IPnpmShrinkwrapYaml = yamlModule.safeLoad(shrinkwrapContent);
       return new PnpmShrinkwrapFile(parsedData, shrinkwrapYamlFilename);
     } catch (error) {
-      throw new Error(`Error reading "${shrinkwrapYamlFilename}":${os.EOL}  ${error.message}`);
+      throw new Error(`Error reading "${shrinkwrapYamlFilename}":${os.EOL}  ${(error as Error).message}`);
     }
   }
 

--- a/apps/rush-lib/src/logic/setup/KeyboardLoop.ts
+++ b/apps/rush-lib/src/logic/setup/KeyboardLoop.ts
@@ -114,7 +114,7 @@ export class KeyboardLoop {
     try {
       this.onKeypress(character, key);
     } catch (error) {
-      throw new InternalError('Uncaught exception in Prompter.onKeypress(): ' + error.toString());
+      throw new InternalError('Uncaught exception in Prompter.onKeypress(): ' + (error as Error).toString());
     }
   };
 }

--- a/apps/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/apps/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -300,7 +300,7 @@ export class SetupPackageRegistry {
     try {
       response = await webClient.fetchAsync(queryUrl);
     } catch (e) {
-      console.log(e.toString());
+      console.log((e as Error).toString());
       return;
     }
 

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -129,7 +129,7 @@ export class ProjectBuilder extends BaseBuilder {
       }
       return await this._executeTaskAsync(context);
     } catch (error) {
-      throw new TaskError('executing', error.message);
+      throw new TaskError('executing', (error as Error).message);
     }
   }
 
@@ -251,7 +251,7 @@ export class ProjectBuilder extends BaseBuilder {
       } catch (error) {
         // To test this code path:
         // Delete a project's ".rush/temp/shrinkwrap-deps.json" then run "rush build --verbose"
-        terminal.writeLine('Unable to calculate incremental build state: ' + error.toString());
+        terminal.writeLine('Unable to calculate incremental build state: ' + (error as Error).toString());
         terminal.writeLine({
           text: 'Rush will proceed without incremental build, caching, and change detection.',
           foregroundColor: ColorValue.Cyan
@@ -362,7 +362,7 @@ export class ProjectBuilder extends BaseBuilder {
                 resolve(TaskStatus.Success);
               }
             } catch (error) {
-              reject(error);
+              reject(error as TaskError);
             }
           });
         }

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -18,6 +18,7 @@ import { Task } from './Task';
 import { TaskStatus } from './TaskStatus';
 import { IBuilderContext } from './BaseBuilder';
 import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
+import { TaskError } from './TaskError';
 
 export interface ITaskRunnerOptions {
   quietMode: boolean;
@@ -281,7 +282,7 @@ export class TaskRunner {
       this._hasAnyFailures = true;
 
       // eslint-disable-next-line require-atomic-updates
-      task.error = error;
+      task.error = error as TaskError;
 
       this._markTaskAsFailed(task);
     }

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskRunner.test.ts
@@ -101,7 +101,7 @@ describe('TaskRunner', () => {
         await taskRunner.executeAsync();
         fail(EXPECTED_FAIL);
       } catch (err) {
-        expect(err.message).toMatchSnapshot();
+        expect((err as Error).message).toMatchSnapshot();
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Error: step 1 failed');
         expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
@@ -122,7 +122,7 @@ describe('TaskRunner', () => {
         await taskRunner.executeAsync();
         fail(EXPECTED_FAIL);
       } catch (err) {
-        expect(err.message).toMatchSnapshot();
+        expect((err as Error).message).toMatchSnapshot();
         const allOutput: string = mockWritable.getAllOutput();
         expect(allOutput).toMatch(/Build step 1/);
         expect(allOutput).toMatch(/Error: step 1 failed/);
@@ -159,7 +159,7 @@ describe('TaskRunner', () => {
           await taskRunner.executeAsync();
           fail(EXPECTED_FAIL);
         } catch (err) {
-          expect(err.message).toMatchSnapshot();
+          expect((err as Error).message).toMatchSnapshot();
           const allMessages: string = mockWritable.getAllOutput();
           expect(allMessages).toContain('Build step 1');
           expect(allMessages).toContain('step 1 succeeded with warnings');

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -176,7 +176,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
       shrinkwrapString = FileSystem.readFile(shrinkwrapFilename);
       shrinkwrapJson = lockfileModule.parse(shrinkwrapString);
     } catch (error) {
-      throw new Error(`Error reading "${shrinkwrapFilename}":` + os.EOL + `  ${error.message}`);
+      throw new Error(`Error reading "${shrinkwrapFilename}":` + os.EOL + `  ${(error as Error).message}`);
     }
 
     return new YarnShrinkwrapFile(shrinkwrapJson.object);

--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -482,7 +482,7 @@ export function runWithErrorAndStatusCode(fn: () => number): void {
     const exitCode: number = fn();
     process.exitCode = exitCode;
   } catch (e) {
-    console.error(os.EOL + os.EOL + e.toString() + os.EOL + os.EOL);
+    console.error(os.EOL + os.EOL + (e as Error).toString() + os.EOL + os.EOL);
   }
 }
 

--- a/apps/rush-lib/src/utilities/Npm.ts
+++ b/apps/rush-lib/src/utilities/Npm.ts
@@ -45,7 +45,7 @@ export class Npm {
         }
       }
     } catch (error) {
-      if (error.message.indexOf('npm ERR! 404') >= 0) {
+      if ((error as Error).message.indexOf('npm ERR! 404') >= 0) {
         console.log(`Package ${packageName} does not exist in the registry.`);
       } else {
         console.log(`Failed to get NPM information about ${packageName}.`);

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -180,7 +180,7 @@ export class Utilities {
         looped = true;
         const currentTime: number = Utilities.getTimeInMs();
         if (currentTime - startTime > maxWaitTimeMs) {
-          throw getTimeoutError(e);
+          throw getTimeoutError(e as Error);
         }
       }
     }
@@ -270,7 +270,7 @@ export class Utilities {
       FileSystem.deleteFolder(folderPath);
     } catch (e) {
       throw new Error(
-        `${e.message}${os.EOL}Often this is caused by a file lock from a process ` +
+        `${(e as Error).message}${os.EOL}Often this is caused by a file lock from a process ` +
           'such as your text editor, command prompt, or a filesystem watcher'
       );
     }
@@ -366,7 +366,7 @@ export class Utilities {
       } catch (error) {
         console.log(os.EOL + 'The command failed:');
         console.log(` ${options.command} ` + options.args.join(' '));
-        console.log(`ERROR: ${error.toString()}`);
+        console.log(`ERROR: ${(error as Error).toString()}`);
 
         if (attemptNumber < maxAttempts) {
           ++attemptNumber;

--- a/build-tests-samples/heft-node-basic-tutorial/package.json
+++ b/build-tests-samples/heft-node-basic-tutorial/package.json
@@ -15,6 +15,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests-samples/heft-node-jest-tutorial/package.json
+++ b/build-tests-samples/heft-node-jest-tutorial/package.json
@@ -14,6 +14,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests-samples/heft-storybook-react-tutorial/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/package.json
@@ -25,7 +25,7 @@
     "react": "~16.13.1",
     "source-map-loader": "~1.1.2",
     "style-loader": "~1.2.1",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2"
   }
 }

--- a/build-tests-samples/heft-webpack-basic-tutorial/package.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/package.json
@@ -22,7 +22,7 @@
     "react": "~16.13.1",
     "react-dom": "~16.13.1",
     "style-loader": "~1.2.1",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2",
     "source-map-loader": "~1.1.2"
   }

--- a/build-tests-samples/packlets-tutorial/package.json
+++ b/build-tests-samples/packlets-tutorial/package.json
@@ -13,6 +13,6 @@
     "@rushstack/heft": "workspace:*",
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-documenter-test/package.json
+++ b/build-tests/api-documenter-test/package.json
@@ -14,6 +14,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-lib2-test/package.json
+++ b/build-tests/api-extractor-lib2-test/package.json
@@ -13,6 +13,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-lib3-test/package.json
+++ b/build-tests/api-extractor-lib3-test/package.json
@@ -16,6 +16,6 @@
     "@types/jest": "25.2.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-scenarios/package.json
+++ b/build-tests/api-extractor-scenarios/package.json
@@ -19,6 +19,6 @@
     "api-extractor-lib3-test": "workspace:*",
     "colors": "~1.2.1",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -18,6 +18,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -17,6 +17,6 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -11,6 +11,6 @@
     "@types/node": "10.17.13",
     "api-extractor-test-02": "workspace:*",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/api-extractor-test-04/package.json
+++ b/build-tests/api-extractor-test-04/package.json
@@ -12,6 +12,6 @@
     "@microsoft/api-extractor": "workspace:*",
     "api-extractor-lib1-test": "workspace:*",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-action-plugin/package.json
+++ b/build-tests/heft-action-plugin/package.json
@@ -13,7 +13,7 @@
     "@rushstack/heft": "workspace:*",
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*"

--- a/build-tests/heft-example-plugin-01/package.json
+++ b/build-tests/heft-example-plugin-01/package.json
@@ -18,6 +18,6 @@
     "@types/node": "10.17.13",
     "@types/tapable": "1.0.6",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-example-plugin-02/package.json
+++ b/build-tests/heft-example-plugin-02/package.json
@@ -23,6 +23,6 @@
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
     "heft-example-plugin-01": "workspace:*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-fastify-test/package.json
+++ b/build-tests/heft-fastify-test/package.json
@@ -16,7 +16,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "fastify": "~3.16.1"

--- a/build-tests/heft-jest-reporters-test/config/jest.config.json
+++ b/build-tests/heft-jest-reporters-test/config/jest.config.json
@@ -1,4 +1,4 @@
 {
   "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-  "reporters": ["default", "../lib/test/customJestReporter.js"]
+  "reporters": ["default", "../lib/test/customJestReporter.cjs"]
 }

--- a/build-tests/heft-jest-reporters-test/package.json
+++ b/build-tests/heft-jest-reporters-test/package.json
@@ -13,7 +13,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "@jest/reporters": "~25.4.0",
     "@jest/types": "~25.4.0"
   }

--- a/build-tests/heft-minimal-rig-test/package.json
+++ b/build-tests/heft-minimal-rig-test/package.json
@@ -8,7 +8,7 @@
     "build": ""
   },
   "dependencies": {
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*"
   }

--- a/build-tests/heft-node-everything-esm-module-test/package.json
+++ b/build-tests/heft-node-everything-esm-module-test/package.json
@@ -21,6 +21,6 @@
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-node-everything-test/package.json
+++ b/build-tests/heft-node-everything-test/package.json
@@ -20,6 +20,6 @@
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-sass-test/package.json
+++ b/build-tests/heft-sass-test/package.json
@@ -28,7 +28,7 @@
     "react": "~16.13.1",
     "sass-loader": "~10.1.1",
     "style-loader": "~1.2.1",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2"
   },
   "dependencies": {

--- a/build-tests/heft-typescript-composite-test/package.json
+++ b/build-tests/heft-typescript-composite-test/package.json
@@ -13,9 +13,10 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/webpack-env": "1.13.0",
+    "@types/jest": "25.2.1",
     "eslint": "~7.30.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/heft-webpack4-everything-test/package.json
+++ b/build-tests/heft-webpack4-everything-test/package.json
@@ -18,7 +18,7 @@
     "file-loader": "~6.0.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2"
   }
 }

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -17,6 +17,6 @@
     "eslint": "~7.30.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.4.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.37.4.tgz
+      '@rushstack/heft': file:rushstack-heft-0.39.0.tgz
       eslint: ~7.30.0
       tslint: ~5.20.1
       typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.4.2
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.37.4.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.39.0.tgz
       eslint: 7.30.0
       tslint: 5.20.1_typescript@4.4.2
       typescript: 4.4.2
@@ -19,16 +19,16 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.4.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.37.4.tgz
+      '@rushstack/heft': file:rushstack-heft-0.39.0.tgz
       eslint: ~7.30.0
       tslint: ~5.20.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.37.4.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.4.2
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.39.0.tgz
       eslint: 7.30.0
-      tslint: 5.20.1_typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.2
+      typescript: 4.4.2
 
 packages:
 
@@ -138,31 +138,6 @@ packages:
     resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.28.3_c791be63d80b830096132a88d884d3c6:
-    resolution: {integrity: sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/scope-manager': 4.28.3
-      debug: 4.3.1
-      eslint: 7.30.0
-      functional-red-black-tree: 1.0.1
-      regexpp: 3.1.0
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@3.9.10
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/4.28.3_dea3c07b05ffc5d33aadcc92b8a0deed:
     resolution: {integrity: sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -188,24 +163,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.28.3_eslint@7.30.0+typescript@3.9.10:
-    resolution: {integrity: sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.28.3
-      '@typescript-eslint/types': 4.28.3
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@3.9.10
-      eslint: 7.30.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils/4.28.3_eslint@7.30.0+typescript@4.4.2:
     resolution: {integrity: sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -222,26 +179,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/parser/4.28.3_eslint@7.30.0+typescript@3.9.10:
-    resolution: {integrity: sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.28.3
-      '@typescript-eslint/types': 4.28.3
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@3.9.10
-      debug: 4.3.1
-      eslint: 7.30.0
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/parser/4.28.3_eslint@7.30.0+typescript@4.4.2:
@@ -275,27 +212,6 @@ packages:
   /@typescript-eslint/types/4.28.3:
     resolution: {integrity: sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dev: true
-
-  /@typescript-eslint/typescript-estree/4.28.3_typescript@3.9.10:
-    resolution: {integrity: sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.28.3
-      '@typescript-eslint/visitor-keys': 4.28.3
-      debug: 4.3.1
-      globby: 11.0.4
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@3.9.10
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree/4.28.3_typescript@4.4.2:
@@ -1614,29 +1530,6 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslint/5.20.1_typescript@3.9.10:
-    resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
-    engines: {node: '>=4.8.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      builtin-modules: 1.1.1
-      chalk: 2.4.2
-      commander: 2.20.3
-      diff: 4.0.2
-      glob: 7.1.7
-      js-yaml: 3.14.1
-      minimatch: 3.0.4
-      mkdirp: 0.5.5
-      resolve: 1.20.0
-      semver: 5.7.1
-      tslib: 1.14.1
-      tsutils: 2.29.0_typescript@3.9.10
-      typescript: 3.9.10
-    dev: true
-
   /tslint/5.20.1_typescript@4.4.2:
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
     engines: {node: '>=4.8.0'}
@@ -1660,15 +1553,6 @@ packages:
       typescript: 4.4.2
     dev: true
 
-  /tsutils/2.29.0_typescript@3.9.10:
-    resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 3.9.10
-    dev: true
-
   /tsutils/2.29.0_typescript@4.4.2:
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
@@ -1676,16 +1560,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.4.2
-    dev: true
-
-  /tsutils/3.21.0_typescript@3.9.10:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 3.9.10
     dev: true
 
   /tsutils/3.21.0_typescript@4.4.2:
@@ -1708,12 +1582,6 @@ packages:
   /type-fest/0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
-    dev: true
-
-  /typescript/3.9.10:
-    resolution: {integrity: sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript/4.4.2:
@@ -1793,32 +1661,6 @@ packages:
       commander: 2.20.3
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@3.9.10:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz
-    name: '@rushstack/eslint-config'
-    version: 2.4.0
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-      typescript: '>=3.0.0'
-    dependencies:
-      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.0.6.tgz
-      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/eslint-plugin': 4.28.3_c791be63d80b830096132a88d884d3c6
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/parser': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/typescript-estree': 4.28.3_typescript@3.9.10
-      eslint: 7.30.0
-      eslint-plugin-promise: 4.2.1
-      eslint-plugin-react: 7.20.6_eslint@7.30.0
-      eslint-plugin-tsdoc: 0.2.14
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-config-2.4.0.tgz
@@ -1851,22 +1693,6 @@ packages:
     version: 1.0.6
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@3.9.10:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz
-    name: '@rushstack/eslint-plugin'
-    version: 0.8.0
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-    dependencies:
-      '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-0.8.0.tgz
@@ -1877,22 +1703,6 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
       '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@4.4.2
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz_eslint@7.30.0+typescript@3.9.10:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.0.tgz
-    name: '@rushstack/eslint-plugin-packlets'
-    version: 0.3.0
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-    dependencies:
-      '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@3.9.10
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -1915,22 +1725,6 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@3.9.10:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz
-    name: '@rushstack/eslint-plugin-security'
-    version: 0.2.0
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-    dependencies:
-      '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.1.tgz
-      '@typescript-eslint/experimental-utils': 4.28.3_eslint@7.30.0+typescript@3.9.10
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz_eslint@7.30.0+typescript@4.4.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.0.tgz
@@ -1947,18 +1741,18 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.37.4.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.37.4.tgz}
+  file:../temp/tarballs/rushstack-heft-0.39.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.39.0.tgz}
     name: '@rushstack/heft'
-    version: 0.37.4
+    version: 0.39.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.6.5.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.1.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.6.6.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.2.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.9.0.tgz
-      '@rushstack/typings-generator': file:../temp/tarballs/rushstack-typings-generator-0.3.10.tgz
+      '@rushstack/typings-generator': file:../temp/tarballs/rushstack-typings-generator-0.3.11.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -1971,21 +1765,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.6.5.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.6.5.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.6.6.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.6.6.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.6.5
+    version: 0.6.6
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.1.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.2.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.0.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.40.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.40.1.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.40.2.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.40.2.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.40.1
+    version: 3.40.2
     dependencies:
       '@types/node': 10.17.13
       colors: 1.2.5
@@ -2024,12 +1818,12 @@ packages:
       string-argv: 0.3.1
     dev: true
 
-  file:../temp/tarballs/rushstack-typings-generator-0.3.10.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-typings-generator-0.3.10.tgz}
+  file:../temp/tarballs/rushstack-typings-generator-0.3.11.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-typings-generator-0.3.11.tgz}
     name: '@rushstack/typings-generator'
-    version: 0.3.10
+    version: 0.3.11
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.1.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.40.2.tgz
       '@types/node': 10.17.13
       chokidar: 3.4.3
       glob: 7.0.6

--- a/build-tests/install-test-workspace/workspace/typescript-v3-test/package.json
+++ b/build-tests/install-test-workspace/workspace/typescript-v3-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rushstack/eslint-config": "*",
     "@rushstack/heft": "*",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "tslint": "~5.20.1",
     "eslint": "~7.30.0"
   }

--- a/build-tests/localization-plugin-test-01/package.json
+++ b/build-tests/localization-plugin-test-01/package.json
@@ -16,7 +16,7 @@
     "@types/webpack-env": "1.13.0",
     "html-webpack-plugin": "~4.5.0",
     "ts-loader": "6.0.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2",
     "webpack-bundle-analyzer": "~3.6.0",
     "webpack-cli": "~3.3.2",

--- a/build-tests/localization-plugin-test-02/package.json
+++ b/build-tests/localization-plugin-test-02/package.json
@@ -18,7 +18,7 @@
     "html-webpack-plugin": "~4.5.0",
     "lodash": "~4.17.15",
     "ts-loader": "6.0.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2",
     "webpack-bundle-analyzer": "~3.6.0",
     "webpack-cli": "~3.3.2",

--- a/build-tests/localization-plugin-test-03/package.json
+++ b/build-tests/localization-plugin-test-03/package.json
@@ -15,7 +15,7 @@
     "@types/webpack-env": "1.13.0",
     "html-webpack-plugin": "~4.5.0",
     "ts-loader": "6.0.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
     "webpack": "~4.44.2",
     "webpack-bundle-analyzer": "~3.6.0",
     "webpack-cli": "~3.3.2",

--- a/build-tests/ts-command-line-test/package.json
+++ b/build-tests/ts-command-line-test/package.json
@@ -11,6 +11,6 @@
     "@rushstack/ts-command-line": "workspace:*",
     "@types/node": "10.17.13",
     "fs-extra": "~7.0.1",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/common/changes/@microsoft/api-documenter/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@microsoft/api-documenter/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-documenter"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor-model/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@microsoft/api-extractor-model/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor-model"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@microsoft/api-extractor/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@microsoft/rush/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-config/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/eslint-config/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-config"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-patch/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/eslint-patch/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin-packlets"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/eslint-plugin-security/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin-security"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/eslint-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-config-file/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-config-file/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-config-file"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-jest-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-jest-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-node-rig/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-node-rig/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-sass-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-sass-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-storybook-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-web-rig/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-webpack4-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-webpack4-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-webpack5-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/heft/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/localization-plugin/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/localization-plugin/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/localization-plugin"
+    }
+  ],
+  "packageName": "@rushstack/localization-plugin",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/node-core-library/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/package-deps-hash/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/package-deps-hash/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/package-deps-hash"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rig-package/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/rig-package/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/rig-package"
+    }
+  ],
+  "packageName": "@rushstack/rig-package",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/terminal/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/terminal/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/terminal"
+    }
+  ],
+  "packageName": "@rushstack/terminal",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/tree-pattern/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/tree-pattern/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/tree-pattern"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/ts-command-line/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/ts-command-line"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/typings-generator/ts-4.4_2021-09-22-20-54.json
+++ b/common/changes/@rushstack/typings-generator/ts-4.4_2021-09-22-20-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/typings-generator"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator",
+  "email": "crisbeto@users.noreply.github.com"
+}

--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -62,8 +62,9 @@ function readPackage(packageJson, context) {
         );
       }
     }
-  } else if (packageJson.name === '@typescript-eslint/types') {
-    // Workaround for https://github.com/typescript-eslint/typescript-eslint/issues/3622
+  } else if (packageJson.name === '@typescript-eslint/types' || packageJson.name === 'tslint-microsoft-contrib') {
+    // The `@typescript-eslint/types` check is a workaround for https://github.com/typescript-eslint/typescript-eslint/issues/3622.
+    // The `tslint-microsoft-contrib` repo is archived so it can't be updated to TS 4.4+.
     if (!packageJson.peerDependencies) {
       packageJson.peerDependencies = {};
     }

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -28,7 +28,7 @@
     // From the allowedAlternativeVersions list below, this should be the TypeScript version that's used to
     // build most of the projects in the repo.  Preferring it avoids errors for indirect dependencies
     // that request it as a peer dependency.
-    "typescript": "~3.9.7",
+    "typescript": "~4.4.2",
 
     // Workaround for https://github.com/microsoft/rushstack/issues/1466
     "eslint": "~7.30.0"
@@ -64,7 +64,7 @@
      * (in addition to whatever "usual" version is being used by other projects in the repo):
      */
     "typescript": [
-      // "~3.9.7" is the (inferred, not alternative) range used by most projects in this repo
+      // "~4.4.2" is the (inferred, not alternative) range used by most projects in this repo
 
       // The oldest supported compiler, used by build-tests/heft-oldest-compiler-test
       // and also build-tests/api-extractor-lib1-test

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': ~0.15.2
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/node-core-library': workspace:*
       '@rushstack/rig-package': workspace:*
       '@rushstack/ts-command-line': workspace:*
@@ -61,7 +61,7 @@ importers:
       resolve: ~1.17.0
       semver: ~7.3.0
       source-map: ~0.6.1
-      typescript: ~4.3.5
+      typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor-model': link:../api-extractor-model
       '@microsoft/tsdoc': 0.13.2
@@ -74,11 +74,11 @@ importers:
       resolve: 1.17.0
       semver: 7.3.5
       source-map: 0.6.1
-      typescript: 4.3.5
+      typescript: 4.4.3
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 10.17.13
@@ -90,8 +90,8 @@ importers:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': ~0.15.2
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
@@ -101,8 +101,8 @@ importers:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
 
@@ -110,9 +110,9 @@ importers:
     specifiers:
       '@microsoft/api-extractor': workspace:*
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
+      '@rushstack/heft': 0.38.1
       '@rushstack/heft-config-file': workspace:*
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/node-core-library': workspace:*
       '@rushstack/rig-package': workspace:*
       '@rushstack/ts-command-line': workspace:*
@@ -135,7 +135,7 @@ importers:
       tapable: 1.1.3
       true-case-path: ~2.2.1
       tslint: ~5.20.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -155,8 +155,8 @@ importers:
     devDependencies:
       '@microsoft/api-extractor': link:../api-extractor
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/argparse': 1.0.38
       '@types/eslint': 7.2.0
       '@types/glob': 7.1.1
@@ -164,8 +164,8 @@ importers:
       '@types/node': 10.17.13
       '@types/semver': 7.3.5
       colors: 1.2.5
-      tslint: 5.20.1_typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      typescript: 4.4.3
 
   ../../apps/rundown:
     specifiers:
@@ -271,7 +271,7 @@ importers:
       strict-uri-encode: ~2.0.0
       tar: ~5.0.5
       true-case-path: ~2.2.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       z-schema: ~3.18.3
     dependencies:
       '@azure/identity': 1.0.3
@@ -332,7 +332,7 @@ importers:
       '@types/tar': 4.0.3
       '@types/z-schema': 3.16.31
       jest: 25.4.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests-samples/heft-node-basic-tutorial:
     specifiers:
@@ -342,7 +342,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -350,7 +350,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests-samples/heft-node-jest-tutorial:
     specifiers:
@@ -360,7 +360,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -368,7 +368,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests-samples/heft-node-rig-tutorial:
     specifiers:
@@ -403,7 +403,7 @@ importers:
       react-dom: ~16.13.1
       source-map-loader: ~1.1.2
       style-loader: ~1.2.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -423,7 +423,7 @@ importers:
       react-dom: 16.13.1_react@16.13.1
       source-map-loader: 1.1.3_webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
-      typescript: 3.9.10
+      typescript: 4.4.3
       webpack: 4.44.2
 
   ../../build-tests-samples/heft-storybook-react-tutorial-storykit:
@@ -489,7 +489,7 @@ importers:
       react-dom: ~16.13.1
       source-map-loader: ~1.1.2
       style-loader: ~1.2.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -507,7 +507,7 @@ importers:
       react-dom: 16.13.1_react@16.13.1
       source-map-loader: 1.1.3_webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
-      typescript: 3.9.10
+      typescript: 4.4.3
       webpack: 4.44.2
 
   ../../build-tests-samples/packlets-tutorial:
@@ -516,13 +516,13 @@ importers:
       '@rushstack/heft': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-documenter-test:
     specifiers:
@@ -531,14 +531,14 @@ importers:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@microsoft/api-documenter': link:../../apps/api-documenter
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-lib1-test:
     specifiers:
@@ -558,13 +558,13 @@ importers:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-lib3-test:
     specifiers:
@@ -573,7 +573,7 @@ importers:
       '@types/node': 10.17.13
       api-extractor-lib1-test: workspace:*
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       api-extractor-lib1-test: link:../api-extractor-lib1-test
     devDependencies:
@@ -581,7 +581,7 @@ importers:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-scenarios:
     specifiers:
@@ -595,7 +595,7 @@ importers:
       api-extractor-lib3-test: workspace:*
       colors: ~1.2.1
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@microsoft/teams-js': 1.3.0-beta.4
@@ -607,7 +607,7 @@ importers:
       api-extractor-lib3-test: link:../api-extractor-lib3-test
       colors: 1.2.5
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-test-01:
     specifiers:
@@ -618,7 +618,7 @@ importers:
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
       long: ^4.0.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@types/jest': 25.2.1
       '@types/long': 4.0.0
@@ -628,7 +628,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-test-02:
     specifiers:
@@ -638,7 +638,7 @@ importers:
       api-extractor-test-01: workspace:*
       fs-extra: ~7.0.1
       semver: ~7.3.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@types/semver': 7.3.5
       api-extractor-test-01: link:../api-extractor-test-01
@@ -647,7 +647,7 @@ importers:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-test-03:
     specifiers:
@@ -655,25 +655,25 @@ importers:
       '@types/node': 10.17.13
       api-extractor-test-02: workspace:*
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@types/jest': 25.2.1
       '@types/node': 10.17.13
       api-extractor-test-02: link:../api-extractor-test-02
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/api-extractor-test-04:
     specifiers:
       '@microsoft/api-extractor': workspace:*
       api-extractor-lib1-test: workspace:*
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       api-extractor-lib1-test: link:../api-extractor-lib1-test
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-action-plugin:
     specifiers:
@@ -682,7 +682,7 @@ importers:
       '@rushstack/node-core-library': workspace:*
       '@types/node': 10.17.13
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
@@ -690,7 +690,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-action-plugin-test:
     specifiers:
@@ -714,7 +714,7 @@ importers:
       '@types/tapable': 1.0.6
       eslint: ~7.30.0
       tapable: 1.1.3
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       tapable: 1.1.3
     devDependencies:
@@ -723,7 +723,7 @@ importers:
       '@types/node': 10.17.13
       '@types/tapable': 1.0.6
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-example-plugin-02:
     specifiers:
@@ -732,14 +732,14 @@ importers:
       '@types/node': 10.17.13
       eslint: ~7.30.0
       heft-example-plugin-01: workspace:*
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 10.17.13
       eslint: 7.30.0
       heft-example-plugin-01: link:../heft-example-plugin-01
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-fastify-test:
     specifiers:
@@ -749,7 +749,7 @@ importers:
       '@types/node': 10.17.13
       eslint: ~7.30.0
       fastify: ~3.16.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       fastify: 3.16.2
     devDependencies:
@@ -758,7 +758,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-jest-reporters-test:
     specifiers:
@@ -769,7 +769,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@jest/reporters': 25.4.0
       '@jest/types': 25.4.0
@@ -778,17 +778,17 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-minimal-rig-test:
     specifiers:
       '@microsoft/api-extractor': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../build-tests/heft-minimal-rig-usage-test:
     specifiers:
@@ -817,7 +817,7 @@ importers:
       heft-example-plugin-02: workspace:*
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -828,9 +828,9 @@ importers:
       eslint: 7.30.0
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
-      tslint: 5.20.1_typescript@3.9.10
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.4.3
+      typescript: 4.4.3
 
   ../../build-tests/heft-node-everything-test:
     specifiers:
@@ -845,7 +845,7 @@ importers:
       heft-example-plugin-02: workspace:*
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -856,9 +856,9 @@ importers:
       eslint: 7.30.0
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
-      tslint: 5.20.1_typescript@3.9.10
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.4.3
+      typescript: 4.4.3
 
   ../../build-tests/heft-sass-test:
     specifiers:
@@ -883,7 +883,7 @@ importers:
       react-dom: ~16.13.1
       sass-loader: ~10.1.1
       style-loader: ~1.2.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
     dependencies:
       buttono: 1.0.4
@@ -908,7 +908,7 @@ importers:
       react-dom: 16.13.1_react@16.13.1
       sass-loader: 10.1.1_node-sass@5.0.0+webpack@4.44.2
       style-loader: 1.2.1_webpack@4.44.2
-      typescript: 3.9.10
+      typescript: 4.4.3
       webpack: 4.44.2
 
   ../../build-tests/heft-typescript-composite-test:
@@ -917,21 +917,23 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
+      '@types/jest': 25.2.1
       '@types/webpack-env': 1.13.0
       eslint: ~7.30.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
+      '@types/jest': 25.2.1
       '@types/webpack-env': 1.13.0
       eslint: 7.30.0
-      tslint: 5.20.1_typescript@3.9.10
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.4.3
+      typescript: 4.4.3
 
   ../../build-tests/heft-web-rig-library-test:
     specifiers:
@@ -955,7 +957,7 @@ importers:
       file-loader: ~6.0.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
@@ -966,9 +968,9 @@ importers:
       '@types/webpack-env': 1.13.0
       eslint: 7.30.0
       file-loader: 6.0.0_webpack@4.44.2
-      tslint: 5.20.1_typescript@3.9.10
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.4.3
+      typescript: 4.4.3
       webpack: 4.44.2
 
   ../../build-tests/heft-webpack5-everything-test:
@@ -982,7 +984,7 @@ importers:
       eslint: ~7.30.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -991,9 +993,9 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
       eslint: 7.30.0
-      tslint: 5.20.1_typescript@3.9.10
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@3.9.10
-      typescript: 3.9.10
+      tslint: 5.20.1_typescript@4.4.3
+      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.4.3
+      typescript: 4.4.3
 
   ../../build-tests/install-test-workspace:
     specifiers:
@@ -1013,7 +1015,7 @@ importers:
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: ~4.5.0
       ts-loader: 6.0.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
       webpack-bundle-analyzer: ~3.6.0
       webpack-cli: ~3.3.2
@@ -1026,8 +1028,8 @@ importers:
       '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.2_webpack@4.44.2
-      ts-loader: 6.0.0_typescript@3.9.10
-      typescript: 3.9.10
+      ts-loader: 6.0.0_typescript@4.4.3
+      typescript: 4.4.3
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
@@ -1045,7 +1047,7 @@ importers:
       html-webpack-plugin: ~4.5.0
       lodash: ~4.17.15
       ts-loader: 6.0.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
       webpack-bundle-analyzer: ~3.6.0
       webpack-cli: ~3.3.2
@@ -1060,8 +1062,8 @@ importers:
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.2_webpack@4.44.2
       lodash: 4.17.21
-      ts-loader: 6.0.0_typescript@3.9.10
-      typescript: 3.9.10
+      ts-loader: 6.0.0_typescript@4.4.3
+      typescript: 4.4.3
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
@@ -1076,7 +1078,7 @@ importers:
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: ~4.5.0
       ts-loader: 6.0.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
       webpack: ~4.44.2
       webpack-bundle-analyzer: ~3.6.0
       webpack-cli: ~3.3.2
@@ -1088,8 +1090,8 @@ importers:
       '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/webpack-env': 1.13.0
       html-webpack-plugin: 4.5.2_webpack@4.44.2
-      ts-loader: 6.0.0_typescript@3.9.10
-      typescript: 3.9.10
+      ts-loader: 6.0.0_typescript@4.4.3
+      typescript: 4.4.3
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 3.6.1
       webpack-cli: 3.3.12_webpack@4.44.2
@@ -1117,12 +1119,12 @@ importers:
       '@rushstack/ts-command-line': workspace:*
       '@types/node': 10.17.13
       fs-extra: ~7.0.1
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
       '@rushstack/ts-command-line': link:../../libraries/ts-command-line
       '@types/node': 10.17.13
       fs-extra: 7.0.1
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../heft-plugins/heft-jest-plugin:
     specifiers:
@@ -1143,7 +1145,7 @@ importers:
       jest-environment-node: ~25.4.0
       jest-snapshot: ~25.4.0
       lodash: ~4.17.15
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
@@ -1163,7 +1165,7 @@ importers:
       '@types/node': 10.17.13
       eslint: 7.30.0
       jest-environment-node: 25.4.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../heft-plugins/heft-sass-plugin:
     specifiers:
@@ -1181,7 +1183,7 @@ importers:
       node-sass: 5.0.0
       postcss: 7.0.32
       postcss-modules: ~1.5.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -1198,7 +1200,7 @@ importers:
       '@types/node': 10.17.13
       '@types/node-sass': 4.11.1
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../heft-plugins/heft-storybook-plugin:
     specifiers:
@@ -1285,8 +1287,8 @@ importers:
   ../../libraries/heft-config-file:
     specifiers:
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/node-core-library': workspace:*
       '@rushstack/rig-package': workspace:*
       '@types/heft-jest': 1.0.1
@@ -1298,8 +1300,8 @@ importers:
       jsonpath-plus: 4.0.0
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
 
@@ -1320,8 +1322,8 @@ importers:
   ../../libraries/node-core-library:
     specifiers:
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@types/fs-extra': 7.0.0
       '@types/heft-jest': 1.0.1
       '@types/jju': 1.4.1
@@ -1350,8 +1352,8 @@ importers:
       z-schema: 3.18.4
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/fs-extra': 7.0.0
       '@types/heft-jest': 1.0.1
       '@types/jju': 1.4.1
@@ -1380,8 +1382,8 @@ importers:
   ../../libraries/rig-package:
     specifiers:
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
@@ -1393,8 +1395,8 @@ importers:
       strip-json-comments: 3.1.1
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
       '@types/resolve': 1.17.1
@@ -1462,24 +1464,24 @@ importers:
   ../../libraries/tree-pattern:
     specifiers:
       '@rushstack/eslint-config': 2.4.0
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@types/heft-jest': 1.0.1
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     devDependencies:
-      '@rushstack/eslint-config': 2.4.0_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/eslint-config': 2.4.0_eslint@7.30.0+typescript@4.4.3
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../libraries/ts-command-line:
     specifiers:
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@types/argparse': 1.0.38
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
@@ -1493,16 +1495,16 @@ importers:
       string-argv: 0.3.1
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/heft-jest': 1.0.1
       '@types/node': 10.17.13
 
   ../../libraries/typings-generator:
     specifiers:
       '@rushstack/eslint-config': workspace:*
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/node-core-library': workspace:*
       '@types/glob': 7.1.1
       '@types/node': 10.17.13
@@ -1515,8 +1517,8 @@ importers:
       glob: 7.0.6
     devDependencies:
       '@rushstack/eslint-config': link:../../stack/eslint-config
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/glob': 7.1.1
 
   ../../repo-scripts/doc-plugin-rush-stack:
@@ -1579,12 +1581,12 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
 
@@ -1596,14 +1598,14 @@ importers:
       '@rushstack/heft-sass-plugin': workspace:*
       '@rushstack/heft-webpack4-plugin': workspace:*
       eslint: ~7.30.0
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@rushstack/heft-sass-plugin': link:../../heft-plugins/heft-sass-plugin
       '@rushstack/heft-webpack4-plugin': link:../../heft-plugins/heft-webpack4-plugin
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
 
@@ -1621,37 +1623,37 @@ importers:
       eslint-plugin-promise: ~4.2.1
       eslint-plugin-react: ~7.20.0
       eslint-plugin-tsdoc: ~0.2.10
-      typescript: ~3.9.7
+      typescript: ~4.4.2
     dependencies:
       '@rushstack/eslint-patch': link:../eslint-patch
       '@rushstack/eslint-plugin': link:../eslint-plugin
       '@rushstack/eslint-plugin-packlets': link:../eslint-plugin-packlets
       '@rushstack/eslint-plugin-security': link:../eslint-plugin-security
-      '@typescript-eslint/eslint-plugin': 4.28.5_807ba90a897c15d8025326b0ee53254e
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@3.9.10
+      '@typescript-eslint/eslint-plugin': 4.28.5_d3ea5ea3249d21f2ae3b3071477ae79b
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.3
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.20.6_eslint@7.30.0
       eslint-plugin-tsdoc: 0.2.14
     devDependencies:
       eslint: 7.30.0
-      typescript: 3.9.10
+      typescript: 4.4.3
 
   ../../stack/eslint-patch:
     specifiers:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@types/node': 10.17.13
     devDependencies:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/node': 10.17.13
 
   ../../stack/eslint-plugin:
     specifiers:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
@@ -1666,8 +1668,8 @@ importers:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
       '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.3.5
     devDependencies:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -1679,8 +1681,8 @@ importers:
 
   ../../stack/eslint-plugin-packlets:
     specifiers:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
@@ -1695,8 +1697,8 @@ importers:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
       '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.3.5
     devDependencies:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -1708,8 +1710,8 @@ importers:
 
   ../../stack/eslint-plugin-security:
     specifiers:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13
       '@rushstack/tree-pattern': workspace:*
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
@@ -1724,8 +1726,8 @@ importers:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
       '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.3.5
     devDependencies:
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-node-rig': 1.1.11_@rushstack+heft@0.34.6
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-node-rig': 1.2.13_@rushstack+heft@0.38.1
       '@types/eslint': 7.2.0
       '@types/estree': 0.0.44
       '@types/heft-jest': 1.0.1
@@ -3513,6 +3515,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@eslint/eslintrc/0.4.3:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -3945,12 +3948,12 @@ packages:
       '@rushstack/node-core-library': 3.38.0
     dev: false
 
-  /@microsoft/api-extractor-model/7.13.4:
-    resolution: {integrity: sha512-NYaR3hJinh089/Gkee8fvmEFf9zKkoUvNxgkqUlKBCDXH2+Ou4tNDuL8G6zjhKBPicHkp2VcL8l7q9H6txUkjQ==}
+  /@microsoft/api-extractor-model/7.13.7:
+    resolution: {integrity: sha512-emwhcaSF/h3WdqBWps4UU0RtGOGzy53IsplxuoLwtCuMAx3namYvJSfUGa5ajGPBao4MCyRYGsMc3EZ6IdR8cQ==}
     dependencies:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
-      '@rushstack/node-core-library': 3.39.1
+      '@rushstack/node-core-library': 3.40.2
     dev: true
 
   /@microsoft/api-extractor/7.15.2:
@@ -3971,16 +3974,16 @@ packages:
       typescript: 4.2.4
     dev: false
 
-  /@microsoft/api-extractor/7.18.2:
-    resolution: {integrity: sha512-xRzTZV6GkUraRiPQPYy6uvttyMvzqssAHXGPlrvR7Nf62/0arZPM+XQ7ik8WafnHZ6nqIQcNp0r9S+qQ9wsjEA==}
+  /@microsoft/api-extractor/7.18.9:
+    resolution: {integrity: sha512-N+fbG+6SwA1i6EW3iGRp/nAT8vQpRSDvZ1DzBUr8xIS7tNfJ0C75ndPPziUT8EmalhLixRnIw6Ncmur8AFELRg==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.13.4
+      '@microsoft/api-extractor-model': 7.13.7
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
-      '@rushstack/node-core-library': 3.39.1
-      '@rushstack/rig-package': 0.2.13
-      '@rushstack/ts-command-line': 4.8.1
+      '@rushstack/node-core-library': 3.40.2
+      '@rushstack/rig-package': 0.3.0
+      '@rushstack/ts-command-line': 4.9.0
       colors: 1.2.5
       lodash: 4.17.21
       resolve: 1.17.0
@@ -4256,25 +4259,25 @@ packages:
       - supports-color
     dev: false
 
-  /@rushstack/eslint-config/2.4.0_eslint@7.30.0+typescript@3.9.10:
+  /@rushstack/eslint-config/2.4.0_eslint@7.30.0+typescript@4.4.3:
     resolution: {integrity: sha512-qH3Q++hoELDgmOV8Hh0h804TBeRSOFv/I2kI6V3qOJEy+reKneyIHAraZrBwFDvMHdBUbXWkWsR/gEpG2sq6QQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
       typescript: '>=3.0.0'
     dependencies:
       '@rushstack/eslint-patch': 1.0.6
-      '@rushstack/eslint-plugin': 0.8.0_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/eslint-plugin-packlets': 0.3.0_eslint@7.30.0+typescript@3.9.10
-      '@rushstack/eslint-plugin-security': 0.2.0_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/eslint-plugin': 4.28.5_807ba90a897c15d8025326b0ee53254e
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@3.9.10
+      '@rushstack/eslint-plugin': 0.8.0_eslint@7.30.0+typescript@4.4.3
+      '@rushstack/eslint-plugin-packlets': 0.3.0_eslint@7.30.0+typescript@4.4.3
+      '@rushstack/eslint-plugin-security': 0.2.0_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/eslint-plugin': 4.28.5_d3ea5ea3249d21f2ae3b3071477ae79b
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.3
       eslint: 7.30.0
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.20.6_eslint@7.30.0
       eslint-plugin-tsdoc: 0.2.14
-      typescript: 3.9.10
+      typescript: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4295,13 +4298,13 @@ packages:
       - typescript
     dev: false
 
-  /@rushstack/eslint-plugin-packlets/0.3.0_eslint@7.30.0+typescript@3.9.10:
+  /@rushstack/eslint-plugin-packlets/0.3.0_eslint@7.30.0+typescript@4.4.3:
     resolution: {integrity: sha512-TyB6HtghT9DxzeRM9lsqFsrNI5/mzI8j0ML5dXemfkGriIZS8sr3mIq4AA0WkG/pIzBelsKGM/7sbOX/gvGISA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -4321,13 +4324,13 @@ packages:
       - typescript
     dev: false
 
-  /@rushstack/eslint-plugin-security/0.2.0_eslint@7.30.0+typescript@3.9.10:
+  /@rushstack/eslint-plugin-security/0.2.0_eslint@7.30.0+typescript@4.4.3:
     resolution: {integrity: sha512-S99MIs5U7toN1Gdx2kEmCyDyCL6RaZmtarxAGX9l15lcji9GNRxePmbjvn0CRONtgcyXrQphMiuleYGkLVBG3g==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -4347,39 +4350,39 @@ packages:
       - typescript
     dev: false
 
-  /@rushstack/eslint-plugin/0.8.0_eslint@7.30.0+typescript@3.9.10:
+  /@rushstack/eslint-plugin/0.8.0_eslint@7.30.0+typescript@4.4.3:
     resolution: {integrity: sha512-75qjEio/F/m7O7+p/xNTF72xDiTPUd7KjJeEv9c5V27mQok/Ok6oG9NV3rlpd2RJ8FJndBCDeaLg3T97LzQKLw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/heft-config-file/0.6.1:
-    resolution: {integrity: sha512-fdVFN8qvAdn4YeQr7k9zQ6jWAzwvnuLfiCOK/5gN+2o3iY8M02ntDmNEXuGfH7jBX6yhRga9UjHqKBh5bzoLpA==}
+  /@rushstack/heft-config-file/0.6.6:
+    resolution: {integrity: sha512-XaY2boTJaIE51fDa6oENsRvmLu0SltynyhC9IzYFb1fzEoHOcIuRMr5HIcobhTDCj41UkbIXEv+QinS6c5GCGw==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': 3.39.1
-      '@rushstack/rig-package': 0.2.13
+      '@rushstack/node-core-library': 3.40.2
+      '@rushstack/rig-package': 0.3.0
       jsonpath-plus: 4.0.0
     dev: true
 
-  /@rushstack/heft-jest-plugin/0.1.12_@rushstack+heft@0.34.6:
-    resolution: {integrity: sha512-fqtCIWFOC168LKgL+fKEdnLcvL/pEmnqr1C1ZkdJuztdWCkW8lzmbbKnfEID9ZIItfVgBZI1rTZlPQZDOTKWWQ==}
+  /@rushstack/heft-jest-plugin/0.1.29_@rushstack+heft@0.38.1:
+    resolution: {integrity: sha512-5gURFujqSukHM04LOgZZCjxJ8Wnvr86//LfmSkepbXt1Pqko4JcdTqMFLdfhYKT0486FTiqcnoCSenz5u4rZYQ==}
     peerDependencies:
-      '@rushstack/heft': ^0.34.6
+      '@rushstack/heft': ^0.38.1
     dependencies:
       '@jest/core': 25.4.0
       '@jest/reporters': 25.4.0
       '@jest/transform': 25.4.0
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-config-file': 0.6.1
-      '@rushstack/node-core-library': 3.39.1
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-config-file': 0.6.6
+      '@rushstack/node-core-library': 3.40.2
       jest-config: 25.4.0
       jest-snapshot: 25.4.0
       lodash: 4.17.21
@@ -4390,15 +4393,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@rushstack/heft-node-rig/1.1.11_@rushstack+heft@0.34.6:
-    resolution: {integrity: sha512-UW7YKrmdumdrCfHrno0y5IDwGcvxZ71KIHj4QxDWV6hjdmoFCg2JLxP/HHgjH0GdIuwnSNQiVAdxonXOzu0Lrw==}
+  /@rushstack/heft-node-rig/1.2.13_@rushstack+heft@0.38.1:
+    resolution: {integrity: sha512-nBe+Zk2kZ/+szNxlEX/74mIY6F+7MQ0UgBhnOPoKAgqw2TpRZ8kGlwmVyitWFH8f46/AznmGg5adt91FAdz4+w==}
     peerDependencies:
-      '@rushstack/heft': ^0.34.6
+      '@rushstack/heft': ^0.38.1
     dependencies:
-      '@microsoft/api-extractor': 7.18.2
-      '@rushstack/heft': 0.34.6
-      '@rushstack/heft-jest-plugin': 0.1.12_@rushstack+heft@0.34.6
-      eslint: 7.12.1
+      '@microsoft/api-extractor': 7.18.9
+      '@rushstack/heft': 0.38.1
+      '@rushstack/heft-jest-plugin': 0.1.29_@rushstack+heft@0.38.1
+      eslint: 7.30.0
       typescript: 3.9.10
     transitivePeerDependencies:
       - bufferutil
@@ -4407,25 +4410,22 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@rushstack/heft/0.34.6:
-    resolution: {integrity: sha512-sWncn3SLpCpVZfVjGrRozOzVKzW/CF+xEYk1n9U4d1szmTmYRKfrFjMjgA8Txn5oeUfvoyo2JuILVcb6LFnZBg==}
+  /@rushstack/heft/0.38.1:
+    resolution: {integrity: sha512-fVG1REjEvvuVR0C9Rd0eBXHZNUELakHm0U15q3ZhQSpIvL1UYtQ46+6VSSKoWGjy+FpP1HHl/GiUyyMLTQKJAQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': 0.6.1
-      '@rushstack/node-core-library': 3.39.1
-      '@rushstack/rig-package': 0.2.13
-      '@rushstack/ts-command-line': 4.8.1
-      '@rushstack/typings-generator': 0.3.8
+      '@rushstack/heft-config-file': 0.6.6
+      '@rushstack/node-core-library': 3.40.2
+      '@rushstack/rig-package': 0.3.0
+      '@rushstack/ts-command-line': 4.9.0
+      '@rushstack/typings-generator': 0.3.11
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
       fast-glob: 3.2.7
       glob: 7.0.6
       glob-escape: 0.0.2
-      node-sass: 5.0.0
-      postcss: 7.0.32
-      postcss-modules: 1.5.0
       prettier: 2.3.2
       semver: 7.3.5
       tapable: 1.1.3
@@ -4446,8 +4446,8 @@ packages:
       z-schema: 3.18.4
     dev: false
 
-  /@rushstack/node-core-library/3.39.1:
-    resolution: {integrity: sha512-HHgMEHZTXQ3NjpQzWd5+fSt2Eod9yFwj6qBPbaeaNtDNkOL8wbLoxVimQNtcH0Qhn4wxF5u2NTDNFsxf2yd1jw==}
+  /@rushstack/node-core-library/3.40.2:
+    resolution: {integrity: sha512-wzcRucwnhOENTfx6hZ2M+CA1Zmp8Dr572mFFtjxmcQzBWTbNFRB1Mi1wLb7DLza+69OUBoSZcHUqydlwL+gvSA==}
     dependencies:
       '@types/node': 10.17.13
       colors: 1.2.5
@@ -4467,8 +4467,8 @@ packages:
       strip-json-comments: 3.1.1
     dev: false
 
-  /@rushstack/rig-package/0.2.13:
-    resolution: {integrity: sha512-qQMAFKvfb2ooaWU9DrGIK9d8QfyHy/HiuITJbWenlKgzcDXQvQgEduk57YF4Y7LLasDJ5ZzLaaXwlfX8qCRe5Q==}
+  /@rushstack/rig-package/0.3.0:
+    resolution: {integrity: sha512-Lj6noF7Q4BBm1hKiBDw94e6uZvq1xlBwM/d2cBFaPqXeGdV+G6r3qaCWfRiSXK0pcHpGGpV5Tb2MdfhVcO6G/g==}
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
@@ -4486,8 +4486,8 @@ packages:
       string-argv: 0.3.1
     dev: false
 
-  /@rushstack/ts-command-line/4.8.1:
-    resolution: {integrity: sha512-rmxvYdCNRbyRs+DYAPye3g6lkCkWHleqO40K8UPvUAzFqEuj6+YCVssBiOmrUDCoM5gaegSNT0wFDYhz24DWtw==}
+  /@rushstack/ts-command-line/4.9.0:
+    resolution: {integrity: sha512-kmT8t+JfnvphISF1C5WwY56RefjwgajhSjs9J4ckvAFXZDXR6F5cvF5/RTh7fGCzIomg8esy2PHO/b52zFoZvA==}
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10
@@ -4495,10 +4495,10 @@ packages:
       string-argv: 0.3.1
     dev: true
 
-  /@rushstack/typings-generator/0.3.8:
-    resolution: {integrity: sha512-IiVzwZKlAzAyFIG8SXzBlpZ8EjPDNdioiGcefsIBR4SPXXYoy/HgXdMTj0X1gdpq0Ro4CyRaJ+5Hj+MhQ/OZEA==}
+  /@rushstack/typings-generator/0.3.11:
+    resolution: {integrity: sha512-dDafJz7OCqhVMGqHvdGLFZCne2ejiDqmJiFBL1hOj0hC3u+8Xv0Dcv+Y1I9QsSwllO3wn658F/sfYT9NYrjyxQ==}
     dependencies:
-      '@rushstack/node-core-library': 3.39.1
+      '@rushstack/node-core-library': 3.40.2
       '@types/node': 10.17.13
       chokidar: 3.4.3
       glob: 7.0.6
@@ -6231,7 +6231,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin/4.28.5_807ba90a897c15d8025326b0ee53254e:
+  /@typescript-eslint/eslint-plugin/4.28.5_d3ea5ea3249d21f2ae3b3071477ae79b:
     resolution: {integrity: sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6242,16 +6242,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@3.9.10
-      '@typescript-eslint/scope-manager': 4.28.5_typescript@3.9.10
+      '@typescript-eslint/experimental-utils': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@4.4.3
+      '@typescript-eslint/scope-manager': 4.28.5_typescript@4.4.3
       debug: 4.3.2
       eslint: 7.30.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@3.9.10
-      typescript: 3.9.10
+      tsutils: 3.21.0_typescript@4.4.3
+      typescript: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6288,23 +6288,6 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.30.0+typescript@3.9.10:
-    resolution: {integrity: sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/types': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@3.9.10
-      eslint: 7.30.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   /@typescript-eslint/experimental-utils/4.28.5_eslint@7.30.0+typescript@4.3.5:
     resolution: {integrity: sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -6322,6 +6305,23 @@ packages:
       - supports-color
       - typescript
     dev: false
+
+  /@typescript-eslint/experimental-utils/4.28.5_eslint@7.30.0+typescript@4.4.3:
+    resolution: {integrity: sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/types': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.3
+      eslint: 7.30.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.30.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   /@typescript-eslint/parser/3.4.0_eslint@7.12.1+typescript@3.9.10:
     resolution: {integrity: sha512-ZUGI/de44L5x87uX5zM14UYcbn79HSXUR+kzcqU42gH0AgpdB/TjuJy3m4ezI7Q/jk3wTQd755mxSDLhQP79KA==}
@@ -6343,25 +6343,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/4.28.5_eslint@7.30.0+typescript@3.9.10:
-    resolution: {integrity: sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/types': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/typescript-estree': 4.28.5_typescript@3.9.10
-      debug: 4.3.2
-      eslint: 7.30.0
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
-
   /@typescript-eslint/parser/4.28.5_eslint@7.30.0+typescript@4.3.5:
     resolution: {integrity: sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -6382,14 +6363,24 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/4.28.5_typescript@3.9.10:
-    resolution: {integrity: sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+  /@typescript-eslint/parser/4.28.5_eslint@7.30.0+typescript@4.4.3:
+    resolution: {integrity: sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@typescript-eslint/types': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/visitor-keys': 4.28.5_typescript@3.9.10
+      '@typescript-eslint/scope-manager': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/types': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/typescript-estree': 4.28.5_typescript@4.4.3
+      debug: 4.3.2
+      eslint: 7.30.0
+      typescript: 4.4.3
     transitivePeerDependencies:
-      - typescript
+      - supports-color
 
   /@typescript-eslint/scope-manager/4.28.5_typescript@4.3.5:
     resolution: {integrity: sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==}
@@ -6397,6 +6388,15 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.28.5_typescript@4.3.5
       '@typescript-eslint/visitor-keys': 4.28.5_typescript@4.3.5
+    transitivePeerDependencies:
+      - typescript
+
+  /@typescript-eslint/scope-manager/4.28.5_typescript@4.4.3:
+    resolution: {integrity: sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dependencies:
+      '@typescript-eslint/types': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/visitor-keys': 4.28.5_typescript@4.4.3
     transitivePeerDependencies:
       - typescript
 
@@ -6409,14 +6409,6 @@ packages:
       typescript: 3.9.10
     dev: false
 
-  /@typescript-eslint/types/4.28.5_typescript@3.9.10:
-    resolution: {integrity: sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      typescript: 3.9.10
-
   /@typescript-eslint/types/4.28.5_typescript@4.3.5:
     resolution: {integrity: sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -6424,6 +6416,14 @@ packages:
       typescript: '*'
     dependencies:
       typescript: 4.3.5
+
+  /@typescript-eslint/types/4.28.5_typescript@4.4.3:
+    resolution: {integrity: sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      typescript: 4.4.3
 
   /@typescript-eslint/typescript-estree/3.10.1_typescript@3.9.10:
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
@@ -6468,26 +6468,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/4.28.5_typescript@3.9.10:
-    resolution: {integrity: sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.28.5_typescript@3.9.10
-      '@typescript-eslint/visitor-keys': 4.28.5_typescript@3.9.10
-      debug: 4.3.2
-      globby: 11.0.4
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@3.9.10
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
-
   /@typescript-eslint/typescript-estree/4.28.5_typescript@4.3.5:
     resolution: {integrity: sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -6508,6 +6488,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/typescript-estree/4.28.5_typescript@4.4.3:
+    resolution: {integrity: sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.28.5_typescript@4.4.3
+      '@typescript-eslint/visitor-keys': 4.28.5_typescript@4.4.3
+      debug: 4.3.2
+      globby: 11.0.4
+      is-glob: 4.0.1
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.4.3
+      typescript: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/visitor-keys/3.10.1:
     resolution: {integrity: sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -6515,20 +6515,20 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: false
 
-  /@typescript-eslint/visitor-keys/4.28.5_typescript@3.9.10:
-    resolution: {integrity: sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': 4.28.5_typescript@3.9.10
-      eslint-visitor-keys: 2.1.0
-    transitivePeerDependencies:
-      - typescript
-
   /@typescript-eslint/visitor-keys/4.28.5_typescript@4.3.5:
     resolution: {integrity: sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
       '@typescript-eslint/types': 4.28.5_typescript@4.3.5
+      eslint-visitor-keys: 2.1.0
+    transitivePeerDependencies:
+      - typescript
+
+  /@typescript-eslint/visitor-keys/4.28.5_typescript@4.4.3:
+    resolution: {integrity: sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==}
+    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dependencies:
+      '@typescript-eslint/types': 4.28.5_typescript@4.4.3
       eslint-visitor-keys: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -7603,6 +7603,7 @@ packages:
 
   /big.js/3.2.0:
     resolution: {integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==}
+    dev: false
 
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -8614,6 +8615,7 @@ packages:
       postcss-modules-local-by-default: 1.2.0
       postcss-modules-scope: 1.1.0
       postcss-modules-values: 1.3.0
+    dev: false
 
   /css-select/4.1.3:
     resolution: {integrity: sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==}
@@ -8629,6 +8631,7 @@ packages:
     dependencies:
       cssesc: 3.0.0
       fastparse: 1.1.2
+    dev: false
 
   /css-what/5.0.1:
     resolution: {integrity: sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==}
@@ -9134,6 +9137,7 @@ packages:
   /emojis-list/2.1.0:
     resolution: {integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=}
     engines: {node: '>= 0.10'}
+    dev: false
 
   /emojis-list/3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -9464,6 +9468,7 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint/7.30.0:
     resolution: {integrity: sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==}
@@ -9843,6 +9848,7 @@ packages:
 
   /fastparse/1.1.2:
     resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
+    dev: false
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -9888,6 +9894,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       flat-cache: 2.0.1
+    dev: false
 
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -10042,6 +10049,7 @@ packages:
       flatted: 2.0.2
       rimraf: 2.6.3
       write: 1.0.3
+    dev: false
 
   /flat-cache/3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
@@ -10056,6 +10064,7 @@ packages:
 
   /flatted/2.0.2:
     resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
+    dev: false
 
   /flatted/3.2.2:
     resolution: {integrity: sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==}
@@ -10299,6 +10308,7 @@ packages:
     resolution: {integrity: sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==}
     dependencies:
       loader-utils: 1.1.0
+    dev: false
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -10494,6 +10504,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.8.1
+    dev: false
 
   /globals/13.11.0:
     resolution: {integrity: sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==}
@@ -10631,6 +10642,7 @@ packages:
   /has-flag/1.0.0:
     resolution: {integrity: sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /has-flag/3.0.0:
     resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
@@ -11044,6 +11056,7 @@ packages:
 
   /icss-replace-symbols/1.1.0:
     resolution: {integrity: sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=}
+    dev: false
 
   /icss-utils/4.1.1:
     resolution: {integrity: sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==}
@@ -12369,6 +12382,7 @@ packages:
   /json5/0.5.1:
     resolution: {integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=}
     hasBin: true
+    dev: false
 
   /json5/1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
@@ -12587,6 +12601,7 @@ packages:
       big.js: 3.2.0
       emojis-list: 2.1.0
       json5: 0.5.1
+    dev: false
 
   /loader-utils/1.4.0:
     resolution: {integrity: sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==}
@@ -12627,6 +12642,7 @@ packages:
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
+    dev: false
 
   /lodash.clonedeep/4.5.0:
     resolution: {integrity: sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=}
@@ -13989,6 +14005,7 @@ packages:
     resolution: {integrity: sha1-thTJcgvmgW6u41+zpfqh26agXds=}
     dependencies:
       postcss: 6.0.1
+    dev: false
 
   /postcss-modules-extract-imports/2.0.0:
     resolution: {integrity: sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==}
@@ -14002,6 +14019,7 @@ packages:
     dependencies:
       css-selector-tokenizer: 0.7.3
       postcss: 6.0.1
+    dev: false
 
   /postcss-modules-local-by-default/3.0.3:
     resolution: {integrity: sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==}
@@ -14018,6 +14036,7 @@ packages:
     dependencies:
       css-selector-tokenizer: 0.7.3
       postcss: 6.0.1
+    dev: false
 
   /postcss-modules-scope/2.2.0:
     resolution: {integrity: sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==}
@@ -14032,6 +14051,7 @@ packages:
     dependencies:
       icss-replace-symbols: 1.1.0
       postcss: 6.0.1
+    dev: false
 
   /postcss-modules-values/3.0.0:
     resolution: {integrity: sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==}
@@ -14048,6 +14068,7 @@ packages:
       lodash.camelcase: 4.3.0
       postcss: 7.0.32
       string-hash: 1.1.3
+    dev: false
 
   /postcss-selector-parser/6.0.6:
     resolution: {integrity: sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==}
@@ -14068,6 +14089,7 @@ packages:
       chalk: 1.1.3
       source-map: 0.5.7
       supports-color: 3.2.3
+    dev: false
 
   /postcss/7.0.32:
     resolution: {integrity: sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==}
@@ -15524,6 +15546,7 @@ packages:
       ansi-styles: 3.2.1
       astral-regex: 1.0.0
       is-fullwidth-code-point: 2.0.0
+    dev: false
 
   /slice-ansi/4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
@@ -15850,6 +15873,7 @@ packages:
 
   /string-hash/1.1.3:
     resolution: {integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=}
+    dev: false
 
   /string-length/3.1.0:
     resolution: {integrity: sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==}
@@ -16050,6 +16074,7 @@ packages:
     engines: {node: '>=0.8.0'}
     dependencies:
       has-flag: 1.0.0
+    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -16103,6 +16128,7 @@ packages:
       lodash: 4.17.21
       slice-ansi: 2.1.0
       string-width: 3.1.0
+    dev: false
 
   /table/6.7.1:
     resolution: {integrity: sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==}
@@ -16465,7 +16491,7 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: true
 
-  /ts-loader/6.0.0_typescript@3.9.10:
+  /ts-loader/6.0.0_typescript@4.4.3:
     resolution: {integrity: sha512-lszy+D41R0Te2+loZxADWS+E1+Z55A+i3dFfFie1AZHL++65JRKVDBPQgeWgRrlv5tbxdU3zOtXp8b7AFR6KEg==}
     engines: {node: '>=8.6'}
     peerDependencies:
@@ -16476,7 +16502,7 @@ packages:
       loader-utils: 1.1.0
       micromatch: 4.0.4
       semver: 6.3.0
-      typescript: 3.9.10
+      typescript: 4.4.3
     dev: false
 
   /ts-pnp/1.2.0_typescript@4.3.5:
@@ -16501,11 +16527,23 @@ packages:
     resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
     peerDependencies:
       tslint: ^5.1.0
-      typescript: ^2.1.0 || ^3.0.0
+      typescript: '*'
     dependencies:
       tslint: 5.20.1_typescript@3.9.10
       tsutils: 2.28.0_typescript@3.9.10
       typescript: 3.9.10
+    dev: false
+
+  /tslint-microsoft-contrib/6.2.0_tslint@5.20.1+typescript@4.4.3:
+    resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
+    peerDependencies:
+      tslint: ^5.1.0
+      typescript: '*'
+    dependencies:
+      tslint: 5.20.1_typescript@4.4.3
+      tsutils: 2.28.0_typescript@4.4.3
+      typescript: 4.4.3
+    dev: true
 
   /tslint/5.20.1_typescript@3.9.10:
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
@@ -16528,6 +16566,30 @@ packages:
       tslib: 1.14.1
       tsutils: 2.29.0_typescript@3.9.10
       typescript: 3.9.10
+    dev: false
+
+  /tslint/5.20.1_typescript@4.4.3:
+    resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
+    engines: {node: '>=4.8.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      builtin-modules: 1.1.1
+      chalk: 2.4.2
+      commander: 2.20.3
+      diff: 4.0.2
+      glob: 7.1.7
+      js-yaml: 3.13.1
+      minimatch: 3.0.4
+      mkdirp: 0.5.5
+      resolve: 1.17.0
+      semver: 5.7.1
+      tslib: 1.14.1
+      tsutils: 2.29.0_typescript@4.4.3
+      typescript: 4.4.3
+    dev: true
 
   /tsutils/2.28.0_typescript@3.9.10:
     resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
@@ -16536,6 +16598,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 3.9.10
+    dev: false
+
+  /tsutils/2.28.0_typescript@4.4.3:
+    resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.4.3
+    dev: true
 
   /tsutils/2.29.0_typescript@3.9.10:
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
@@ -16544,6 +16616,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 3.9.10
+    dev: false
+
+  /tsutils/2.29.0_typescript@4.4.3:
+    resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.4.3
+    dev: true
 
   /tsutils/3.21.0_typescript@3.9.10:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -16553,6 +16635,7 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 3.9.10
+    dev: false
 
   /tsutils/3.21.0_typescript@4.3.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -16562,6 +16645,15 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.3.5
+
+  /tsutils/3.21.0_typescript@4.4.3:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.4.3
 
   /tty-browserify/0.0.0:
     resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}
@@ -16645,6 +16737,12 @@ packages:
 
   /typescript/4.3.5:
     resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.4.3:
+    resolution: {integrity: sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 
@@ -17633,6 +17731,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       mkdirp: 0.5.5
+    dev: false
 
   /ws/6.2.2:
     resolution: {integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "31a9a242f3375c49722325d80345e36c7933f979",
-  "preferredVersionsHash": "1fbc26d2c5b3248616b9edccd6bef064075243bc"
+  "pnpmShrinkwrapHash": "4d6b1ad3a4913a31e38abf32d94ee577abce84bb",
+  "preferredVersionsHash": "fe0ea762c60633ea39d8abd6f7e0791352654f89"
 }

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -37,6 +37,6 @@
     "@types/node": "10.17.13",
     "eslint": "~7.30.0",
     "jest-environment-node": "~25.4.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/heft-plugins/heft-jest-plugin/src/HeftJestDataFile.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestDataFile.ts
@@ -62,7 +62,7 @@ export class HeftJestDataFile {
     try {
       dataFile = await JsonFile.loadAsync(jsonFilePath);
     } catch (e) {
-      if (FileSystem.isFileDoesNotExistError(e)) {
+      if (FileSystem.isFileDoesNotExistError(e as Error)) {
         throw new Error(
           `Could not find the Jest TypeScript data file at "${jsonFilePath}". Was the compiler invoked?`
         );

--- a/heft-plugins/heft-jest-plugin/src/jest-build-transform.ts
+++ b/heft-plugins/heft-jest-plugin/src/jest-build-transform.ts
@@ -131,7 +131,7 @@ export function process(
     try {
       libCode = FileSystem.readFile(libFilePath);
     } catch (error) {
-      if (FileSystem.isNotExistError(error)) {
+      if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(
           'jest-build-transform: The expected transpiler output file does not exist:\n' + libFilePath
         );
@@ -146,7 +146,7 @@ export function process(
     try {
       originalSourceMap = FileSystem.readFile(sourceMapFilePath);
     } catch (error) {
-      if (FileSystem.isNotExistError(error)) {
+      if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(
           'jest-build-transform: The source map file is missing -- check your tsconfig.json settings:\n' +
             sourceMapFilePath

--- a/heft-plugins/heft-jest-plugin/src/jestWorkerPatch.ts
+++ b/heft-plugins/heft-jest-plugin/src/jestWorkerPatch.ts
@@ -124,7 +124,7 @@ function applyPatch(): void {
   } catch (e) {
     console.error();
     console.error(`ERROR: ${patchName} failed to patch the "jest-worker" package:`);
-    console.error(e.toString());
+    console.error((e as Error).toString());
     console.error();
 
     throw e;

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -34,6 +34,6 @@
     "@types/node": "10.17.13",
     "@types/node-sass": "4.11.1",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/heft-plugins/heft-sass-plugin/src/utilities/Async.ts
+++ b/heft-plugins/heft-sass-plugin/src/utilities/Async.ts
@@ -8,7 +8,7 @@ export class Async {
     try {
       fn().catch((e) => scopedLogger.emitError(e));
     } catch (e) {
-      scopedLogger.emitError(e);
+      scopedLogger.emitError(e as Error);
     }
   }
 }

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -158,7 +158,7 @@ export class StorybookPlugin implements IHeftPlugin<IStorybookPluginOptions> {
         baseFolderPath: heftConfiguration.buildFolder
       });
     } catch (ex) {
-      throw new Error(`The ${TASK_NAME} task cannot start: ` + ex.message);
+      throw new Error(`The ${TASK_NAME} task cannot start: ` + (ex as Error).message);
     }
 
     this._logger.terminal.writeVerboseLine(`Found "${this._storykitPackageName}" in ` + storykitFolder);
@@ -180,7 +180,7 @@ export class StorybookPlugin implements IHeftPlugin<IStorybookPluginOptions> {
         baseFolderPath: storykitModuleFolder
       });
     } catch (ex) {
-      throw new Error(`The ${TASK_NAME} task cannot start: ` + ex.message);
+      throw new Error(`The ${TASK_NAME} task cannot start: ` + (ex as Error).message);
     }
     this._logger.terminal.writeVerboseLine(
       `Resolved startupModulePath is "${this._resolvedStartupModulePath}"`

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -59,7 +59,7 @@ export class WebpackConfigurationLoader {
         );
       }
     } catch (error) {
-      logger.emitError(error);
+      logger.emitError(error as Error);
     }
 
     if (webpackConfigJs) {

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
@@ -230,7 +230,7 @@ export class WebpackPlugin implements IHeftPlugin {
             {}
           );
         } catch (e) {
-          logger.emitError(e);
+          logger.emitError(e as Error);
         }
       } else {
         try {
@@ -238,7 +238,7 @@ export class WebpackPlugin implements IHeftPlugin {
             (compiler as WebpackCompiler).run.bind(compiler)
           );
         } catch (e) {
-          logger.emitError(e);
+          logger.emitError(e as Error);
         }
       }
 

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
@@ -59,7 +59,7 @@ export class WebpackConfigurationLoader {
         );
       }
     } catch (error) {
-      logger.emitError(error);
+      logger.emitError(error as Error);
     }
 
     if (webpackConfigJs) {

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -238,7 +238,7 @@ export class WebpackPlugin implements IHeftPlugin {
             {}
           );
         } catch (e) {
-          logger.emitError(e);
+          logger.emitError(e as Error);
         }
       } else {
         try {
@@ -247,7 +247,7 @@ export class WebpackPlugin implements IHeftPlugin {
           );
           await LegacyAdapters.convertCallbackToPromise(compiler.close.bind(compiler));
         } catch (e) {
-          logger.emitError(e);
+          logger.emitError(e as Error);
         }
       }
 

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13"
   }

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -241,7 +241,7 @@ export class ConfigurationFile<TConfigurationFile> {
     try {
       return await this.loadConfigurationFileForProjectAsync(terminal, projectPath, rigConfig);
     } catch (e) {
-      if (FileSystem.isNotExistError(e)) {
+      if (FileSystem.isNotExistError(e as Error)) {
         return undefined;
       }
       throw e;
@@ -339,7 +339,7 @@ export class ConfigurationFile<TConfigurationFile> {
     try {
       fileText = await FileSystem.readFileAsync(resolvedConfigurationFilePath);
     } catch (e) {
-      if (FileSystem.isNotExistError(e)) {
+      if (FileSystem.isNotExistError(e as Error)) {
         if (rigConfig) {
           terminal.writeDebugLine(
             `Config file "${resolvedConfigurationFilePathForLogging}" does not exist. Attempting to load via rig.`
@@ -358,7 +358,7 @@ export class ConfigurationFile<TConfigurationFile> {
           );
         }
 
-        e.message = `File does not exist: ${resolvedConfigurationFilePathForLogging}`;
+        (e as Error).message = `File does not exist: ${resolvedConfigurationFilePathForLogging}`;
       }
 
       throw e;
@@ -409,7 +409,7 @@ export class ConfigurationFile<TConfigurationFile> {
           undefined
         );
       } catch (e) {
-        if (FileSystem.isNotExistError(e)) {
+        if (FileSystem.isNotExistError(e as Error)) {
           throw new Error(
             `In file "${resolvedConfigurationFilePathForLogging}", file referenced in "extends" property ` +
               `("${configurationJson.extends}") cannot be resolved.`
@@ -567,7 +567,7 @@ export class ConfigurationFile<TConfigurationFile> {
         );
       } catch (e) {
         // Ignore cases where a configuration file doesn't exist in a rig
-        if (!FileSystem.isNotExistError(e)) {
+        if (!FileSystem.isNotExistError(e as Error)) {
           throw e;
         } else {
           terminal.writeDebugLine(

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -24,8 +24,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/fs-extra": "7.0.0",
     "@types/heft-jest": "1.0.1",
     "@types/jju": "1.4.1",

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -84,7 +84,7 @@ export class Async {
     callback: (entry: TEntry, arrayIndex: number) => Promise<void>,
     options?: IAsyncParallelismOptions | undefined
   ): Promise<void> {
-    await new Promise((resolve: () => void, reject: (error: Error) => void) => {
+    await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
       const concurrency: number =
         options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
       let operationsInProgress: number = 1;
@@ -104,7 +104,7 @@ export class Async {
                 .then(() => onOperationCompletion())
                 .catch(reject);
             } catch (error) {
-              reject(error);
+              reject(error as Error);
             }
           } else {
             break;

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -517,7 +517,7 @@ export class FileSystem {
         fsx.moveSync(options.sourcePath, options.destinationPath, { overwrite: options.overwrite });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -545,7 +545,7 @@ export class FileSystem {
         await fsx.move(options.sourcePath, options.destinationPath, { overwrite: options.overwrite });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -708,7 +708,7 @@ export class FileSystem {
         fsx.writeFileSync(filePath, contents, { encoding: options.encoding });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -744,7 +744,7 @@ export class FileSystem {
         await fsx.writeFile(filePath, contents, { encoding: options.encoding });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -786,7 +786,7 @@ export class FileSystem {
         fsx.appendFileSync(filePath, contents, { encoding: options.encoding });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -822,7 +822,7 @@ export class FileSystem {
         await fsx.appendFile(filePath, contents, { encoding: options.encoding });
       } catch (error) {
         if (options.ensureFolderExists) {
-          if (!FileSystem.isNotExistError(error)) {
+          if (!FileSystem.isNotExistError(error as Error)) {
             throw error;
           }
 
@@ -1013,7 +1013,7 @@ export class FileSystem {
       try {
         fsx.unlinkSync(filePath);
       } catch (error) {
-        if (options.throwIfNotExists || !FileSystem.isNotExistError(error)) {
+        if (options.throwIfNotExists || !FileSystem.isNotExistError(error as Error)) {
           throw error;
         }
       }
@@ -1036,7 +1036,7 @@ export class FileSystem {
       try {
         await fsx.unlink(filePath);
       } catch (error) {
-        if (options.throwIfNotExists || !FileSystem.isNotExistError(error)) {
+        if (options.throwIfNotExists || !FileSystem.isNotExistError(error as Error)) {
           throw error;
         }
       }
@@ -1313,7 +1313,7 @@ export class FileSystem {
     try {
       linkFn();
     } catch (error) {
-      if (FileSystem.isExistError(error)) {
+      if (FileSystem.isExistError(error as Error)) {
         // Link exists, handle it
         switch (options.alreadyExistsBehavior) {
           case AlreadyExistsBehavior.Ignore:
@@ -1334,7 +1334,7 @@ export class FileSystem {
         // retrying. There are also cases where the target file must exist, so validate in
         // those cases to avoid confusing the missing directory with the missing target file.
         if (
-          FileSystem.isNotExistError(error) &&
+          FileSystem.isNotExistError(error as Error) &&
           (!options.linkTargetMustExist || FileSystem.exists(options.linkTargetPath))
         ) {
           this.ensureFolder(nodeJsPath.dirname(options.newLinkPath));
@@ -1353,7 +1353,7 @@ export class FileSystem {
     try {
       await linkFn();
     } catch (error) {
-      if (FileSystem.isExistError(error)) {
+      if (FileSystem.isExistError(error as Error)) {
         // Link exists, handle it
         switch (options.alreadyExistsBehavior) {
           case AlreadyExistsBehavior.Ignore:
@@ -1374,7 +1374,7 @@ export class FileSystem {
         // retrying. There are also cases where the target file must exist, so validate in
         // those cases to avoid confusing the missing directory with the missing target file.
         if (
-          FileSystem.isNotExistError(error) &&
+          FileSystem.isNotExistError(error as Error) &&
           (!options.linkTargetMustExist || (await FileSystem.existsAsync(options.linkTargetPath)))
         ) {
           await this.ensureFolderAsync(nodeJsPath.dirname(options.newLinkPath));
@@ -1390,7 +1390,7 @@ export class FileSystem {
     try {
       return fn();
     } catch (error) {
-      FileSystem._updateErrorMessage(error);
+      FileSystem._updateErrorMessage(error as Error);
       throw error;
     }
   }
@@ -1399,7 +1399,7 @@ export class FileSystem {
     try {
       return await fn();
     } catch (error) {
-      FileSystem._updateErrorMessage(error);
+      FileSystem._updateErrorMessage(error as Error);
       throw error;
     }
   }

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -118,11 +118,11 @@ export class JsonFile {
       const contents: string = FileSystem.readFile(jsonFilename);
       return jju.parse(contents);
     } catch (error) {
-      if (FileSystem.isNotExistError(error)) {
+      if (FileSystem.isNotExistError(error as Error)) {
         throw error;
       } else {
         throw new Error(
-          `Error reading "${JsonFile._formatPathForError(jsonFilename)}":` + os.EOL + `  ${error.message}`
+          `Error reading "${JsonFile._formatPathForError(jsonFilename)}":` + os.EOL + `  ${(error as Error).message}`
         );
       }
     }
@@ -136,11 +136,11 @@ export class JsonFile {
       const contents: string = await FileSystem.readFileAsync(jsonFilename);
       return jju.parse(contents);
     } catch (error) {
-      if (FileSystem.isNotExistError(error)) {
+      if (FileSystem.isNotExistError(error as Error)) {
         throw error;
       } else {
         throw new Error(
-          `Error reading "${JsonFile._formatPathForError(jsonFilename)}":` + os.EOL + `  ${error.message}`
+          `Error reading "${JsonFile._formatPathForError(jsonFilename)}":` + os.EOL + `  ${(error as Error).message}`
         );
       }
     }
@@ -294,7 +294,7 @@ export class JsonFile {
       try {
         oldBuffer = FileSystem.readFileToBuffer(jsonFilename);
       } catch (error) {
-        if (!FileSystem.isNotExistError(error)) {
+        if (!FileSystem.isNotExistError(error as Error)) {
           throw error;
         }
       }
@@ -352,7 +352,7 @@ export class JsonFile {
       try {
         oldBuffer = await FileSystem.readFileToBufferAsync(jsonFilename);
       } catch (error) {
-        if (!FileSystem.isNotExistError(error)) {
+        if (!FileSystem.isNotExistError(error as Error)) {
           throw error;
         }
       }

--- a/libraries/node-core-library/src/LegacyAdapters.ts
+++ b/libraries/node-core-library/src/LegacyAdapters.ts
@@ -81,7 +81,7 @@ export class LegacyAdapters {
           fn(cb);
         }
       } catch (e) {
-        reject(e);
+        reject(e as Error);
       }
     });
   }

--- a/libraries/package-deps-hash/src/test/getPackageDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getPackageDeps.test.ts
@@ -140,7 +140,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -173,7 +173,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -200,7 +200,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -228,7 +228,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -278,7 +278,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -309,7 +309,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -340,7 +340,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -371,7 +371,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();
@@ -402,7 +402,7 @@ describe('getPackageDeps', () => {
 
       filePaths.forEach((filePath) => expect(results.get(filePath)).toEqual(expectedFiles[filePath]));
     } catch (e) {
-      return _done(e);
+      return _done(e as Error);
     }
 
     _done();

--- a/libraries/rig-package/package.json
+++ b/libraries/rig-package/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft-node-rig": "1.1.11",
-    "@rushstack/heft": "0.34.6",
+    "@rushstack/heft-node-rig": "1.2.13",
+    "@rushstack/heft": "0.38.1",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13",
     "@types/resolve": "1.17.1",

--- a/libraries/rig-package/src/RigConfig.ts
+++ b/libraries/rig-package/src/RigConfig.ts
@@ -230,7 +230,7 @@ export class RigConfig {
       }
       RigConfig._validateSchema(json);
     } catch (error) {
-      config = RigConfig._handleConfigError(error, projectFolderPath, rigConfigFilePath);
+      config = RigConfig._handleConfigError(error as Error, projectFolderPath, rigConfigFilePath);
     }
 
     if (!config) {
@@ -275,7 +275,7 @@ export class RigConfig {
 
       RigConfig._validateSchema(json);
     } catch (error) {
-      config = RigConfig._handleConfigError(error, projectFolderPath, rigConfigFilePath);
+      config = RigConfig._handleConfigError(error as Error, projectFolderPath, rigConfigFilePath);
     }
 
     if (!config) {

--- a/libraries/rushell/src/test/Parser.test.ts
+++ b/libraries/rushell/src/test/Parser.test.ts
@@ -26,7 +26,7 @@ function matchErrorSnapshot(input: string): void {
   try {
     parser.parse();
   } catch (e) {
-    error = e;
+    error = e as Error;
   }
   expect({
     input: escape(tokenizer.input.toString()),

--- a/libraries/terminal/src/SplitterTransform.ts
+++ b/libraries/terminal/src/SplitterTransform.ts
@@ -51,7 +51,7 @@ export class SplitterTransform extends TerminalWritable {
         try {
           destination.close();
         } catch (error) {
-          errors.push(error);
+          errors.push(error as Error);
         }
       }
     }

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -14,10 +14,10 @@
   "dependencies": {},
   "devDependencies": {
     "@rushstack/eslint-config": "2.4.0",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/heft-jest": "1.0.1",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/heft-jest": "1.0.1",
     "@types/node": "10.17.13"
   }

--- a/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
+++ b/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
@@ -39,7 +39,7 @@ export class EnvironmentVariableParser {
           throw new Error(
             `The ${environmentValue} environment variable value looks like a JSON array` +
               ` but failed to parse: ` +
-              ex.message
+              (ex as Error).message
           );
         }
       } else {

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -155,7 +155,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
           process.exitCode = err.exitCode;
         }
       } else {
-        let message: string = (err.message || 'An unknown error occurred').trim();
+        let message: string = ((err as Error).message || 'An unknown error occurred').trim();
 
         // If the message doesn't already start with "Error:" then add a prefix
         if (!/^(error|internal error|warning)\b/i.test(message)) {

--- a/libraries/typings-generator/package.json
+++ b/libraries/typings-generator/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/glob": "7.1.1"
   }
 }

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -17,7 +17,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -19,7 +19,7 @@
     "@rushstack/heft-sass-plugin": "workspace:*",
     "@rushstack/heft-webpack4-plugin": "workspace:*",
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/stack/eslint-config/package.json
+++ b/stack/eslint-config/package.json
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "eslint": "~7.30.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.4.2"
   }
 }

--- a/stack/eslint-patch/package.json
+++ b/stack/eslint-patch/package.json
@@ -23,8 +23,8 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/node": "10.17.13"
   }
 }

--- a/stack/eslint-plugin-packlets/package.json
+++ b/stack/eslint-plugin-packlets/package.json
@@ -26,8 +26,8 @@
     "eslint": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/eslint": "7.2.0",
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",

--- a/stack/eslint-plugin-packlets/src/readme.ts
+++ b/stack/eslint-plugin-packlets/src/readme.ts
@@ -97,7 +97,7 @@ const readme: TSESLint.RuleModule<MessageIds, Options> = {
               context.report({
                 node: node,
                 messageId: 'error-reading-file',
-                data: { readmePath, errorMessage: error.toString() }
+                data: { readmePath, errorMessage: (error as Error).toString() }
               });
             }
           }

--- a/stack/eslint-plugin-security/package.json
+++ b/stack/eslint-plugin-security/package.json
@@ -25,8 +25,8 @@
     "eslint": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/eslint": "7.2.0",
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",

--- a/stack/eslint-plugin/package.json
+++ b/stack/eslint-plugin/package.json
@@ -29,8 +29,8 @@
     "eslint": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.34.6",
-    "@rushstack/heft-node-rig": "1.1.11",
+    "@rushstack/heft": "0.38.1",
+    "@rushstack/heft-node-rig": "1.2.13",
     "@types/eslint": "7.2.0",
     "@types/estree": "0.0.44",
     "@types/heft-jest": "1.0.1",

--- a/webpack/localization-plugin/src/LocalizationPlugin.ts
+++ b/webpack/localization-plugin/src/LocalizationPlugin.ts
@@ -511,7 +511,7 @@ export class LocalizationPlugin implements Webpack.Plugin {
           localizedResourcePath
         );
       } catch (e) {
-        errors.push(e);
+        errors.push(e as Error);
       }
 
       if (resolvedTranslatedData) {


### PR DESCRIPTION
## Summary

Updates the required version of TypeScript to 4.4.2.

## Details

Projects that currently depend on packages like `api-extractor` can't use the new `useUnknownInCatchVariables` compiler option, because the version of TypeScript is set to 4.3.5. These changes update to 4.4.2.