### PR TITLE
[api-extractor-model] Remove "const" keyword before enum to use with typescript isolatedModules

### DIFF
--- a/apps/api-extractor-model/src/items/ApiItem.ts
+++ b/apps/api-extractor-model/src/items/ApiItem.ts
@@ -15,7 +15,7 @@ import { ApiItemContainerMixin } from '../mixins/ApiItemContainerMixin';
  *
  * @public
  */
-export const enum ApiItemKind {
+export enum ApiItemKind {
   CallSignature = 'CallSignature',
   Class = 'Class',
   Constructor = 'Constructor',

--- a/apps/api-extractor-model/src/mixins/Excerpt.ts
+++ b/apps/api-extractor-model/src/mixins/Excerpt.ts
@@ -5,7 +5,7 @@ import { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/Declara
 import { Text } from '@rushstack/node-core-library';
 
 /** @public */
-export const enum ExcerptTokenKind {
+export enum ExcerptTokenKind {
   /**
    * Generic text without any special properties
    */

--- a/common/changes/@microsoft/api-extractor-model/master_2021-12-06-21-04.json
+++ b/common/changes/@microsoft/api-extractor-model/master_2021-12-06-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "remove \"const\" keyword before enums to allow use with typescript isolatedModules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor-model/master_2021-12-06-21-04.json
+++ b/common/changes/@microsoft/api-extractor-model/master_2021-12-06-21-04.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor-model",
-      "comment": "remove \"const\" keyword before enums to allow use with typescript isolatedModules",
-      "type": "patch"
+      "comment": "Replace const enums with conventional enums to allow for compatibility with JavaScript consumers.",
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/api-extractor-model"

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -23,7 +23,7 @@ export class AedocDefinitions {
     static readonly preapprovedTag: TSDocTagDefinition;
     // (undocumented)
     static get tsdocConfiguration(): TSDocConfiguration;
-    }
+}
 
 // Warning: (ae-forgotten-export) The symbol "ApiCallSignature_base" needs to be exported by the entry point index.d.ts
 //
@@ -122,7 +122,7 @@ export class ApiDocumentedItem extends ApiItem {
     serializeInto(jsonObject: Partial<IApiDocumentedItemJson>): void;
     // (undocumented)
     get tsdocComment(): tsdoc.DocComment | undefined;
-    }
+}
 
 // Warning: (ae-forgotten-export) The symbol "ApiEntryPoint_base" needs to be exported by the entry point index.d.ts
 //
@@ -284,7 +284,7 @@ export namespace ApiItemContainerMixin {
 }
 
 // @public
-export const enum ApiItemKind {
+export enum ApiItemKind {
     // (undocumented)
     CallSignature = "CallSignature",
     // (undocumented)
@@ -446,7 +446,7 @@ export class ApiPackage extends ApiPackage_base {
     // (undocumented)
     saveToJsonFile(apiJsonFilename: string, options?: IApiPackageSaveOptions): void;
     get tsdocConfiguration(): TSDocConfiguration;
-    }
+}
 
 // @public
 export function ApiParameterListMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiParameterListMixin);
@@ -632,10 +632,10 @@ export class ExcerptToken {
     get canonicalReference(): DeclarationReference | undefined;
     get kind(): ExcerptTokenKind;
     get text(): string;
-    }
+}
 
 // @public (undocumented)
-export const enum ExcerptTokenKind {
+export enum ExcerptTokenKind {
     Content = "Content",
     Reference = "Reference"
 }
@@ -913,6 +913,5 @@ export class TypeParameter {
     name: string;
     get tsdocTypeParamBlock(): tsdoc.DocParamBlock | undefined;
 }
-
 
 ```


### PR DESCRIPTION
## Summary

When a typescript project is using [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules), referencing exported `const` enums  is not allowed.

## Details

Setting `isolatedModules` to `true` is recommended for projects transpiled with babel or [esbuild](https://esbuild.github.io/content-types/#isolated-modules). Unlike `tsc`, these tools evaluate files independently. Setting the `isolatedModules` flag e.g. forces developers to indicate whether they are exporting a type or value, since transpilers evaluating modules independently cannot infer this information.

However, the flag also alerts when a `const` enum is used. It seems that `tsc` evaluates `const enums` across modules and inlines the constants at compile. No `enum` object is created, which is problematic of independent transpilation.

I found [this article helpful](https://ncjamieson.com/dont-export-const-enums/) for understanding the effect of specifying `const`.

By removing the `const` keyword, the enums can safely be used in projects using `isolatedModules`. This change is similar to [this recent PR](https://github.com/microsoft/rushstack/pull/3060).

## How it was tested

I used `npm link` and no longer saw the error. Note also that I did not face the error with the `ReleaseTag` enum which is not using `const`. 
