### PR TITLE
feat(rush): add new filterLog hook in pnpmfile shim

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -56,6 +56,7 @@
     "z-schema": "~3.18.3"
   },
   "devDependencies": {
+    "@pnpm/logger": "4.0.0",
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",

--- a/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { LogBase } from '@pnpm/logger';
 import type { IPackageJson } from '@rushstack/node-core-library';
 import type { IPnpmShrinkwrapYaml } from './PnpmShrinkwrapFile';
-import type { LogBase } from '@pnpm/logger';
 
 /**
  * The `settings` parameter passed to {@link IPnpmfileShim.hooks.readPackage} and

--- a/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -3,6 +3,7 @@
 
 import type { IPackageJson } from '@rushstack/node-core-library';
 import type { IPnpmShrinkwrapYaml } from './PnpmShrinkwrapFile';
+import type { LogBase } from '@pnpm/logger';
 
 /**
  * The `settings` parameter passed to {@link IPnpmfileShim.hooks.readPackage} and
@@ -27,16 +28,7 @@ export interface IPnpmfileContext {
 /**
  * The `log` parameter passed to {@link IPnpmfile.hooks.filterLog}.
  */
-export type IPnpmLog = (
-  | {
-      level: 'debug' | 'error';
-    }
-  | {
-      level: 'info' | 'warn';
-      prefix: string;
-      message: string;
-    }
-) & {
+export type IPnpmLog = LogBase & {
   [key: string]: unknown;
 };
 

--- a/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -47,6 +47,10 @@ export interface IPnpmfile {
   hooks?: {
     afterAllResolved?: (lockfile: IPnpmShrinkwrapYaml, context: IPnpmfileContext) => IPnpmShrinkwrapYaml;
     readPackage?: (pkg: IPackageJson, context: IPnpmfileContext) => IPackageJson;
+    /**
+     * @remarks
+     * This function is not supported by PNPM versions before 6.17.0.
+     */
     filterLog?: (log: IPnpmLog) => boolean;
   };
 }

--- a/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/apps/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -25,11 +25,28 @@ export interface IPnpmfileContext {
 }
 
 /**
+ * The `log` parameter passed to {@link IPnpmfile.hooks.filterLog}.
+ */
+export type IPnpmLog = (
+  | {
+      level: 'debug' | 'error';
+    }
+  | {
+      level: 'info' | 'warn';
+      prefix: string;
+      message: string;
+    }
+) & {
+  [key: string]: unknown;
+};
+
+/**
  * The pnpmfile, as defined by the pnpmfile API contract.
  */
 export interface IPnpmfile {
   hooks?: {
     afterAllResolved?: (lockfile: IPnpmShrinkwrapYaml, context: IPnpmfileContext) => IPnpmShrinkwrapYaml;
     readPackage?: (pkg: IPackageJson, context: IPnpmfileContext) => IPackageJson;
+    filterLog?: (log: IPnpmLog) => boolean;
   };
 }

--- a/apps/rush-lib/src/logic/pnpm/PnpmfileShim.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmfileShim.ts
@@ -111,7 +111,10 @@ const pnpmfileShim: IPnpmfile = {
       setPreferredVersions(pkg.devDependencies);
       setPreferredVersions(pkg.optionalDependencies);
       return userPnpmfile?.hooks?.readPackage ? userPnpmfile.hooks.readPackage(pkg, context) : pkg;
-    }
+    },
+
+    // Call the original pnpmfile (if it exists)
+    filterLog: userPnpmfile?.hooks?.filterLog
   }
 };
 

