### PR TITLE
[eslint-config] Re-enable 'eslint-plugin-promise' rules

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.43.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.44.0.tgz
       eslint: ~8.3.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.43.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.0.tgz
       eslint: 8.3.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.43.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.44.0.tgz
       eslint: ~8.3.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.43.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.0.tgz
       eslint: 8.3.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
@@ -542,6 +542,15 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-plugin-promise/6.0.0_eslint@8.3.0:
+    resolution: {integrity: sha1-AXZSwHyYFkE6QeEcMK3ELD1V/xg=}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.3.0
     dev: true
 
   /eslint-plugin-react/7.27.1_eslint@8.3.0:
@@ -1679,6 +1688,7 @@ packages:
       '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
       eslint: 8.3.0
+      eslint-plugin-promise: 6.0.0_eslint@8.3.0
       eslint-plugin-react: 7.27.1_eslint@8.3.0
       eslint-plugin-tsdoc: 0.2.14
       typescript: 4.5.2
@@ -1740,10 +1750,10 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.43.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.43.2.tgz}
+  file:../temp/tarballs/rushstack-heft-0.44.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.44.0.tgz}
     name: '@rushstack/heft'
-    version: 0.43.2
+    version: 0.44.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:

--- a/common/changes/@rushstack/eslint-config/user-danade-ReenableEslintPluginPromise_2021-12-22-02-33.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-ReenableEslintPluginPromise_2021-12-22-02-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Re-enable eslint-plugin-promise rules which now support ESLint v8",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1186,6 +1186,7 @@ importers:
       '@typescript-eslint/parser': ~5.6.0
       '@typescript-eslint/typescript-estree': ~5.6.0
       eslint: ~8.3.0
+      eslint-plugin-promise: ~6.0.0
       eslint-plugin-react: ~7.27.1
       eslint-plugin-tsdoc: ~0.2.14
       typescript: ~4.5.2
@@ -1198,6 +1199,7 @@ importers:
       '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
       '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
+      eslint-plugin-promise: 6.0.0_eslint@8.3.0
       eslint-plugin-react: 7.27.1_eslint@8.3.0
       eslint-plugin-tsdoc: 0.2.14
     devDependencies:
@@ -10017,6 +10019,15 @@ packages:
       optionator: 0.8.3
     optionalDependencies:
       source-map: 0.6.1
+
+  /eslint-plugin-promise/6.0.0_eslint@8.3.0:
+    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.3.0
+    dev: false
 
   /eslint-plugin-react/7.27.1_eslint@7.30.0:
     resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8f53532ad47748ac29025ff560e44472e10ea2e7",
+  "pnpmShrinkwrapHash": "47aca98c44b4e322021c9f4f7f8bba4ddd58a905",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }

--- a/eslint/eslint-config/package.json
+++ b/eslint/eslint-config/package.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/experimental-utils": "~5.6.0",
     "@typescript-eslint/parser": "~5.6.0",
     "@typescript-eslint/typescript-estree": "~5.6.0",
+    "eslint-plugin-promise": "~6.0.0",
     "eslint-plugin-react": "~7.27.1",
     "eslint-plugin-tsdoc": "~0.2.14"
   },

--- a/eslint/eslint-config/profile/_common.js
+++ b/eslint/eslint-config/profile/_common.js
@@ -42,10 +42,9 @@ function buildRules(profile) {
       // Plugin documentation: https://www.npmjs.com/package/@rushstack/eslint-plugin-security
       '@rushstack/eslint-plugin-security',
       // Plugin documentation: https://www.npmjs.com/package/@typescript-eslint/eslint-plugin
-      '@typescript-eslint/eslint-plugin'
+      '@typescript-eslint/eslint-plugin',
       // Plugin documentation: https://www.npmjs.com/package/eslint-plugin-promise
-      // TODO: Re-enable once updated to support eslint v8: https://github.com/xjamundx/eslint-plugin-promise/issues/218
-      // 'eslint-plugin-promise'
+      'eslint-plugin-promise'
     ],
 
     // Manually authored .d.ts files are generally used to describe external APIs that are  not expected
@@ -761,8 +760,7 @@ function buildRules(profile) {
           'prefer-const': 'warn',
 
           // RATIONALE:         Catches a common coding mistake where "resolve" and "reject" are confused.
-          // TODO: Re-enable once updated to support eslint v8: https://github.com/xjamundx/eslint-plugin-promise/issues/218
-          // 'promise/param-names': 'error',
+          'promise/param-names': 'error',
 
           // RATIONALE:         Catches code that is likely to be incorrect
           // STANDARDIZED BY:   eslint\conf\eslint-recommended.js


### PR DESCRIPTION
## Summary

Now that the `eslint-plugin-promise` package has been updated to support ESLint 8 (see https://github.com/xjamundx/eslint-plugin-promise/issues/218), we can re-enable the rule that we consumed but disabled during adding of ESLint 8 support.

## How it was tested

Rebuilding full project
