### PR TITLE
[heft] Fix typo in folder path

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptPlugin.ts
@@ -239,7 +239,7 @@ export class TypeScriptPlugin implements IHeftPlugin {
 
     const typeScriptBuilderConfiguration: ITypeScriptBuilderConfiguration = {
       buildFolder: heftConfiguration.buildFolder,
-      buildMetadataFolder: Path.convertToSlashes(`${heftConfiguration.buildFolder}/temp}`),
+      buildMetadataFolder: Path.convertToSlashes(`${heftConfiguration.buildFolder}/temp`),
       typeScriptToolPath: toolPackageResolution.typeScriptPackagePath!,
       tslintToolPath: toolPackageResolution.tslintPackagePath,
       eslintToolPath: toolPackageResolution.eslintPackagePath,

--- a/common/changes/@rushstack/heft/fix-typo_2021-09-22-01-27.json
+++ b/common/changes/@rushstack/heft/fix-typo_2021-09-22-01-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix typo in temp folder path.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
Fixes an accidental typo in the metadata folder path introduced in #2919.

Tested via running @rushstack/heft on itself and confirming no unexpected output files.