### PR TITLE
[heft-node-rig] Use jest-environment-node for Jest

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-noderigtestenvironment_2021-11-30-18-37.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-noderigtestenvironment_2021-11-30-18-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-node-rig/user-danade-noderigtestenvironment_2021-11-30-18-31.json
+++ b/common/changes/@rushstack/heft-node-rig/user-danade-noderigtestenvironment_2021-11-30-18-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Set default Jest environment in Jest configuration to \"jest-environment-node\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-web-rig/user-danade-noderigtestenvironment_2021-11-30-18-37.json
+++ b/common/changes/@rushstack/heft-web-rig/user-danade-noderigtestenvironment_2021-11-30-18-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Set default Jest environment in Jest configuration to \"jest-environment-jsdom\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -419,6 +419,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "jest-environment-jsdom",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "jest-environment-node",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1218,7 +1218,7 @@ importers:
       '@types/node': 12.20.24
       eslint: ~7.30.0
       jest-config: ~25.4.0
-      jest-environment-node: ~25.4.0
+      jest-environment-node: ~25.5.0
       jest-snapshot: ~25.4.0
       lodash: ~4.17.15
       typescript: ~4.4.2
@@ -1240,7 +1240,7 @@ importers:
       '@types/lodash': 4.14.116
       '@types/node': 12.20.24
       eslint: 7.30.0
-      jest-environment-node: 25.4.0
+      jest-environment-node: 25.5.0
       typescript: 4.4.4
 
   ../../heft-plugins/heft-sass-plugin:
@@ -1682,16 +1682,16 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       eslint: ~7.30.0
-      jest-environment-node: ~25.4.0
+      jest-environment-node: ~25.5.0
       typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       eslint: 7.30.0
+      jest-environment-node: 25.5.0
       typescript: 4.4.4
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
-      jest-environment-node: 25.4.0
 
   ../../rigs/heft-web-rig:
     specifiers:
@@ -1701,6 +1701,7 @@ importers:
       '@rushstack/heft-sass-plugin': workspace:*
       '@rushstack/heft-webpack4-plugin': workspace:*
       eslint: ~7.30.0
+      jest-environment-jsdom: ~25.5.0
       typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
@@ -1708,6 +1709,7 @@ importers:
       '@rushstack/heft-sass-plugin': link:../../heft-plugins/heft-sass-plugin
       '@rushstack/heft-webpack4-plugin': link:../../heft-plugins/heft-webpack4-plugin
       eslint: 7.30.0
+      jest-environment-jsdom: 25.5.0
       typescript: 4.4.4
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
@@ -12256,7 +12258,7 @@ packages:
       deepmerge: 4.2.2
       glob: 7.2.0
       jest-environment-jsdom: 25.5.0
-      jest-environment-node: 25.4.0
+      jest-environment-node: 25.5.0
       jest-get-type: 25.2.6
       jest-jasmine2: 25.5.4
       jest-regex-util: 25.2.6
@@ -12340,17 +12342,6 @@ packages:
       - bufferutil
       - canvas
       - utf-8-validate
-
-  /jest-environment-node/25.4.0:
-    resolution: {integrity: sha512-wryZ18vsxEAKFH7Z74zi/y/SyI1j6UkVZ6QsllBuT/bWlahNfQjLNwFsgh/5u7O957dYFoXj4yfma4n4X6kU9A==}
-    engines: {node: '>= 8.3'}
-    dependencies:
-      '@jest/environment': 25.5.0
-      '@jest/fake-timers': 25.5.0
-      '@jest/types': 25.4.0
-      jest-mock: 25.5.0
-      jest-util: 25.5.0
-      semver: 6.3.0
 
   /jest-environment-node/25.5.0:
     resolution: {integrity: sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1682,6 +1682,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       eslint: ~7.30.0
+      jest-environment-node: ~25.4.0
       typescript: ~4.4.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
@@ -1690,6 +1691,7 @@ importers:
       typescript: 4.4.4
     devDependencies:
       '@rushstack/heft': link:../../apps/heft
+      jest-environment-node: 25.4.0
 
   ../../rigs/heft-web-rig:
     specifiers:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "566ce268d3ef1a34443fd97b4014e3549e33e67d",
+  "pnpmShrinkwrapHash": "1316e4465054a940952834f11797118ea52d6232",
   "preferredVersionsHash": "fe0ea762c60633ea39d8abd6f7e0791352654f89"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "195a7393a3c1b2af8fc132a5bdca52eccae4e09d",
+  "pnpmShrinkwrapHash": "566ce268d3ef1a34443fd97b4014e3549e33e67d",
   "preferredVersionsHash": "fe0ea762c60633ea39d8abd6f7e0791352654f89"
 }

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -37,7 +37,7 @@
     "@types/lodash": "4.14.116",
     "@types/node": "12.20.24",
     "eslint": "~7.30.0",
-    "jest-environment-node": "~25.4.0",
+    "jest-environment-node": "~25.5.0",
     "typescript": "~4.4.2"
   }
 }

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -18,10 +18,10 @@
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
     "eslint": "~7.30.0",
+    "jest-environment-node": "~25.5.0",
     "typescript": "~4.4.2"
   },
   "devDependencies": {
-    "@rushstack/heft": "workspace:*",
-    "jest-environment-node": "~25.4.0"
+    "@rushstack/heft": "workspace:*"
   }
 }

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -21,6 +21,7 @@
     "typescript": "~4.4.2"
   },
   "devDependencies": {
-    "@rushstack/heft": "workspace:*"
+    "@rushstack/heft": "workspace:*",
+    "jest-environment-node": "~25.4.0"
   }
 }

--- a/rigs/heft-node-rig/profiles/default/config/jest.config.json
+++ b/rigs/heft-node-rig/profiles/default/config/jest.config.json
@@ -1,3 +1,5 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json"
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
+
+  "testEnvironment": "jest-environment-node"
 }

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -20,6 +20,7 @@
     "@rushstack/heft-sass-plugin": "workspace:*",
     "@rushstack/heft-webpack4-plugin": "workspace:*",
     "eslint": "~7.30.0",
+    "jest-environment-jsdom": "~25.5.0",
     "typescript": "~4.4.2"
   },
   "devDependencies": {

--- a/rigs/heft-web-rig/profiles/library/config/jest.config.json
+++ b/rigs/heft-web-rig/profiles/library/config/jest.config.json
@@ -1,3 +1,5 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json"
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
+
+  "testEnvironment": "jest-environment-jsdom"
 }


### PR DESCRIPTION
## Summary

Consumers of the Node rig should now consume `jest-environment-node` instead of the default `jest-environment-jsdom`.

## Details

The `@rushstack/heft-node-rig` package had been using the default `testEnvironment` value for Jest, which (as of 25.x, the current version of Jest used by `@rushstack/heft-jest-plugin` at time of PR publish) defaults to `jest-environment-jsdom`. This is unexpected and can lead to issues with behaviour of code intended to work in browsers or in Node. Additionally, the `jest-environment-node` environment can provide significant performance improvements for Jest tests. This is the reason that `jest-environment-node` was made the default in Jest 27.x (see blog post here: https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults)

This PR also hardcodes the dependency on `jest-environment-jsdom` for `@rushstack/heft-web-rig` since different versions of Jest provide different default test environments.

## How it was tested

Forcing repo rebuild (not sourcing from cache) on local machine.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
