### PR TITLE
[CI] Suppress browserslist update warning

### DIFF
--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -14,3 +14,7 @@ steps:
     displayName: 'Rush Install'
   - script: 'node common/scripts/install-run-rush.js rebuild --verbose --production'
     displayName: 'Rush Rebuild'
+    env:
+      # Prevent time-based browserslist update warning
+      # See https://github.com/microsoft/rushstack/issues/2981
+      BROWSERSLIST_IGNORE_OLD_DATA: 1


### PR DESCRIPTION
## Summary

Add a workaround for the time-based browserslist update warning to rushstack CI.

Related to #2981.

## Details

This PR is to unblock the CI pipeline for now, see issue above for more discussion about a permanent solution.
