### PR TITLE
[rush] Create a rush-tester project to run rush-lib locally with the built-in plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ These GitHub repositories provide supplementary resources for Rush Stack:
 | [/build-tests/localization-plugin-test-02](./build-tests/localization-plugin-test-02/) | Building this project exercises @microsoft/localization-plugin. This tests that the loader works correctly with the exportAsDefault option unset. |
 | [/build-tests/localization-plugin-test-03](./build-tests/localization-plugin-test-03/) | Building this project exercises @microsoft/localization-plugin. This tests that the plugin works correctly with the exportAsDefault option set to true. |
 | [/build-tests/rush-project-change-analyzer-test](./build-tests/rush-project-change-analyzer-test/) | This is an example project that uses rush-lib's ProjectChangeAnalyzer to  |
+| [/build-tests/rush-tester](./build-tests/rush-tester/) | This is a project that can be used to run the copy of Rush from inside the rushstack repo with plugin support. |
 | [/build-tests/set-webpack-public-path-plugin-webpack4-test](./build-tests/set-webpack-public-path-plugin-webpack4-test/) | Building this project tests the set-webpack-public-path-plugin using Webpack 4 |
 | [/build-tests/ts-command-line-test](./build-tests/ts-command-line-test/) | Building this project is a regression test for ts-command-line |
 | [/libraries/rushell](./libraries/rushell/) | Execute shell commands using a consistent syntax on every platform |

