### PR TITLE
[rush] Update "rush init" to write files with LF line endings instead of CRLF line endings on non-Windows OSes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Prevent Git to auto detect text files and perform LF normalization.
-* -text
+# Set default behavior to automatically normalize line endings.
+* text=auto
 
 # The item with `binary` is treated as binary file.
 # The item with `eol=lf` is converted to LF on checkin, back to LF on checkout.
@@ -17,45 +17,17 @@
 # > git add .gitattributes
 # > git commit -m "Apply end-of-line normalization based on updated .gitattributes file"
 
-*.aspx            text eol=crlf
-*.bowerrc         text eol=lf
 *.cmd             text eol=crlf
-*.command         text eol=lf
-*.config          text eol=crlf
-*.cs              text eol=crlf
-*.csproj          text eol=crlf
-*.css             text eol=crlf
 *.dll             binary
-*.editorconfig    text eol=lf
 *.eot             binary
-*.example         text eol=crlf
 *.exe             binary
 *.gif             binary
-*.gitattributes   text eol=lf
-*.gitignore       text eol=lf
-*.gitmodules      text eol=lf
-*.html            text eol=crlf
 *.ico             binary
 *.jpg             binary
-*.js              text eol=crlf
-*.json            text eol=crlf
-*.less            text eol=crlf
-*.map             text eol=lf
-*.md              text eol=crlf
-*.npmignore       text eol=lf
 *.png             binary
-*.ps1             text eol=crlf
-*.rels            text eol=crlf
-*.resx            text eol=crlf
-*.scss            text eol=crlf
-*.sln             text eol=crlf
-*.svg             text elf=lf
-*.ts              text eol=crlf
-*.tsx             text eol=crlf
 *.ttf             binary
 *.woff            binary
 *.wsp             binary
-*.xml             text eol=crlf
 
 # NPM "bin" scripts MUST have LF, or else the executable fails to run on Mac.
 # This fnmatch expression only matches files in a "bin" folder and without

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -219,14 +219,16 @@ export class InitAction extends BaseConfiglessRushAction {
   // A single-line section may appear inside a block section, in which case it will get
   // commented twice.
   private _copyTemplateFile(sourcePath: string, destinationPath: string): void {
+    const destinationFileExists: boolean = FileSystem.exists(destinationPath);
+
     if (!this._overwriteParameter.value) {
-      if (FileSystem.exists(destinationPath)) {
+      if (destinationFileExists) {
         console.log(colors.yellow('Not overwriting already existing file: ') + destinationPath);
         return;
       }
     }
 
-    if (FileSystem.exists(destinationPath)) {
+    if (destinationFileExists) {
       console.log(colors.yellow(`Overwriting: ${destinationPath}`));
     } else {
       console.log(`Generating: ${destinationPath}`);
@@ -341,7 +343,7 @@ export class InitAction extends BaseConfiglessRushAction {
     }
 
     // Write the output
-    FileSystem.writeFile(destinationPath, outputLines.join('\r\n'), {
+    FileSystem.writeFile(destinationPath, outputLines.join('\n'), {
       ensureFolderExists: true
     });
   }

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -343,7 +343,7 @@ export class InitAction extends BaseConfiglessRushAction {
     }
 
     // Write the output
-    FileSystem.writeFile(destinationPath, outputLines.join('\n'), {
+    FileSystem.writeFile(destinationPath, outputLines.join(os.EOL), {
       ensureFolderExists: true
     });
   }

--- a/common/changes/@microsoft/rush/update-gitattributes_2021-12-25-21-22.json
+++ b/common/changes/@microsoft/rush/update-gitattributes_2021-12-25-21-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Update \"rush init\" to write files with LF line endings instead of CRLF line endings.",
+      "comment": "Update \"rush init\" to write files with OS-default line endings (CRLF on Windows, LF otherwise) instead of always writing CRLF line endings.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/update-gitattributes_2021-12-25-21-22.json
+++ b/common/changes/@microsoft/rush/update-gitattributes_2021-12-25-21-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update \"rush init\" to write files with LF line endings instead of CRLF line endings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft-config-file/update-gitattributes_2021-12-27-04-40.json
+++ b/common/changes/@rushstack/heft-config-file/update-gitattributes_2021-12-27-04-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
+++ b/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
@@ -185,7 +185,7 @@ Object {
 `;
 
 exports[`ConfigurationFile error cases Throws an error when the file isn't valid JSON 1`] = `
-[Error: In config file "<project root>/src/test/errorCases/invalidJson/config.json": SyntaxError: Unexpected token '\\n' at 2:19
+[Error: In config file "<project root>/src/test/errorCases/invalidJson/config.json": SyntaxError: Unexpected token '}' at 2:19
   "filePaths": "A
                  ^]
 `;

--- a/libraries/heft-config-file/src/test/errorCases/invalidJson/.gitattributes
+++ b/libraries/heft-config-file/src/test/errorCases/invalidJson/.gitattributes
@@ -1,0 +1,1 @@
+*.json text eol=lf


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3095 

We will keep https://github.com/microsoft/rushstack/issues/1467 open until this change has been applied to all other Rush Stack projects.

## Details

This also gets rid of the `.gitattributes` overrides for text files.

## How it was tested

Ran `rush init` on Windows and on Linux.