### PR TITLE
[api-extractor] Changes _checkCompilerCompatibility bundled ts log message from info to verbose level

### DIFF
--- a/apps/api-extractor/src/api/Extractor.ts
+++ b/apps/api-extractor/src/api/Extractor.ts
@@ -433,7 +433,7 @@ export class Extractor {
     extractorConfig: ExtractorConfig,
     messageRouter: MessageRouter
   ): void {
-    messageRouter.logInfo(
+    messageRouter.logVerbose(
       ConsoleMessageId.Preamble,
       `Analysis will use the bundled TypeScript version ${ts.version}`
     );

--- a/common/changes/@microsoft/api-extractor/change-extractor-ts-version-message-from-info-to-verbose_2021-12-21-02-49.json
+++ b/common/changes/@microsoft/api-extractor/change-extractor-ts-version-message-from-info-to-verbose_2021-12-21-02-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Changes _checkCompilerCompatibility bundled ts log message from info to verbose level",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
This PR simply changes the extractor message detailing the TS version used in the analysis from the `info` level into the `verbose` level. When using the `api-extractor` in parallel generating summarised types for a group of packages, the massage becomes annoying and there is not really a way to turn it off. Having that said, I believe this is better suited as a verbose message.