### PR TITLE
[rush] Allow multiple remote URLs to be specified in the rush.json repository.url field.

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -94,15 +94,7 @@ export interface IEventHooksJson {
 /**
  * Part of IRushConfigurationJson.
  */
-export interface IRushRepositoryJson {
-  /**
-   * Remote url(s) of the repository. If a value is provided, \"rush change\" will
-   * use one of these to find the right remote to compare against. Specifying multiple URLs
-   * is useful if a GitHub repository is renamed or for "<projectName>.visualstudio.com" vs
-   * "dev.azure.com/<projectName>" URLs.
-   */
-  url?: string | string[];
-
+export interface IRushRepositoryJsonBase {
   /**
    * The default branch name. This tells "rush change" which remote branch to compare against.
    */
@@ -114,6 +106,28 @@ export interface IRushRepositoryJson {
    */
   defaultRemote?: string;
 }
+
+export interface IRushRepositoryJsonSingleUrl extends IRushRepositoryJsonBase {
+  /**
+   * The remote url of the repository. If a value is provided,
+   * \"rush change\" will use it to find the right remote to compare against.
+   *
+   * @deprecated Use "urls" instead.
+   */
+  url?: string;
+}
+
+export interface IRushRepositoryJsonMultipleUrls extends IRushRepositoryJsonBase {
+  /**
+   * Remote url(s) of the repository. If a value is provided, \"rush change\" will
+   * use one of these to find the right remote to compare against. Specifying multiple URLs
+   * is useful if a GitHub repository is renamed or for "<projectName>.visualstudio.com" vs
+   * "dev.azure.com/<projectName>" URLs.
+   */
+  urls?: string[];
+}
+
+export type IRushRepositoryJson = IRushRepositoryJsonSingleUrl | IRushRepositoryJsonMultipleUrls;
 
 /**
  * This represents the available PNPM store options
@@ -458,7 +472,7 @@ export class RushConfiguration {
   private _hotfixChangeEnabled: boolean;
 
   // Repository info
-  private _repositoryUrls: string[] | undefined;
+  private _repositoryUrls: string[];
   private _repositoryDefaultBranch: string;
   private _repositoryDefaultRemote: string;
 
@@ -697,13 +711,23 @@ export class RushConfiguration {
       rushConfigurationJson.repository = {};
     }
 
-    this._repositoryUrls = Array.isArray(rushConfigurationJson.repository.url)
-      ? rushConfigurationJson.repository.url
-      : rushConfigurationJson.repository.url
-      ? [rushConfigurationJson.repository.url]
-      : undefined;
     this._repositoryDefaultBranch = rushConfigurationJson.repository.defaultBranch || DEFAULT_BRANCH;
     this._repositoryDefaultRemote = rushConfigurationJson.repository.defaultRemote || DEFAULT_REMOTE;
+    const repositoryFieldWithMultipleUrls: IRushRepositoryJsonMultipleUrls =
+      rushConfigurationJson.repository as IRushRepositoryJsonMultipleUrls;
+    const repositoryFieldWithSingleUrl: IRushRepositoryJsonSingleUrl =
+      rushConfigurationJson.repository as IRushRepositoryJsonSingleUrl;
+    if (repositoryFieldWithMultipleUrls.urls) {
+      if (repositoryFieldWithSingleUrl.url) {
+        throw new Error("The 'repository.url' field cannot be used when 'repository.urls' is present");
+      }
+
+      this._repositoryUrls = repositoryFieldWithMultipleUrls.urls;
+    } else if (repositoryFieldWithSingleUrl.url) {
+      this._repositoryUrls = [repositoryFieldWithSingleUrl.url];
+    } else {
+      this._repositoryUrls = [];
+    }
 
     this._telemetryEnabled = !!rushConfigurationJson.telemetryEnabled;
     this._eventHooks = new EventHooks(rushConfigurationJson.eventHooks || {});
@@ -1342,7 +1366,7 @@ export class RushConfiguration {
    * is useful if a GitHub repository is renamed or for "<projectName>.visualstudio.com" vs
    * "dev.azure.com/<projectName>" URLs.
    */
-  public get repositoryUrls(): string[] | undefined {
+  public get repositoryUrls(): string[] {
     return this._repositoryUrls;
   }
 

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -96,9 +96,12 @@ export interface IEventHooksJson {
  */
 export interface IRushRepositoryJson {
   /**
-   * The remote url of the repository. This helps "rush change" find the right remote to compare against.
+   * Remote url(s) of the repository. If a value is provided, \"rush change\" will
+   * use one of these to find the right remote to compare against. Specifying multiple URLs
+   * is useful if a GitHub repository is renamed or for "<projectName>.visualstudio.com" vs
+   * "dev.azure.com/<projectName>" URLs.
    */
-  url?: string;
+  url?: string | string[];
 
   /**
    * The default branch name. This tells "rush change" which remote branch to compare against.
@@ -455,7 +458,7 @@ export class RushConfiguration {
   private _hotfixChangeEnabled: boolean;
 
   // Repository info
-  private _repositoryUrl: string | undefined;
+  private _repositoryUrls: string[] | undefined;
   private _repositoryDefaultBranch: string;
   private _repositoryDefaultRemote: string;
 
@@ -694,7 +697,11 @@ export class RushConfiguration {
       rushConfigurationJson.repository = {};
     }
 
-    this._repositoryUrl = rushConfigurationJson.repository.url;
+    this._repositoryUrls = Array.isArray(rushConfigurationJson.repository.url)
+      ? rushConfigurationJson.repository.url
+      : rushConfigurationJson.repository.url
+      ? [rushConfigurationJson.repository.url]
+      : undefined;
     this._repositoryDefaultBranch = rushConfigurationJson.repository.defaultBranch || DEFAULT_BRANCH;
     this._repositoryDefaultRemote = rushConfigurationJson.repository.defaultRemote || DEFAULT_REMOTE;
 
@@ -1330,10 +1337,13 @@ export class RushConfiguration {
   }
 
   /**
-   * The remote url of the repository. This helps "rush change" find the right remote to compare against.
+   * Remote URL(s) of the repository. If a value is provided, \"rush change\" will
+   * use one of these to find the right remote to compare against. Specifying multiple URLs
+   * is useful if a GitHub repository is renamed or for "<projectName>.visualstudio.com" vs
+   * "dev.azure.com/<projectName>" URLs.
    */
-  public get repositoryUrl(): string | undefined {
-    return this._repositoryUrl;
+  public get repositoryUrls(): string[] | undefined {
+    return this._repositoryUrls;
   }
 
   /**

--- a/apps/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -236,6 +236,11 @@ describe('RushConfiguration', () => {
     );
   });
 
+  it('fails to load repo/rush-repository-url-urls.json', () => {
+    const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-repository-url-urls.json');
+    expect(() => RushConfiguration.loadFromConfigurationFile(rushFilename)).toThrowErrorMatchingSnapshot();
+  });
+
   describe('PNPM Store Paths', () => {
     afterEach(() => {
       EnvironmentConfiguration['_pnpmStorePathOverride'] = undefined;

--- a/apps/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -78,7 +78,7 @@ describe('RushConfiguration', () => {
 
     expect(rushConfiguration.packageManagerToolVersion).toEqual('4.5.0');
 
-    expect(rushConfiguration.repositoryUrl).toEqual('someFakeUrl');
+    expect(rushConfiguration.repositoryUrls).toEqual(['someFakeUrl']);
     expect(rushConfiguration.projectFolderMaxDepth).toEqual(99);
     expect(rushConfiguration.projectFolderMinDepth).toEqual(1);
     expect(rushConfiguration.hotfixChangeEnabled).toEqual(true);
@@ -158,7 +158,7 @@ describe('RushConfiguration', () => {
 
     expect(rushConfiguration.packageManagerToolVersion).toEqual('6.0.0');
 
-    expect(rushConfiguration.repositoryUrl).toEqual('someFakeUrl');
+    expect(rushConfiguration.repositoryUrls).toEqual(['someFakeUrl']);
     expect(rushConfiguration.projectFolderMaxDepth).toEqual(99);
     expect(rushConfiguration.projectFolderMinDepth).toEqual(1);
 
@@ -203,6 +203,7 @@ describe('RushConfiguration', () => {
       rushConfiguration.getPnpmfilePath(),
       './repo/common/config/rush/pnpmfile.js'
     );
+    expect(rushConfiguration.repositoryUrls).toEqual(['someFakeUrl', 'otherFakeUrl']);
 
     done();
   });

--- a/apps/rush-lib/src/api/test/__snapshots__/RushConfiguration.test.ts.snap
+++ b/apps/rush-lib/src/api/test/__snapshots__/RushConfiguration.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RushConfiguration fails to load repo/rush-repository-url-urls.json 1`] = `"The 'repository.url' field cannot be used when 'repository.urls' is present"`;

--- a/apps/rush-lib/src/api/test/repo/rush-pnpm-5.json
+++ b/apps/rush-lib/src/api/test/repo/rush-pnpm-5.json
@@ -10,7 +10,7 @@
   },
 
   "repository": {
-    "url": "someFakeUrl"
+    "url": ["someFakeUrl", "otherFakeUrl"]
   },
 
   "gitPolicy": {

--- a/apps/rush-lib/src/api/test/repo/rush-repository-url-urls.json
+++ b/apps/rush-lib/src/api/test/repo/rush-repository-url-urls.json
@@ -10,7 +10,8 @@
   },
 
   "repository": {
-    "urls": ["someFakeUrl", "otherFakeUrl"]
+    "url": "someFakeUrl",
+    "urls": ["otherFakeUrl"]
   },
 
   "gitPolicy": {

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -305,10 +305,10 @@ export class Git {
       } else {
         const errorMessage: string =
           repositoryUrls.length > 1
-            ? `Unable to find a git remote matching the repository URL (${repositoryUrls[0]}). `
-            : `Unable to find a git remote matching one of the repository URLs (${repositoryUrls.join(
+            ? `Unable to find a git remote matching one of the repository URLs (${repositoryUrls.join(
                 ', '
-              )}). `;
+              )}). `
+            : `Unable to find a git remote matching the repository URL (${repositoryUrls[0]}). `;
         console.log(colors.yellow(errorMessage + 'Detected changes are likely to be incorrect.'));
 
         return this._rushConfiguration.repositoryDefaultFullyQualifiedRemoteBranch;

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -257,8 +257,8 @@ export class Git {
    * @param rushConfiguration - rush configuration
    */
   public getRemoteDefaultBranch(): string {
-    const repositoryUrls: string[] | undefined = this._rushConfiguration.repositoryUrls;
-    if (repositoryUrls && repositoryUrls.length > 0) {
+    const repositoryUrls: string[] = this._rushConfiguration.repositoryUrls;
+    if (repositoryUrls.length > 0) {
       const gitPath: string = this.getGitPathOrThrow();
       const output: string = Utilities.executeCommandAndCaptureOutput(
         gitPath,

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -258,7 +258,7 @@ export class Git {
    */
   public getRemoteDefaultBranch(): string {
     const repositoryUrls: string[] | undefined = this._rushConfiguration.repositoryUrls;
-    if (repositoryUrls) {
+    if (repositoryUrls && repositoryUrls.length > 0) {
       const gitPath: string = this.getGitPathOrThrow();
       const output: string = Utilities.executeCommandAndCaptureOutput(
         gitPath,

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -211,8 +211,19 @@
       "type": "object",
       "properties": {
         "url": {
-          "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against.",
-          "type": "string"
+          "oneOf": [
+            {
+              "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against.",
+              "type": "string"
+            },
+            {
+              "description": "All allowed remote urls of the repository. If a value is provided, \"rush change\" will use one of these to find the right remote to compare against. Specifying multiple URLs is useful if a GitHub repository is renamed or for \"<projectName>.visualstudio.com\" vs \"dev.azure.com/<projectName>\" URLs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "defaultBranch": {
           "description": "The default branch name. This tells \"rush change\" which remote branch to compare against. The default value is \"master\"",

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -211,19 +211,15 @@
       "type": "object",
       "properties": {
         "url": {
-          "oneOf": [
-            {
-              "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against.",
-              "type": "string"
-            },
-            {
-              "description": "All allowed remote urls of the repository. If a value is provided, \"rush change\" will use one of these to find the right remote to compare against. Specifying multiple URLs is useful if a GitHub repository is renamed or for \"<projectName>.visualstudio.com\" vs \"dev.azure.com/<projectName>\" URLs.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
+          "type": "string",
+          "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against."
+        },
+        "urls": {
+          "description": "All allowed remote urls of the repository. If a value is provided, \"rush change\" will use one of these to find the right remote to compare against. Specifying multiple URLs is useful if a GitHub repository is renamed or for \"<projectName>.visualstudio.com\" vs \"dev.azure.com/<projectName>\" URLs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "defaultBranch": {
           "description": "The default branch name. This tells \"rush change\" which remote branch to compare against. The default value is \"master\"",

--- a/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-43.json
+++ b/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Allow multiple remote URLs to be specified in the rush.json repository.url field.",
+      "comment": "Allow multiple remote URLs to be specified in the rush.json in the new repository.urls field.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-43.json
+++ b/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow multiple remote URLs to be specified in the rush.json repository.url field.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-44.json
+++ b/common/changes/@microsoft/rush/multiple-remote-urls_2021-12-09-00-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING CHANGE) Replace the RushConfiguration repositoryUrl field with repositoryUrls to support multiple remote URLs specified in rush.json.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -539,7 +539,7 @@ export class RushConfiguration {
     get repositoryDefaultBranch(): string;
     get repositoryDefaultFullyQualifiedRemoteBranch(): string;
     get repositoryDefaultRemote(): string;
-    get repositoryUrls(): string[] | undefined;
+    get repositoryUrls(): string[];
     // @internal
     get rushConfigurationJson(): IRushConfigurationJson;
     get rushJsonFile(): string;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -539,7 +539,7 @@ export class RushConfiguration {
     get repositoryDefaultBranch(): string;
     get repositoryDefaultFullyQualifiedRemoteBranch(): string;
     get repositoryDefaultRemote(): string;
-    get repositoryUrl(): string | undefined;
+    get repositoryUrls(): string[] | undefined;
     // @internal
     get rushConfigurationJson(): IRushConfigurationJson;
     get rushJsonFile(): string;


### PR DESCRIPTION
## Summary

Allow multiple remote URLs to be specified in the rush.json repository.url field.

## Details

This change allows repositories that have multiple possible remote URLs to specify the `repository.url` field in `rush.json`. This is useful when a GitHub repository is changed and contributors still have clones using the old repo URL (i.e. - `github.com/microsoft/web-build-tools` to `github.com/microsoft/rushstack`) or in Azure DevOps repositories that have multiple allowed URLs (i.e. `myorg.visualstudio.com` vs `dev.azure.com/myorg`).

This is a breaking change in the `RushConfiguration` API.

## How it was tested

Added a unit test case covering this.