### PR TITLE
[package-deps-hash] Use --merge-base flag when diffing against a target branch

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/use-merge-base_2021-12-08-22-09.json
+++ b/common/changes/@rushstack/package-deps-hash/use-merge-base_2021-12-08-22-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "When detecting changes relative to a target branch, use the merge base between the target branch and the current commit as the comparison ref.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -276,6 +276,8 @@ export function getRepoChanges(
       'diff-index',
       '--color=never',
       '--no-renames',
+      // rush change targets origin/main with this, and usually the current branch is not synced, so use the merge-base
+      '--merge-base',
       '--no-commit-id',
       '--cached',
       '-z',


### PR DESCRIPTION
## Summary
Use the `--merge-base` flag when running change detection against a target branch, so that changes to the target branch since the point at which the current branch was forked are not included in the selection.

## Details
Fixes a regression introduced when changing from `git diff` to `git diff-index` for change detection.

## How it was tested
Verified using a stale branch that only local changes in said branch were included, rather than changes to `master` since the branch was forked.