### PR TITLE
[package-deps-hash] Provide a more useful error message if the git version is too old.

### DIFF
--- a/common/changes/@microsoft/rush/git-version-check_2021-12-16-00-37.json
+++ b/common/changes/@microsoft/rush/git-version-check_2021-12-16-00-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Provide a more useful error message if the git version is too old.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/git-version-check_2021-12-15-23-18.json
+++ b/common/changes/@rushstack/package-deps-hash/git-version-check_2021-12-15-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Provide a more useful error message if the git version is too old.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public
+export function ensureGitMinimumVersion(gitPath?: string): void;
+
+// @public
 export function getGitHashForFiles(filesToHash: string[], packagePath: string, gitPath?: string): Map<string, string>;
 
 // @public

--- a/libraries/package-deps-hash/src/getPackageDeps.ts
+++ b/libraries/package-deps-hash/src/getPackageDeps.ts
@@ -5,6 +5,8 @@ import * as child_process from 'child_process';
 import * as path from 'path';
 import { Executable } from '@rushstack/node-core-library';
 
+import { ensureGitMinimumVersion } from './getRepoState';
+
 /**
  * Parses a quoted filename sourced from the output of the "git status" command.
  *
@@ -153,6 +155,8 @@ export function getGitHashForFiles(
     );
 
     if (result.status !== 0) {
+      ensureGitMinimumVersion(gitPath);
+
       throw new Error(`git hash-object exited with status ${result.status}: ${result.stderr}`);
     }
 
@@ -190,6 +194,8 @@ export function gitLsTree(path: string, gitPath?: string): string {
   );
 
   if (result.status !== 0) {
+    ensureGitMinimumVersion(gitPath);
+
     throw new Error(`git ls-tree exited with status ${result.status}: ${result.stderr}`);
   }
 
@@ -217,6 +223,8 @@ export function gitStatus(path: string, gitPath?: string): string {
   );
 
   if (result.status !== 0) {
+    ensureGitMinimumVersion(gitPath);
+
     throw new Error(`git status exited with status ${result.status}: ${result.stderr}`);
   }
 

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -346,7 +346,10 @@ function getGitVersion(gitPath?: string): IGitVersion {
   const result: child_process.SpawnSyncReturns<string> = Executable.spawnSync(gitPath || 'git', ['version']);
 
   if (result.status !== 0) {
-    throw new Error(`git version exited with status ${result.status}: ${result.stderr}`);
+    throw new Error(
+      `While validating the Git installation, the "git version" command failed with ` +
+        `status ${result.status}: ${result.stderr}`
+    );
   }
 
   return parseGitVersion(result.stdout);
@@ -362,7 +365,10 @@ export function parseGitVersion(gitVersionOutput: string): IGitVersion {
   const versionRegex: RegExp = /^git version (\d+)\.(\d+)\.(\d+)/;
   const match: RegExpMatchArray | null = versionRegex.exec(gitVersionOutput);
   if (!match) {
-    throw new Error(`Unable to parse git version output: ${gitVersionOutput}`);
+    throw new Error(
+      `While validating the Git installation, the "git version" command produced ` +
+        `unexpected output: "${gitVersionOutput}"`
+    );
   }
 
   const major: number = parseInt(match[1], 10);

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -336,6 +336,12 @@ export function getGitVersion(gitPath?: string): IGitVersion {
 }
 
 export function parseGitVersion(gitVersionOutput: string): IGitVersion {
+  // This regexp matches output of "git version" that looks like `git version <number>.<number>.<number>(+whatever)`
+  // Examples:
+  // - git version 1.2.3
+  // - git version 1.2.3.4.5
+  // - git version 1.2.3windows.1
+  // - git version 1.2.3.windows.1
   const versionRegex: RegExp = /^git version (\d+)\.(\d+)\.(\d+)/;
   const match: RegExpMatchArray | null = versionRegex.exec(gitVersionOutput);
   if (!match) {

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -14,5 +14,10 @@
  */
 
 export { getPackageDeps, getGitHashForFiles } from './getPackageDeps';
-export { getRepoChanges, getRepoRoot, getRepoState } from './getRepoState';
-export { IFileDiffStatus } from './getRepoState';
+export {
+  IFileDiffStatus,
+  getRepoChanges,
+  getRepoRoot,
+  getRepoState,
+  ensureGitMinimumVersion
+} from './getRepoState';

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -24,16 +24,16 @@ describe('getRepoState', () => {
 
   it('Rejects invalid git version responses', () => {
     expect(() => parseGitVersion('2.22.0.windows.1')).toThrowErrorMatchingInlineSnapshot(
-      `"Unable to parse git version output: 2.22.0.windows.1"`
+      `"While validating the Git installation, the \\"git version\\" command produced unexpected output: \\"2.22.0.windows.1\\""`
     );
     expect(() => parseGitVersion('git version 2.30.A')).toThrowErrorMatchingInlineSnapshot(
-      `"Unable to parse git version output: git version 2.30.A"`
+      `"While validating the Git installation, the \\"git version\\" command produced unexpected output: \\"git version 2.30.A\\""`
     );
     expect(() => parseGitVersion('git version 2.30')).toThrowErrorMatchingInlineSnapshot(
-      `"Unable to parse git version output: git version 2.30"`
+      `"While validating the Git installation, the \\"git version\\" command produced unexpected output: \\"git version 2.30\\""`
     );
     expect(() => parseGitVersion('git version .2.30')).toThrowErrorMatchingInlineSnapshot(
-      `"Unable to parse git version output: git version .2.30"`
+      `"While validating the Git installation, the \\"git version\\" command produced unexpected output: \\"git version .2.30\\""`
     );
   });
 });

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { parseGitVersion } from '../getRepoState';
+
+describe('getRepoState', () => {
+  it('Can parse valid git version responses', () => {
+    expect(parseGitVersion('git version 2.30.2.windows.1')).toEqual({
+      major: 2,
+      minor: 30,
+      patch: 2
+    });
+    expect(parseGitVersion('git version 2.30.2.windows.1.g8b8f8e')).toEqual({
+      major: 2,
+      minor: 30,
+      patch: 2
+    });
+    expect(parseGitVersion('git version 2.30.2')).toEqual({
+      major: 2,
+      minor: 30,
+      patch: 2
+    });
+  });
+
+  it('Rejects invalid git version responses', () => {
+    expect(() => parseGitVersion('2.22.0.windows.1')).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to parse git version output: 2.22.0.windows.1"`
+    );
+    expect(() => parseGitVersion('git version 2.30.A')).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to parse git version output: git version 2.30.A"`
+    );
+    expect(() => parseGitVersion('git version 2.30')).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to parse git version output: git version 2.30"`
+    );
+    expect(() => parseGitVersion('git version .2.30')).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to parse git version output: git version .2.30"`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Currently if a user is using a git version older than 2.30.0, `rush version` will provide a confusing error message (it prints the `git diff-index --help` message). This change checks the git version if `git diff-index` exits with a nonzero exit code and informs the user if their git version is too old.

## How it was tested

Installed git 2.29.0 and ran `rush change -v`.