### PR TITLE
[rush] Fixes git hooks install error when rush is not at the git root

### DIFF
--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -172,7 +172,10 @@ export class Git {
     }
 
     if (hooksResult.result) {
-      const absoluteHooksPath: string = path.resolve(repoInfo.root, hooksResult.result);
+      const absoluteHooksPath: string = path.resolve(
+        this._rushConfiguration.rushJsonFolder,
+        hooksResult.result
+      );
       return absoluteHooksPath === defaultHooksPath;
     }
 

--- a/common/changes/@microsoft/rush/fix--3111_2021-12-24-15-33.json
+++ b/common/changes/@microsoft/rush/fix--3111_2021-12-24-15-33.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix error in situation where rush is not located at git root",
+      "comment": "Fix an issue with installing Git hooks that occurs when the rush.json folder isn't at the repo's root.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix--3111_2021-12-24-15-33.json
+++ b/common/changes/@microsoft/rush/fix--3111_2021-12-24-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix error in situation where rush is not located at git root",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Fixes #3111

## Details

Turns out an assumption about directory where `git` is running was incorrect.

## How it was tested

Ran `install` in both rush and reproduction repo with `core.hooksPath` both set and unset.
