### PR TITLE
[rush] Stop deleting pnpm store after failed workspace installs

### DIFF
--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -329,57 +329,42 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       );
     }
 
-    try {
-      Utilities.executeCommandWithRetry(
-        {
-          command: packageManagerFilename,
-          args: installArgs,
-          workingDirectory: this.rushConfiguration.commonTempFolder,
-          environment: packageManagerEnv,
-          suppressOutput: false
-        },
-        this.options.maxInstallAttempts,
-        () => {
-          if (this.rushConfiguration.packageManager === 'pnpm') {
-            console.log(colors.yellow(`Deleting the "node_modules" folder`));
-            this.installRecycler.moveFolder(commonNodeModulesFolder);
+    Utilities.executeCommandWithRetry(
+      {
+        command: packageManagerFilename,
+        args: installArgs,
+        workingDirectory: this.rushConfiguration.commonTempFolder,
+        environment: packageManagerEnv,
+        suppressOutput: false
+      },
+      this.options.maxInstallAttempts,
+      () => {
+        if (this.rushConfiguration.packageManager === 'pnpm') {
+          console.log(colors.yellow(`Deleting the "node_modules" folder`));
+          this.installRecycler.moveFolder(commonNodeModulesFolder);
 
-            // Leave the pnpm-store as is for the retry. This ensures that packages that have already
-            // been downloaded need not be downloaded again, thereby potentially increasing the chances
-            // of a subsequent successful install.
+          // Leave the pnpm-store as is for the retry. This ensures that packages that have already
+          // been downloaded need not be downloaded again, thereby potentially increasing the chances
+          // of a subsequent successful install.
 
-            Utilities.createFolderWithRetry(commonNodeModulesFolder);
-          }
+          Utilities.createFolderWithRetry(commonNodeModulesFolder);
         }
-      );
-
-      // Ensure that node_modules folders exist after install, since the timestamps on these folders are used
-      // to determine if the install can be skipped
-      const projectNodeModulesFolders: string[] = [
-        path.join(this.rushConfiguration.commonTempFolder, RushConstants.nodeModulesFolderName),
-        ...this.rushConfiguration.projects.map((x) => {
-          return path.join(x.projectFolder, RushConstants.nodeModulesFolderName);
-        })
-      ];
-
-      for (const nodeModulesFolder of projectNodeModulesFolders) {
-        FileSystem.ensureFolder(nodeModulesFolder);
       }
-    } catch (error) {
-      // All the install attempts failed.
+    );
 
-      if (
-        this.rushConfiguration.packageManager === 'pnpm' &&
-        this.rushConfiguration.pnpmOptions.pnpmStore === 'local'
-      ) {
-        // If the installation has failed even after the retries, then pnpm store may
-        // have got into a corrupted, irrecoverable state. Delete the store so that a
-        // future install can create the store afresh.
-        console.log(colors.yellow(`Deleting the "pnpm-store" folder`));
-        this.installRecycler.moveFolder(this.rushConfiguration.pnpmOptions.pnpmStorePath);
-      }
+    // If all attempts fail we just terminate. No special handling needed.
 
-      throw error;
+    // Ensure that node_modules folders exist after install, since the timestamps on these folders are used
+    // to determine if the install can be skipped
+    const projectNodeModulesFolders: string[] = [
+      path.join(this.rushConfiguration.commonTempFolder, RushConstants.nodeModulesFolderName),
+      ...this.rushConfiguration.projects.map((x) => {
+        return path.join(x.projectFolder, RushConstants.nodeModulesFolderName);
+      })
+    ];
+
+    for (const nodeModulesFolder of projectNodeModulesFolders) {
+      FileSystem.ensureFolder(nodeModulesFolder);
     }
 
     console.log('');

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -259,11 +259,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // files
     // Example: [ "C:\MyRepo\projects\projectA\node_modules", "C:\MyRepo\projects\projectA\package.json" ]
     potentiallyChangedFiles.push(
-      ...this.rushConfiguration.projects.map((x) => {
-        return path.join(x.projectFolder, RushConstants.nodeModulesFolderName);
+      ...this.rushConfiguration.projects.map((project) => {
+        return path.join(project.projectFolder, RushConstants.nodeModulesFolderName);
       }),
-      ...this.rushConfiguration.projects.map((x) => {
-        return path.join(x.projectFolder, FileConstants.PackageJson);
+      ...this.rushConfiguration.projects.map((project) => {
+        return path.join(project.projectFolder, FileConstants.PackageJson);
       })
     );
 
@@ -358,8 +358,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // to determine if the install can be skipped
     const projectNodeModulesFolders: string[] = [
       path.join(this.rushConfiguration.commonTempFolder, RushConstants.nodeModulesFolderName),
-      ...this.rushConfiguration.projects.map((x) => {
-        return path.join(x.projectFolder, RushConstants.nodeModulesFolderName);
+      ...this.rushConfiguration.projects.map((project) => {
+        return path.join(project.projectFolder, RushConstants.nodeModulesFolderName);
       })
     ];
 
@@ -381,8 +381,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
 
     // Write or delete all project shrinkwraps related to the install
     await Promise.all(
-      this.rushConfiguration.projects.map(async (x) => {
-        await tempShrinkwrapFile.getProjectShrinkwrap(x)?.updateProjectShrinkwrapAsync();
+      this.rushConfiguration.projects.map(async (project) => {
+        await tempShrinkwrapFile.getProjectShrinkwrap(project)?.updateProjectShrinkwrapAsync();
       })
     );
 

--- a/common/changes/@microsoft/rush/stop-deleting-pnpm-store_2021-11-18-01-52.json
+++ b/common/changes/@microsoft/rush/stop-deleting-pnpm-store_2021-11-18-01-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Stop deleting the pnpm-store after failed workspace installs. Usually a multiple failure is due to a network error or a package that does not exist in the registry, not an issue with the pnpm-store.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Stops deleting the pnpm store after max retries have been reached for a workspace install.

## Details
Breaking the pnpm store is a situation that in practice does not happen. The two most common causes of failed install are that the requested package does not exist in the registry (happens a lot when mirroring packages, or due to user error in package.json), or a network error on the machine. Neither situation is helped by deleting the local cache.

## How it was tested

