### PR TITLE
[node-core-library] Eliminate const enums from node-core-library's public API.

### DIFF
--- a/common/changes/@rushstack/node-core-library/ncl-no-const-enums_2021-12-02-19-15.json
+++ b/common/changes/@rushstack/node-core-library/ncl-no-const-enums_2021-12-02-19-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Replace const enums with conventional enums to allow for compatability with JavaScript consumers.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -10,7 +10,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 
 // @public
-export const enum AlreadyExistsBehavior {
+export enum AlreadyExistsBehavior {
     Error = "error",
     Ignore = "ignore",
     Overwrite = "overwrite"
@@ -128,7 +128,7 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
 }
 
 // @public
-export const enum Encoding {
+export enum Encoding {
     // (undocumented)
     Utf8 = "utf8"
 }
@@ -180,7 +180,7 @@ export type ExecutableStdioMapping = 'pipe' | 'ignore' | 'inherit' | ExecutableS
 export type ExecutableStdioStreamMapping = 'pipe' | 'ignore' | 'inherit' | NodeJS.WritableStream | NodeJS.ReadableStream | number | undefined;
 
 // @public
-export const enum FileConstants {
+export enum FileConstants {
     PackageJson = "package.json"
 }
 
@@ -261,7 +261,7 @@ export class FileWriter {
 }
 
 // @public
-export const enum FolderConstants {
+export enum FolderConstants {
     Git = ".git",
     NodeModules = "node_modules"
 }
@@ -646,7 +646,7 @@ export class MapExtensions {
 }
 
 // @public
-export const enum NewlineKind {
+export enum NewlineKind {
     CrLf = "\r\n",
     Lf = "\n",
     OsDefault = "os"
@@ -701,7 +701,7 @@ export class Path {
 }
 
 // @public
-export const enum PosixModeBits {
+export enum PosixModeBits {
     AllExecute = 73,
     AllRead = 292,
     AllWrite = 146,

--- a/libraries/node-core-library/src/Constants.ts
+++ b/libraries/node-core-library/src/Constants.ts
@@ -6,7 +6,7 @@
  *
  * @public
  */
-export const enum FileConstants {
+export enum FileConstants {
   /**
    * "package.json" - the configuration file that defines an NPM package
    */
@@ -18,7 +18,7 @@ export const enum FileConstants {
  *
  * @public
  */
-export const enum FolderConstants {
+export enum FolderConstants {
   /**
    * ".git" - the data storage for a Git working folder
    */

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -146,7 +146,7 @@ export interface IFileSystemCopyFileOptions extends IFileSystemCopyFileBaseOptio
  *
  * @public
  */
-export const enum AlreadyExistsBehavior {
+export enum AlreadyExistsBehavior {
   /**
    * If the output file path already exists, try to overwrite the existing object.
    *

--- a/libraries/node-core-library/src/PosixModeBits.ts
+++ b/libraries/node-core-library/src/PosixModeBits.ts
@@ -19,7 +19,7 @@
  *
  * @public
  */
-export const enum PosixModeBits {
+export enum PosixModeBits {
   // The bits
 
   /**

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
  * The allowed types of encodings, as supported by Node.js
  * @public
  */
-export const enum Encoding {
+export enum Encoding {
   Utf8 = 'utf8'
 }
 
@@ -15,7 +15,7 @@ export const enum Encoding {
  * Enumeration controlling conversion of newline characters.
  * @public
  */
-export const enum NewlineKind {
+export enum NewlineKind {
   /**
    * Windows-style newlines
    */


### PR DESCRIPTION
## Summary

Addresses https://github.com/microsoft/rushstack/issues/3058.

## Details

This allows for compatibility with consumers writing code in JavaScript, or who use `isolatedModules` in TypeScript.

## How it was tested

Build passes.