### PR TITLE
[Rush] Add support for "git:" protocol in selection parameter values

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -3,7 +3,6 @@
 
 /* eslint max-lines: off */
 
-import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as semver from 'semver';
@@ -1680,7 +1679,7 @@ export class RushConfiguration {
       this._pathTrees.set(rootPath, (pathTree = new LookupByPath()));
       for (const project of this.projects) {
         const relativePath: string = path.relative(rootPath, project.projectFolder);
-        pathTree.setItemFromSegments(LookupByPath.iteratePathSegments(relativePath, os.EOL), project);
+        pathTree.setItemFromSegments(LookupByPath.iteratePathSegments(relativePath, path.sep), project);
       }
     }
     return pathTree;

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -91,7 +91,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }
 
-  protected abstract buildInstallOptions(): IInstallManagerOptions;
+  protected abstract buildInstallOptionsAsync(): Promise<IInstallManagerOptions>;
 
   protected async runAsync(): Promise<void> {
     VersionMismatchFinder.ensureConsistentVersions(this.rushConfiguration, {
@@ -137,7 +137,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
       throw new Error(`The value of "${this._maxInstallAttempts.longName}" must be positive and nonzero.`);
     }
 
-    const installManagerOptions: IInstallManagerOptions = this.buildInstallOptions();
+    const installManagerOptions: IInstallManagerOptions = await this.buildInstallOptionsAsync();
 
     const installManager: BaseInstallManager =
       installManagerFactoryModule.InstallManagerFactory.getInstallManager(

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import { ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library';
 
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
@@ -44,7 +45,8 @@ export class InstallAction extends BaseInstallAction {
     });
   }
 
-  protected buildInstallOptions(): IInstallManagerOptions {
+  protected async buildInstallOptionsAsync(): Promise<IInstallManagerOptions> {
+    const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     return {
       debug: this.parser.isDebug,
       allowShrinkwrapUpdates: false,
@@ -59,7 +61,7 @@ export class InstallAction extends BaseInstallAction {
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
       // These are derived independently of the selection for command line brevity
-      pnpmFilterArguments: this._selectionParameters!.getPnpmFilterArguments(),
+      pnpmFilterArguments: await this._selectionParameters!.getPnpmFilterArgumentsAsync(terminal),
       checkOnly: this._checkOnlyParameter.value
     };
   }

--- a/apps/rush-lib/src/cli/actions/ListAction.ts
+++ b/apps/rush-lib/src/cli/actions/ListAction.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Import, Sort } from '@rushstack/node-core-library';
+import { ConsoleTerminalProvider, Import, Sort, Terminal } from '@rushstack/node-core-library';
+import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+
 import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
-import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { VersionPolicyDefinitionName } from '../../api/VersionPolicy';
 import { SelectionParameterSet } from '../SelectionParameterSet';
@@ -109,8 +110,11 @@ export class ListAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    const selection: Set<RushConfigurationProject> = this._selectionParameters.getSelectedProjects();
-    Sort.sortSetBy(selection, (x) => x.packageName);
+    const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
+    const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
+      terminal
+    );
+    Sort.sortSetBy(selection, (x: RushConfigurationProject) => x.packageName);
     if (this._jsonFlag.value && this._detailedFlag.value) {
       throw new Error(`The parameters "--json" and "--detailed" cannot be used together.`);
     }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -56,7 +56,7 @@ export class UpdateAction extends BaseInstallAction {
     });
   }
 
