### PR TITLE
[rush] Add a start-dev entrypoint to Rush to include the plugins inside the repo.

### DIFF
--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -9,6 +9,7 @@ import { RushXCommandLine } from '../cli/RushXCommandLine';
 import { CommandLineMigrationAdvisor } from '../cli/CommandLineMigrationAdvisor';
 import { Utilities } from '../utilities/Utilities';
 import { EnvironmentVariableNames } from './EnvironmentConfiguration';
+import { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 
 /**
  * Options to pass to the rush "launch" functions.
@@ -28,6 +29,13 @@ export interface ILaunchOptions {
    * with this version of Rush, so we shouldn't print a similar error.
    */
   alreadyReportedNodeTooNewError?: boolean;
+
+  /**
+   * Used to specify Rush plugins that are dependencies of the "\@microsoft/rush" package.
+   *
+   * @internal
+   */
+  builtInPluginConfigurations?: IBuiltInPluginConfiguration[];
 }
 
 /**
@@ -66,7 +74,8 @@ export class Rush {
 
     Rush._assignRushInvokedFolder();
     const parser: RushCommandLineParser = new RushCommandLineParser({
-      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError
+      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
+      builtInPluginConfigurations: options.builtInPluginConfigurations
     });
     parser.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise
   }

--- a/apps/rush-lib/src/api/RushPluginsConfiguration.ts
+++ b/apps/rush-lib/src/api/RushPluginsConfiguration.ts
@@ -4,6 +4,9 @@
 import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema } from '@rushstack/node-core-library';
 
+/**
+ * @internal
+ */
 export interface IRushPluginConfigurationBase {
   packageName: string;
   pluginName: string;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -53,6 +53,7 @@ import { SetupAction } from './actions/SetupAction';
 import { ICustomCommandLineConfigurationInfo, PluginManager } from '../pluginFramework/PluginManager';
 import { RushSession } from '../pluginFramework/RushSession';
 import { PhasedScriptAction } from './scriptActions/PhasedScriptAction';
+import { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 
 /**
  * Options for `RushCommandLineParser`.
@@ -60,6 +61,7 @@ import { PhasedScriptAction } from './scriptActions/PhasedScriptAction';
 export interface IRushCommandLineParserOptions {
   cwd: string; // Defaults to `cwd`
   alreadyReportedNodeTooNewError: boolean;
+  builtInPluginConfigurations: IBuiltInPluginConfiguration[];
 }
 
 export class RushCommandLineParser extends CommandLineParser {
@@ -118,7 +120,8 @@ export class RushCommandLineParser extends CommandLineParser {
     this.pluginManager = new PluginManager({
       rushSession: this.rushSession,
       rushConfiguration: this.rushConfiguration,
-      terminal: this._terminal
+      terminal: this._terminal,
+      builtInPluginConfigurations: this._rushOptions.builtInPluginConfigurations
     });
 
     this._populateActions();
@@ -188,7 +191,8 @@ export class RushCommandLineParser extends CommandLineParser {
   private _normalizeOptions(options: Partial<IRushCommandLineParserOptions>): IRushCommandLineParserOptions {
     return {
       cwd: options.cwd || process.cwd(),
-      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError || false
+      alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError || false,
+      builtInPluginConfigurations: options.builtInPluginConfigurations || []
     };
   }
 

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -80,6 +80,8 @@ export {
 export { RushLifecycleHooks } from './pluginFramework/RushLifeCycle';
 
 export { IRushPlugin } from './pluginFramework/IRushPlugin';
+export { IBuiltInPluginConfiguration as _IBuiltInPluginConfiguration } from './pluginFramework/PluginLoader/BuiltInPluginLoader';
+export { IRushPluginConfigurationBase as _IRushPluginConfigurationBase } from './api/RushPluginsConfiguration';
 export { ILogger } from './pluginFramework/logging/Logger';
 
 export { ICloudBuildCacheProvider } from './logic/buildCache/ICloudBuildCacheProvider';

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
@@ -1,20 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Import } from '@rushstack/node-core-library';
+import { IRushPluginConfigurationBase } from '../../api/RushPluginsConfiguration';
+import { IPluginLoaderOptions, PluginLoaderBase } from './PluginLoaderBase';
 
-import { PluginLoaderBase } from './PluginLoaderBase';
+export interface IBuiltInPluginConfiguration extends IRushPluginConfigurationBase {
+  pluginPackageFolder: string;
+}
 
 /**
- * Built-in plugin loader.
- * Loading those plugins are directly installed by Rush.
+ * @remarks
+ * Used to load plugins that are dependencies of Rush.
  */
-export class BuiltInPluginLoader extends PluginLoaderBase {
-  protected override onGetPackageFolder(): string {
-    const packageFolder: string = Import.resolvePackage({
-      baseFolderPath: __dirname,
-      packageName: this._packageName
-    });
-    return packageFolder;
+export class BuiltInPluginLoader extends PluginLoaderBase<IBuiltInPluginConfiguration> {
+  public readonly packageFolder: string;
+
+  public constructor(options: IPluginLoaderOptions<IBuiltInPluginConfiguration>) {
+    super(options);
+    this.packageFolder = options.pluginConfiguration.pluginPackageFolder;
   }
 }

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/BuiltInPluginLoader.ts
@@ -4,6 +4,9 @@
 import { IRushPluginConfigurationBase } from '../../api/RushPluginsConfiguration';
 import { IPluginLoaderOptions, PluginLoaderBase } from './PluginLoaderBase';
 
+/**
+ * @internal
+ */
 export interface IBuiltInPluginConfiguration extends IRushPluginConfigurationBase {
   pluginPackageFolder: string;
 }

--- a/apps/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginManager.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { FileSystem, InternalError, IPackageJson, ITerminal } from '@rushstack/node-core-library';
+import { FileSystem, Import, InternalError, ITerminal } from '@rushstack/node-core-library';
 import { CommandLineConfiguration } from '../api/CommandLineConfiguration';
 
 import { RushConfiguration } from '../api/RushConfiguration';
-import { IRushPluginConfigurationBase } from '../api/RushPluginsConfiguration';
-import { BuiltInPluginLoader } from './PluginLoader/BuiltInPluginLoader';
+import { BuiltInPluginLoader, IBuiltInPluginConfiguration } from './PluginLoader/BuiltInPluginLoader';
 import { IRushPlugin } from './IRushPlugin';
-import { RemotePluginLoader } from './PluginLoader/RemotePluginLoader';
+import { AutoinstallerPluginLoader } from './PluginLoader/AutoinstallerPluginLoader';
 import { RushSession } from './RushSession';
 import { PluginLoaderBase } from './PluginLoader/PluginLoaderBase';
 
@@ -28,7 +27,7 @@ export class PluginManager {
   private readonly _rushConfiguration: RushConfiguration;
   private readonly _rushSession: RushSession;
   private readonly _builtInPluginLoaders: BuiltInPluginLoader[];
-  private readonly _remotePluginLoaders: RemotePluginLoader[];
+  private readonly _autoinstallerPluginLoaders: AutoinstallerPluginLoader[];
   private readonly _installedAutoinstallerNames: Set<string>;
   private readonly _loadedPluginNames: Set<string> = new Set<string>();
 
@@ -50,21 +49,25 @@ export class PluginManager {
     // The plugins have devDependencies on Rush, which would create a circular dependency in our local
     // workspace if we added them to rush-lib/package.json.  Instead we put them in a special section
     // "publishOnlyDependencies" which gets moved into "dependencies" during publishing.
-    const builtInPluginConfigurations: IRushPluginConfigurationBase[] = [];
+    const builtInPluginConfigurations: IBuiltInPluginConfiguration[] = [];
 
-    const ownPackageJson: IPackageJson = require('../../package.json');
-    if (ownPackageJson.dependencies!['@rushstack/rush-amazon-s3-build-cache-plugin']) {
-      builtInPluginConfigurations.push({
-        packageName: '@rushstack/rush-amazon-s3-build-cache-plugin',
-        pluginName: 'rush-amazon-s3-build-cache-plugin'
-      });
+    const ownPackageJsonDependencies: Record<string, string> = require('../../package.json').dependencies;
+    function tryAddBuiltInPlugin(builtInPluginName: string): void {
+      const pluginPackageName: string = `@rushstack/${builtInPluginName}`;
+      if (ownPackageJsonDependencies[pluginPackageName]) {
+        builtInPluginConfigurations.push({
+          packageName: pluginPackageName,
+          pluginName: builtInPluginName,
+          pluginPackageFolder: Import.resolvePackage({
+            packageName: pluginPackageName,
+            baseFolderPath: __dirname
+          })
+        });
+      }
     }
-    if (ownPackageJson.dependencies!['@rushstack/rush-azure-storage-build-cache-plugin']) {
-      builtInPluginConfigurations.push({
-        packageName: '@rushstack/rush-azure-storage-build-cache-plugin',
-        pluginName: 'rush-azure-storage-build-cache-plugin'
-      });
-    }
+
+    tryAddBuiltInPlugin('rush-amazon-s3-build-cache-plugin');
+    tryAddBuiltInPlugin('rush-azure-storage-build-cache-plugin');
 
     this._builtInPluginLoaders = builtInPluginConfigurations.map((pluginConfiguration) => {
       return new BuiltInPluginLoader({
@@ -74,10 +77,10 @@ export class PluginManager {
       });
     });
 
-    this._remotePluginLoaders = (
+    this._autoinstallerPluginLoaders = (
       this._rushConfiguration?._rushPluginsConfiguration.configuration.plugins ?? []
     ).map((pluginConfiguration) => {
-      return new RemotePluginLoader({
+      return new AutoinstallerPluginLoader({
         pluginConfiguration,
         rushConfiguration: this._rushConfiguration,
         terminal: this._terminal
@@ -95,16 +98,16 @@ export class PluginManager {
   }
 
   public async updateAsync(): Promise<void> {
-    await this._preparePluginAutoinstallersAsync(this._remotePluginLoaders);
+    await this._preparePluginAutoinstallersAsync(this._autoinstallerPluginLoaders);
     const preparedAutoinstallerNames: Set<string> = new Set<string>();
-    for (const { autoinstaller } of this._remotePluginLoaders) {
-      const storePath: string = RemotePluginLoader.getPluginAutoinstallerStorePath(autoinstaller);
+    for (const { autoinstaller } of this._autoinstallerPluginLoaders) {
+      const storePath: string = AutoinstallerPluginLoader.getPluginAutoinstallerStorePath(autoinstaller);
       if (!preparedAutoinstallerNames.has(autoinstaller.name)) {
         FileSystem.ensureEmptyFolder(storePath);
         preparedAutoinstallerNames.add(autoinstaller.name);
       }
     }
-    for (const pluginLoader of this._remotePluginLoaders) {
+    for (const pluginLoader of this._autoinstallerPluginLoaders) {
       pluginLoader.update();
     }
   }
@@ -115,7 +118,7 @@ export class PluginManager {
     await this.tryInitializeAssociatedCommandPluginsAsync(commandName);
   }
 
-  public async _preparePluginAutoinstallersAsync(pluginLoaders: RemotePluginLoader[]): Promise<void> {
+  public async _preparePluginAutoinstallersAsync(pluginLoaders: AutoinstallerPluginLoader[]): Promise<void> {
     for (const { autoinstaller } of pluginLoaders) {
       if (!this._installedAutoinstallerNames.has(autoinstaller.name)) {
         await autoinstaller.prepareAsync();
@@ -126,14 +129,14 @@ export class PluginManager {
 
   public async tryInitializeUnassociatedPluginsAsync(): Promise<void> {
     try {
-      const remotePluginLoaders: RemotePluginLoader[] = this._getUnassociatedPluginLoaders(
-        this._remotePluginLoaders
+      const autoinstallerPluginLoaders: AutoinstallerPluginLoader[] = this._getUnassociatedPluginLoaders(
+        this._autoinstallerPluginLoaders
       );
-      await this._preparePluginAutoinstallersAsync(remotePluginLoaders);
+      await this._preparePluginAutoinstallersAsync(autoinstallerPluginLoaders);
       const builtInPluginLoaders: BuiltInPluginLoader[] = this._getUnassociatedPluginLoaders(
         this._builtInPluginLoaders
       );
-      this._initializePlugins([...builtInPluginLoaders, ...remotePluginLoaders]);
+      this._initializePlugins([...builtInPluginLoaders, ...autoinstallerPluginLoaders]);
     } catch (e) {
       this._error = e as Error;
     }
@@ -141,16 +144,16 @@ export class PluginManager {
 
   public async tryInitializeAssociatedCommandPluginsAsync(commandName: string): Promise<void> {
     try {
-      const remotePluginLoaders: RemotePluginLoader[] = this._getPluginLoadersForCommand(
+      const autoinstallerPluginLoaders: AutoinstallerPluginLoader[] = this._getPluginLoadersForCommand(
         commandName,
-        this._remotePluginLoaders
+        this._autoinstallerPluginLoaders
       );
-      await this._preparePluginAutoinstallersAsync(remotePluginLoaders);
+      await this._preparePluginAutoinstallersAsync(autoinstallerPluginLoaders);
       const builtInPluginLoaders: BuiltInPluginLoader[] = this._getPluginLoadersForCommand(
         commandName,
         this._builtInPluginLoaders
       );
-      this._initializePlugins([...builtInPluginLoaders, ...remotePluginLoaders]);
+      this._initializePlugins([...builtInPluginLoaders, ...autoinstallerPluginLoaders]);
     } catch (e) {
       this._error = e as Error;
     }
@@ -158,7 +161,7 @@ export class PluginManager {
 
   public tryGetCustomCommandLineConfigurationInfos(): ICustomCommandLineConfigurationInfo[] {
     const commandLineConfigurationInfos: ICustomCommandLineConfigurationInfo[] = [];
-    for (const pluginLoader of this._remotePluginLoaders) {
+    for (const pluginLoader of this._autoinstallerPluginLoaders) {
       const commandLineConfiguration: CommandLineConfiguration | undefined =
         pluginLoader.getCommandLineConfiguration();
       if (commandLineConfiguration) {
@@ -185,7 +188,7 @@ export class PluginManager {
     }
   }
 
-  private _getUnassociatedPluginLoaders<T extends RemotePluginLoader | BuiltInPluginLoader>(
+  private _getUnassociatedPluginLoaders<T extends AutoinstallerPluginLoader | BuiltInPluginLoader>(
     pluginLoaders: T[]
   ): T[] {
     return pluginLoaders.filter((pluginLoader) => {
@@ -193,7 +196,7 @@ export class PluginManager {
     });
   }
 
-  private _getPluginLoadersForCommand<T extends RemotePluginLoader | BuiltInPluginLoader>(
+  private _getPluginLoadersForCommand<T extends AutoinstallerPluginLoader | BuiltInPluginLoader>(
     commandName: string,
     pluginLoaders: T[]
   ): T[] {

--- a/apps/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginManager.ts
@@ -2,8 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import { FileSystem, Import, InternalError, ITerminal } from '@rushstack/node-core-library';
-import { CommandLineConfiguration } from '../api/CommandLineConfiguration';
 
+import { CommandLineConfiguration } from '../api/CommandLineConfiguration';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { BuiltInPluginLoader, IBuiltInPluginConfiguration } from './PluginLoader/BuiltInPluginLoader';
 import { IRushPlugin } from './IRushPlugin';
@@ -15,6 +15,7 @@ export interface IPluginManagerOptions {
   terminal: ITerminal;
   rushConfiguration: RushConfiguration;
   rushSession: RushSession;
+  builtInPluginConfigurations: IBuiltInPluginConfiguration[];
 }
 
 export interface ICustomCommandLineConfigurationInfo {
@@ -49,7 +50,7 @@ export class PluginManager {
     // The plugins have devDependencies on Rush, which would create a circular dependency in our local
     // workspace if we added them to rush-lib/package.json.  Instead we put them in a special section
     // "publishOnlyDependencies" which gets moved into "dependencies" during publishing.
-    const builtInPluginConfigurations: IBuiltInPluginConfiguration[] = [];
+    const builtInPluginConfigurations: IBuiltInPluginConfiguration[] = options.builtInPluginConfigurations;
 
     const ownPackageJsonDependencies: Record<string, string> = require('../../package.json').dependencies;
     function tryAddBuiltInPlugin(builtInPluginName: string): void {

--- a/apps/rush/.npmignore
+++ b/apps/rush/.npmignore
@@ -28,5 +28,6 @@
 #--------------------------------------------
 
 /lib/start-dev.*
+/lib/start-dev-docs.*
 
 # (Add your project-specific overrides here)

--- a/apps/rush/.npmignore
+++ b/apps/rush/.npmignore
@@ -27,4 +27,6 @@
 # DO NOT MODIFY THE TEMPLATE ABOVE THIS LINE
 #--------------------------------------------
 
+/lib/start-dev.*
+
 # (Add your project-specific overrides here)

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -41,6 +41,8 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
+    "@rushstack/rush-amazon-s3-build-cache-plugin": "workspace:*",
+    "@rushstack/rush-azure-storage-build-cache-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
     "@types/semver": "7.3.5"

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -24,7 +24,8 @@
   "engineStrict": true,
   "homepage": "https://rushjs.io",
   "scripts": {
-    "build": "heft test --clean"
+    "build": "heft test --clean",
+    "start": "node lib/start-dev-docs.js"
   },
   "bin": {
     "rush": "./bin/rush",

--- a/apps/rush/src/start-dev-docs.ts
+++ b/apps/rush/src/start-dev-docs.ts
@@ -1,0 +1,6 @@
+import { Colors, ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library';
+
+const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
+
+terminal.writeLine('For instructions on debugging Rush, please see this documentation:');
+terminal.writeLine(Colors.bold('https://rushjs.io/pages/contributing/debugging/'));

--- a/apps/rush/src/start-dev.ts
+++ b/apps/rush/src/start-dev.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// This file is used during development to load the built-in plugins and to bypass
+// some other checks
+
+import * as rushLib from '@microsoft/rush-lib';
+import { PackageJsonLookup, Import } from '@rushstack/node-core-library';
+
+import { MinimalRushConfiguration } from './MinimalRushConfiguration';
+import { RushCommandSelector } from './RushCommandSelector';
+
+const builtInPluginConfigurations: rushLib._IBuiltInPluginConfiguration[] = [];
+
+function includePlugin(pluginName: string): void {
+  const pluginPackageName: string = `@rushstack/${pluginName}`;
+  builtInPluginConfigurations.push({
+    packageName: pluginPackageName,
+    pluginName: pluginName,
+    pluginPackageFolder: Import.resolvePackage({
+      packageName: pluginPackageName,
+      baseFolderPath: __dirname
+    })
+  });
+}
+
+includePlugin('rush-amazon-s3-build-cache-plugin');
+includePlugin('rush-azure-storage-build-cache-plugin');
+
+// Load the configuration
+const configuration: MinimalRushConfiguration | undefined =
+  MinimalRushConfiguration.loadFromDefaultLocation();
+
+const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
+RushCommandSelector.execute(currentPackageVersion, rushLib, {
+  isManaged: !!configuration,
+  alreadyReportedNodeTooNewError: false,
+  builtInPluginConfigurations
+});

--- a/common/changes/@microsoft/rush/break-cyclic-dependency_2022-01-03-01-18.json
+++ b/common/changes/@microsoft/rush/break-cyclic-dependency_2022-01-03-01-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -191,6 +191,8 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-node-rig': workspace:*
       '@rushstack/node-core-library': workspace:*
+      '@rushstack/rush-amazon-s3-build-cache-plugin': workspace:*
+      '@rushstack/rush-azure-storage-build-cache-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/semver': 7.3.5
@@ -205,6 +207,8 @@ importers:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@rushstack/rush-amazon-s3-build-cache-plugin': link:../../rush-plugins/rush-amazon-s3-build-cache-plugin
+      '@rushstack/rush-azure-storage-build-cache-plugin': link:../../rush-plugins/rush-azure-storage-build-cache-plugin
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/semver': 7.3.5

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "47aca98c44b4e322021c9f4f7f8bba4ddd58a905",
+  "pnpmShrinkwrapHash": "bb7c90e284febcc7531af0f4c81381fc194a5b6a",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -191,6 +191,12 @@ export class ExperimentsConfiguration {
     get configuration(): Readonly<IExperimentsJson>;
 }
 
+// @internal (undocumented)
+export interface _IBuiltInPluginConfiguration extends _IRushPluginConfigurationBase {
+    // (undocumented)
+    pluginPackageFolder: string;
+}
+
 // @beta (undocumented)
 export interface ICloudBuildCacheProvider {
     // (undocumented)
@@ -263,6 +269,8 @@ export interface IGetChangedProjectsOptions {
 // @public
 export interface ILaunchOptions {
     alreadyReportedNodeTooNewError?: boolean;
+    // @internal
+    builtInPluginConfigurations?: _IBuiltInPluginConfiguration[];
     isManaged: boolean;
 }
 
@@ -309,6 +317,14 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
 export interface IRushPlugin {
     // (undocumented)
     apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void;
+}
+
+// @internal (undocumented)
+export interface _IRushPluginConfigurationBase {
+    // (undocumented)
+    packageName: string;
+    // (undocumented)
+    pluginName: string;
 }
 
 // @beta (undocumented)


### PR DESCRIPTION
## Summary

Proposed as an alternative to https://github.com/microsoft/rushstack/pull/3115.

This change adds a "start-dev" entrypoint in the `apps/rush` project to run Rush with the plugins inside the repo.

## Details

This change includes some refactors to the plugin manager and adds an internal `builtInPluginConfigurations` property to `ILaunchOptions` to allow the `@microsoft/rush` project to provide plugins to rush-lib.

## How it was tested 

Tested by running `node apps/rush/lib/start-dev build` in a repo that uses the Azure build cache.