### PR TITLE
[rush] Fix an issue where parameter values containing spaces aren't correctly passed to global commands.

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -104,6 +104,17 @@ export class GlobalScriptAction extends BaseScriptAction {
       customParameter.appendToArgList(customParameterValues);
     }
 
+    for (let i: number = 0; i < customParameterValues.length; i++) {
+      let customParameterValue: string = customParameterValues[i];
+      customParameterValue = customParameterValue.replace(/"/g, '\\"');
+
+      if (customParameterValue.indexOf(' ') >= 0) {
+        customParameterValue = `"${customParameterValue}"`;
+      }
+
+      customParameterValues[i] = customParameterValue;
+    }
+
     let shellCommand: string = this._shellCommand;
     if (customParameterValues.length > 0) {
       shellCommand += ' ' + customParameterValues.join(' ');

--- a/common/changes/@microsoft/rush/fix-global-command-escaping_2021-12-01-00-30.json
+++ b/common/changes/@microsoft/rush/fix-global-command-escaping_2021-12-01-00-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where parameter values containing spaces are incorrectly passed to global scripts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3027

## Details

Escapes quotemarks in args and wraps args containing spaces in quotemarks before passing them to the shell.

## How it was tested

Tested with https://github.com/iclanton/rushstack/commit/44c1948519788c7b13b21939c5402473623ef2da and running `rush my-global-command --my-string "x \"y z"`