### PR TITLE
Lock node-fetch to avoid breaking change in 2.6.3 version

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -42,7 +42,7 @@
     "jszip": "~3.7.1",
     "lodash": "~4.17.15",
     "minimatch": "~3.0.2",
-    "node-fetch": "~2.6.1",
+    "node-fetch": "2.6.2",
     "npm-package-arg": "~6.1.0",
     "npm-packlist": "~2.1.2",
     "read-package-tree": "~5.1.5",

--- a/common/changes/@microsoft/rush/lock-node-fetch_2021-09-21-05-46.json
+++ b/common/changes/@microsoft/rush/lock-node-fetch_2021-09-21-05-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Lock node-fetch dependency to 2.6.2 to an incompatibility with 2.6.3 in the Azure Cloud Cache Provider.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -261,7 +261,7 @@ importers:
       jszip: ~3.7.1
       lodash: ~4.17.15
       minimatch: ~3.0.2
-      node-fetch: ~2.6.1
+      node-fetch: 2.6.2
       npm-package-arg: ~6.1.0
       npm-packlist: ~2.1.2
       read-package-tree: ~5.1.5

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "171fa57abd1dd8bfa5a39da755ea3bc206057cf0",
+  "pnpmShrinkwrapHash": "31a9a242f3375c49722325d80345e36c7933f979",
   "preferredVersionsHash": "1fbc26d2c5b3248616b9edccd6bef064075243bc"
 }


### PR DESCRIPTION
## Summary
Version 2.6.3 of `node-fetch` made a breaking change to the encoding state of URLs that is incompatible with the expectations of `@azure/core-http` with regards to including SAS tokens in URLs. This locks the version used by Rush to 2.6.2 to avoid breaking customers who use the Azure cloud cache provider.

## How it was tested
Verified locally that installing with node-fetch 2.6.2 does not reproduce the authentication error encountered during cloud cache writes. Fresh installs started failing ~7 hours ago, which lines up with when version 2.6.3 of node-fetch was released.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
