### PR TITLE
[rush] Mark rush list as safe for simultaneous rush processes.

### DIFF
--- a/apps/rush-lib/src/cli/actions/ListAction.ts
+++ b/apps/rush-lib/src/cli/actions/ListAction.ts
@@ -64,7 +64,8 @@ export class ListAction extends BaseRushAction {
         'List package names, and optionally version (--version) and ' +
         'path (--path) or full path (--full-path), for projects in the ' +
         'current rush config.',
-      parser
+      parser,
+      safeForSimultaneousRushProcesses: true
     });
   }
 
@@ -97,7 +98,7 @@ export class ListAction extends BaseRushAction {
       description:
         'For the non --json view, if this flag is specified, ' +
         'include path (-p), version (-v) columns along with ' +
-        'the project’s applicable: versionPolicy, versionPolicyName, ' +
+        "the project's applicable: versionPolicy, versionPolicyName, " +
         'shouldPublish, and reviewPolicy fields.'
     });
 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -700,7 +700,7 @@ Optional arguments:
                         be displayed in a column along with the package name.
   --detailed            For the non --json view, if this flag is specified, 
                         include path (-p), version (-v) columns along with 
-                        the project’s applicable: versionPolicy, 
+                        the project's applicable: versionPolicy, 
                         versionPolicyName, shouldPublish, and reviewPolicy 
                         fields.
   --json                If this flag is specified, output will be in JSON 

--- a/common/changes/@microsoft/rush/list-simultaneous-processes_2021-12-15-20-29.json
+++ b/common/changes/@microsoft/rush/list-simultaneous-processes_2021-12-15-20-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow \"rush list\" to be invoked while other rush processes are running in the same repo.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Mark rush list as safe for simultaneous rush processes.

## How it was tested

Ran locally.