--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -28,6 +28,13 @@ export interface ILaunchOptions {
    * with this version of Rush, so we shouldn't print a similar error.
    */
   alreadyReportedNodeTooNewError?: boolean;
+
+  /**
+   * If the built-in plugins are dependencies of a different package than `rush-lib`,
+   * the path to that package should be specified here. This is useful for development
+   * of the built-in plugins.
+   */
+  builtInPluginsProjectPath?: string;
 }
 
 /**
@@ -66,7 +73,8 @@ export class Rush {
 
     Rush._assignRushInvokedFolder();
     const parser: RushCommandLineParser = new RushCommandLineParser({
-      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError
+      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
+      builtInPluginsProjectPath: options.builtInPluginsProjectPath
     });
     parser.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise
   }

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -58,6 +58,11 @@ import { ProjectLogWritable } from '../logic/taskExecution/ProjectLogWritable';
 export interface IRushCommandLineParserOptions {
   cwd: string; // Defaults to `cwd`
   alreadyReportedNodeTooNewError: boolean;
+
+  /**
+   * {@see ILaunchOptions.builtInPluginsProjectPath}
+   */
+  builtInPluginsProjectPath?: string;
 }
 
 export class RushCommandLineParser extends CommandLineParser {
@@ -116,6 +121,7 @@ export class RushCommandLineParser extends CommandLineParser {
     this.pluginManager = new PluginManager({
       rushSession: this.rushSession,
       rushConfiguration: this.rushConfiguration,
+      builtInPluginsProjectPath: options?.builtInPluginsProjectPath,
       terminal: this._terminal
     });
 

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
@@ -3,16 +3,27 @@
 
 import { Import } from '@rushstack/node-core-library';
 
-import { PluginLoaderBase } from './PluginLoaderBase';
+import { IPluginLoaderBaseOptions, PluginLoaderBase } from './PluginLoaderBase';
+
+export interface IBuiltInPluginLoaderOptions extends IPluginLoaderBaseOptions {
+  builtInPluginsProjectRootPath: string;
+}
 
 /**
  * Built-in plugin loader.
  * Loading those plugins are directly installed by Rush.
  */
 export class BuiltInPluginLoader extends PluginLoaderBase {
+  private readonly _builtInPluginsProjectRootPath: string;
+
+  public constructor(options: IBuiltInPluginLoaderOptions) {
+    super(options);
+    this._builtInPluginsProjectRootPath = options.builtInPluginsProjectRootPath;
+  }
+
   protected override onGetPackageFolder(): string {
     const packageFolder: string = Import.resolvePackage({
-      baseFolderPath: __dirname,
+      baseFolderPath: this._builtInPluginsProjectRootPath,
       packageName: this._packageName
     });
     return packageFolder;

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -30,7 +30,7 @@ export interface IRushPluginManifestJson {
   plugins: IRushPluginManifest[];
 }
 
-export interface IPluginLoaderOptions {
+export interface IPluginLoaderBaseOptions {
   pluginConfiguration: IRushPluginConfigurationBase;
   rushConfiguration: RushConfiguration;
   terminal: ITerminal;
@@ -50,7 +50,7 @@ export abstract class PluginLoaderBase {
 
   private _cachedPackageFolder: string | undefined = undefined;
 
-  public constructor({ pluginConfiguration, rushConfiguration, terminal }: IPluginLoaderOptions) {
+  public constructor({ pluginConfiguration, rushConfiguration, terminal }: IPluginLoaderBaseOptions) {
     this._packageName = pluginConfiguration.packageName;
     this._pluginName = pluginConfiguration.pluginName;
     this._rushConfiguration = rushConfiguration;

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/RemotePluginLoader.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/RemotePluginLoader.ts
@@ -2,17 +2,19 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { FileSystem, JsonFile, JsonObject, JsonSchema, ITerminal } from '@rushstack/node-core-library';
-import { RushConfiguration } from '../../api/RushConfiguration';
+import { FileSystem, JsonFile, JsonObject, JsonSchema } from '@rushstack/node-core-library';
 import { IRushPluginConfiguration } from '../../api/RushPluginsConfiguration';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import { RushConstants } from '../../logic/RushConstants';
-import { IRushPluginManifest, IRushPluginManifestJson, PluginLoaderBase } from './PluginLoaderBase';
+import {
+  IPluginLoaderBaseOptions,
+  IRushPluginManifest,
+  IRushPluginManifestJson,
+  PluginLoaderBase
+} from './PluginLoaderBase';
 
-export interface IRemotePluginLoaderOptions {
+export interface IRemotePluginLoaderOptions extends IPluginLoaderBaseOptions {
   pluginConfiguration: IRushPluginConfiguration;
-  rushConfiguration: RushConfiguration;
-  terminal: ITerminal;
 }
 
 /**
@@ -21,13 +23,12 @@ export interface IRemotePluginLoaderOptions {
 export class RemotePluginLoader extends PluginLoaderBase {
   private _autoinstaller: Autoinstaller;
 
-  public constructor({ pluginConfiguration, rushConfiguration, terminal }: IRemotePluginLoaderOptions) {
-    super({
-      pluginConfiguration,
-      rushConfiguration,
-      terminal
-    });
-    this._autoinstaller = new Autoinstaller(pluginConfiguration.autoinstallerName, this._rushConfiguration);
+  public constructor(options: IRemotePluginLoaderOptions) {
+    super(options);
+    this._autoinstaller = new Autoinstaller(
+      options.pluginConfiguration.autoinstallerName,
+      this._rushConfiguration
+    );
   }
 
   protected override onGetPackageFolder(): string {

--- a/build-tests/rush-tester/.eslintrc.js
+++ b/build-tests/rush-tester/.eslintrc.js
@@ -1,0 +1,10 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname }
+};

--- a/build-tests/rush-tester/config/rig.json
+++ b/build-tests/rush-tester/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "@rushstack/heft-node-rig"
+}

--- a/build-tests/rush-tester/package.json
+++ b/build-tests/rush-tester/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rush-tester",
+  "description": "This is a project that can be used to run the copy of Rush from inside the rushstack repo with plugin support.",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "heft build --clean",
+    "start": "heft start"
+  },
+  "dependencies": {
+    "@rushstack/rush-amazon-s3-build-cache-plugin": "workspace:*",
+    "@rushstack/rush-azure-storage-build-cache-plugin": "workspace:*",
+    "@microsoft/rush-lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@rushstack/eslint-config": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@types/node": "12.20.24",
+    "@rushstack/heft-node-rig": "workspace:*"
+  }
+}

--- a/build-tests/rush-tester/src/start.ts
+++ b/build-tests/rush-tester/src/start.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Rush } from '@microsoft/rush-lib/lib/api/Rush';
+
+Rush.launch(Rush.version, { isManaged: false, builtInPluginsProjectPath: `${__dirname}/..` });

--- a/build-tests/rush-tester/src/startx.ts
+++ b/build-tests/rush-tester/src/startx.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Rush } from '@microsoft/rush-lib/lib/api/Rush';
+
+Rush.launchRushX(Rush.version, { isManaged: false, builtInPluginsProjectPath: `${__dirname}/..` });

--- a/build-tests/rush-tester/tsconfig.json
+++ b/build-tests/rush-tester/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/common/changes/@microsoft/rush/rush-test-project_2021-12-26-09-03.json
+++ b/common/changes/@microsoft/rush/rush-test-project_2021-12-26-09-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -15,11 +15,11 @@
       "allowedCategories": [ "tests" ]
     },
     {
-      "name": "@jest/create-cache-key-function",
+      "name": "@jest/core",
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "@jest/core",
+      "name": "@jest/create-cache-key-function",
       "allowedCategories": [ "libraries" ]
     },
     {
@@ -160,11 +160,11 @@
     },
     {
       "name": "@rushstack/rush-amazon-s3-build-cache-plugin",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "tests" ]
     },
     {
       "name": "@rushstack/rush-azure-storage-build-cache-plugin",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "tests" ]
     },
     {
       "name": "@rushstack/rush-sdk",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1143,6 +1143,25 @@ importers:
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/node': 12.20.24
 
+  ../../build-tests/rush-tester:
+    specifiers:
+      '@microsoft/rush-lib': workspace:*
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/rush-amazon-s3-build-cache-plugin': workspace:*
+      '@rushstack/rush-azure-storage-build-cache-plugin': workspace:*
+      '@types/node': 12.20.24
+    dependencies:
+      '@microsoft/rush-lib': link:../../apps/rush-lib
+      '@rushstack/rush-amazon-s3-build-cache-plugin': link:../../rush-plugins/rush-amazon-s3-build-cache-plugin
+      '@rushstack/rush-azure-storage-build-cache-plugin': link:../../rush-plugins/rush-azure-storage-build-cache-plugin
+    devDependencies:
+      '@rushstack/eslint-config': link:../../eslint/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@types/node': 12.20.24
+
   ../../build-tests/set-webpack-public-path-plugin-webpack4-test:
     specifiers:
       '@rushstack/eslint-config': workspace:*

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "47aca98c44b4e322021c9f4f7f8bba4ddd58a905",
+  "pnpmShrinkwrapHash": "363dca66bd4511c63b40fd3c939b76d395258a0c",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -263,6 +263,7 @@ export interface IGetChangedProjectsOptions {
 // @public
 export interface ILaunchOptions {
     alreadyReportedNodeTooNewError?: boolean;
+    builtInPluginsProjectPath?: string;
     isManaged: boolean;
 }
 

--- a/rush.json
+++ b/rush.json
@@ -778,6 +778,12 @@
       "shouldPublish": false
     },
     {
+      "packageName": "rush-tester",
+      "projectFolder": "build-tests/rush-tester",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
+    {
       "packageName": "set-webpack-public-path-plugin-webpack4-test",
       "projectFolder": "build-tests/set-webpack-public-path-plugin-webpack4-test",
       "reviewCategory": "tests",


### PR DESCRIPTION
## Summary

Currently, running `node <path-to-rush-lib-in-rushstack-repo>/lib/start.js build` in a project that uses the Azure Storage or Amazon S3 cache providers will fail. There is a circular dependency between `rush-lib` and the built-in plugin packages that gets fixed up at publish-time. This PR adds a `/build-tests/rush-tester` project that has relationships with the built-in plugin packages wired up.

## How it was tested

Ran `node <path-to-rush-tester>/lib/start.js build` in a project that uses the Azure Storage cache provider.