### PR TITLE
[rush] Allow disabling local cache writes, disable during watch mode

### DIFF
--- a/apps/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/apps/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -72,6 +72,7 @@ export class BuildCacheConfiguration {
    * Typically it is enabled in the build-cache.json config file.
    */
   public readonly buildCacheEnabled: boolean;
+  public cacheWriteEnabled: boolean;
 
   public readonly getCacheEntryId: GetCacheEntryIdFunction;
   public readonly localCacheProvider: FileSystemBuildCacheProvider;
@@ -80,6 +81,8 @@ export class BuildCacheConfiguration {
   private constructor(options: IBuildCacheConfigurationOptions) {
     this.buildCacheEnabled =
       EnvironmentConfiguration.buildCacheEnabled ?? options.buildCacheJson.buildCacheEnabled;
+    this.cacheWriteEnabled =
+      !!this.buildCacheEnabled && EnvironmentConfiguration.buildCacheWriteAllowed !== false;
 
     this.getCacheEntryId = options.getCacheEntryId;
     this.localCacheProvider = new FileSystemBuildCacheProvider({

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -163,6 +163,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
     };
 
     if (this._watchForChanges) {
+      if (buildCacheConfiguration) {
+        // Cache writes are not supported during watch mode, only reads.
+        buildCacheConfiguration.cacheWriteEnabled = false;
+      }
       await this._runWatch(executeOptions);
     } else {
       await this._runOnce(executeOptions);

--- a/common/changes/@microsoft/rush/local-cache-write-disable_2021-11-30-01-27.json
+++ b/common/changes/@microsoft/rush/local-cache-write-disable_2021-11-30-01-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Respect the RUSH_BUILD_CACHE_WRITE_ALLOWED environment variable value \"0\" (disabled) even for the local build cache, e.g. to save CPU cycles on CI machines that will throw out the local machine state. Disables cache writes for watch mode commands.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/local-cache-write-disable_2021-11-30-01-27.json
+++ b/common/changes/@microsoft/rush/local-cache-write-disable_2021-11-30-01-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Respect the RUSH_BUILD_CACHE_WRITE_ALLOWED environment variable value \"0\" (disabled) even for the local build cache, e.g. to save CPU cycles on CI machines that will throw out the local machine state. Disables cache writes for watch mode commands.",
+      "comment": "(EXPERIMENTAL) Improve the RUSH_BUILD_CACHE_WRITE_ALLOWED environment variable behavior so that it also affects the local build cache. This saves CPU cycles on CI machines that only run a single build. It also avoids cache writes for watch mode commands.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary
Modifies ProjectBuildCache to respect the `RUSH_BUILD_CACHE_WRITE_ALLOWED` environment variable globally, instead of being a per-provider setting. This means that setting it will disable writes to both the local cache and the cloud cache, if both apply.

## Details
If `process.env.RUSH_BUILD_CACHE_WRITE_ALLOWED === '0'`, no cache writes will be performed whatsoever. Expected to be of utility for CI machines where the local state is ephemeral and therefore constructing the local cache entry is wasted work.

Updates watch mode commands to disable build cache writes to improve performance and avoid flooding the cache.

## How it was tested
Ran a local build without the environment variable and verified that cache write was performed.
Set the variable and ran a local build, verified that no cache write was performed.
Ran a watch mode command and verified that no cache writes were performed.