### PR TITLE
[api-documenter] Fix broken markdown links for enum members

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -1112,6 +1112,7 @@ export class MarkdownDocumenter {
       switch (hierarchyItem.kind) {
         case ApiItemKind.Model:
         case ApiItemKind.EntryPoint:
+        case ApiItemKind.EnumMember:
           break;
         case ApiItemKind.Package:
           baseName = Utilities.getSafeFilenameForName(PackageName.getUnscopedName(hierarchyItem.displayName));

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -825,7 +825,7 @@
             {
               "kind": "EnumMember",
               "canonicalReference": "api-documenter-test!DocEnum.Two:member",
-              "docComment": "/**\n * These are some docs for Two\n */\n",
+              "docComment": "/**\n * These are some docs for Two.\n *\n * {@link DocEnum.One} is a direct link to another enum member.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenum.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenum.md
@@ -18,6 +18,6 @@ export declare enum DocEnum
 |  Member | Value | Description |
 |  --- | --- | --- |
 |  One | <code>1</code> | These are some docs for One |
-|  Two | <code>2</code> | These are some docs for Two |
+|  Two | <code>2</code> | These are some docs for Two.[DocEnum.One](./api-documenter-test.docenum.md) is a direct link to another enum member. |
 |  Zero | <code>0</code> | These are some docs for Zero |
 

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docenum.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docenum.yml
@@ -16,7 +16,10 @@ fields:
   - name: Two
     uid: 'api-documenter-test!DocEnum.Two:member'
     package: api-documenter-test!
-    summary: These are some docs for Two
+    summary: |-
+      These are some docs for Two.
+
+      [DocEnum.One](xref:api-documenter-test!DocEnum.One:member) is a direct link to another enum member.
     value: '2'
   - name: Zero
     uid: 'api-documenter-test!DocEnum.Zero:member'

--- a/build-tests/api-documenter-test/src/DocEnums.ts
+++ b/build-tests/api-documenter-test/src/DocEnums.ts
@@ -18,7 +18,9 @@ export enum DocEnum {
   One = 1,
 
   /**
-   * These are some docs for Two
+   * These are some docs for Two.
+   *
+   * {@link DocEnum.One} is a direct link to another enum member.
    */
   Two = DocEnum.One + 1
 }

--- a/common/changes/@microsoft/api-documenter/enelson-api-enum-link_2021-11-01-12-51.json
+++ b/common/changes/@microsoft/api-documenter/enelson-api-enum-link_2021-11-01-12-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Links to enum members go to the enum page in markdown output",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
## Summary

For markdown output, we write a single output page for an Enum, but not separate pages for Enum Members.

Correct generated links for Enum Members to point at their parent Enum page.

Fixes #2552.

## Details

_Note:_ I'm not that familiar with the YAML output; it looks like the YAML output is correct, based on the updated integration tests, but we can do a similar fix there if necessary.

## How it was tested

 - Updated `build-tests/api-documenter-test` integration test and validated output markdown was incorrect.
 - Inserted fix and validated output markdown was correct.
