### PR TITLE
[heft] Fix directory separators in generated tsBuildInfoFile

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -147,7 +147,9 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         .replace(/\+/g, '-')
         .replace(/\//g, '_');
 
-      this.__tsCacheFilePath = `${this._configuration.buildMetadataFolder}/ts_${serializedConfigHash}.json`;
+      // Paranoia. If backslashes sneak it in breaks incremental compilation
+      const normalizedCacheFolder: string = Path.convertToSlashes(this._configuration.buildMetadataFolder);
+      this.__tsCacheFilePath = `${normalizedCacheFolder}/ts_${serializedConfigHash}.json`;
     }
 
     return this.__tsCacheFilePath;

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -147,7 +147,9 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
         .replace(/\+/g, '-')
         .replace(/\//g, '_');
 
-      // Paranoia. If backslashes sneak it in breaks incremental compilation
+      // This conversion is theoretically redundant, but it is here to make absolutely sure that the path is formatted
+      // using only '/' as the directory separator so that incremental builds don't break on Windows.
+      // TypeScript will normalize to '/' when serializing, but not on the direct input, and uses exact string equality.
       const normalizedCacheFolder: string = Path.convertToSlashes(this._configuration.buildMetadataFolder);
       this.__tsCacheFilePath = `${normalizedCacheFolder}/ts_${serializedConfigHash}.json`;
     }

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { Terminal, FileSystem } from '@rushstack/node-core-library';
+import { Terminal, FileSystem, Path } from '@rushstack/node-core-library';
 
 import { TypeScriptBuilder, ITypeScriptBuilderConfiguration } from './TypeScriptBuilder';
 import { HeftSession } from '../../pluginFramework/HeftSession';
@@ -205,7 +205,9 @@ export class TypeScriptPlugin implements IHeftPlugin {
 
     const { project = './tsconfig.json' } = typescriptConfigurationJson || {};
 
-    const tsconfigFilePath: string = path.resolve(heftConfiguration.buildFolder, project);
+    const tsconfigFilePath: string = Path.convertToSlashes(
+      path.resolve(heftConfiguration.buildFolder, project)
+    );
     logger.terminal.writeVerboseLine(`Looking for tsconfig at ${tsconfigFilePath}`);
     buildProperties.isTypeScriptProject = await FileSystem.existsAsync(tsconfigFilePath);
     if (!buildProperties.isTypeScriptProject) {
@@ -237,7 +239,7 @@ export class TypeScriptPlugin implements IHeftPlugin {
 
     const typeScriptBuilderConfiguration: ITypeScriptBuilderConfiguration = {
       buildFolder: heftConfiguration.buildFolder,
-      buildMetadataFolder: path.join(heftConfiguration.buildFolder, 'temp'),
+      buildMetadataFolder: Path.convertToSlashes(`${heftConfiguration.buildFolder}/temp}`),
       typeScriptToolPath: toolPackageResolution.typeScriptPackagePath!,
       tslintToolPath: toolPackageResolution.tslintPackagePath,
       eslintToolPath: toolPackageResolution.eslintPackagePath,

--- a/common/changes/@rushstack/heft/fix-incremental-again_2021-09-21-20-53.json
+++ b/common/changes/@rushstack/heft/fix-incremental-again_2021-09-21-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix formatting of tsBuildInfoFile tsconfig option. TypeScript uses an exact string match for change detection and normalizes slashes to '/' upon saving the file. Therefore the inputs need to be normalized as well.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
Fixes incremental emit of TypeScript to only emit changed files.

## Details
TypeScript internally normalizes all directory separators to `/` so that it can use exact string comparisons to test for changes. However, it only applies this transformation to the `tsBuildInfoFile` value when serializing the tsBuildInfo JSON to disk. It expects the input in the tsconfig to have already been normalized.
As a result, constructing the path using `path.join()` on Windows produces an incorrect path that will always fail to match the serialized value.

## How it was tested
Run:
```
heft build --verbose
heft build --verbose
```
Verify that the second time does not emit any files.