### PR TITLE
[eslint-config] Set README paths to mixins to correct paths

### DIFF
--- a/common/changes/@rushstack/eslint-config/user-danade-FixMixinDocs_2021-11-09-20-39.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-FixMixinDocs_2021-11-09-20-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/user-danade-FixMixinDocs_2021-11-09-20-39.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/user-danade-FixMixinDocs_2021-11-09-20-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/stack/eslint-config/README.md
+++ b/stack/eslint-config/README.md
@@ -177,7 +177,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/friendly-locals" // <----
+    "@rushstack/eslint-config/mixins/friendly-locals" // <----
   ],
   parserOptions: { tsconfigRootDir: __dirname }
 };
@@ -200,7 +200,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/packlets" // <----
+    "@rushstack/eslint-config/mixins/packlets" // <----
   ],
   parserOptions: { tsconfigRootDir: __dirname }
 };
@@ -224,7 +224,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/tsdoc" // <----
+    "@rushstack/eslint-config/mixins/tsdoc" // <----
   ],
   parserOptions: { tsconfigRootDir: __dirname }
 };

--- a/stack/eslint-plugin-packlets/README.md
+++ b/stack/eslint-plugin-packlets/README.md
@@ -143,7 +143,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/packlets" // <--- ADD THIS
+    "@rushstack/eslint-config/mixins/packlets" // <--- ADD THIS
   ],
   parserOptions: { tsconfigRootDir: __dirname }
 };
@@ -171,7 +171,7 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: [
     "@rushstack/eslint-config/profile/node",
-    "@rushstack/eslint-config/profile/mixins/packlets"
+    "@rushstack/eslint-config/mixins/packlets"
   ],
   parserOptions: { tsconfigRootDir: __dirname },
   overrides: [


### PR DESCRIPTION
## Summary
Updates the import paths to ESLint mixin configurations to be to the actual path. Fixes #2997
