### PR TITLE
[rush] Add an option to not pass phase-control flag parameters on to project commands.

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -329,6 +329,20 @@ export class CommandLineConfiguration {
           case 'flag': {
             const addPhasesToCommandSet: Set<string> = new Set<string>();
 
+            if (
+              normalizedParameter.doNotIncludeInProjectCommandLine &&
+              !normalizedParameter.addPhasesToCommand?.length &&
+              !normalizedParameter.skipPhasesForCommand?.length
+            ) {
+              throw new Error(
+                `In ${RushConstants.commandLineFilename}, the parameter "${normalizedParameter.longName}" ` +
+                  'has the "doNotIncludeInProjectCommandLine" property set to true, but does not specify ' +
+                  'any phases in the "addPhasesToCommand" or "skipPhasesForCommand" properties. The ' +
+                  '"doNotIncludeInProjectCommandLine" parameter only applies to flag parameters that ' +
+                  'control phase execution.'
+              );
+            }
+
             if (normalizedParameter.addPhasesToCommand) {
               for (const phaseName of normalizedParameter.addPhasesToCommand) {
                 addPhasesToCommandSet.add(phaseName);

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -81,6 +81,7 @@ export interface IBaseParameterJson {
  */
 export interface IFlagParameterJson extends IBaseParameterJson {
   parameterKind: 'flag';
+  doNotIncludeInProjectCommandLine?: boolean;
   addPhasesToCommand?: string[];
   skipPhasesForCommand?: string[];
 }

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -28,6 +28,7 @@ export interface IBaseScriptActionOptions<TCommand extends Command> extends IBas
 export abstract class BaseScriptAction<TCommand extends Command> extends BaseRushAction {
   protected readonly commandLineConfiguration: CommandLineConfiguration;
   protected readonly customParameters: CommandLineParameter[] = [];
+  protected readonly customParametersToPassToScript: CommandLineParameter[] = [];
   protected readonly command: TCommand;
 
   public constructor(options: IBaseScriptActionOptions<TCommand>) {
@@ -44,6 +45,7 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
     // Find any parameters that are associated with this command
     for (const parameter of this.command.associatedParameters) {
       let customParameter: CommandLineParameter | undefined;
+      let shouldIncludeInScript: boolean = true;
 
       switch (parameter.parameterKind) {
         case 'flag':
@@ -53,6 +55,7 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
             description: parameter.description,
             required: parameter.required
           });
+          shouldIncludeInScript = !parameter.doNotIncludeInProjectCommandLine;
           break;
         case 'choice':
           customParameter = this.defineChoiceParameter({
@@ -82,6 +85,9 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
       }
 
       this.customParameters.push(customParameter);
+      if (shouldIncludeInScript) {
+        this.customParametersToPassToScript.push(customParameter);
+      }
     }
   }
 }

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -108,7 +108,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
 
     // Collect all custom parameter values
     const customParameterValues: string[] = [];
-    for (const customParameter of this.customParameters) {
+    for (const customParameter of this.customParametersToPassToScript) {
       customParameter.appendToArgList(customParameterValues);
     }
 

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -335,6 +335,11 @@
             "parameterKind": {
               "enum": ["flag"]
             },
+            "doNotIncludeInProjectCommandLine": {
+              "title": "Do not include in project command line",
+              "description": "If true, then this parameter will not be passed along to projects' build commands. This only applies to parameters with \"addPhasesToCommand\" and/or \"skipPhasesForCommand\" properties set.",
+              "type": "boolean"
+            },
             "addPhasesToCommand": {
               "title": "Add phases to command",
               "description": "Include the phases listed here in the command's execution if this parameter is specified.",
@@ -365,6 +370,7 @@
             "associatedPhases": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
+            "doNotIncludeInProjectCommandLine": { "$ref": "#/definitions/anything" },
             "addPhasesToCommand": { "$ref": "#/definitions/anything" },
             "skipPhasesForCommand": { "$ref": "#/definitions/anything" }
           }

--- a/common/changes/@microsoft/rush/dont-pass-phase-flag-params-to-scripts_2022-01-02-23-42.json
+++ b/common/changes/@microsoft/rush/dont-pass-phase-flag-params-to-scripts_2022-01-02-23-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Currently the design for flag parameters that manipulate which phases are executed conflicts with the design for caching. Using a flag to omit a phase from execution suggests that the phase may not be necessary to get a developer who has just pulled changes into their local clone ready to start work (a `_phase:test` phase excluded by a `--lite` flag for example). However, if the flag is also passed on to the `_phase:build` phase, it ends up being part of the `_phase:build`'s cache entry's hash, meaning that `_phase:build` won't be able to be restored from cache unless the cache was populated by a `rush build --lite` run.

I expect that a repo with phased commands and a remote cache will commonly run `rush build` in CI and then expect developers to run `rush build --lite` to get going in the morning on their local machines. `rush build --lite` should pull the output of the `_phase:build` phase from the cache that was populated by the CI run. This doesn't work if `_phase:build`'s cache entry IDs include the `--lite` flag.

## Details

To address this issue, I propose adding a `"doNotIncludeInProjectCommandLine"` property to `"flag"` parameters in `common/config/rush/command-line.json` that prevents the parameter from being passed on to projects' individual script executions. This property is only allowed for flags that control which phases are executed.

## How it was tested

TBD.