### PR TITLE
[node-core-library] Allow Async.mapAsync and Async.forEachAsync to take an iterator.

### DIFF
--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -5,8 +5,9 @@ import * as chokidar from 'chokidar';
 import * as path from 'path';
 import glob from 'fast-glob';
 import { performance } from 'perf_hooks';
-import { AlreadyExistsBehavior, FileSystem } from '@rushstack/node-core-library';
+import { AlreadyExistsBehavior, FileSystem, Async } from '@rushstack/node-core-library';
 
+import { HeftAsync as HeftAsync } from '../utilities/HeftAsync';
 import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 import { HeftEventPluginBase } from '../pluginFramework/HeftEventPluginBase';
 import { HeftSession } from '../pluginFramework/HeftSession';
@@ -18,7 +19,6 @@ import {
   HeftEvent
 } from '../utilities/CoreConfigFiles';
 import { IBuildStageProperties } from '../stages/BuildStage';
-import { Async } from '../utilities/Async';
 import { Constants } from '../utilities/Constants';
 
 interface ICopyFileDescriptor {
@@ -113,7 +113,7 @@ export class CopyFilesPlugin extends HeftEventPluginBase<IHeftConfigurationCopyF
 
     // Then enter watch mode if requested
     if (options.watchMode) {
-      Async.runWatcherWithErrorHandling(async () => await this._runWatchAsync(options), logger);
+      HeftAsync.runWatcherWithErrorHandling(async () => await this._runWatchAsync(options), logger);
     }
   }
 
@@ -124,9 +124,8 @@ export class CopyFilesPlugin extends HeftEventPluginBase<IHeftConfigurationCopyF
 
     let copiedFileCount: number = 0;
     let linkedFileCount: number = 0;
