### PR TITLE
[rush] Use lockfile diffing for more granular Git changed project detection

### DIFF
--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -12,9 +12,11 @@ import { CommandLineParameterProvider, CommandLineStringListParameter } from '@r
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { Selection } from '../logic/Selection';
-import { EvaluateSelectorMode } from '../logic/selectors/ISelectorParser';
 import type { ISelectorParser as ISelectorParser } from '../logic/selectors/ISelectorParser';
-import { GitChangedProjectSelectorParser } from '../logic/selectors/GitChangedProjectSelectorParser';
+import {
+  GitChangedProjectSelectorParser,
+  IGitSelectorParserOptions
+} from '../logic/selectors/GitChangedProjectSelectorParser';
 import { NamedProjectSelectorParser } from '../logic/selectors/NamedProjectSelectorParser';
 import { VersionPolicyProjectSelectorParser } from '../logic/selectors/VersionPolicyProjectSelectorParser';
 
@@ -39,7 +41,11 @@ export class SelectionParameterSet {
 
   private readonly _selectorParserByScope: Map<string, ISelectorParser<RushConfigurationProject>>;
 
-  public constructor(rushConfiguration: RushConfiguration, action: CommandLineParameterProvider) {
+  public constructor(
+    rushConfiguration: RushConfiguration,
+    action: CommandLineParameterProvider,
+    gitOptions: IGitSelectorParserOptions
+  ) {
     this._rushConfiguration = rushConfiguration;
 
     const selectorParsers: Map<string, ISelectorParser<RushConfigurationProject>> = new Map<
@@ -48,7 +54,7 @@ export class SelectionParameterSet {
     >();
 
     selectorParsers.set('name', new NamedProjectSelectorParser(rushConfiguration));
-    selectorParsers.set('git', new GitChangedProjectSelectorParser(rushConfiguration));
+    selectorParsers.set('git', new GitChangedProjectSelectorParser(rushConfiguration, gitOptions));
     selectorParsers.set('version-policy', new VersionPolicyProjectSelectorParser(rushConfiguration));
     this._selectorParserByScope = selectorParsers;
 
@@ -173,10 +179,7 @@ export class SelectionParameterSet {
    *
    * If no parameters are specified, returns all projects in the Rush config file.
    */
-  public async getSelectedProjectsAsync(
-    terminal: ITerminal,
-    forIncremental: boolean
-  ): Promise<Set<RushConfigurationProject>> {
+  public async getSelectedProjectsAsync(terminal: ITerminal): Promise<Set<RushConfigurationProject>> {
     // Hack out the old version-policy parameters
     for (const value of this._fromVersionPolicy.values) {
       (this._fromProject.values as string[]).push(`version-policy:${value}`);
@@ -184,8 +187,6 @@ export class SelectionParameterSet {
     for (const value of this._toVersionPolicy.values) {
       (this._toProject.values as string[]).push(`version-policy:${value}`);
     }
-
-    const mode: EvaluateSelectorMode = forIncremental ? EvaluateSelectorMode.IncrementalBuild : EvaluateSelectorMode.RushChange;
 
     const selectors: CommandLineStringListParameter[] = [
       this._onlyProject,
@@ -221,7 +222,7 @@ export class SelectionParameterSet {
       impactedByExceptProjects
     ] = await Promise.all(
       selectors.map((param: CommandLineStringListParameter) => {
-        return this._evaluateProjectParameterAsync(param, terminal, mode);
+        return this._evaluateProjectParameterAsync(param, terminal);
       })
     );
 
@@ -258,27 +259,22 @@ export class SelectionParameterSet {
    */
   public async getPnpmFilterArgumentsAsync(terminal: ITerminal): Promise<string[]> {
     const args: string[] = [];
-    const mode: EvaluateSelectorMode = EvaluateSelectorMode.RushChange;
 
     // Include exactly these projects (--only)
-    for (const project of await this._evaluateProjectParameterAsync(
-      this._onlyProject,
-      terminal,
-      mode
-    )) {
+    for (const project of await this._evaluateProjectParameterAsync(this._onlyProject, terminal)) {
       args.push('--filter', project.packageName);
     }
 
     // Include all projects that depend on these projects, and all dependencies thereof
     const fromProjects: Set<RushConfigurationProject> = Selection.union(
       // --from
-      await this._evaluateProjectParameterAsync(this._fromProject, terminal, mode)
+      await this._evaluateProjectParameterAsync(this._fromProject, terminal)
     );
 
     // All specified projects and all projects that they depend on
     for (const project of Selection.union(
       // --to
-      await this._evaluateProjectParameterAsync(this._toProject, terminal, mode),
+      await this._evaluateProjectParameterAsync(this._toProject, terminal),
       // --from / --from-version-policy
       Selection.expandAllConsumers(fromProjects)
     )) {
@@ -287,21 +283,13 @@ export class SelectionParameterSet {
 
     // --to-except
     // All projects that the project directly or indirectly declares as a dependency
-    for (const project of await this._evaluateProjectParameterAsync(
-      this._toExceptProject,
-      terminal,
-      mode
-    )) {
+    for (const project of await this._evaluateProjectParameterAsync(this._toExceptProject, terminal)) {
       args.push('--filter', `${project.packageName}^...`);
     }
 
     // --impacted-by
     // The project and all projects directly or indirectly declare it as a dependency
-    for (const project of await this._evaluateProjectParameterAsync(
-      this._impactedByProject,
-      terminal,
-      mode
-    )) {
+    for (const project of await this._evaluateProjectParameterAsync(this._impactedByProject, terminal)) {
       args.push('--filter', `...${project.packageName}`);
     }
 
@@ -309,8 +297,7 @@ export class SelectionParameterSet {
     // All projects that directly or indirectly declare the specified project as a dependency
     for (const project of await this._evaluateProjectParameterAsync(
       this._impactedByExceptProject,
-      terminal,
-      mode
+      terminal
     )) {
       args.push('--filter', `...^${project.packageName}`);
     }
@@ -341,8 +328,7 @@ export class SelectionParameterSet {
    */
   private async _evaluateProjectParameterAsync(
     listParameter: CommandLineStringListParameter,
-    terminal: ITerminal,
-    mode: EvaluateSelectorMode
+    terminal: ITerminal
   ): Promise<Set<RushConfigurationProject>> {
     const parameterName: string = listParameter.longName;
     const selection: Set<RushConfigurationProject> = new Set();
@@ -398,8 +384,7 @@ export class SelectionParameterSet {
       for (const project of await handler.evaluateSelectorAsync({
         unscopedSelector,
         terminal,
-        parameterName,
-        mode
+        parameterName
       })) {
         selection.add(project);
       }

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -336,7 +336,7 @@ export class ChangeAction extends BaseRushAction {
         shouldFetch: !this._noFetchParameter.value,
         // Lockfile evaluation will expand the set of projects that request change files
         // Not enabling, since this would be a breaking change
-        includeLockfile: false,
+        includeExternalDependencies: false,
         // Since install may not have happened, cannot read rush-project.json
         enableFiltering: false
       });

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -330,7 +330,7 @@ export class ChangeAction extends BaseRushAction {
   private async _getChangedProjectNamesAsync(): Promise<string[]> {
     const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const changedProjects: Set<RushConfigurationProject> =
-      await projectChangeAnalyzer.getProjectsWithChangesAsync({
+      await projectChangeAnalyzer.getProjectsWithLocalFileChangesAsync({
         targetBranchName: this._targetBranch,
         terminal: this._terminal,
         shouldFetch: !this._noFetchParameter.value

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -330,10 +330,15 @@ export class ChangeAction extends BaseRushAction {
   private async _getChangedProjectNamesAsync(): Promise<string[]> {
     const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const changedProjects: Set<RushConfigurationProject> =
-      await projectChangeAnalyzer.getProjectsWithLocalFileChangesAsync({
+      await projectChangeAnalyzer.getChangedProjectsAsync({
         targetBranchName: this._targetBranch,
         terminal: this._terminal,
-        shouldFetch: !this._noFetchParameter.value
+        shouldFetch: !this._noFetchParameter.value,
+        // Lockfile evaluation will expand the set of projects that request change files
+        // Not enabling, since this would be a breaking change
+        includeLockfile: false,
+        // Since install may not have happened, cannot read rush-project.json
+        enableFiltering: false
       });
     const projectHostMap: Map<RushConfigurationProject, string> = this._generateHostMap();
 

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -37,7 +37,13 @@ export class InstallAction extends BaseInstallAction {
   protected onDefineParameters(): void {
     super.onDefineParameters();
 
-    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this);
+    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
+      // Include lockfile processing since this expands the selection, and we need to select
+      // at least the same projects selected with the same query to "rush build"
+      includeLockfile: true,
+      // Disable filtering because rush-project.json is riggable and therefore may not be available
+      enableFiltering: false
+    });
 
     this._checkOnlyParameter = this.defineFlagParameter({
       parameterLongName: '--check-only',

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -40,7 +40,7 @@ export class InstallAction extends BaseInstallAction {
     this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
       // Include lockfile processing since this expands the selection, and we need to select
       // at least the same projects selected with the same query to "rush build"
-      includeLockfile: true,
+      includeExternalDependencies: true,
       // Disable filtering because rush-project.json is riggable and therefore may not be available
       enableFiltering: false
     });

--- a/apps/rush-lib/src/cli/actions/ListAction.ts
+++ b/apps/rush-lib/src/cli/actions/ListAction.ts
@@ -109,7 +109,7 @@ export class ListAction extends BaseRushAction {
     this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
       // Include lockfile processing since this expands the selection, and we need to select
       // at least the same projects selected with the same query to "rush build"
-      includeLockfile: true,
+      includeExternalDependencies: true,
       // Disable filtering because rush-project.json is riggable and therefore may not be available
       enableFiltering: false
     });

--- a/apps/rush-lib/src/cli/actions/ListAction.ts
+++ b/apps/rush-lib/src/cli/actions/ListAction.ts
@@ -106,14 +106,19 @@ export class ListAction extends BaseRushAction {
       description: 'If this flag is specified, output will be in JSON format.'
     });
 
-    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this);
+    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
+      // Include lockfile processing since this expands the selection, and we need to select
+      // at least the same projects selected with the same query to "rush build"
+      includeLockfile: true,
+      // Disable filtering because rush-project.json is riggable and therefore may not be available
+      enableFiltering: false
+    });
   }
 
   protected async runAsync(): Promise<void> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
-      terminal,
-      false
+      terminal
     );
     Sort.sortSetBy(selection, (x: RushConfigurationProject) => x.packageName);
     if (this._jsonFlag.value && this._detailedFlag.value) {

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -282,9 +282,9 @@ export class BulkScriptAction extends BaseScriptAction {
     this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
       // Include lockfile processing since this expands the selection, and we need to select
       // at least the same projects selected with the same query to "rush build"
-      includeLockfile: true,
+      includeExternalDependencies: true,
       // Enable filtering to reduce evaluation cost
-      enableFiltering: false
+      enableFiltering: true
     });
 
     this._verboseParameter = this.defineFlagParameter({

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -131,8 +131,7 @@ export class BulkScriptAction extends BaseScriptAction {
     }
 
     const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
-      terminal,
-      true
+      terminal
     );
 
     if (!selection.size) {
@@ -280,7 +279,13 @@ export class BulkScriptAction extends BaseScriptAction {
       });
     }
 
-    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this);
+    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
+      // Include lockfile processing since this expands the selection, and we need to select
+      // at least the same projects selected with the same query to "rush build"
+      includeLockfile: true,
+      // Enable filtering to reduce evaluation cost
+      enableFiltering: false
+    });
 
     this._verboseParameter = this.defineFlagParameter({
       parameterLongName: '--verbose',

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -21,6 +21,11 @@ interface IResultOrError<TResult> {
   result?: TResult;
 }
 
+export interface IGetBlobOptions {
+  blobSpec: string;
+  repositoryRoot: string;
+}
+
 export class Git {
   private readonly _rushConfiguration: RushConfiguration;
   private _checkedGitPath: boolean = false;
@@ -207,11 +212,11 @@ export class Git {
     return result;
   }
 
-  public getFileContent(targetBranch: string, gitRelativePath: string, repositoryRoot: string): string {
+  public getBlobContent({ blobSpec, repositoryRoot }: IGetBlobOptions): string {
     const gitPath: string = this.getGitPathOrThrow();
     const output: string = Utilities.executeCommandAndCaptureOutput(
       gitPath,
-      ['cat-file', 'blob', `${targetBranch}:${gitRelativePath}`, '--'],
+      ['cat-file', 'blob', blobSpec, '--'],
       repositoryRoot
     );
 

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -207,6 +207,17 @@ export class Git {
     return result;
   }
 
+  public getFileContent(targetBranch: string, gitRelativePath: string, repositoryRoot: string): string {
+    const gitPath: string = this.getGitPathOrThrow();
+    const output: string = Utilities.executeCommandAndCaptureOutput(
+      gitPath,
+      ['cat-file', 'blob', `${targetBranch}:${gitRelativePath}`, '--'],
+      repositoryRoot
+    );
+
+    return output;
+  }
+
   /**
    * @param pathPrefix - An optional path prefix "git diff"s should be filtered by.
    * @returns

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -191,7 +191,7 @@ export class Git {
     const gitPath: string = this.getGitPathOrThrow();
     const output: string = Utilities.executeCommandAndCaptureOutput(
       gitPath,
-      ['--no-optional-locks', 'merge-base', 'HEAD', `${targetBranch}`, '--'],
+      ['--no-optional-locks', 'merge-base', 'HEAD', targetBranch, '--'],
       this._rushConfiguration.rushJsonFolder
     );
     const result: string = output.trim();

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -183,6 +183,22 @@ export class Git {
     }
   }
 
+  public getMergeBase(targetBranch: string, terminal: ITerminal, shouldFetch: boolean = false): string {
+    if (shouldFetch) {
+      this._fetchRemoteBranch(targetBranch, terminal);
+    }
+
+    const gitPath: string = this.getGitPathOrThrow();
+    const output: string = Utilities.executeCommandAndCaptureOutput(
+      gitPath,
+      ['--no-optional-locks', 'merge-base', 'HEAD', `${targetBranch}`, '--'],
+      this._rushConfiguration.rushJsonFolder
+    );
+    const result: string = output.trim();
+
+    return result;
+  }
+
   public getChangedFolders(
     targetBranch: string,
     terminal: ITerminal,

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -224,7 +224,7 @@ export class ProjectChangeAnalyzer {
 
       if (shrinkwrapStatus) {
         if (shrinkwrapStatus.status !== 'M') {
-          // The lockfile was created or deleted. Affects all projects.
+          terminal.writeLine(`Lockfile was created or deleted. Assuming all projects are affected.`);
           return new Set(rushConfiguration.projects);
         }
 
@@ -255,7 +255,9 @@ export class ProjectChangeAnalyzer {
             }
           }
         } else {
-          // Diffing only supported for pnpm. Must assume it affects all projects since we can't be sure.
+          terminal.writeLine(
+            `Lockfile has changed and lockfile content comparison is only supported for pnpm. Assuming all projects are affected.`
+          );
           return new Set(rushConfiguration.projects);
         }
       }
@@ -287,7 +289,7 @@ export class ProjectChangeAnalyzer {
     }
 
     if (enableFiltering) {
-      // Reading rush-project.json may be problematic if, e.g.
+      // Reading rush-project.json may be problematic if, e.g. rush install has not yet occurred and rigs are in use
       await Async.forEachAsync(
         changesByProject,
         async ([project, projectChanges]) => {

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -199,11 +199,14 @@ export class ProjectChangeAnalyzer {
   ): Promise<Set<RushConfigurationProject>> {
     const { _rushConfiguration: rushConfiguration } = this;
 
-    const { targetBranchName, terminal, includeExternalDependencies, enableFiltering } = options;
+    const { targetBranchName, terminal, includeExternalDependencies, enableFiltering, shouldFetch } = options;
 
     const gitPath: string = this._git.getGitPathOrThrow();
     const repoRoot: string = getRepoRoot(rushConfiguration.rushJsonFolder);
-    const repoChanges: Map<string, IFileDiffStatus> = getRepoChanges(repoRoot, targetBranchName, gitPath);
+
+    const mergeCommit: string = this._git.getMergeBase(targetBranchName, terminal, shouldFetch);
+
+    const repoChanges: Map<string, IFileDiffStatus> = getRepoChanges(repoRoot, mergeCommit, gitPath);
 
     const changedProjects: Set<RushConfigurationProject> = new Set();
 
@@ -237,7 +240,7 @@ export class ProjectChangeAnalyzer {
 
           const oldShrinkwrapText: string = this._git.getBlobContent({
             // <ref>:<path> syntax: https://git-scm.com/docs/gitrevisions
-            blobSpec: `${targetBranchName}:${shrinkwrapFile}`,
+            blobSpec: `${mergeCommit}:${shrinkwrapFile}`,
             repositoryRoot: repoRoot
           });
           const oldShrinkWrap: PnpmShrinkwrapFile = PnpmShrinkwrapFile.loadFromString(oldShrinkwrapText);

--- a/apps/rush-lib/src/logic/RepoStateFile.ts
+++ b/apps/rush-lib/src/logic/RepoStateFile.ts
@@ -155,8 +155,7 @@ export class RepoStateFile {
       rushConfiguration.pnpmOptions.preventManualShrinkwrapChanges;
     if (preventShrinkwrapChanges) {
       const pnpmShrinkwrapFile: PnpmShrinkwrapFile | undefined = PnpmShrinkwrapFile.loadFromFile(
-        rushConfiguration.getCommittedShrinkwrapFilename(this._variant),
-        rushConfiguration.pnpmOptions
+        rushConfiguration.getCommittedShrinkwrapFilename(this._variant)
       );
 
       if (pnpmShrinkwrapFile) {

--- a/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
+++ b/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
@@ -6,7 +6,7 @@ import { BaseShrinkwrapFile } from './base/BaseShrinkwrapFile';
 import { NpmShrinkwrapFile } from './npm/NpmShrinkwrapFile';
 import { PnpmShrinkwrapFile } from './pnpm/PnpmShrinkwrapFile';
 import { YarnShrinkwrapFile } from './yarn/YarnShrinkwrapFile';
-import { PackageManagerOptionsConfigurationBase, PnpmOptionsConfiguration } from '../api/RushConfiguration';
+import { PackageManagerOptionsConfigurationBase } from '../api/RushConfiguration';
 
 export class ShrinkwrapFileFactory {
   public static getShrinkwrapFile(
@@ -18,12 +18,26 @@ export class ShrinkwrapFileFactory {
       case 'npm':
         return NpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
       case 'pnpm':
-        return PnpmShrinkwrapFile.loadFromFile(
-          shrinkwrapFilename,
-          packageManagerOptions as PnpmOptionsConfiguration
-        );
+        return PnpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
       case 'yarn':
         return YarnShrinkwrapFile.loadFromFile(shrinkwrapFilename);
+      default:
+        throw new Error(`Invalid package manager: ${packageManager}`);
+    }
+  }
+
+  public static parseShrinkwrapFile(
+    packageManager: PackageManagerName,
+    packageManagerOptions: PackageManagerOptionsConfigurationBase,
+    shrinkwrapContent: string
+  ): BaseShrinkwrapFile | undefined {
+    switch (packageManager) {
+      case 'npm':
+        return NpmShrinkwrapFile.loadFromString(shrinkwrapContent);
+      case 'pnpm':
+        return PnpmShrinkwrapFile.loadFromString(shrinkwrapContent);
+      case 'yarn':
+        return YarnShrinkwrapFile.loadFromString(shrinkwrapContent);
       default:
         throw new Error(`Invalid package manager: ${packageManager}`);
     }

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -47,26 +47,27 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   public static loadFromFile(shrinkwrapJsonFilename: string): NpmShrinkwrapFile | undefined {
-    let data: string | undefined = undefined;
     try {
-      if (!FileSystem.exists(shrinkwrapJsonFilename)) {
+      const shrinkwrapContent: string = FileSystem.readFile(shrinkwrapJsonFilename);
+      return NpmShrinkwrapFile.loadFromString(shrinkwrapContent);
+    } catch (error) {
+      if (FileSystem.isNotExistError(error as Error)) {
         return undefined; // file does not exist
       }
-
-      // We don't use JsonFile/jju here because shrinkwrap.json is a special NPM file format
-      // and typically very large, so we want to load it the same way that NPM does.
-      data = FileSystem.readFile(shrinkwrapJsonFilename);
-      if (data.charCodeAt(0) === 0xfeff) {
-        // strip BOM
-        data = data.slice(1);
-      }
-
-      return new NpmShrinkwrapFile(JSON.parse(data));
-    } catch (error) {
       throw new Error(
         `Error reading "${shrinkwrapJsonFilename}":` + os.EOL + `  ${(error as Error).message}`
       );
     }
+  }
+
+  public static loadFromString(shrinkwrapContent: string): NpmShrinkwrapFile {
+    // We don't use JsonFile/jju here because shrinkwrap.json is a special NPM file format
+    // and typically very large, so we want to load it the same way that NPM does.
+    // strip BOM
+    const data: string =
+      shrinkwrapContent.charCodeAt(0) === 0xfeff ? shrinkwrapContent.slice(1) : shrinkwrapContent;
+
+    return new NpmShrinkwrapFile(JSON.parse(data));
   }
 
   /** @override */

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -61,12 +61,12 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   public static loadFromString(shrinkwrapContent: string): NpmShrinkwrapFile {
-    // We don't use JsonFile/jju here because shrinkwrap.json is a special NPM file format
-    // and typically very large, so we want to load it the same way that NPM does.
     // strip BOM
     const data: string =
       shrinkwrapContent.charCodeAt(0) === 0xfeff ? shrinkwrapContent.slice(1) : shrinkwrapContent;
 
+    // We don't use JsonFile/jju here because shrinkwrap.json is a special NPM file format
+    // and typically very large, so we want to load it the same way that NPM does.
     return new NpmShrinkwrapFile(JSON.parse(data));
   }
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -56,8 +56,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       // Use shrinkwrap from temp as the committed shrinkwrap may not always be up to date
       // See https://github.com/microsoft/rushstack/issues/1273#issuecomment-492779995
       const pnpmShrinkwrapFile: PnpmShrinkwrapFile | undefined = PnpmShrinkwrapFile.loadFromFile(
-        this._rushConfiguration.tempShrinkwrapFilename,
-        this._rushConfiguration.pnpmOptions
+        this._rushConfiguration.tempShrinkwrapFilename
       );
 
       if (!pnpmShrinkwrapFile) {

--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
@@ -88,7 +88,7 @@ export class PnpmProjectShrinkwrapFile extends BaseProjectShrinkwrapFile {
 
     const projectShrinkwrapMap: Map<string, string> = new Map();
     for (const [name, version] of allDependencies) {
-      if (name.indexOf('@rush-temp/') < 0) {
+      if (name.indexOf(`${RushConstants.rushTempNpmScope}/`) < 0) {
         // Only select the shrinkwrap dependencies that are non-local since we already handle local
         // project changes
         this._addDependencyRecursive(projectShrinkwrapMap, name, version, parentShrinkwrapEntry);

--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
@@ -5,11 +5,7 @@ import * as crypto from 'crypto';
 import { InternalError, JsonFile } from '@rushstack/node-core-library';
 
 import { BaseProjectShrinkwrapFile } from '../base/BaseProjectShrinkwrapFile';
-import {
-  PnpmShrinkwrapFile,
-  IPnpmShrinkwrapDependencyYaml,
-  IPnpmShrinkwrapImporterYaml
-} from './PnpmShrinkwrapFile';
+import { PnpmShrinkwrapFile, IPnpmShrinkwrapDependencyYaml } from './PnpmShrinkwrapFile';
 import { DependencySpecifier } from '../DependencySpecifier';
 import { RushConstants } from '../RushConstants';
 
@@ -68,30 +64,9 @@ export class PnpmProjectShrinkwrapFile extends BaseProjectShrinkwrapFile {
       this.project.rushConfiguration.commonTempFolder,
       this.project.projectFolder
     );
-    const importer: IPnpmShrinkwrapImporterYaml | undefined = this.shrinkwrapFile.getImporter(importerKey);
-    if (!importer) {
-      // It's not in here. This is possible when perfoming filtered installs
-      return undefined;
-    }
 
-    // Only select the importer dependencies that are non-local since we already handle local
-    // project changes
-    const externalDependencies: [string, string][] = [
-      ...Object.entries(importer.dependencies || {}),
-      ...Object.entries(importer.devDependencies || {}),
-      ...Object.entries(importer.optionalDependencies || {})
-    ];
-
-    // Not used in workspace mode
-    const parentEntry: IPnpmShrinkwrapDependencyYaml = {};
-
-    const projectShrinkwrapMap: Map<string, string> = new Map();
-    for (const [name, version] of externalDependencies) {
-      // Add to the manifest and provide all the parent dependencies
-      if (!version.includes('link:')) {
-        this._addDependencyRecursive(projectShrinkwrapMap, name, version, parentEntry);
-      }
-    }
+    const projectShrinkwrapMap: Map<string, string> | undefined =
+      this.shrinkwrapFile.getIntegrityForImporter(importerKey);
 
     return projectShrinkwrapMap;
   }

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -476,7 +476,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /** @override */
-  public getProjectShrinkwrap(project: RushConfigurationProject): PnpmProjectShrinkwrapFile | undefined {
+  public getProjectShrinkwrap(project: RushConfigurationProject): PnpmProjectShrinkwrapFile {
     return new PnpmProjectShrinkwrapFile(this, project);
   }
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -650,11 +650,13 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const shrinkwrapEntry: IPnpmShrinkwrapDependencyYaml | undefined = this.packages.get(specifier);
     if (!shrinkwrapEntry) {
       if (!optional) {
-        throw new Error(`Missing shrinkwrap entry for non-optional dependency ${specifier}`);
-      } else {
-        // Indicate an empty entry
-        return integrityMap;
+        // This algorithm heeds to be robust against missing shrinkwrap entries, so we can't just throw
+        // Instead set it to a value which will not match any valid shrinkwrap record
+        integrityMap.set(specifier, 'Missing shrinkwrap entry!');
       }
+
+      // Indicate an empty entry
+      return integrityMap;
     }
 
     let selfIntegrity: string | undefined = shrinkwrapEntry.resolution?.integrity;

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -513,7 +513,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
         const sha256Digest: string = crypto
           .createHash('sha256')
-          .update(JSON.stringify(importerKey))
+          .update(JSON.stringify(importer))
           .digest('base64');
         const selfIntegrity: string = `${importerKey}:${sha256Digest}:`;
         integrityMap.set(importerKey, selfIntegrity);

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -4,7 +4,16 @@ import { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
 import { IGetChangedProjectsOptions, ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
 
 export interface IGitSelectorParserOptions {
-  includeLockfile: boolean;
+  /**
+   * If set to `true`, consider a project's external dependency installation layout as defined in the
+   * package manager lockfile when determining if it has changed.
+   */
+  includeExternalDependencies: boolean;
+
+  /**
+   * If set to `true` apply the `incrementalBuildIgnoredGlobs` property in a project's `rush-project.json`
+   * and exclude matched files from change detection.
+   */
   enableFiltering: boolean;
 }
 

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -19,7 +19,7 @@ export class GitChangedProjectSelectorParser implements ISelectorParser<RushConf
 
     switch (mode) {
       case EvaluateSelectorMode.RushChange: {
-        return await projectChangeAnalyzer.getProjectsWithChangesAsync({
+        return await projectChangeAnalyzer.getProjectsWithLocalFileChangesAsync({
           terminal,
           targetBranchName: unscopedSelector
         });

--- a/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
@@ -1,15 +1,9 @@
 import type { ITerminal } from '@rushstack/node-core-library';
 
-export enum EvaluateSelectorMode {
-  RushChange,
-  IncrementalBuild
-}
-
 export interface IEvaluateSelectorOptions {
   unscopedSelector: string;
   terminal: ITerminal;
   parameterName: string;
-  mode: EvaluateSelectorMode;
 }
 
 export interface ISelectorParser<T> {

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -167,7 +167,8 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
 
   public static loadFromFile(shrinkwrapFilename: string): YarnShrinkwrapFile | undefined {
     try {
-      return YarnShrinkwrapFile.loadFromString(shrinkwrapFilename);
+      const shrinkwrapContent: string = FileSystem.readFile(shrinkwrapFilename);
+      return YarnShrinkwrapFile.loadFromString(shrinkwrapContent);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         return undefined; // file does not exist

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -166,19 +166,18 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   public static loadFromFile(shrinkwrapFilename: string): YarnShrinkwrapFile | undefined {
-    let shrinkwrapString: string;
-    let shrinkwrapJson: YarnPkgLockfileTypes.ParseResult;
     try {
-      if (!FileSystem.exists(shrinkwrapFilename)) {
+      return YarnShrinkwrapFile.loadFromString(shrinkwrapFilename);
+    } catch (error) {
+      if (FileSystem.isNotExistError(error as Error)) {
         return undefined; // file does not exist
       }
-
-      shrinkwrapString = FileSystem.readFile(shrinkwrapFilename);
-      shrinkwrapJson = lockfileModule.parse(shrinkwrapString);
-    } catch (error) {
       throw new Error(`Error reading "${shrinkwrapFilename}":` + os.EOL + `  ${(error as Error).message}`);
     }
+  }
 
+  public static loadFromString(shrinkwrapContent: string): YarnShrinkwrapFile {
+    const shrinkwrapJson: YarnPkgLockfileTypes.ParseResult = lockfileModule.parse(shrinkwrapContent);
     return new YarnShrinkwrapFile(shrinkwrapJson.object);
   }
 

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -11,7 +11,7 @@ async function runAsync(): Promise<void> {
   const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
   const changedProjects: Set<RushConfigurationProject> =
-    await projectChangeAnalyzer.getProjectsWithChangesAsync({
+    await projectChangeAnalyzer.getProjectsWithLocalFileChangesAsync({
       targetBranchName: rushConfiguration.repositoryDefaultBranch,
       terminal
     });

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -10,11 +10,13 @@ async function runAsync(): Promise<void> {
   //#region Step 1: Get the list of changed projects
   const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
-  const changedProjects: Set<RushConfigurationProject> =
-    await projectChangeAnalyzer.getProjectsWithLocalFileChangesAsync({
-      targetBranchName: rushConfiguration.repositoryDefaultBranch,
-      terminal
-    });
+  const changedProjects: Set<RushConfigurationProject> = await projectChangeAnalyzer.getChangedProjectsAsync({
+    targetBranchName: rushConfiguration.repositoryDefaultBranch,
+    terminal,
+
+    includeExternalDependencies: true,
+    enableFiltering: false
+  });
   //#endregion
 
   //#region Step 2: Expand all consumers

--- a/common/changes/@microsoft/rush/lockfile-diff_2021-11-30-23-57.json
+++ b/common/changes/@microsoft/rush/lockfile-diff_2021-11-30-23-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "When computing the set of projects affected by a Git change, if the change contains the lockfile and the package manager is pnpm, diff the content of the lockfile to determine which projects were affeted by the lockfile change, instead of assuming all projects are affected.",
+      "comment": "When computing the set of projects affected by a Git change, if the change modifies the lockfile and the package manager is pnpm, diff the content of the lockfile to determine which projects were affected by the lockfile change, instead of assuming all projects are affected.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/lockfile-diff_2021-11-30-23-57.json
+++ b/common/changes/@microsoft/rush/lockfile-diff_2021-11-30-23-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "When computing the set of projects affected by a Git change, if the change contains the lockfile and the package manager is pnpm, diff the content of the lockfile to determine which projects were affeted by the lockfile change, instead of assuming all projects are affected.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -251,6 +251,10 @@ export interface IExperimentsJson {
 // @beta (undocumented)
 export interface IGetChangedProjectsOptions {
     // (undocumented)
+    enableFiltering: boolean;
+    // (undocumented)
+    includeLockfile: boolean;
+    // (undocumented)
     shouldFetch?: boolean;
     // (undocumented)
     targetBranchName: string;
@@ -452,8 +456,7 @@ export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
-    getProjectsImpactedByDiffAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
-    getProjectsWithLocalFileChangesAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
+    getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
     _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;
     // @internal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -453,7 +453,7 @@ export class ProjectChangeAnalyzer {
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
     getProjectsImpactedByDiffAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
-    getProjectsWithChangesAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
+    getProjectsWithLocalFileChangesAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
     _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;
     // @internal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -250,10 +250,8 @@ export interface IExperimentsJson {
 
 // @beta (undocumented)
 export interface IGetChangedProjectsOptions {
-    // (undocumented)
     enableFiltering: boolean;
-    // (undocumented)
-    includeLockfile: boolean;
+    includeExternalDependencies: boolean;
     // (undocumented)
     shouldFetch?: boolean;
     // (undocumented)


### PR DESCRIPTION
## Summary
When running a command like `rush list --only git:HEAD`, if the set of touched files includes the lockfile and the package manager is `pnpm`, compares the old and new lockfiles to determine affected projects instead of assuming that the change affects all projects.

## Details
Adds a `getFileContent` method to the `Git` wrapper to read the content of a file at a previous commit.
Adds a `loadFromString` API to the `ShrinkwrapFileFactory` and underlying package-manager-specific files.
Updates `ProjectChangeAnalyzer` to, upon seeing a lockfile modification, if the package manager is `pnpm` (since project shrinkwraps are not implemented for other package managers), load both the old and current lockfiles and compare the project shrinkwrap entries.
Adds a `hasChanged` method to the `PnpmProjectShrinkwrapFile` class to abstract the comparison operation.
Optimizes bulk computation of `PnpmProjectShrinkwrapFile` content by caching the dependencies of external packages for the entire lockfile, so that the per-package computations can be reused across projects. The cache lives as long as the lockfile object, which is always thrown out as soon as the per-project shrinkwraps have been computed.

Fixes #3053

## How it was tested
Staged various temporary changes to `common/config/rush/pnpm-lock.yaml` and verified the set of projects selected by `rush list --only git:HEAD`