### PR TITLE
[eslint-plugin-packlets] Check imports from tsconfig#compilerOptions.paths

### DIFF
--- a/eslint/eslint-plugin-packlets/src/PackletAnalyzer.ts
+++ b/eslint/eslint-plugin-packlets/src/PackletAnalyzer.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as fs from 'fs';
+import { CompilerOptions, MapLike } from 'typescript';
 import { Path } from './Path';
 
 export type InputFileMessageIds =
@@ -64,7 +65,15 @@ export class PackletAnalyzer {
    */
   public readonly isEntryPoint: boolean;
 
-  private constructor(inputFilePath: string, tsconfigFilePath: string | undefined) {
+  /**
+   * We want to ensure packlets don't import local code outside of other packlets,
+   * in typescript projects we can set path aliases in the compilerOptions.paths definition.
+   * This extends our import checks to include these path aliases.
+   * Example { "compilerOptions": { "paths": { "@my-org/*": ['app/*'], "@tools": ['tools'] } } }
+   */
+  public isModulePathAnAlias: (modulePath: string) => boolean = () => false;
+
+  private constructor(inputFilePath: string, compilerOptions: CompilerOptions) {
     this.inputFilePath = inputFilePath;
     this.error = undefined;
     this.nothingToDo = false;
@@ -75,6 +84,8 @@ export class PackletAnalyzer {
 
     // Example: /path/to/my-project/src
     let srcFolderPath: string | undefined;
+    // Example: /path/to/my-project/tsconfig.json
+    const tsconfigFilePath: string | undefined = compilerOptions['configFilePath'] as string;
 
     if (!tsconfigFilePath) {
       this.error = { messageId: 'missing-tsconfig' };
@@ -100,9 +111,26 @@ export class PackletAnalyzer {
     // Example: [ 'packlets', 'my-packlet', 'index.ts' ]
     const pathParts: string[] = inputFilePathRelativeToSrc.split(/[\/\\]+/);
 
-    let underPackletsFolder: boolean = false;
-
     const expectedPackletsFolder: string = Path.join(srcFolderPath, 'packlets');
+
+    // Construct the path alias tester
+    // Example { "compilerOptions": { "paths": { "@my-org/*": ['app/*'], "@tools": ['tools'] } } }
+    const tsconfigPaths: MapLike<string[]> = compilerOptions.paths ? compilerOptions.paths : {};
+    // Remove any path mappings which are pointing to src/packlets, or node_modules
+    // (this would be nice to make configurable)
+    const nonPackletMappings: [string, string[]][] = Object.entries(tsconfigPaths).filter(
+      ([, paths]) =>
+        !paths.some((path) => path.startsWith('src/packlets') || path.startsWith('node_modules/'))
+    );
+    // Create a test for each compilerOptions.paths to test that the
+    const tsconfigPathTests: RegExp[] = nonPackletMappings
+      .map(([alias]) => alias) // get just the aliases
+      .map((alias) => alias.replace('/*', '')) // '@my-org/*' -> '@my-org', '@tools' -> '@tools'
+      .map((alias) => new RegExp(`^${alias}$|^${alias}\/`));
+    this.isModulePathAnAlias = (modulePath: string): boolean =>
+      tsconfigPathTests.some((re) => re.test(modulePath));
+
+    let underPackletsFolder: boolean = false;
 
     for (let i = 0; i < pathParts.length; ++i) {
       const pathPart: string = pathParts[i];
@@ -164,8 +192,8 @@ export class PackletAnalyzer {
     }
   }
 
-  public static analyzeInputFile(inputFilePath: string, tsconfigFilePath: string | undefined) {
-    return new PackletAnalyzer(inputFilePath, tsconfigFilePath);
+  public static analyzeInputFile(inputFilePath: string, tsconfigCompilerOptions: CompilerOptions) {
+    return new PackletAnalyzer(inputFilePath, tsconfigCompilerOptions);
   }
 
   public analyzeImport(modulePath: string): IAnalyzerError | undefined {
@@ -180,8 +208,10 @@ export class PackletAnalyzer {
     // Example: /path/to/my-project/src/other-packlet/index
     const importedPath: string = Path.resolve(inputFileFolder, modulePath);
 
+    console.log(`modulePath: ${modulePath} tests ${this.isModulePathAnAlias(modulePath)}`);
+
     // Is the imported path referring to a file under the src/packlets folder?
-    if (Path.isUnder(importedPath, this.packletsFolderPath)) {
+    if (!this.isModulePathAnAlias(modulePath) && Path.isUnder(importedPath, this.packletsFolderPath)) {
       // Example: other-packlet/index
       const importedPathRelativeToPackletsFolder: string = Path.relative(
         this.packletsFolderPath,

--- a/eslint/eslint-plugin-packlets/src/circular-deps.ts
+++ b/eslint/eslint-plugin-packlets/src/circular-deps.ts
@@ -39,12 +39,10 @@ const circularDeps: TSESLint.RuleModule<MessageIds, Options> = {
 
     // Example: /path/to/my-project/tsconfig.json
     const program: ts.Program = ESLintUtils.getParserServices(context).program;
-    const tsconfigFilePath: string | undefined = program.getCompilerOptions()['configFilePath'] as string;
+    const compilerOptions = program.getCompilerOptions();
+    const tsconfigFilePath: string | undefined = compilerOptions['configFilePath'] as string;
 
-    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(
-      inputFilePath,
-      tsconfigFilePath
-    );
+    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(inputFilePath, compilerOptions);
     if (packletAnalyzer.nothingToDo) {
       return {};
     }

--- a/eslint/eslint-plugin-packlets/src/mechanics.ts
+++ b/eslint/eslint-plugin-packlets/src/mechanics.ts
@@ -3,6 +3,7 @@
 
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { MapLike } from 'typescript';
 
 import { PackletAnalyzer, IAnalyzerError, InputFileMessageIds, ImportMessageIds } from './PackletAnalyzer';
 
@@ -52,15 +53,9 @@ const mechanics: TSESLint.RuleModule<MessageIds, Options> = {
     // Example: /path/to/my-project/src/packlets/my-packlet/index.ts
     const inputFilePath: string = context.getFilename();
 
-    // Example: /path/to/my-project/tsconfig.json
-    const tsconfigFilePath: string | undefined = ESLintUtils.getParserServices(
-      context
-    ).program.getCompilerOptions()['configFilePath'] as string;
+    const compilerOptions = ESLintUtils.getParserServices(context).program.getCompilerOptions();
 
-    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(
-      inputFilePath,
-      tsconfigFilePath
-    );
+    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(inputFilePath, compilerOptions);
     if (packletAnalyzer.nothingToDo) {
       return {};
     }
@@ -102,14 +97,15 @@ const mechanics: TSESLint.RuleModule<MessageIds, Options> = {
             if (typeof modulePath !== 'string') {
               return;
             }
-
             if (!(modulePath.startsWith('.') || modulePath.startsWith('..'))) {
-              // It's not a local import.
+              if (!packletAnalyzer.isModulePathAnAlias(modulePath)) {
+                // It's not a local import.
 
-              // Examples:
-              //   import { X } from "npm-package";
-              //   import { X } from "raw-loader!./webpack-file.ts";
-              return;
+                // Examples:
+                //   import { X } from "npm-package";
+                //   import { X } from "raw-loader!./webpack-file.ts";
+                return;
+              }
             }
 
             const lint: IAnalyzerError | undefined = packletAnalyzer.analyzeImport(modulePath);

--- a/eslint/eslint-plugin-packlets/src/readme.ts
+++ b/eslint/eslint-plugin-packlets/src/readme.ts
@@ -55,15 +55,9 @@ const readme: TSESLint.RuleModule<MessageIds, Options> = {
     // Example: /path/to/my-project/src/packlets/my-packlet/index.ts
     const inputFilePath: string = context.getFilename();
 
-    // Example: /path/to/my-project/tsconfig.json
-    const tsconfigFilePath: string | undefined = ESLintUtils.getParserServices(
-      context
-    ).program.getCompilerOptions()['configFilePath'] as string;
+    const compilerOptions = ESLintUtils.getParserServices(context).program.getCompilerOptions();
 
-    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(
-      inputFilePath,
-      tsconfigFilePath
-    );
+    const packletAnalyzer: PackletAnalyzer = PackletAnalyzer.analyzeInputFile(inputFilePath, compilerOptions);
 
     if (!packletAnalyzer.nothingToDo && !packletAnalyzer.error) {
       if (packletAnalyzer.isEntryPoint) {

--- a/eslint/eslint-plugin-packlets/src/test/PacketAnalyzer.test.ts
+++ b/eslint/eslint-plugin-packlets/src/test/PacketAnalyzer.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { CompilerOptions } from 'typescript';
+import { PackletAnalyzer } from '../PackletAnalyzer';
+
+describe('PacketAnalyzer', () => {
+  describe('with tsconfig compilerOptions.paths specified', () => {
+    const projectPath = '/path/to/my-project';
+    const filepath = `${projectPath}/src/packlets/metrics/stat.ts`;
+    const compilerOptions: CompilerOptions = {
+      configFilePath: `${projectPath}/tsconfig.json`,
+      paths: {
+        '@legacy/*': ['app/*'],
+        '@config': ['config'],
+        '@myorg/packlets/*': ['src/packlets/*'],
+        jquery: ['node_modules/jquery/dist/jquery']
+      }
+    };
+    const packletAnalyzer = PackletAnalyzer.analyzeInputFile(filepath, compilerOptions);
+    test('.isModulePathAnAlias', () => {
+      expect(packletAnalyzer.nothingToDo).toEqual(false);
+      expect(packletAnalyzer.isModulePathAnAlias('@myorg/packlets/logging')).toEqual(false);
+      expect(packletAnalyzer.isModulePathAnAlias('jquery')).toEqual(false);
+      expect(packletAnalyzer.isModulePathAnAlias('@legacy')).toEqual(true);
+      expect(packletAnalyzer.isModulePathAnAlias('@legacy-')).toEqual(false);
+      expect(packletAnalyzer.isModulePathAnAlias('@config')).toEqual(true);
+      expect(packletAnalyzer.isModulePathAnAlias('@legacy/service')).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/rushstack/issues/3121

## Summary

The packlets plugin checks local imports to ensure that we only import local code from other packlets — but there is a common edge case in Typescript repositories for which this fails: imports that use aliases defined in the `tsconfig.json`'s `compilerOptions.paths`. This change extends the packets plugin definition of a local import to include Typescript path aliases. 

## Details

Imagine this directory structure:

```
repo
├── app
└── src
    └── packlets
        ├── logger
        └── metrics
```

Now take this import statment in `src/packlets/logger/log.ts`:

```ts
import { Thing } from '../../app' // ERROR
```

However, if your `tsconfig.json` had the following configuration:

```json
{
  "compilerOptions": {
    "paths": {
      "@app": ["app"],
    }
  }
}
```

An alias in your `src/packlets/logger/log.ts` would pass linting:

```ts
import { Thing } from '@app' // ALLOWED
```
It is also common to have aliases for `node_modules` and packets themselves, so this filters out path aliases for these cases. So, take this more worked `tsconfig.json` example:

```json
{
  "compilerOptions": {
    "paths": {
      "@app": ["app"],
      "@myorg/packlets/*": ["src/packlets/*"],
      "jquery": ["node_modules/jquery/dist/jquery"],
    }
  }
}
```
The following would happen to these imports in your `src/packlets/logger/log.ts`:

```ts
import { Thing } from '@app' // ERROR
import * as jquery from 'jquery' // ALLOWED
import * as metrics from '@myorg/packlets/metrics' // ALLOWED
```
## Details

### Alternatives

I considered a few alternatives (or extensions):

1. Don't look at `tsconfig.json`, but allow configuration of the plugin which specifies a list of import path prefixes that should be seen as "local". The downside here is that additional maintenance is required for repo maintainers when `compilerOptions.paths` gets updated they must also remember to update the plugin configuration.
2. Extend my implementation with configuration to specify which aliases should be not be seen as "local". Since my implementation hard-codes both `src/packlets` and `node_modules` as `ignored`, this is in the spirit of this change.
3. Extend my implementation with configuration allowing users to configure which of the `compilerOptions.paths` aliases they want to opt-in to the linter — explicitly failing the linting step if the alias is not present. This reduces the maintenance overhead of alternative (1), making it so there isn't a silent failure.

### Missing cases

This implementation ignores `compilerOptions.paths` which contain `src/packlets` and `node_modules`, but, it is likely that users will want to opt-out of more than these paths. This could be achieved by alternative (2).

### Backwards compatibility

It will cause previously hidden local imports to be surfaced in codebases.

## How it was tested

* I added some unit tests for the `.isModulePathAnAlias` function
* I ran the plugin against a large internal codebase where we are using packlets as an intermediate step towards npm modules. It found all the expected issues in the initial packlets we created where they imported using a path alias.