-    await Async.forEachLimitAsync(
+    await Async.forEachAsync(
       copyDescriptors,
-      Constants.maxParallelism,
       async (copyDescriptor: ICopyFileDescriptor) => {
         if (copyDescriptor.hardlink) {
           linkedFileCount++;
@@ -143,7 +142,8 @@ export class CopyFilesPlugin extends HeftEventPluginBase<IHeftConfigurationCopyF
             alreadyExistsBehavior: AlreadyExistsBehavior.Overwrite
           });
         }
-      }
+      },
+      { concurrency: Constants.maxParallelism }
     );
 
     return {

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -7,7 +7,7 @@ import glob from 'fast-glob';
 import { performance } from 'perf_hooks';
 import { AlreadyExistsBehavior, FileSystem, Async } from '@rushstack/node-core-library';
 
-import { HeftAsync as HeftAsync } from '../utilities/HeftAsync';
+import { HeftAsync } from '../utilities/HeftAsync';
 import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 import { HeftEventPluginBase } from '../pluginFramework/HeftEventPluginBase';
 import { HeftSession } from '../pluginFramework/HeftSession';

--- a/apps/heft/src/plugins/RunScriptPlugin.ts
+++ b/apps/heft/src/plugins/RunScriptPlugin.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { Async } from '@rushstack/node-core-library';
+
 import { HeftEventPluginBase } from '../pluginFramework/HeftEventPluginBase';
 import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 import { HeftSession } from '../pluginFramework/HeftSession';
@@ -12,7 +14,6 @@ import {
 } from '../utilities/CoreConfigFiles';
 import { IBuildStageProperties } from '../stages/BuildStage';
 import { ITestStageProperties } from '../stages/TestStage';
-import { Async } from '../utilities/Async';
 import { Constants } from '../utilities/Constants';
 
 /**
@@ -88,9 +89,8 @@ export class RunScriptPlugin extends HeftEventPluginBase<IHeftConfigurationRunSc
     heftConfiguration: HeftConfiguration,
     properties: TStageProperties
   ): Promise<void> {
-    await Async.forEachLimitAsync(
+    await Async.forEachAsync(
       runScriptEventActions,
-      Constants.maxParallelism,
       async (runScriptEventAction) => {
         // The scriptPath property should be fully resolved since it is included in the resolution logic used by
         // HeftConfiguration
@@ -127,7 +127,8 @@ export class RunScriptPlugin extends HeftEventPluginBase<IHeftConfigurationRunSc
         } else if (runScript.runAsync) {
           await runScript.runAsync(runScriptOptions);
         }
-      }
+      },
+      { concurrency: Constants.maxParallelism }
     );
   }
 }

--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -11,7 +11,8 @@ import {
   IPackageJson,
   ITerminalProvider,
   FileSystem,
-  Path
+  Path,
+  Async
 } from '@rushstack/node-core-library';
 import type * as TTypescript from 'typescript';
 import {
@@ -24,7 +25,6 @@ import {
   ISubprocessRunnerBaseConfiguration,
   SubprocessRunnerBase
 } from '../../utilities/subprocess/SubprocessRunnerBase';
-import { Async } from '../../utilities/Async';
 import { PerformanceMeasurer, PerformanceMeasurerAsync } from '../../utilities/Performance';
 import { Tslint } from './Tslint';
 import { Eslint } from './Eslint';
@@ -423,11 +423,11 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
     // Using async file system I/O for theoretically better peak performance
     // Also allows to run concurrently with linting
     const writePromise: Promise<{ duration: number }> = measureTsPerformanceAsync('Write', () =>
-      Async.forEachLimitAsync(
+      Async.forEachAsync(
         emitResult.filesToWrite,
-        this._configuration.maxWriteParallelism,
         async ({ filePath, data }) =>
-          this._cachedFileSystem.writeFile(filePath, data, { ensureFolderExists: true })
+          this._cachedFileSystem.writeFile(filePath, data, { ensureFolderExists: true }),
+        { concurrency: this._configuration.maxWriteParallelism }
       )
     );
     //#endregion

--- a/apps/heft/src/utilities/HeftAsync.ts
+++ b/apps/heft/src/utilities/HeftAsync.ts
@@ -1,19 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Async as CoreAsync } from '@rushstack/node-core-library';
 import { ScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 
-export class Async {
-  public static async forEachLimitAsync<TEntry>(
-    array: TEntry[],
-    parallelismLimit: number,
-    fn: (entry: TEntry) => Promise<void>
-  ): Promise<void> {
-    // Defer to the implementation in node-core-library
-    return CoreAsync.forEachAsync(array, fn, { concurrency: parallelismLimit });
-  }
-
+export class HeftAsync {
   public static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: ScopedLogger): void {
     try {
       fn().catch((e) => scopedLogger.emitError(e));

--- a/common/changes/@rushstack/heft/ianc-async-iterator_2021-09-23-19-45.json
+++ b/common/changes/@rushstack/heft/ianc-async-iterator_2021-09-23-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/ianc-async-iterator_2021-09-23-03-15.json
+++ b/common/changes/@rushstack/node-core-library/ianc-async-iterator_2021-09-23-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Allow Async.mapAsync and Async.forEachAsync to take an iterator.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -31,8 +31,8 @@ export class AnsiEscape {
 
 // @beta
 export class Async {
-    static forEachAsync<TEntry>(array: TEntry[], callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
-    static mapAsync<TEntry, TRetVal>(array: TEntry[], callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
+    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
+    static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static sleep(ms: number): Promise<void>;
 }
 

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -96,7 +96,7 @@ export class Async {
     let arrayIndex: number = 0;
     let iteratorIsDone: boolean = false;
     await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
-      async function onOperationCompletion(): Promise<void> {
+      async function onOperationCompletionAsync(): Promise<void> {
         operationsInProgress--;
         if (operationsInProgress === 0 && iteratorIsDone) {
           resolve();
@@ -110,7 +110,7 @@ export class Async {
             operationsInProgress++;
             try {
               Promise.resolve(callback(nextIteratorResult.value, arrayIndex++))
-                .then(() => onOperationCompletion())
+                .then(() => onOperationCompletionAsync())
                 .catch(reject);
             } catch (error) {
               reject(error as Error);
@@ -121,7 +121,7 @@ export class Async {
         }
       }
 
-      onOperationCompletion().catch(reject);
+      onOperationCompletionAsync().catch(reject);
     });
   }
 

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -116,6 +116,12 @@ export class Async {
               reject(error as Error);
             }
           } else {
+            if (arrayIndex === 0) {
+              // If arrayIndex was never incremented and the iterator is done, we were handed an empty iterator
+              // and we should resolve
+              resolve();
+            }
+
             break;
           }
         }

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -36,7 +36,7 @@ export class Async {
    * then the loop stops immediately.  Any remaining array items will be skipped, and
    * overall operation will reject with the first error that was encountered.
    *
-   * @param array - the array of inputs for the callback function
+   * @param iterable - the array of inputs for the callback function
    * @param callback - a function that starts an asynchronous promise for an element
    *   from the array
    * @param options - options for customizing the control flow
@@ -44,14 +44,14 @@ export class Async {
    *   as the original input `array`
    */
   public static async mapAsync<TEntry, TRetVal>(
-    array: TEntry[],
+    iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
     callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>,
     options?: IAsyncParallelismOptions | undefined
   ): Promise<TRetVal[]> {
     const result: TRetVal[] = [];
 
     await Async.forEachAsync(
-      array,
+      iterable,
       async (item: TEntry, arrayIndex: number): Promise<void> => {
         result[arrayIndex] = await callback(item, arrayIndex);
       },
@@ -74,33 +74,42 @@ export class Async {
    * then the loop stops immediately.  Any remaining array items will be skipped, and
    * overall operation will reject with the first error that was encountered.
    *
-   * @param array - the array of inputs for the callback function
+   * @param iterable - the array of inputs for the callback function
    * @param callback - a function that starts an asynchronous promise for an element
    *   from the array
    * @param options - options for customizing the control flow
    */
   public static async forEachAsync<TEntry>(
-    array: TEntry[],
+    iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
     callback: (entry: TEntry, arrayIndex: number) => Promise<void>,
     options?: IAsyncParallelismOptions | undefined
   ): Promise<void> {
-    await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
-      const concurrency: number =
-        options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
-      let operationsInProgress: number = 1;
-      let arrayIndex: number = 0;
+    const concurrency: number =
+      options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
+    let operationsInProgress: number = 1;
 
-      function onOperationCompletion(): void {
+    const iterator: Iterator<TEntry> | AsyncIterator<TEntry> = (
+      (iterable as Iterable<TEntry>)[Symbol.iterator] ||
+      (iterable as AsyncIterable<TEntry>)[Symbol.asyncIterator]
+    ).call(iterable);
+
+    let arrayIndex: number = 0;
+    let iteratorIsDone: boolean = false;
+    await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
+      async function onOperationCompletion(): Promise<void> {
         operationsInProgress--;
-        if (operationsInProgress === 0 && arrayIndex >= array.length) {
+        if (operationsInProgress === 0 && iteratorIsDone) {
           resolve();
         }
 
         while (operationsInProgress < concurrency) {
-          if (arrayIndex < array.length) {
+          const nextIteratorResult: IteratorResult<TEntry> = await iterator.next();
+          // eslint-disable-next-line require-atomic-updates
+          iteratorIsDone = !!nextIteratorResult.done;
+          if (!iteratorIsDone) {
             operationsInProgress++;
             try {
-              Promise.resolve(callback(array[arrayIndex], arrayIndex++))
+              Promise.resolve(callback(nextIteratorResult.value, arrayIndex++))
                 .then(() => onOperationCompletion())
                 .catch(reject);
             } catch (error) {
@@ -112,7 +121,7 @@ export class Async {
         }
       }
 
-      onOperationCompletion();
+      onOperationCompletion().catch(reject);
     });
   }
 

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -55,6 +55,72 @@ describe('Async', () => {
       ]);
       expect(maxRunning).toEqual(3);
     });
+
+    it('rejects if a sync iterator throws an error', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const syncIterator: Iterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return { done: false, value: iteratorIndex };
+          } else {
+            throw expectedError;
+          }
+        }
+      };
+      const syncIterable: Iterable<number> = {
+        [Symbol.iterator]: () => syncIterator
+      };
+
+      await expect(() => Async.mapAsync(syncIterable, async (item) => `result ${item}`)).rejects.toThrow(
+        expectedError
+      );
+    });
+
+    it('rejects if an async iterator throws an error', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const asyncIterator: AsyncIterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return Promise.resolve({ done: false, value: iteratorIndex });
+          } else {
+            throw expectedError;
+          }
+        }
+      };
+      const syncIterable: AsyncIterable<number> = {
+        [Symbol.asyncIterator]: () => asyncIterator
+      };
+
+      await expect(() => Async.mapAsync(syncIterable, async (item) => `result ${item}`)).rejects.toThrow(
+        expectedError
+      );
+    });
+
+    it('rejects if an async iterator rejects', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const asyncIterator: AsyncIterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return Promise.resolve({ done: false, value: iteratorIndex });
+          } else {
+            return Promise.reject(expectedError);
+          }
+        }
+      };
+      const syncIterable: AsyncIterable<number> = {
+        [Symbol.asyncIterator]: () => asyncIterator
+      };
+
+      await expect(() => Async.mapAsync(syncIterable, async (item) => `result ${item}`)).rejects.toThrow(
+        expectedError
+      );
+    });
   });
 
   describe('forEachAsync', () => {
@@ -105,6 +171,72 @@ describe('Async', () => {
         'Something broke'
       );
       expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects if a sync iterator throws an error', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const syncIterator: Iterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return { done: false, value: iteratorIndex };
+          } else {
+            throw expectedError;
+          }
+        }
+      };
+      const syncIterable: Iterable<number> = {
+        [Symbol.iterator]: () => syncIterator
+      };
+
+      await expect(() =>
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(1))
+      ).rejects.toThrow(expectedError);
+    });
+
+    it('rejects if an async iterator throws an error', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const asyncIterator: AsyncIterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return Promise.resolve({ done: false, value: iteratorIndex });
+          } else {
+            throw expectedError;
+          }
+        }
+      };
+      const syncIterable: AsyncIterable<number> = {
+        [Symbol.asyncIterator]: () => asyncIterator
+      };
+
+      await expect(() =>
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(1))
+      ).rejects.toThrow(expectedError);
+    });
+
+    it('rejects if an async iterator rejects', async () => {
+      const expectedError: Error = new Error('iterator error');
+      let iteratorIndex: number = 0;
+      const asyncIterator: AsyncIterator<number> = {
+        next: () => {
+          if (iteratorIndex < 5) {
+            iteratorIndex++;
+            return Promise.resolve({ done: false, value: iteratorIndex });
+          } else {
+            return Promise.reject(expectedError);
+          }
+        }
+      };
+      const syncIterable: AsyncIterable<number> = {
+        [Symbol.asyncIterator]: () => asyncIterator
+      };
+
+      await expect(() =>
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(1))
+      ).rejects.toThrow(expectedError);
     });
   });
 });

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -5,6 +5,11 @@ import { Async } from '../Async';
 
 describe('Async', () => {
   describe('mapAsync', () => {
+    it('handles an empty array correctly', async () => {
+      const result = await Async.mapAsync([] as number[], async (item) => `result ${item}`);
+      expect(result).toEqual([]);
+    });
+
     it('returns the same result as built-in Promise.all', async () => {
       const array: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
       const fn: (item: number) => Promise<string> = async (item) => `result ${item}`;
@@ -124,6 +129,24 @@ describe('Async', () => {
   });
 
   describe('forEachAsync', () => {
+    it('handles an empty array correctly', async () => {
+      let running: number = 0;
+      let maxRunning: number = 0;
+
+      const array: number[] = [];
+
+      const fn: (item: number) => Promise<void> = jest.fn(async (item) => {
+        running++;
+        await Async.sleep(1);
+        maxRunning = Math.max(maxRunning, running);
+        running--;
+      });
+
+      await Async.forEachAsync(array, fn, { concurrency: 3 });
+      expect(fn).toHaveBeenCalledTimes(0);
+      expect(maxRunning).toEqual(0);
+    });
+
     it('if concurrency is set, ensures no more than N operations occur in parallel', async () => {
       let running: number = 0;
       let maxRunning: number = 0;


### PR DESCRIPTION
## Summary

Right now the `Async` functions can't take an iterator. This means that you can't directly call `Async.forEachAsync(new Set())`. This PR allows those functions to take any iterator or async iterator.

## How it was tested

There are tests for `Async` that validate this. I've added tests to ensure that errors thrown by iterators are also handled.