-  protected buildInstallOptions(): IInstallManagerOptions {
+  protected async buildInstallOptionsAsync(): Promise<IInstallManagerOptions> {
     return {
       debug: this.parser.isDebug,
       allowShrinkwrapUpdates: true,

--- a/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
+++ b/apps/rush-lib/src/cli/actions/WriteBuildCacheAction.ts
@@ -85,7 +85,7 @@ export class WriteBuildCacheAction extends BaseRushAction {
     });
 
     const trackedFiles: string[] = Array.from(
-      (await projectChangeAnalyzer._tryGetProjectDependenciesAsync(project.packageName, terminal))!.keys()
+      (await projectChangeAnalyzer._tryGetProjectDependenciesAsync(project, terminal))!.keys()
     );
     const commandLineConfigFilePath: string = path.join(
       this.rushConfiguration.commonRushConfigFolder,

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -126,7 +126,9 @@ export class BulkScriptAction extends BaseScriptAction {
       buildCacheConfiguration = await BuildCacheConfiguration.tryLoadAsync(terminal, this.rushConfiguration);
     }
 
-    const selection: Set<RushConfigurationProject> = this._selectionParameters.getSelectedProjects();
+    const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
+      terminal
+    );
 
     if (!selection.size) {
       terminal.writeLine(colors.yellow(`The command line selection parameters did not match any projects.`));

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -120,8 +120,7 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
 "usage: rush build [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                   [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
-                  [--from-version-policy VERSION_POLICY_NAME]
-                  [--changed-since REF] [--changed-since-only REF] [-v] [-c]
+                  [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
                   [--ignore-hooks] [-s] [-m]
                   
 
@@ -224,23 +223,6 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
-                        subsets of projects\\".
-  --changed-since REF   Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF, 
-                        then expand the selection to include all affected 
-                        projects and all dependencies thereof, analogous to 
-                        \\"--from\\". For details, refer to the website article 
-                        \\"Selecting subsets of projects\\".
-  --changed-since-only REF
-                        Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF. 
-                        Note that this parameter is \\"unsafe\\" as it may 
-                        produce a selection that excludes some dependencies. 
-                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
@@ -379,9 +361,8 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
 "usage: rush import-strings [-h] [-p COUNT] [-t PROJECT] [-T PROJECT]
                            [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
-                           [--from-version-policy VERSION_POLICY_NAME]
-                           [--changed-since REF] [--changed-since-only REF]
-                           [-v] [--ignore-hooks]
+                           [--from-version-policy VERSION_POLICY_NAME] [-v]
+                           [--ignore-hooks]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -476,23 +457,6 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  --changed-since REF   Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF, 
-                        then expand the selection to include all affected 
-                        projects and all dependencies thereof, analogous to 
-                        \\"--from\\". For details, refer to the website article 
-                        \\"Selecting subsets of projects\\".
-  --changed-since-only REF
-                        Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF. 
-                        Note that this parameter is \\"unsafe\\" as it may 
-                        produce a selection that excludes some dependencies. 
-                        For details, refer to the website article \\"Selecting 
-                        subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
@@ -573,9 +537,7 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
                     [--variant VARIANT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME]
-                    [--changed-since REF] [--changed-since-only REF]
-                    [--check-only]
+                    [--from-version-policy VERSION_POLICY_NAME] [--check-only]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -696,23 +658,6 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
-  --changed-since REF   Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF, 
-                        then expand the selection to include all affected 
-                        projects and all dependencies thereof, analogous to 
-                        \\"--from\\". For details, refer to the website article 
-                        \\"Selecting subsets of projects\\".
-  --changed-since-only REF
-                        Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF. 
-                        Note that this parameter is \\"unsafe\\" as it may 
-                        produce a selection that excludes some dependencies. 
-                        For details, refer to the website article \\"Selecting 
-                        subsets of projects\\".
   --check-only          Only check the validity of the shrinkwrap file 
                         without performing an install.
 "
@@ -740,7 +685,6 @@ exports[`CommandLineHelp prints the help for each action: list 1`] = `
                  [-i PROJECT] [-I PROJECT]
                  [--to-version-policy VERSION_POLICY_NAME]
                  [--from-version-policy VERSION_POLICY_NAME]
-                 [--changed-since REF] [--changed-since-only REF]
                  
 
 List package names, and optionally version (--version) and path (--path) or 
@@ -837,23 +781,6 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
-                        subsets of projects\\".
-  --changed-since REF   Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF, 
-                        then expand the selection to include all affected 
-                        projects and all dependencies thereof, analogous to 
-                        \\"--from\\". For details, refer to the website article 
-                        \\"Selecting subsets of projects\\".
-  --changed-since-only REF
-                        Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF. 
-                        Note that this parameter is \\"unsafe\\" as it may 
-                        produce a selection that excludes some dependencies. 
-                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
 "
 `;
@@ -975,8 +902,7 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
 "usage: rush rebuild [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME]
-                    [--changed-since REF] [--changed-since-only REF] [-v]
+                    [--from-version-policy VERSION_POLICY_NAME] [-v]
                     [--ignore-hooks] [-s] [-m]
                     
 
@@ -1076,23 +1002,6 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
-                        subsets of projects\\".
-  --changed-since REF   Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF, 
-                        then expand the selection to include all affected 
-                        projects and all dependencies thereof, analogous to 
-                        \\"--from\\". For details, refer to the website article 
-                        \\"Selecting subsets of projects\\".
-  --changed-since-only REF
-                        Normally all projects in the monorepo will be 
-                        processed; adding this parameter will instead select 
-                        a subset of projects. Will include all projects that 
-                        Git reports committed or staged changes to since REF. 
-                        Note that this parameter is \\"unsafe\\" as it may 
-                        produce a selection that excludes some dependencies. 
-                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -120,7 +120,8 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
 "usage: rush build [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                   [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
-                  [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
+                  [--from-version-policy VERSION_POLICY_NAME]
+                  [--changed-since REF] [--changed-since-only REF] [-v] [-c]
                   [--ignore-hooks] [-s] [-m]
                   
 
@@ -223,6 +224,23 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
+  --changed-since REF   Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF, 
+                        then expand the selection to include all affected 
+                        projects and all dependencies thereof, analogous to 
+                        \\"--from\\". For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
+  --changed-since-only REF
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF. 
+                        Note that this parameter is \\"unsafe\\" as it may 
+                        produce a selection that excludes some dependencies. 
+                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
@@ -361,8 +379,9 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
 "usage: rush import-strings [-h] [-p COUNT] [-t PROJECT] [-T PROJECT]
                            [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
-                           [--from-version-policy VERSION_POLICY_NAME] [-v]
-                           [--ignore-hooks]
+                           [--from-version-policy VERSION_POLICY_NAME]
+                           [--changed-since REF] [--changed-since-only REF]
+                           [-v] [--ignore-hooks]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
 
@@ -457,6 +476,23 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --changed-since REF   Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF, 
+                        then expand the selection to include all affected 
+                        projects and all dependencies thereof, analogous to 
+                        \\"--from\\". For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
+  --changed-since-only REF
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF. 
+                        Note that this parameter is \\"unsafe\\" as it may 
+                        produce a selection that excludes some dependencies. 
+                        For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
@@ -537,7 +573,9 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
                     [--variant VARIANT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME] [--check-only]
+                    [--from-version-policy VERSION_POLICY_NAME]
+                    [--changed-since REF] [--changed-since-only REF]
+                    [--check-only]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -658,6 +696,23 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --changed-since REF   Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF, 
+                        then expand the selection to include all affected 
+                        projects and all dependencies thereof, analogous to 
+                        \\"--from\\". For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
+  --changed-since-only REF
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF. 
+                        Note that this parameter is \\"unsafe\\" as it may 
+                        produce a selection that excludes some dependencies. 
+                        For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
   --check-only          Only check the validity of the shrinkwrap file 
                         without performing an install.
 "
@@ -685,6 +740,7 @@ exports[`CommandLineHelp prints the help for each action: list 1`] = `
                  [-i PROJECT] [-I PROJECT]
                  [--to-version-policy VERSION_POLICY_NAME]
                  [--from-version-policy VERSION_POLICY_NAME]
+                 [--changed-since REF] [--changed-since-only REF]
                  
 
 List package names, and optionally version (--version) and path (--path) or 
@@ -781,6 +837,23 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
+  --changed-since REF   Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF, 
+                        then expand the selection to include all affected 
+                        projects and all dependencies thereof, analogous to 
+                        \\"--from\\". For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
+  --changed-since-only REF
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF. 
+                        Note that this parameter is \\"unsafe\\" as it may 
+                        produce a selection that excludes some dependencies. 
+                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
 "
 `;
@@ -902,7 +975,8 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
 "usage: rush rebuild [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME] [-v]
+                    [--from-version-policy VERSION_POLICY_NAME]
+                    [--changed-since REF] [--changed-since-only REF] [-v]
                     [--ignore-hooks] [-s] [-m]
                     
 
@@ -1002,6 +1076,23 @@ Optional arguments:
                         parameter is equivalent to specifying \\"--from\\" for 
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
+                        subsets of projects\\".
+  --changed-since REF   Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF, 
+                        then expand the selection to include all affected 
+                        projects and all dependencies thereof, analogous to 
+                        \\"--from\\". For details, refer to the website article 
+                        \\"Selecting subsets of projects\\".
+  --changed-since-only REF
+                        Normally all projects in the monorepo will be 
+                        processed; adding this parameter will instead select 
+                        a subset of projects. Will include all projects that 
+                        Git reports committed or staged changes to since REF. 
+                        Note that this parameter is \\"unsafe\\" as it may 
+                        produce a selection that excludes some dependencies. 
+                        For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -80,7 +80,7 @@ export class ProjectWatcher {
 
     for (const project of this._projectsToWatch) {
       const projectState: Map<string, string> = (await previousState._tryGetProjectDependenciesAsync(
-        project.packageName,
+        project,
         this._terminal
       ))!;
       const projectFolder: string = project.projectRelativeFolder;
@@ -242,14 +242,12 @@ export class ProjectWatcher {
 
     const changedProjects: Set<RushConfigurationProject> = new Set();
     for (const project of this._projectsToWatch) {
-      const { packageName } = project;
+      const [previous, current] = await Promise.all([
+        previousState._tryGetProjectDependenciesAsync(project, this._terminal),
+        state._tryGetProjectDependenciesAsync(project, this._terminal)
+      ]);
 
-      if (
-        ProjectWatcher._haveProjectDepsChanged(
-          (await previousState._tryGetProjectDependenciesAsync(packageName, this._terminal))!,
-          (await state._tryGetProjectDependenciesAsync(packageName, this._terminal))!
-        )
-      ) {
+      if (ProjectWatcher._haveProjectDepsChanged(previous!, current!)) {
         // May need to detect if the nature of the change will break the process, e.g. changes to package.json
         changedProjects.add(project);
       }

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -449,7 +449,7 @@ export class ProjectBuildCache {
         projectsThatHaveBeenProcessed.add(projectToProcess);
 
         const projectState: string | undefined = await projectChangeAnalyzer._tryGetProjectStateHashAsync(
-          projectToProcess.packageName,
+          projectToProcess,
           options.terminal
         );
         if (!projectState) {

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -1,0 +1,30 @@
+import type { ITerminal } from '@rushstack/node-core-library';
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { ISelectorParser } from './ISelectorParser';
+import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
+
+export class GitChangedProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
+  private readonly _rushConfiguration: RushConfiguration;
+
+  public constructor(rushConfiguration: RushConfiguration) {
+    this._rushConfiguration = rushConfiguration;
+  }
+
+  public async evaluateSelectorAsync(
+    unscopedSelector: string,
+    terminal: ITerminal,
+    parameterName: string
+  ): Promise<Iterable<RushConfigurationProject>> {
+    const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this._rushConfiguration);
+
+    return await projectChangeAnalyzer.getChangedProjectsAsync({
+      terminal,
+      targetBranchName: unscopedSelector
+    });
+  }
+
+  public getCompletions(): Iterable<string> {
+    return [this._rushConfiguration.repositoryDefaultBranch, 'HEAD~1', 'HEAD'];
+  }
+}

--- a/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
@@ -1,0 +1,10 @@
+import type { ITerminal } from '@rushstack/node-core-library';
+
+export interface ISelectorParser<T> {
+  evaluateSelectorAsync(
+    unscopedSpecifier: string,
+    terminal: ITerminal,
+    parameterName: string
+  ): Promise<Iterable<T>>;
+  getCompletions(): Iterable<string>;
+}

--- a/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
@@ -1,0 +1,53 @@
+import type { ITerminal } from '@rushstack/node-core-library';
+import { AlreadyReportedError, PackageName } from '@rushstack/node-core-library';
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { ISelectorParser } from './ISelectorParser';
+
+export class NamedProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
+  private readonly _rushConfiguration: RushConfiguration;
+
+  public constructor(rushConfiguration: RushConfiguration) {
+    this._rushConfiguration = rushConfiguration;
+  }
+
+  public async evaluateSelectorAsync(
+    unscopedSelector: string,
+    terminal: ITerminal,
+    parameterName: string
+  ): Promise<Iterable<RushConfigurationProject>> {
+    const project: RushConfigurationProject | undefined =
+      this._rushConfiguration.findProjectByShorthandName(unscopedSelector);
+    if (!project) {
+      terminal.writeErrorLine(
+        `The project name "${unscopedSelector}" passed to "${parameterName}" does not exist in rush.json.`
+      );
+      throw new AlreadyReportedError();
+    }
+
+    return [project];
+  }
+
+  public getCompletions(): Iterable<string> {
+    const unscopedNamesMap: Map<string, number> = new Map<string, number>();
+
+    const scopedNames: Set<string> = new Set();
+    for (const project of this._rushConfiguration.rushConfigurationJson.projects) {
+      scopedNames.add(project.packageName);
+      const unscopedName: string = PackageName.getUnscopedName(project.packageName);
+      const count: number = unscopedNamesMap.get(unscopedName) || 0;
+      unscopedNamesMap.set(unscopedName, count + 1);
+    }
+
+    const unscopedNames: string[] = [];
+    for (const [unscopedName, unscopedNameCount] of unscopedNamesMap) {
+      // don't suggest ambiguous unscoped names
+      if (unscopedNameCount === 1 && !scopedNames.has(unscopedName)) {
+        unscopedNames.push(unscopedName);
+      }
+    }
+
+    return unscopedNames.sort().concat([...scopedNames].sort());
+  }
+}

--- a/apps/rush-lib/src/logic/selectors/VersionPolicyProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/VersionPolicyProjectSelectorParser.ts
@@ -1,0 +1,41 @@
+import type { ITerminal } from '@rushstack/node-core-library';
+import { AlreadyReportedError } from '@rushstack/node-core-library';
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { ISelectorParser } from './ISelectorParser';
+
+export class VersionPolicyProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
+  private readonly _rushConfiguration: RushConfiguration;
+
+  public constructor(rushConfiguration: RushConfiguration) {
+    this._rushConfiguration = rushConfiguration;
+  }
+
+  public async evaluateSelectorAsync(
+    unscopedSelector: string,
+    terminal: ITerminal,
+    parameterName: string
+  ): Promise<Iterable<RushConfigurationProject>> {
+    const selection: Set<RushConfigurationProject> = new Set();
+
+    if (!this._rushConfiguration.versionPolicyConfiguration.versionPolicies.has(unscopedSelector)) {
+      terminal.writeErrorLine(
+        `The version policy "${unscopedSelector}" passed to "${parameterName}" does not exist in version-policies.json.`
+      );
+      throw new AlreadyReportedError();
+    }
+
+    for (const project of this._rushConfiguration.projects) {
+      if (project.versionPolicyName === unscopedSelector) {
+        selection.add(project);
+      }
+    }
+
+    return selection;
+  }
+
+  public getCompletions(): Iterable<string> {
+    return this._rushConfiguration.versionPolicyConfiguration.versionPolicies.keys();
+  }
+}

--- a/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectBuilder.ts
@@ -221,10 +221,7 @@ export class ProjectBuilder extends BaseBuilder {
       let trackedFiles: string[] | undefined;
       try {
         const fileHashes: Map<string, string> | undefined =
-          await this._projectChangeAnalyzer._tryGetProjectDependenciesAsync(
-            this._rushProject.packageName,
-            terminal
-          );
+          await this._projectChangeAnalyzer._tryGetProjectDependenciesAsync(this._rushProject, terminal);
 
         if (fileHashes) {
           const files: { [filePath: string]: string } = {};

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -7,57 +7,36 @@ async function runAsync(): Promise<void> {
     startingFolder: process.cwd()
   });
 
-  //#region Step 1: Determine each project's downstream dependencies
-  const projectDirectDependentsMap: Map<RushConfigurationProject, Set<RushConfigurationProject>> = new Map<
-    RushConfigurationProject,
-    Set<RushConfigurationProject>
-  >();
-  for (const project of rushConfiguration.projects) {
-    projectDirectDependentsMap.set(project, new Set<RushConfigurationProject>());
-  }
-
-  for (const project of rushConfiguration.projects) {
-    for (const dependencyProject of project.dependencyProjects) {
-      projectDirectDependentsMap.get(dependencyProject)!.add(project);
-    }
-  }
-  //#endregion
-
-  //#region Step 2: Get the list of changed projects and recursively collect their downstream dependencies
+  //#region Step 1: Get the list of changed projects
   const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
-  const changedProjects: AsyncIterable<RushConfigurationProject> =
-    projectChangeAnalyzer.getChangedProjectsAsync({
-      targetBranchName: rushConfiguration.repositoryDefaultBranch,
-      terminal
-    });
-  const projectsNeedingValidation: Set<RushConfigurationProject> = new Set<RushConfigurationProject>();
-  function addProject(project: RushConfigurationProject): void {
-    if (!projectsNeedingValidation.has(project)) {
-      projectsNeedingValidation.add(project);
+  const changedProjects: Set<RushConfigurationProject> = await projectChangeAnalyzer.getChangedProjectsAsync({
+    targetBranchName: rushConfiguration.repositoryDefaultBranch,
+    terminal
+  });
+  //#endregion
 
-      for (const projectDirectDependent of projectDirectDependentsMap.get(project)!) {
-        addProject(projectDirectDependent);
-      }
+  //#region Step 2: Expand all consumers
+  for (const project of changedProjects) {
+    for (const consumer of project.consumingProjects) {
+      changedProjects.add(consumer);
     }
-  }
-  for await (const project of changedProjects) {
-    addProject(project);
   }
   //#endregion
 
-  //#region Step 3: Print the list of projects that were changed and their downstream dependencies
+  //#region Step 3: Print the list of projects that were changed and their consumers
   terminal.writeLine('Projects needing validation due to changes: ');
-  const namesOfProjectsNeedingValidation: string[] = Array.from(projectsNeedingValidation)
-    .map((project) => project.packageName)
-    .sort();
+  const namesOfProjectsNeedingValidation: string[] = Array.from(
+    changedProjects,
+    (project) => project.packageName
+  ).sort();
   for (const nameOfProjectsNeedingValidation of namesOfProjectsNeedingValidation) {
     terminal.writeLine(` - ${nameOfProjectsNeedingValidation}`);
   }
   //#endregion
 }
 
-runAsync().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+process.exitCode = 1;
+runAsync().then(() => {
+  process.exitCode = 0;
+}, console.error);

--- a/common/changes/@microsoft/rush/git-repo-relative_2021-10-14-02-07.json
+++ b/common/changes/@microsoft/rush/git-repo-relative_2021-10-14-02-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Added support for the \"--changed-since REF\" and \"--changed-since-only REF\" selection parameters, which select projects that have been modified since the specified Git revision. Updated state computation and change detection to operate at the root of the Git repository that contains rush.json, rather than from the immediate parent folder. This allows nesting rush.json in a subfolder.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/git-repo-relative_2021-10-14-02-07.json
+++ b/common/changes/@rushstack/node-core-library/git-repo-relative_2021-10-14-02-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Updated Path.convertToSlashes() to use replace(/\\\\/g, '/') instead of split/join for better performance.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/package-deps-hash/git-repo-relative_2021-10-14-02-07.json
+++ b/common/changes/@rushstack/package-deps-hash/git-repo-relative_2021-10-14-02-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Added repo-level state extraction and change listing functions to support having rush.json in a subfolder of the repository.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -10,4 +10,25 @@ export function getGitHashForFiles(filesToHash: string[], packagePath: string, g
 // @public
 export function getPackageDeps(packagePath?: string, excludedPaths?: string[], gitPath?: string): Map<string, string>;
 
+// @beta
+export function getRepoChanges(currentWorkingDirectory: string, revision?: string, gitPath?: string): Map<string, IFileDiffStatus>;
+
+// @beta
+export function getRepoRoot(currentWorkingDirectory: string, gitPath?: string): string;
+
+// @beta
+export function getRepoState(currentWorkingDirectory: string, gitPath?: string): Map<string, string>;
+
+// @beta
+export interface IFileDiffStatus {
+    // (undocumented)
+    mode: string;
+    // (undocumented)
+    newhash: string;
+    // (undocumented)
+    oldhash: string;
+    // (undocumented)
+    status: 'A' | 'D' | 'M';
+}
+
 ```

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -327,11 +327,13 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
-    getChangedProjectsAsync(options: IGetChangedProjectsOptions): AsyncIterable<RushConfigurationProject>;
+    // (undocumented)
+    _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
+    getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
-    _tryGetProjectDependenciesAsync(projectName: string, terminal: ITerminal): Promise<Map<string, string> | undefined>;
+    _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;
     // @internal
-    _tryGetProjectStateHashAsync(projectName: string, terminal: ITerminal): Promise<string | undefined>;
+    _tryGetProjectStateHashAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<string | undefined>;
 }
 
 // @public
@@ -374,13 +376,16 @@ export class RushConfiguration {
     get experimentsConfiguration(): ExperimentsConfiguration;
     findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
     findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
-    findProjectForPosixRelativePath(posixRelativePath: string): RushConfigurationProject | undefined;
     getCommittedShrinkwrapFilename(variant?: string | undefined): string;
     getCommonVersions(variant?: string | undefined): CommonVersionsConfiguration;
     getCommonVersionsFilePath(variant?: string | undefined): string;
     getImplicitlyPreferredVersions(variant?: string | undefined): Map<string, string>;
     getPnpmfilePath(variant?: string | undefined): string;
     getProjectByName(projectName: string): RushConfigurationProject | undefined;
+    // Warning: (ae-forgotten-export) The symbol "LookupByPath" needs to be exported by the entry point index.d.ts
+    //
+    // @beta (undocumented)
+    getProjectLookupForRoot(rootPath: string): LookupByPath<RushConfigurationProject>;
     getRepoState(variant?: string | undefined): RepoStateFile;
     getRepoStateFilePath(variant?: string | undefined): string;
     get gitAllowedEmailRegExps(): string[];

--- a/libraries/node-core-library/src/Path.ts
+++ b/libraries/node-core-library/src/Path.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { Text } from './Text';
 
 /**
  * Options for {@link Path.formatConcisely}.
@@ -106,7 +105,7 @@ export class Path {
    * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
    */
   public static convertToSlashes(inputPath: string): string {
-    return Text.replaceAll(inputPath, '\\', '/');
+    return inputPath.replace(/\\/g, '/');
   }
 
   /**
@@ -116,7 +115,7 @@ export class Path {
    * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
    */
   public static convertToBackslashes(inputPath: string): string {
-    return Text.replaceAll(inputPath, '/', '\\');
+    return inputPath.replace(/\//g, '\\');
   }
 
   /**

--- a/libraries/package-deps-hash/config/jest.config.json
+++ b/libraries/package-deps-hash/config/jest.config.json
@@ -1,3 +1,5 @@
 {
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json"
+  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json",
+  // Tests in this package break isolation and so must run serially
+  "maxWorkers": 1
 }

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type * as child_process from 'child_process';
+import { Executable } from '@rushstack/node-core-library';
+
+/**
+ * Parses the output of the "git ls-tree -r -z" command
+ * @internal
+ */
+export function parseGitLsTree(output: string): Map<string, string> {
+  const result: Map<string, string> = new Map();
+
+  // Parse the output
+  // With the -z modifier, paths are delimited by nulls
+  // A line looks like:
+  // <mode> <type> <newhash>\t<path>\0
+  // 100644 blob a300ccb0b36bd2c85ef18e3c619a2c747f95959e\ttools/prettier-git/prettier-git.js\0
+
+  let last: number = 0;
+  let index: number = output.indexOf('\0', last);
+  while (index >= 0) {
+    const item: string = output.slice(last, index);
+
+    const tabIndex: number = item.indexOf('\t');
+    const filePath: string = item.slice(tabIndex + 1);
+
+    // The newHash will be all zeros if the file is deleted, or a hash if it exists
+    const hash: string = item.slice(tabIndex - 40, tabIndex);
+    result.set(filePath, hash);
+
+    last = index + 1;
+    index = output.indexOf('\0', last);
+  }
+
+  return result;
+}
+
+/**
+ * Information about the changes to a file.
+ * @beta
+ */
+export interface IFileDiffStatus {
+  mode: string;
+  oldhash: string;
+  newhash: string;
+  status: 'A' | 'D' | 'M';
+}
+
+/**
+ * Parses the output of `git diff-index --color=never --no-renames --no-commit-id -z <REVISION> --
+ * Returns a map of file path to diff
+ * @internal
+ */
+export function parseGitDiffIndex(output: string): Map<string, IFileDiffStatus> {
+  const result: Map<string, IFileDiffStatus> = new Map();
+
+  // Parse the output
+  // With the -z modifier, paths are delimited by nulls
+  // A line looks like:
+  // :<oldmode> <newmode> <oldhash> <newhash> <status>\0<path>\0
+  // :100644 100644 a300ccb0b36bd2c85ef18e3c619a2c747f95959e 0000000000000000000000000000000000000000 M\0tools/prettier-git/prettier-git.js\0
+
+  let last: number = 0;
+  let index: number = output.indexOf('\0', last);
+  while (index >= 0) {
+    const header: string = output.slice(last, index);
+    const status: IFileDiffStatus['status'] = header.slice(-1) as IFileDiffStatus['status'];
+
+    last = index + 1;
+    index = output.indexOf('\0', last);
+    const filePath: string = output.slice(last, index);
+
+    // We passed --no-renames above, so a rename will be a delete of the old location and an add at the new.
+    // The newHash will be all zeros if the file is deleted, or a hash if it exists
+    const mode: string = header.slice(8, 14);
+    const oldhash: string = header.slice(-83, -43);
+    const newhash: string = header.slice(-42, -2);
+    result.set(filePath, {
+      mode,
+      oldhash,
+      newhash,
+      status
+    });
+
+    last = index + 1;
+    index = output.indexOf('\0', last);
+  }
+
+  return result;
+}
+
+/**
+ * Parses the output of `git status -z -u`
+ *
+ * @param output - The raw output from Git
+ * @returns a map of file path to if it exists
+ * @internal
+ */
+export function parseGitStatus(output: string): Map<string, boolean> {
+  const result: Map<string, boolean> = new Map();
+
+  // Parse the output
+  // With the -z modifier, paths are delimited by nulls
+  // A line looks like:
+  // XY <path>\0
+  //  M tools/prettier-git/prettier-git.js\0
+
+  let last: number = 0;
+  let index: number = output.indexOf('\0', last);
+  while (index >= 0) {
+    // We passed --no-renames above, so a rename will be a delete of the old location and an add at the new.
+    const workingTreeStatus: string = output.charAt(last + 2);
+    const exists: boolean =
+      workingTreeStatus !== 'D' && (workingTreeStatus !== ' ' || output.charAt(last + 1) !== 'D');
+    const filePath: string = output.slice(last + 3, index);
+
+    result.set(filePath, exists);
+
+    last = index + 1;
+    index = output.indexOf('\0', last);
+  }
+
+  return result;
+}
+
+const repoRootCache: Map<string, string> = new Map();
+
+/**
+ * Finds the root of the current Git repository
+ *
+ * @param currentWorkingDirectory - The working directory for which to locate the repository
+ * @param gitPath - The path to the Git executable
+ *
+ * @returns The full path to the root directory of the Git repository
+ * @beta
+ */
+export function getRepoRoot(currentWorkingDirectory: string, gitPath?: string): string {
+  let cachedResult: string | undefined = repoRootCache.get(currentWorkingDirectory);
+  if (!cachedResult) {
+    const result: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+      gitPath || 'git',
+      ['--no-optional-locks', 'rev-parse', '--show-toplevel'],
+      {
+        currentWorkingDirectory
+      }
+    );
+
+    if (result.status !== 0) {
+      throw new Error(`git rev-parse exited with status ${result.status}: ${result.stderr}`);
+    }
+
+    repoRootCache.set(currentWorkingDirectory, (cachedResult = result.stdout.trim()));
+  }
+
+  return cachedResult;
+}
+
+/**
+ * Augments the state value with modifications that are not in the index.
+ * @param rootDirectory - The root directory of the Git repository
+ * @param state - The current map of git path -> object hash. Will be mutated.
+ * @param gitPath - The path to the Git executable
+ * @internal
+ */
+export function applyWorkingTreeState(
+  rootDirectory: string,
+  state: Map<string, string>,
+  gitPath?: string
+): void {
+  const statusResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+    gitPath || 'git',
+    ['--no-optional-locks', 'status', '-z', '-u', '--no-renames', '--'],
+    {
+      currentWorkingDirectory: rootDirectory
+    }
+  );
+
+  if (statusResult.status !== 0) {
+    throw new Error(`git status exited with status ${statusResult.status}: ${statusResult.stderr}`);
+  }
+
+  const locallyModified: Map<string, boolean> = parseGitStatus(statusResult.stdout);
+
+  const filesToHash: string[] = [];
+  for (const [filePath, exists] of locallyModified) {
+    if (exists) {
+      filesToHash.push(filePath);
+    } else {
+      state.delete(filePath);
+    }
+  }
+
+  if (filesToHash.length) {
+    // Use --stdin-paths arg to pass the list of files to git in order to avoid issues with
+    // command length
+    const hashObjectResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+      gitPath || 'git',
+      ['hash-object', '--stdin-paths'],
+      { input: filesToHash.join('\n') }
+    );
+
+    if (hashObjectResult.status !== 0) {
+      throw new Error(
+        `git hash-object exited with status ${hashObjectResult.status}: ${hashObjectResult.stderr}`
+      );
+    }
+
+    const hashStdout: string = hashObjectResult.stdout.trim();
+
+    // The result of "git hash-object" will be a list of file hashes delimited by newlines
+    const hashes: string[] = hashStdout.split('\n');
+
+    if (hashes.length !== filesToHash.length) {
+      throw new Error(
+        `Passed ${filesToHash.length} file paths to Git to hash, but received ${hashes.length} hashes.`
+      );
+    }
+
+    const len: number = hashes.length;
+    for (let i: number = 0; i < len; i++) {
+      const hash: string = hashes[i];
+      const filePath: string = filesToHash[i];
+      state.set(filePath, hash);
+    }
+  }
+}
+
+/**
+ * Gets the object hashes for all files in the Git repo, combining the current commit with working tree state.
+ * @param currentWorkingDirectory - The working directory. Only used to find the repository root.
+ * @param gitPath - The path to the Git executable
+ * @beta
+ */
+export function getRepoState(currentWorkingDirectory: string, gitPath?: string): Map<string, string> {
+  const rootDirectory: string = getRepoRoot(currentWorkingDirectory, gitPath);
+
+  const lsTreeResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+    gitPath || 'git',
+    ['--no-optional-locks', 'ls-tree', '-r', '-z', '--full-name', 'HEAD', '--'],
+    {
+      currentWorkingDirectory: rootDirectory
+    }
+  );
+
+  if (lsTreeResult.status !== 0) {
+    throw new Error(`git ls-tree exited with status ${lsTreeResult.status}: ${lsTreeResult.stderr}`);
+  }
+
+  const state: Map<string, string> = parseGitLsTree(lsTreeResult.stdout);
+
+  applyWorkingTreeState(rootDirectory, state, gitPath);
+
+  return state;
+}
+
+/**
+ * Find all changed files tracked by Git, their current hashes, and the nature of the change. Only useful if all changes are staged or committed.
+ * @param currentWorkingDirectory - The working directory. Only used to find the repository root.
+ * @param revision - The Git revision specifier to detect changes relative to. Defaults to HEAD (i.e. will compare staged vs. committed)
+ * @param gitPath - The path to the Git executable
+ * @returns A map from the Git file path to the corresponding file change metadata
+ * @beta
+ */
+export function getRepoChanges(
+  currentWorkingDirectory: string,
+  revision: string = 'HEAD',
+  gitPath?: string
+): Map<string, IFileDiffStatus> {
+  const rootDirectory: string = getRepoRoot(currentWorkingDirectory, gitPath);
+
+  const result: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+    gitPath || 'git',
+    [
+      '--no-optional-locks',
+      'diff-index',
+      '--color=never',
+      '--no-renames',
+      '--no-commit-id',
+      '--cached',
+      '-z',
+      revision,
+      '--'
+    ],
+    {
+      currentWorkingDirectory: rootDirectory
+    }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`git diff-index exited with status ${result.status}: ${result.stderr}`);
+  }
+
+  const changes: Map<string, IFileDiffStatus> = parseGitDiffIndex(result.stdout);
+
+  return changes;
+}

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -14,3 +14,5 @@
  */
 
 export { getPackageDeps, getGitHashForFiles } from './getPackageDeps';
+export { getRepoChanges, getRepoRoot, getRepoState } from './getRepoState';
+export { IFileDiffStatus } from './getRepoState';

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+import { getRepoState, parseGitLsTree, getRepoRoot } from '../getRepoState';
+
+import { FileSystem, FileConstants } from '@rushstack/node-core-library';
+
+const SOURCE_PATH: string = path.join(__dirname).replace(path.join('lib', 'test'), path.join('src', 'test'));
+
+const TEST_PREFIX: string = `libraries/package-deps-hash/src/test/`;
+const TEST_PROJECT_PATH: string = path.join(SOURCE_PATH, 'testProject');
+
+const FILTERS: string[] = [`testProject/`, `nestedTestProject/`];
+
+function getRelevantEntries(results: Map<string, string>): Map<string, string> {
+  const relevantResults: Map<string, string> = new Map();
+  for (const [key, hash] of results) {
+    if (key.startsWith(TEST_PREFIX)) {
+      const partialKey: string = key.slice(TEST_PREFIX.length);
+      for (const filter of FILTERS) {
+        if (partialKey.startsWith(filter)) {
+          relevantResults.set(partialKey, hash);
+        }
+      }
+    }
+  }
+  return relevantResults;
+}
+
+describe(`getRepoRoot`, () => {
+  it(`returns the correct directory`, () => {
+    const root: string = getRepoRoot(__dirname);
+    const expectedRoot: string = path.resolve(__dirname, '../../../..').replace(/\\/g, '/');
+    expect(root).toEqual(expectedRoot);
+  });
+});
+
+describe('parseGitLsTree', () => {
+  it('can handle a blob', () => {
+    const filename: string = 'src/typings/tsd.d.ts';
+    const hash: string = '3451bccdc831cb43d7a70ed8e628dcf9c7f888c8';
+
+    const output: string = `100644 blob ${hash}\t${filename}\x00`;
+    const changes: Map<string, string> = parseGitLsTree(output);
+
+    expect(changes.size).toEqual(1); // Expect there to be exactly 1 change
+    expect(changes.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
+  });
+
+  it('can handle a submodule', () => {
+    const filename: string = 'rushstack';
+    const hash: string = 'c5880bf5b0c6c1f2e2c43c95beeb8f0a808e8bac';
+
+    const output: string = `160000 commit ${hash}\t${filename}\x00`;
+    const changes: Map<string, string> = parseGitLsTree(output);
+
+    expect(changes.size).toEqual(1); // Expect there to be exactly 1 change
+    expect(changes.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
+  });
+
+  it('can handle multiple lines', () => {
+    const filename1: string = 'src/typings/tsd.d.ts';
+    const hash1: string = '3451bccdc831cb43d7a70ed8e628dcf9c7f888c8';
+
+    const filename2: string = 'src/foo bar/tsd.d.ts';
+    const hash2: string = '0123456789abcdef1234567890abcdef01234567';
+
+    const output: string = `100644 blob ${hash1}\t${filename1}\x00100666 blob ${hash2}\t${filename2}\0`;
+    const changes: Map<string, string> = parseGitLsTree(output);
+
+    expect(changes.size).toEqual(2); // Expect there to be exactly 2 changes
+    expect(changes.get(filename1)).toEqual(hash1); // Expect the hash to be ${hash1}
+    expect(changes.get(filename2)).toEqual(hash2); // Expect the hash to be ${hash2}
+  });
+});
+
+describe('getPackageDeps', () => {
+  it('can parse committed files', () => {
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+    const expectedFiles: Map<string, string> = new Map(
+      Object.entries({
+        'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+        [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+        'testProject/file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+        'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+        'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+        [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+      })
+    );
+
+    for (const [filePath, hash] of expectedFiles) {
+      expect(filteredResults.get(filePath)).toEqual(hash);
+    }
+    expect(filteredResults.size).toEqual(expectedFiles.size);
+  });
+
+  it('can handle adding one file', () => {
+    const tempFilePath: string = path.join(TEST_PROJECT_PATH, 'a.txt');
+
+    FileSystem.writeFile(tempFilePath, 'a');
+
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+
+    try {
+      const expectedFiles: Map<string, string> = new Map(
+        Object.entries({
+          'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+          'testProject/a.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          'testProject/file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+          'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+          [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+        })
+      );
+
+      for (const [filePath, hash] of expectedFiles) {
+        expect(filteredResults.get(filePath)).toEqual(hash);
+      }
+      expect(filteredResults.size).toEqual(expectedFiles.size);
+    } finally {
+      FileSystem.deleteFile(tempFilePath);
+    }
+  });
+
+  it('can handle adding two files', () => {
+    const tempFilePath1: string = path.join(TEST_PROJECT_PATH, 'a.txt');
+    const tempFilePath2: string = path.join(TEST_PROJECT_PATH, 'b.txt');
+
+    FileSystem.writeFile(tempFilePath1, 'a');
+    FileSystem.writeFile(tempFilePath2, 'a');
+
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+
+    try {
+      const expectedFiles: Map<string, string> = new Map(
+        Object.entries({
+          'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+          'testProject/a.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          'testProject/b.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          'testProject/file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+          'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+          [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+        })
+      );
+
+      for (const [filePath, hash] of expectedFiles) {
+        expect(filteredResults.get(filePath)).toEqual(hash);
+      }
+      expect(filteredResults.size).toEqual(expectedFiles.size);
+    } finally {
+      FileSystem.deleteFile(tempFilePath1);
+      FileSystem.deleteFile(tempFilePath2);
+    }
+  });
+
+  it('can handle removing one file', () => {
+    const testFilePath: string = path.join(TEST_PROJECT_PATH, 'file1.txt');
+
+    FileSystem.deleteFile(testFilePath);
+
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+
+    try {
+      const expectedFiles: Map<string, string> = new Map(
+        Object.entries({
+          'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+          'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+          'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+          [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+        })
+      );
+
+      for (const [filePath, hash] of expectedFiles) {
+        expect(filteredResults.get(filePath)).toEqual(hash);
+      }
+      expect(filteredResults.size).toEqual(expectedFiles.size);
+    } finally {
+      execSync(`git checkout-index --force HEAD -- ${testFilePath}testProject/file1.txt`, {
+        stdio: 'ignore',
+        cwd: getRepoRoot(__dirname)
+      });
+    }
+  });
+
+  it('can handle changing one file', () => {
+    const testFilePath: string = path.join(TEST_PROJECT_PATH, 'file1.txt');
+
+    FileSystem.writeFile(testFilePath, 'abc');
+
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+
+    try {
+      const expectedFiles: Map<string, string> = new Map(
+        Object.entries({
+          'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+          'testProject/file1.txt': 'f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f',
+          'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+          'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+          [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+        })
+      );
+
+      for (const [filePath, hash] of expectedFiles) {
+        expect(filteredResults.get(filePath)).toEqual(hash);
+      }
+      expect(filteredResults.size).toEqual(expectedFiles.size);
+    } finally {
+      execSync(`git checkout-index --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
+        stdio: 'ignore',
+        cwd: getRepoRoot(__dirname)
+      });
+    }
+  });
+
+  it('can handle uncommitted filenames with spaces and non-ASCII characters', () => {
+    const tempFilePath1: string = path.join(TEST_PROJECT_PATH, 'a file.txt');
+    const tempFilePath2: string = path.join(TEST_PROJECT_PATH, 'a  file name.txt');
+    const tempFilePath3: string = path.join(TEST_PROJECT_PATH, 'newFile批把.txt');
+
+    FileSystem.writeFile(tempFilePath1, 'a');
+    FileSystem.writeFile(tempFilePath2, 'a');
+    FileSystem.writeFile(tempFilePath3, 'a');
+
+    const results: Map<string, string> = getRepoState(__dirname);
+    const filteredResults: Map<string, string> = getRelevantEntries(results);
+
+    try {
+      const expectedFiles: Map<string, string> = new Map(
+        Object.entries({
+          'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          [`nestedTestProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576',
+          'testProject/a file.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          'testProject/a  file name.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          'testProject/file1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
+          'testProject/file  2.txt': 'a385f754ec4fede884a4864d090064d9aeef8ccb',
+          'testProject/file蝴蝶.txt': 'ae814af81e16cb2ae8c57503c77e2cab6b5462ba',
+          'testProject/newFile批把.txt': '2e65efe2a145dda7ee51d1741299f848e5bf752e',
+          [`testProject/${FileConstants.PackageJson}`]: '18a1e415e56220fa5122428a4ef8eb8874756576'
+        })
+      );
+
+      for (const [filePath, hash] of expectedFiles) {
+        expect(filteredResults.get(filePath)).toEqual(hash);
+      }
+      expect(filteredResults.size).toEqual(expectedFiles.size);
+    } finally {
+      FileSystem.deleteFile(tempFilePath1);
+      FileSystem.deleteFile(tempFilePath2);
+      FileSystem.deleteFile(tempFilePath3);
+    }
+  });
+});

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -186,7 +186,7 @@ describe('getPackageDeps', () => {
       }
       expect(filteredResults.size).toEqual(expectedFiles.size);
     } finally {
-      execSync(`git checkout-index --force HEAD -- ${testFilePath}testProject/file1.txt`, {
+      execSync(`git checkout-index --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
         stdio: 'ignore',
         cwd: getRepoRoot(__dirname)
       });

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -186,7 +186,7 @@ describe('getPackageDeps', () => {
       }
       expect(filteredResults.size).toEqual(expectedFiles.size);
     } finally {
-      execSync(`git checkout-index --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
+      execSync(`git checkout --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
         stdio: 'ignore',
         cwd: getRepoRoot(__dirname)
       });
@@ -218,7 +218,7 @@ describe('getPackageDeps', () => {
       }
       expect(filteredResults.size).toEqual(expectedFiles.size);
     } finally {
-      execSync(`git checkout-index --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
+      execSync(`git checkout --force HEAD -- ${TEST_PREFIX}testProject/file1.txt`, {
         stdio: 'ignore',
         cwd: getRepoRoot(__dirname)
       });


### PR DESCRIPTION
## Summary
~~Adds support for two new command-line selection parameters:~~
- ~~`--changed-since REF`: Selects all projects that have had committed or staged changes in the Git repository since revision REF, then performs the same expansion as `--from`, i.e. selects all consumers of those projects, and all dependencies required to build the resulting set.~~
- ~~`--changed-since-only REF`: Selects all projects that have had committed or staged changes in the Git repository since revision REF. No expansion is performed.~~
Revises the parser for command line selection parameters to accept values of the format `${protocol}:${specifier}`. If the input does not contain the character `:`, the protocol is inferred as `'name'`. Protocol handlers:
- `git:${REF}` - Find all projects that contain Git changes since the Git revision REF
- `name:${'.' | packageName}` - Find the Rush project named `packageName`, or if `'.'`, the project in the current working directory
- `version-policy:${policyName}` - Find all projects with the version policy name `policyName` (case sensitive)

Also updates ProjectChangeAnalyzer to handle having `rush.json` in a subfolder of the Git repository. Git operations for change detection will always be performed relative to the repository root, rather than the folder that contains `rush.json`.

## Details
Adds new APIs in`@rushstack/package-deps-hash` to support queries that always resolve to the root.
Revises the logic for matching a git path to a project to compute paths relative to the repository root.

Fixes #2701
Fixes #2874 

Does not yet include the additional logic to perform lockfile diffing in `ProjectChangeAnalyzer#getChangedProjectsAsync`, but all requisite information is available at the call site (old object ID of the shrinkwrap file).

## How it was tested
For the new parameters, local execution of `rush list --to git:HEAD~1` and similar.
