### PR TITLE
feat(eslint-patch): Find patch targets independently of disk layout

### DIFF
--- a/common/changes/@rushstack/eslint-patch/asmundg-fix-pnmp-layout_2021-10-27-13-11.json
+++ b/common/changes/@rushstack/eslint-patch/asmundg-fix-pnmp-layout_2021-10-27-13-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "feat(eslint-patch): Find patch targets independently of disk layout",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/stack/eslint-patch/src/modern-module-resolution.ts
+++ b/stack/eslint-patch/src/modern-module-resolution.ts
@@ -31,17 +31,34 @@ for (let currentModule = module; ; ) {
   if (!eslintrcBundlePath) {
     // For ESLint >=8.0.0, all @eslint/eslintrc code is bundled at this path:
     //   .../@eslint/eslintrc/dist/eslintrc.cjs
-    if (/[\\/]@eslint[\\/]eslintrc[\\/]dist[\\/]eslintrc\.cjs$/i.test(currentModule.filename)) {
-      const eslintrcFolder: string = path.join(path.dirname(currentModule.filename), '..');
-      eslintrcBundlePath = path.join(eslintrcFolder, 'dist/eslintrc.cjs');
-    }
+    try {
+      const eslintrcFolder = path.dirname(
+        require.resolve('@eslint/eslintrc/package.json', { paths: [currentModule.path] })
+      );
+
+      // Make sure we actually resolved the module in our call path
+      // and not some other spurious dependency.
+      if (path.join(eslintrcFolder, 'dist/eslintrc.cjs') == currentModule.filename) {
+        eslintrcBundlePath = path.join(eslintrcFolder, 'dist/eslintrc.cjs');
+      }
+    } catch {}
   } else {
     // Next look for a file in ESLint's folder
     //   .../eslint/lib/cli-engine/cli-engine.js
-    if (/[\\/]eslint[\\/]lib[\\/]cli-engine[\\/]cli-engine\.js$/i.test(currentModule.filename)) {
-      eslintFolder = path.join(path.dirname(currentModule.filename), '../..');
-      break;
-    }
+    try {
+      const eslintCandidateFolder = path.dirname(
+        require.resolve('eslint/package.json', {
+          paths: [currentModule.path]
+        })
+      );
+
+      // Make sure we actually resolved the module in our call path
+      // and not some other spurious dependency.
+      if (path.join(eslintCandidateFolder, 'lib/cli-engine/cli-engine.js') == currentModule.filename) {
+        eslintFolder = eslintCandidateFolder;
+        break;
+      }
+    } catch {}
   }
 
   if (!currentModule.parent) {
@@ -56,18 +73,33 @@ if (!eslintFolder) {
     if (!configArrayFactoryPath) {
       // For ESLint >=7.8.0, config-array-factory.js is at this path:
       //   .../@eslint/eslintrc/lib/config-array-factory.js
-      if (/[\\/]@eslint[\\/]eslintrc[\\/]lib[\\/]config-array-factory\.js$/i.test(currentModule.filename)) {
-        const eslintrcFolder: string = path.join(path.dirname(currentModule.filename), '..');
-        configArrayFactoryPath = path.join(eslintrcFolder, 'lib/config-array-factory');
-        moduleResolverPath = path.join(eslintrcFolder, 'lib/shared/relative-module-resolver');
-      }
+      try {
+        const eslintrcFolder = path.dirname(
+          require.resolve('@eslint/eslintrc/package.json', {
+            paths: [currentModule.path]
+          })
+        );
+
+        if (path.join(eslintrcFolder, '/lib/config-array-factory.js') == currentModule.filename) {
+          configArrayFactoryPath = path.join(eslintrcFolder, 'lib/config-array-factory.js');
+          moduleResolverPath = path.join(eslintrcFolder, 'lib/shared/relative-module-resolver');
+        }
+      } catch {}
     } else {
       // Next look for a file in ESLint's folder
       //   .../eslint/lib/cli-engine/cli-engine.js
-      if (/[\\/]eslint[\\/]lib[\\/]cli-engine[\\/]cli-engine\.js$/i.test(currentModule.filename)) {
-        eslintFolder = path.join(path.dirname(currentModule.filename), '../..');
-        break;
-      }
+      try {
+        const eslintCandidateFolder = path.dirname(
+          require.resolve('eslint/package.json', {
+            paths: [currentModule.path]
+          })
+        );
+
+        if (path.join(eslintCandidateFolder, 'lib/cli-engine/cli-engine.js') == currentModule.filename) {
+          eslintFolder = eslintCandidateFolder;
+          break;
+        }
+      } catch {}
     }
 
     if (!currentModule.parent) {


### PR DESCRIPTION
## Summary

When using package managers like pnpm and yarn pnp, which store packages
in a flat store and adds symlinks in node_modules, the real path of
package folders will have version numbers and disambiguating hashes in
them.

This means that naively looking at folder names when looking for eslint
patch targets won't work.

Instead, we use module resolution semantics to compare the path of
resolved patch targets to the current call stack. This lets us
unambiguously locate patch targets in our call stack without making
assumptions about disk layout.

## Details

## How it was tested

Tested in internal repo with pnpm-style layout

* MacOS (case sensitive FS)
  * eslint 8.1.0
    * NodeJS 12/14/16
   * eslint 7.32.0
     * NodeJS 12/14/16
* Windows
  * eslint 8.1.0
    * NodeJS 12/14/16
   * eslint 7.32.0
     * NodeJS 12/14/16

Validated that config fails without patch present.