### PR TITLE
[rush] Fix issues with `rush change` and the new diffing behavior.

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -330,11 +330,10 @@ export class ChangeAction extends BaseRushAction {
   private async _getChangedProjectNamesAsync(): Promise<string[]> {
     const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const changedProjects: Set<RushConfigurationProject> =
-      await projectChangeAnalyzer.getChangedProjectsAsync({
+      await projectChangeAnalyzer.getProjectsWithChangesAsync({
         targetBranchName: this._targetBranch,
         terminal: this._terminal,
-        shouldFetch: !this._noFetchParameter.value,
-        ignoreShrinkwrapChanges: true
+        shouldFetch: !this._noFetchParameter.value
       });
     const projectHostMap: Map<RushConfigurationProject, string> = this._generateHostMap();
 

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -333,7 +333,8 @@ export class ChangeAction extends BaseRushAction {
       await projectChangeAnalyzer.getChangedProjectsAsync({
         targetBranchName: this._targetBranch,
         terminal: this._terminal,
-        shouldFetch: !this._noFetchParameter.value
+        shouldFetch: !this._noFetchParameter.value,
+        ignoreShrinkwrapChanges: true
       });
     const projectHostMap: Map<RushConfigurationProject, string> = this._generateHostMap();
 

--- a/apps/rush-lib/src/cli/actions/ListAction.ts
+++ b/apps/rush-lib/src/cli/actions/ListAction.ts
@@ -112,7 +112,8 @@ export class ListAction extends BaseRushAction {
   protected async runAsync(): Promise<void> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
-      terminal
+      terminal,
+      false
     );
     Sort.sortSetBy(selection, (x: RushConfigurationProject) => x.packageName);
     if (this._jsonFlag.value && this._detailedFlag.value) {

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -131,7 +131,8 @@ export class BulkScriptAction extends BaseScriptAction {
     }
 
     const selection: Set<RushConfigurationProject> = await this._selectionParameters.getSelectedProjectsAsync(
-      terminal
+      terminal,
+      true
     );
 
     if (!selection.size) {

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -254,7 +254,7 @@ export class ProjectChangeAnalyzer {
             changedProjects.add(project);
           }
         },
-        { concurrency: 50 }
+        { concurrency: 10 }
       );
       return changedProjects;
     } else {

--- a/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -28,7 +28,6 @@ import { LookupByPath } from './LookupByPath';
 export interface IGetChangedProjectsOptions {
   targetBranchName: string;
   terminal: ITerminal;
-  ignoreShrinkwrapChanges?: boolean;
   shouldFetch?: boolean;
 }
 
@@ -181,7 +180,7 @@ export class ProjectChangeAnalyzer {
    * Gets a list of projects that have changed in the current state of the repo
    * when compared to the specified branch.
    */
-  public async getChangedProjectsAsync(
+  public async getProjectsWithChangesAsync(
     options: IGetChangedProjectsOptions
   ): Promise<Set<RushConfigurationProject>> {
     return await this._getChangedProjectsInternalAsync(options, false);
@@ -189,10 +188,10 @@ export class ProjectChangeAnalyzer {
 
   /**
    * Gets a list of projects that have changed in the current state of the repo
-   * when compared to the specified branch, taking settings in the rush-project.json file
-   * into consideration.
+   * when compared to the specified branch, taking the shrinkwrap and settings in
+   * the rush-project.json file into consideration.
    */
-  public async getChangedProjectsForIncrementalBuildAsync(
+  public async getProjectsImpactedByDiffAsync(
     options: IGetChangedProjectsOptions
   ): Promise<Set<RushConfigurationProject>> {
     return await this._getChangedProjectsInternalAsync(options, true);
@@ -211,7 +210,7 @@ export class ProjectChangeAnalyzer {
     );
     const { terminal } = options;
 
-    if (!options.ignoreShrinkwrapChanges) {
+    if (forIncrementalBuild) {
       // Determine the current variant from the link JSON.
       const variant: string | undefined = this._rushConfiguration.currentInstalledVariant;
 

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -14,14 +14,22 @@ export class GitChangedProjectSelectorParser implements ISelectorParser<RushConf
   public async evaluateSelectorAsync(
     unscopedSelector: string,
     terminal: ITerminal,
-    parameterName: string
+    parameterName: string,
+    forIncrementalBuild: boolean
   ): Promise<Iterable<RushConfigurationProject>> {
     const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this._rushConfiguration);
 
-    return await projectChangeAnalyzer.getChangedProjectsAsync({
-      terminal,
-      targetBranchName: unscopedSelector
-    });
+    if (forIncrementalBuild) {
+      return await projectChangeAnalyzer.getChangedProjectsForIncrementalBuildAsync({
+        terminal,
+        targetBranchName: unscopedSelector
+      });
+    } else {
+      return await projectChangeAnalyzer.getChangedProjectsAsync({
+        terminal,
+        targetBranchName: unscopedSelector
+      });
+    }
   }
 
   public getCompletions(): Iterable<string> {

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -19,14 +19,14 @@ export class GitChangedProjectSelectorParser implements ISelectorParser<RushConf
 
     switch (mode) {
       case EvaluateSelectorMode.RushChange: {
-        return await projectChangeAnalyzer.getChangedProjectsAsync({
+        return await projectChangeAnalyzer.getProjectsWithChangesAsync({
           terminal,
           targetBranchName: unscopedSelector
         });
       }
 
       case EvaluateSelectorMode.IncrementalBuild: {
-        return await projectChangeAnalyzer.getChangedProjectsForIncrementalBuildAsync({
+        return await projectChangeAnalyzer.getProjectsImpactedByDiffAsync({
           terminal,
           targetBranchName: unscopedSelector
         });

--- a/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
@@ -4,7 +4,8 @@ export interface ISelectorParser<T> {
   evaluateSelectorAsync(
     unscopedSpecifier: string,
     terminal: ITerminal,
-    parameterName: string
+    parameterName: string,
+    forIncrementalBuild: boolean
   ): Promise<Iterable<T>>;
   getCompletions(): Iterable<string>;
 }

--- a/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
@@ -1,11 +1,18 @@
 import type { ITerminal } from '@rushstack/node-core-library';
 
+export enum EvaluateSelectorMode {
+  RushChange,
+  IncrementalBuild
+}
+
+export interface IEvaluateSelectorOptions {
+  unscopedSelector: string;
+  terminal: ITerminal;
+  parameterName: string;
+  mode: EvaluateSelectorMode;
+}
+
 export interface ISelectorParser<T> {
-  evaluateSelectorAsync(
-    unscopedSpecifier: string,
-    terminal: ITerminal,
-    parameterName: string,
-    forIncrementalBuild: boolean
-  ): Promise<Iterable<T>>;
+  evaluateSelectorAsync(options: IEvaluateSelectorOptions): Promise<Iterable<T>>;
   getCompletions(): Iterable<string>;
 }

--- a/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
@@ -1,9 +1,8 @@
-import type { ITerminal } from '@rushstack/node-core-library';
 import { AlreadyReportedError, PackageName } from '@rushstack/node-core-library';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import type { ISelectorParser } from './ISelectorParser';
+import type { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
 
 export class NamedProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
   private readonly _rushConfiguration: RushConfiguration;
@@ -12,11 +11,11 @@ export class NamedProjectSelectorParser implements ISelectorParser<RushConfigura
     this._rushConfiguration = rushConfiguration;
   }
 
-  public async evaluateSelectorAsync(
-    unscopedSelector: string,
-    terminal: ITerminal,
-    parameterName: string
-  ): Promise<Iterable<RushConfigurationProject>> {
+  public async evaluateSelectorAsync({
+    unscopedSelector,
+    terminal,
+    parameterName
+  }: IEvaluateSelectorOptions): Promise<Iterable<RushConfigurationProject>> {
     const project: RushConfigurationProject | undefined =
       this._rushConfiguration.findProjectByShorthandName(unscopedSelector);
     if (!project) {

--- a/apps/rush-lib/src/logic/selectors/VersionPolicyProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/VersionPolicyProjectSelectorParser.ts
@@ -1,9 +1,8 @@
-import type { ITerminal } from '@rushstack/node-core-library';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import type { ISelectorParser } from './ISelectorParser';
+import type { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
 
 export class VersionPolicyProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
   private readonly _rushConfiguration: RushConfiguration;
@@ -12,11 +11,11 @@ export class VersionPolicyProjectSelectorParser implements ISelectorParser<RushC
     this._rushConfiguration = rushConfiguration;
   }
 
-  public async evaluateSelectorAsync(
-    unscopedSelector: string,
-    terminal: ITerminal,
-    parameterName: string
-  ): Promise<Iterable<RushConfigurationProject>> {
+  public async evaluateSelectorAsync({
+    unscopedSelector,
+    terminal,
+    parameterName
+  }: IEvaluateSelectorOptions): Promise<Iterable<RushConfigurationProject>> {
     const selection: Set<RushConfigurationProject> = new Set();
 
     if (!this._rushConfiguration.versionPolicyConfiguration.versionPolicies.has(unscopedSelector)) {

--- a/build-tests/rush-project-change-analyzer-test/src/start.ts
+++ b/build-tests/rush-project-change-analyzer-test/src/start.ts
@@ -10,10 +10,11 @@ async function runAsync(): Promise<void> {
   //#region Step 1: Get the list of changed projects
   const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
-  const changedProjects: Set<RushConfigurationProject> = await projectChangeAnalyzer.getChangedProjectsAsync({
-    targetBranchName: rushConfiguration.repositoryDefaultBranch,
-    terminal
-  });
+  const changedProjects: Set<RushConfigurationProject> =
+    await projectChangeAnalyzer.getProjectsWithChangesAsync({
+      targetBranchName: rushConfiguration.repositoryDefaultBranch,
+      terminal
+    });
   //#endregion
 
   //#region Step 2: Expand all consumers

--- a/common/changes/@microsoft/rush/rush-change-ignore-shrinkwrap_2021-12-01-09-55.json
+++ b/common/changes/@microsoft/rush/rush-change-ignore-shrinkwrap_2021-12-01-09-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -251,8 +251,6 @@ export interface IExperimentsJson {
 // @beta (undocumented)
 export interface IGetChangedProjectsOptions {
     // (undocumented)
-    ignoreShrinkwrapChanges?: boolean;
-    // (undocumented)
     shouldFetch?: boolean;
     // (undocumented)
     targetBranchName: string;
@@ -454,8 +452,8 @@ export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
-    getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
-    getChangedProjectsForIncrementalBuildAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
+    getProjectsImpactedByDiffAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
+    getProjectsWithChangesAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
     _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;
     // @internal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -251,6 +251,8 @@ export interface IExperimentsJson {
 // @beta (undocumented)
 export interface IGetChangedProjectsOptions {
     // (undocumented)
+    ignoreShrinkwrapChanges?: boolean;
+    // (undocumented)
     shouldFetch?: boolean;
     // (undocumented)
     targetBranchName: string;
@@ -453,6 +455,7 @@ export class ProjectChangeAnalyzer {
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
     getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
+    getChangedProjectsForIncrementalBuildAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
     _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;
     // @internal


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3053 and https://github.com/microsoft/rushstack/issues/3054.

## Details

https://github.com/microsoft/rushstack/pull/2968 changed the project change detection logic to consider the shrinkwrap file and a `incrementalBuildIgnoredGlobs` field in `rush-project.json`. These are relevant for incremental build, but not for `rush change`. This PR restores some of the old behavior.

## How it was tested

Tested with `rush change -v` in a repo with a shrinkwrap change after running `rush purge`.