### PR TITLE
[rush] Fix an issue where a flag paramter not associated with the build command will cause the build to fail.

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -42,48 +42,46 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
     }
 
     // Find any parameters that are associated with this command
-    for (const parameter of this.commandLineConfiguration.parameters) {
-      if (this.command.associatedParameters.has(parameter)) {
-        let customParameter: CommandLineParameter | undefined;
+    for (const parameter of this.command.associatedParameters) {
+      let customParameter: CommandLineParameter | undefined;
 
-        switch (parameter.parameterKind) {
-          case 'flag':
-            customParameter = this.defineFlagParameter({
-              parameterShortName: parameter.shortName,
-              parameterLongName: parameter.longName,
-              description: parameter.description,
-              required: parameter.required
-            });
-            break;
-          case 'choice':
-            customParameter = this.defineChoiceParameter({
-              parameterShortName: parameter.shortName,
-              parameterLongName: parameter.longName,
-              description: parameter.description,
-              required: parameter.required,
-              alternatives: parameter.alternatives.map((x) => x.name),
-              defaultValue: parameter.defaultValue
-            });
-            break;
-          case 'string':
-            customParameter = this.defineStringParameter({
-              parameterLongName: parameter.longName,
-              parameterShortName: parameter.shortName,
-              description: parameter.description,
-              required: parameter.required,
-              argumentName: parameter.argumentName
-            });
-            break;
-          default:
-            throw new Error(
-              `${RushConstants.commandLineFilename} defines a parameter "${
-                (parameter as ParameterJson).longName
-              }" using an unsupported parameter kind "${(parameter as ParameterJson).parameterKind}"`
-            );
-        }
-
-        this.customParameters.push(customParameter);
+      switch (parameter.parameterKind) {
+        case 'flag':
+          customParameter = this.defineFlagParameter({
+            parameterShortName: parameter.shortName,
+            parameterLongName: parameter.longName,
+            description: parameter.description,
+            required: parameter.required
+          });
+          break;
+        case 'choice':
+          customParameter = this.defineChoiceParameter({
+            parameterShortName: parameter.shortName,
+            parameterLongName: parameter.longName,
+            description: parameter.description,
+            required: parameter.required,
+            alternatives: parameter.alternatives.map((x) => x.name),
+            defaultValue: parameter.defaultValue
+          });
+          break;
+        case 'string':
+          customParameter = this.defineStringParameter({
+            parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
+            description: parameter.description,
+            required: parameter.required,
+            argumentName: parameter.argumentName
+          });
+          break;
+        default:
+          throw new Error(
+            `${RushConstants.commandLineFilename} defines a parameter "${
+              (parameter as ParameterJson).longName
+            }" using an unsupported parameter kind "${(parameter as ParameterJson).parameterKind}"`
+          );
       }
+
+      this.customParameters.push(customParameter);
     }
   }
 }

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -133,7 +133,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
     }
 
     const phasesToRun: Set<string> = new Set(this._actionPhases);
-    for (const parameter of this.commandLineConfiguration.parameters) {
+    for (const parameter of this.command.associatedParameters) {
       if (parameter.parameterKind === 'flag') {
         if (this.getFlagParameter(parameter.longName)!.value) {
           const flagParameter: IFlagParameterJson = parameter as IFlagParameterJson;

--- a/common/changes/@microsoft/rush/fix-phased-commands-params-issue_2021-12-30-03-59.json
+++ b/common/changes/@microsoft/rush/fix-phased-commands-params-issue_2021-12-30-03-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

The phased builds feature currently checks all flag parameters if they're set before adding or removing phases to run for those flags. This fails if the flag isn't associated with the command.

## How it was tested

Tested by running `rush build` in the repo where the issue was discovered.