### PR TITLE
[rush-lib] Fix 'shinkwrap' typo

### DIFF
--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -220,7 +220,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       // Now validate that the shrinkwrap file matches what is in the package.json
       if (shrinkwrapFile?.isWorkspaceProjectModified(rushProject, this.options.variant)) {
         shrinkwrapWarnings.push(
-          `Dependencies of project "${rushProject.packageName}" do not match the current shinkwrap.`
+          `Dependencies of project "${rushProject.packageName}" do not match the current shrinkwrap.`
         );
         shrinkwrapIsUpToDate = false;
       }

--- a/common/changes/@microsoft/rush/drieman-typoShinkwrap_2021-09-23-20-46.json
+++ b/common/changes/@microsoft/rush/drieman-typoShinkwrap_2021-09-23-20-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fixed an output typo.",
+      "comment": "Fix typo when project dependencies do not match the current shrinkwrap",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/drieman-typoShinkwrap_2021-09-23-20-46.json
+++ b/common/changes/@microsoft/rush/drieman-typoShinkwrap_2021-09-23-20-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixed an output typo.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "DavidRieman@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
Fixed a simple typo where "shinkwrap" should have been "shrinkwrap".

## Details
Searched repo for the misspelled word (as noticed by a fellow dev from rush command output).  Fixed it.

## How it was tested
Searched full repo for the misspelled string.  This did not turn up any additional hits, so the typo does not appear to be duplicated inside any unit tests, etc.  Ran `rush build --to rush-lib` which I assume runs associated unit tests (if any), and the process completed green without error.
