### PR TITLE
[rush-lib] increase maxBuffer to 10mb when `executeCommand`

### DIFF
--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -774,7 +774,8 @@ export class Utilities {
       stdio: stdio,
       env: keepEnvironment
         ? environment
-        : Utilities._createEnvironmentForRushCommand({ initialEnvironment: environment })
+        : Utilities._createEnvironmentForRushCommand({ initialEnvironment: environment }),
+      maxBuffer: 10 * 1024 * 1024 // Set default max buffer size to 10MB
     };
 
     // This is needed since we specify shell=true below.

--- a/common/changes/@microsoft/rush/feat-increase-maxBuffer_2021-12-21-03-55.json
+++ b/common/changes/@microsoft/rush/feat-increase-maxBuffer_2021-12-21-03-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "[rush-lib] increase maxBuffer to 10mb when executeCommand",
+      "comment": "Fix an issue that occurs when running a command with a selection argument with a Git ref (like `--from git:main`) in a repo with a pnpm lockfile larger than 1MB.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/feat-increase-maxBuffer_2021-12-21-03-55.json
+++ b/common/changes/@microsoft/rush/feat-increase-maxBuffer_2021-12-21-03-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-lib] increase maxBuffer to 10mb when executeCommand",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

The default `maxBuffer` 1MB is too small. 

we should increase to decrease the `ENOBUFS` error when executing git command. for example:

`rush build --from git:master` will throw `ENOBUFS` error when `pnpm-lock.yaml` is larger than 1MB. 

`rush build --from git:master` execute `git cat-file blob common/config/rush/pnpm-lock.yaml` command using `child_process.spawnSync`. because `pnpm-lock.yaml` is larger than 1MB so the `ENOBUFS` is throwed.

```
$ ls -alh common/config/rush/pnpm-lock.yaml
-rw-r--r--  1 feng  staff   1.9M Dec 21 11:22 common/config/rush/pnpm-lock.yaml

$ rush --debug build --from git:master


Rush Multi-Project Build Tool 5.58.0 - https://rushjs.io
Node.js version is 14.18.1 (LTS)


Trying to acquire lock for pnpm-6.10.0
Acquired lock for pnpm-6.10.0
Found pnpm version 6.10.0 in /Users/feng/.rush/node-v14.18.1/pnpm-6.10.0

Symlinking "/Users/feng/Projects/test-infra-monorepo/common/temp/pnpm-local"
  --> "/Users/feng/.rush/node-v14.18.1/pnpm-6.10.0"
Acquiring lock for "common/autoinstallers/command-plugins" folder...
Autoinstaller folder is already up to date

Starting "rush build"


ERROR: spawnSync /bin/sh ENOBUFS


Error: spawnSync /bin/sh ENOBUFS


    at Object.spawnSync (internal/child_process.js:1077:20)
    at Object.spawnSync (child_process.js:776:24)
    at Function._executeCommandInternal (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/utilities/Utilities.js:546:36)
    at Function.executeCommandAndCaptureOutput (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/utilities/Utilities.js:199:34)
    at Git._executeGitCommandAndCaptureOutput (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/logic/Git.js:464:42)
    at Git.getBlobContent (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/logic/Git.js:218:29)
    at ProjectChangeAnalyzer.getChangedProjectsAsync (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/logic/ProjectChangeAnalyzer.js:168:57)
    at GitChangedProjectSelectorParser.evaluateSelectorAsync (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/logic/selectors/GitChangedProjectSelectorParser.js:13:44)
    at SelectionParameterSet._evaluateProjectParameterAsync (/Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/cli/SelectionParameterSet.js:276:49)
    at /Users/feng/.rush/node-v14.18.1/rush-5.58.0/node_modules/@microsoft/rush-lib/lib/cli/SelectionParameterSet.js:166:25
```

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

There is a [issue](https://github.com/nodejs/node/issues/9829) about default maxBuffer is too small in node. the popular `execa` package is also using 10MB maxBuffer as a default when start(now they increase to 100MB). I think 10MB will be a more reasonable default for rush


## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

local. using the project above which `rush build --from git:master` fail.

```
$ node ~/Projects/rushstack/apps/rush-lib/lib/start.js --debug build --from git:master

Rush Multi-Project Build Tool 5.58.0 (unmanaged) - https://rushjs.io
Node.js version is 14.18.1 (LTS)


Trying to acquire lock for pnpm-6.10.0
Acquired lock for pnpm-6.10.0
Found pnpm version 6.10.0 in /Users/bytedance/.rush/node-v14.18.1/pnpm-6.10.0

Symlinking "/Users/bytedance/Projects/test-infra-monorepo/common/temp/pnpm-local"
  --> "/Users/bytedance/.rush/node-v14.18.1/pnpm-6.10.0"
Acquiring lock for "common/autoinstallers/command-plugins" folder...
Autoinstaller folder is already up to date

Starting "rush build"

Executing a maximum of 12 simultaneous processes...

==[ project  1 ]==========================[ 1 of 32 ]==
```

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