--- a/common/changes/@microsoft/rush/feat-pnpmfile-filter-log_2021-10-28-03-38.json
+++ b/common/changes/@microsoft/rush/feat-pnpmfile-filter-log_2021-10-28-03-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Supports filterLog hook in pnpmfile",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -3,6 +3,10 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
   "packages": [
     {
+      "name": "@pnpm/logger",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "react",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -3,10 +3,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
   "packages": [
     {
-      "name": "@pnpm/logger",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
       "name": "react",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -71,6 +71,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@pnpm/logger",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@rushstack/eslint-config",
       "allowedCategories": [ "libraries", "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -218,6 +218,7 @@ importers:
       '@azure/identity': ~1.0.0
       '@azure/storage-blob': ~12.3.0
       '@pnpm/link-bins': ~5.3.7
+      '@pnpm/logger': 4.0.0
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@rushstack/heft-config-file': workspace:*
@@ -310,6 +311,7 @@ importers:
       true-case-path: 2.2.1
       z-schema: 3.18.4
     devDependencies:
+      '@pnpm/logger': 4.0.0
       '@rushstack/eslint-config': link:../../stack/eslint-config
       '@rushstack/heft': link:../heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
@@ -4203,6 +4205,14 @@ packages:
       ramda: 0.27.1
     dev: false
 
+  /@pnpm/logger/4.0.0:
+    resolution: {integrity: sha512-SIShw+k556e7S7tLZFVSIHjCdiVog1qWzcKW2RbLEHPItdisAFVNIe34kYd9fMSswTlSRLS/qRjw3ZblzWmJ9Q==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      bole: 4.0.0
+      ndjson: 2.0.0
+    dev: true
+
   /@pnpm/package-bins/4.1.0:
     resolution: {integrity: sha512-57/ioGYLBbVRR80Ux9/q2i3y8Q+uQADc3c+Yse8jr/60YLOi3jcWz13e2Jy+ANYtZI258Qc5wk2X077rp0Ly/Q==}
     engines: {node: '>=10.16'}
@@ -7644,6 +7654,13 @@ packages:
       raw-body: 2.4.0
       type-is: 1.6.18
 
+  /bole/4.0.0:
+    resolution: {integrity: sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==}
+    dependencies:
+      fast-safe-stringify: 2.0.7
+      individual: 3.0.0
+    dev: true
+
   /bonjour/3.5.0:
     resolution: {integrity: sha1-jokKGD2O6aI5OzhExpGkK897yfU=}
     dependencies:
@@ -9871,7 +9888,6 @@ packages:
 
   /fast-safe-stringify/2.0.7:
     resolution: {integrity: sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==}
-    dev: false
 
   /fastify-error/0.3.1:
     resolution: {integrity: sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==}
@@ -11222,6 +11238,10 @@ packages:
   /indent-string/4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  /individual/3.0.0:
+    resolution: {integrity: sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0=}
+    dev: true
 
   /infer-owner/1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
@@ -13213,6 +13233,18 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
+
+  /ndjson/2.0.0:
+    resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      json-stringify-safe: 5.0.1
+      minimist: 1.2.5
+      readable-stream: 3.6.0
+      split2: 3.2.2
+      through2: 4.0.2
+    dev: true
 
   /negotiator/0.6.2:
     resolution: {integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==}
@@ -15829,6 +15861,12 @@ packages:
     dependencies:
       extend-shallow: 3.0.2
 
+  /split2/3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+    dependencies:
+      readable-stream: 3.6.0
+    dev: true
+
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
 
@@ -16421,6 +16459,12 @@ packages:
     dependencies:
       readable-stream: 2.3.7
       xtend: 4.0.2
+
+  /through2/4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+    dependencies:
+      readable-stream: 3.6.0
+    dev: true
 
   /thunky/1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "e0e0c48d35c6d3a8facfe2bab3e51a25715d8fd6",
+  "pnpmShrinkwrapHash": "0e6a7696a58c3eb44b65242a64aa80da8d95c773",
   "preferredVersionsHash": "fe0ea762c60633ea39d8abd6f7e0791352654f89"
 }


### PR DESCRIPTION


## Summary

pnpm adds a new hook for filtering out info and warning logs from `pnpm@6.17.0`.

![image](https://user-images.githubusercontent.com/16147702/138487577-ed196b5b-fd17-40b1-8bed-6e9ada703082.png)


## Details

Adding `filterLog` in `PnpmfileShim`.

## How it was tested

Local
