### PR TITLE
[rush] Fix an issue with parameter associations with phases.

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -34,6 +34,8 @@ export interface IPhase extends IPhaseJson {
    * a phase with name "_phase:compile" has a `logFilenameIdentifier` of "_phase_compile".
    */
   logFilenameIdentifier: string;
+
+  associatedParameters: Set<Parameter>;
 }
 
 export interface ICommandWithParameters {
@@ -116,16 +118,7 @@ export class CommandLineConfiguration {
   /**
    * These path will be prepended to the PATH environment variable
    */
-  private _additionalPathFolders: string[] = [];
-
-  private readonly _commandsByPhaseName: Map<string, Set<IPhasedCommand>> = new Map();
-
-  /**
-   * This maps phase names to the names of all other phases that depend on it or are
-   * dependent on it. This is used to determine which commands a phase affects, even
-   * if that phase isn't explicitly listed for that command.
-   */
-  private readonly _relatedPhaseSetsByPhaseName: Map<string, Set<string>> = new Map();
+  private readonly _additionalPathFolders: string[] = [];
 
   /**
    * A map of bulk command names to their corresponding synthetic phase identifiers
@@ -163,9 +156,9 @@ export class CommandLineConfiguration {
         this.phases.set(phase.name, {
           ...phase,
           isSynthetic: false,
-          logFilenameIdentifier: this._normalizeNameForLogFilenameIdentifiers(phase.name)
+          logFilenameIdentifier: this._normalizeNameForLogFilenameIdentifiers(phase.name),
+          associatedParameters: new Set()
         });
-        this._commandsByPhaseName.set(phase.name, new Set<IPhasedCommand>());
       }
     }
 
@@ -194,9 +187,6 @@ export class CommandLineConfiguration {
       }
 
       this._checkForPhaseSelfCycles(phase);
-      const relatedPhaseSet: Set<string> = new Set<string>();
-      this._populateRelatedPhaseSets(phase.name, relatedPhaseSet);
-      this._relatedPhaseSetsByPhaseName.set(phase.name, relatedPhaseSet);
     }
 
     let buildCommandPhases: string[] | undefined;
@@ -225,8 +215,6 @@ export class CommandLineConfiguration {
                     `"${normalizedCommand.name}" command, the phase "${phaseName}" does not exist.`
                 );
               }
-
-              this._populateCommandsForPhase(phaseName, normalizedCommand);
             }
 
             if (normalizedCommand.skipPhasesForCommand) {
@@ -238,8 +226,6 @@ export class CommandLineConfiguration {
                       `"${phaseName}" does not exist.`
                   );
                 }
-
-                this._populateCommandsForPhase(phaseName, normalizedCommand);
               }
             }
 
@@ -322,8 +308,6 @@ export class CommandLineConfiguration {
 
         this.parameters.push(normalizedParameter);
 
-        let parameterHasAssociations: boolean = false;
-
         // Do some basic validation
         switch (normalizedParameter.parameterKind) {
           case 'flag': {
@@ -339,9 +323,6 @@ export class CommandLineConfiguration {
                       `that lists phase "${phaseName}" in its "addPhasesToCommand" ` +
                       'property that does not exist.'
                   );
-                } else {
-                  this._populateCommandAssociatedParametersForPhase(phaseName, normalizedParameter);
-                  parameterHasAssociations = true;
                 }
               }
             }
@@ -361,9 +342,6 @@ export class CommandLineConfiguration {
                       `that lists phase "${phaseName}" in both its "addPhasesToCommand" ` +
                       'and "skipPhasesForCommand" properties.'
                   );
-                } else {
-                  this._populateCommandAssociatedParametersForPhase(phaseName, normalizedParameter);
-                  parameterHasAssociations = true;
                 }
               }
             }
@@ -389,50 +367,50 @@ export class CommandLineConfiguration {
           }
         }
 
+        let parameterHasAssociations: boolean = false;
         if (normalizedParameter.associatedCommands) {
-          for (let i: number = 0; i < normalizedParameter.associatedCommands.length; i++) {
-            const associatedCommandName: string = normalizedParameter.associatedCommands[i];
+          for (const associatedCommandName of normalizedParameter.associatedCommands) {
             const syntheticPhaseName: string | undefined =
               this._syntheticPhasesNamesByTranslatedBulkCommandName.get(associatedCommandName);
             if (syntheticPhaseName) {
-              // If this parameter was associated with a bulk command, change the association to
-              // the command's synthetic phase
+              // If this parameter was associated with a bulk command, include the association
+              // with the synthetic phase
               normalizedParameter.associatedPhases!.push(syntheticPhaseName);
-              normalizedParameter.associatedCommands.splice(i, 1);
-              i--;
-              this._populateCommandAssociatedParametersForPhase(syntheticPhaseName, normalizedParameter);
-              parameterHasAssociations = true;
-            } else if (!this.commands.has(associatedCommandName)) {
+            }
+
+            const associatedCommand: Command | undefined = this.commands.get(associatedCommandName);
+            if (!associatedCommand) {
               throw new Error(
                 `${RushConstants.commandLineFilename} defines a parameter "${normalizedParameter.longName}" ` +
                   `that is associated with a command "${associatedCommandName}" that does not exist or does ` +
                   'not support custom parameters.'
               );
             } else {
-              const associatedCommand: Command = this.commands.get(associatedCommandName)!;
               associatedCommand.associatedParameters.add(normalizedParameter);
               parameterHasAssociations = true;
             }
           }
         }
 
-        for (const associatedPhase of normalizedParameter.associatedPhases || []) {
-          if (!this.phases.has(associatedPhase)) {
-            throw new Error(
-              `${RushConstants.commandLineFilename} defines a parameter "${normalizedParameter.longName}" ` +
-                `that is associated with a phase "${associatedPhase}" that does not exist.`
-            );
-          } else {
-            this._populateCommandAssociatedParametersForPhase(associatedPhase, normalizedParameter);
-            parameterHasAssociations = true;
+        if (normalizedParameter.associatedPhases) {
+          for (const associatedPhaseName of normalizedParameter.associatedPhases) {
+            const associatedPhase: IPhase | undefined = this.phases.get(associatedPhaseName);
+            if (!associatedPhase) {
+              throw new Error(
+                `${RushConstants.commandLineFilename} defines a parameter "${normalizedParameter.longName}" ` +
+                  `that is associated with a phase "${associatedPhaseName}" that does not exist.`
+              );
+            } else {
+              associatedPhase.associatedParameters.add(normalizedParameter);
+            }
           }
-        }
 
-        if (!parameterHasAssociations) {
-          throw new Error(
-            `${RushConstants.commandLineFilename} defines a parameter "${normalizedParameter.longName}"` +
-              ` that lists no associated commands or phases.`
-          );
+          if (!parameterHasAssociations) {
+            throw new Error(
+              `${RushConstants.commandLineFilename} defines a parameter "${normalizedParameter.longName}"` +
+                ` that lists no associated commands.`
+            );
+          }
         }
       }
     }
@@ -464,26 +442,6 @@ export class CommandLineConfiguration {
             } else {
               this._checkForPhaseSelfCycles(dependency, checkedPhases);
             }
-          }
-        }
-      }
-    }
-  }
-
-  private _populateRelatedPhaseSets(phaseName: string, relatedPhaseSet: Set<string>): void {
-    if (!relatedPhaseSet.has(phaseName)) {
-      relatedPhaseSet.add(phaseName);
-      const phase: IPhase = this.phases.get(phaseName)!;
-      if (phase.dependencies) {
-        if (phase.dependencies.self) {
-          for (const dependencyName of phase.dependencies.self) {
-            this._populateRelatedPhaseSets(dependencyName, relatedPhaseSet);
-          }
-        }
-
-        if (phase.dependencies.upstream) {
-          for (const dependencyName of phase.dependencies.upstream) {
-            this._populateRelatedPhaseSets(dependencyName, relatedPhaseSet);
           }
         }
       }
@@ -557,20 +515,6 @@ export class CommandLineConfiguration {
     return name.replace(/:/g, '_'); // Replace colons with underscores to be filesystem-safe
   }
 
-  private _populateCommandsForPhase(phaseName: string, command: IPhasedCommand): void {
-    const populateRelatedPhaseSet: Set<string> = this._relatedPhaseSetsByPhaseName.get(phaseName)!;
-    for (const relatedPhaseSetIdentifier of populateRelatedPhaseSet) {
-      this._commandsByPhaseName.get(relatedPhaseSetIdentifier)!.add(command);
-    }
-  }
-
-  private _populateCommandAssociatedParametersForPhase(phaseName: string, parameter: Parameter): void {
-    const commands: Set<Command> = this._commandsByPhaseName.get(phaseName)!;
-    for (const command of commands) {
-      command.associatedParameters.add(parameter);
-    }
-  }
-
   private _translateBulkCommandToPhasedCommand(command: IBulkCommandJson): IPhasedCommand {
     const phaseName: string = command.name;
     const phaseForBulkCommand: IPhase = {
@@ -581,13 +525,11 @@ export class CommandLineConfiguration {
       },
       ignoreMissingScript: command.ignoreMissingScript,
       allowWarningsOnSuccess: command.allowWarningsInSuccessfulBuild,
-      logFilenameIdentifier: this._normalizeNameForLogFilenameIdentifiers(command.name)
+      logFilenameIdentifier: this._normalizeNameForLogFilenameIdentifiers(command.name),
+      associatedParameters: new Set()
     };
     this.phases.set(phaseName, phaseForBulkCommand);
     this._syntheticPhasesNamesByTranslatedBulkCommandName.set(command.name, phaseName);
-    const relatedPhaseSet: Set<string> = new Set<string>();
-    this._populateRelatedPhaseSets(phaseName, relatedPhaseSet);
-    this._relatedPhaseSetsByPhaseName.set(phaseName, relatedPhaseSet);
 
     const translatedCommand: IPhasedCommand = {
       ...command,
@@ -597,8 +539,6 @@ export class CommandLineConfiguration {
       associatedParameters: new Set<Parameter>(),
       phases: [phaseName]
     };
-    this._commandsByPhaseName.set(phaseName, new Set<IPhasedCommand>());
-    this._populateCommandsForPhase(phaseName, translatedCommand);
     return translatedCommand;
   }
 }

--- a/apps/rush-lib/src/api/test/CommandLineConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/CommandLineConfiguration.test.ts
@@ -211,46 +211,7 @@ describe(CommandLineConfiguration.name, () => {
             parameterKind: 'flag',
             longName: '--flag',
             associatedPhases: ['_phase:a'],
-            description: 'flag'
-          }
-        ]
-      });
-
-      const command: Command | undefined = commandLineConfiguration.commands.get('custom-phased');
-      expect(command).toBeDefined();
-      const associatedParametersArray: Parameter[] = Array.from(command!.associatedParameters);
-      expect(associatedParametersArray).toHaveLength(1);
-      expect(associatedParametersArray[0].longName).toEqual('--flag');
-    });
-
-    it("correctly populates the associatedParameters object for a parameter associated with a custom phased command's transitive phase", () => {
-      const commandLineConfiguration: CommandLineConfiguration = new CommandLineConfiguration({
-        commands: [
-          {
-            commandKind: 'phased',
-            name: 'custom-phased',
-            summary: 'custom-phased',
-            enableParallelism: true,
-            safeForSimultaneousRushProcesses: false,
-            phases: ['_phase:a']
-          }
-        ],
-        phases: [
-          {
-            name: '_phase:a',
-            dependencies: {
-              upstream: ['_phase:b']
-            }
-          },
-          {
-            name: '_phase:b'
-          }
-        ],
-        parameters: [
-          {
-            parameterKind: 'flag',
-            longName: '--flag',
-            associatedPhases: ['_phase:b'],
+            associatedCommands: ['custom-phased'],
             description: 'flag'
           }
         ]

--- a/apps/rush-lib/src/api/test/__snapshots__/CommandLineConfiguration.test.ts.snap
+++ b/apps/rush-lib/src/api/test/__snapshots__/CommandLineConfiguration.test.ts.snap
@@ -17,3 +17,5 @@ exports[`CommandLineConfiguration Forbids a misnamed phase 3`] = `"In command-li
 exports[`CommandLineConfiguration Forbids a misnamed phase 4`] = `"In command-line.json, the phase \\"_phase:A\\"'s name is not a valid phase name. Phase names must begin with the required prefix \\"_phase:\\" followed by a name containing lowercase letters, numbers, or hyphens. The name must start with a letter and must not end with a hyphen."`;
 
 exports[`CommandLineConfiguration Forbids a misnamed phase 5`] = `"In command-line.json, the phase \\"_phase:A-\\"'s name is not a valid phase name. Phase names must begin with the required prefix \\"_phase:\\" followed by a name containing lowercase letters, numbers, or hyphens. The name must start with a letter and must not end with a hyphen."`;
+
+exports[`CommandLineConfiguration parameters does not allow a parameter to only be associated with phased commands but not have any associated phases 1`] = `"command-line.json defines a parameter \\"--flag\\" that is only associated with phased commands, but lists no associated phases."`;

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -3,7 +3,7 @@
 
 import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { BaseRushAction, IBaseRushActionOptions } from '../actions/BaseRushAction';
-import { Command, CommandLineConfiguration } from '../../api/CommandLineConfiguration';
+import { Command, CommandLineConfiguration, Parameter } from '../../api/CommandLineConfiguration';
 import { RushConstants } from '../../logic/RushConstants';
 import type { ParameterJson } from '../../api/CommandLineJson';
 
@@ -13,6 +13,11 @@ import type { ParameterJson } from '../../api/CommandLineJson';
 export interface IBaseScriptActionOptions<TCommand extends Command> extends IBaseRushActionOptions {
   commandLineConfiguration: CommandLineConfiguration;
   command: TCommand;
+}
+
+export interface IRegisteredCustomParameter {
+  parameter: Parameter;
+  tsCommandLineParameter: CommandLineParameter;
 }
 
 /**
@@ -27,7 +32,7 @@ export interface IBaseScriptActionOptions<TCommand extends Command> extends IBas
  */
 export abstract class BaseScriptAction<TCommand extends Command> extends BaseRushAction {
   protected readonly commandLineConfiguration: CommandLineConfiguration;
-  protected readonly customParameters: CommandLineParameter[] = [];
+  protected readonly customParameters: IRegisteredCustomParameter[] = [];
   protected readonly command: TCommand;
 
   public constructor(options: IBaseScriptActionOptions<TCommand>) {
@@ -43,11 +48,11 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
 
     // Find any parameters that are associated with this command
     for (const parameter of this.command.associatedParameters) {
-      let customParameter: CommandLineParameter | undefined;
+      let tsCommandLineParameter: CommandLineParameter | undefined;
 
       switch (parameter.parameterKind) {
         case 'flag':
-          customParameter = this.defineFlagParameter({
+          tsCommandLineParameter = this.defineFlagParameter({
             parameterShortName: parameter.shortName,
             parameterLongName: parameter.longName,
             description: parameter.description,
@@ -55,7 +60,7 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
           });
           break;
         case 'choice':
-          customParameter = this.defineChoiceParameter({
+          tsCommandLineParameter = this.defineChoiceParameter({
             parameterShortName: parameter.shortName,
             parameterLongName: parameter.longName,
             description: parameter.description,
@@ -65,7 +70,7 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
           });
           break;
         case 'string':
-          customParameter = this.defineStringParameter({
+          tsCommandLineParameter = this.defineStringParameter({
             parameterLongName: parameter.longName,
             parameterShortName: parameter.shortName,
             description: parameter.description,
@@ -81,7 +86,10 @@ export abstract class BaseScriptAction<TCommand extends Command> extends BaseRus
           );
       }
 
-      this.customParameters.push(customParameter);
+      this.customParameters.push({
+        parameter,
+        tsCommandLineParameter
+      });
     }
   }
 }

--- a/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -99,9 +99,8 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommand> {
 
     // Collect all custom parameter values
     const customParameterValues: string[] = [];
-
-    for (const customParameter of this.customParameters) {
-      customParameter.appendToArgList(customParameterValues);
+    for (const { tsCommandLineParameter } of this.customParameters) {
+      tsCommandLineParameter.appendToArgList(customParameterValues);
     }
 
     for (let i: number = 0; i < customParameterValues.length; i++) {

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -106,12 +106,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
     // if parallelism is not enabled, then restrict to 1 core
     const parallelism: string | undefined = this._enableParallelism ? this._parallelismParameter!.value : '1';
 
-    // Collect all custom parameter values
-    const customParameterValues: string[] = [];
-    for (const customParameter of this.customParameters) {
-      customParameter.appendToArgList(customParameterValues);
-    }
-
     const changedProjectsOnly: boolean = this._isIncrementalBuildAllowed && this._changedProjectsOnly.value;
 
     const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
@@ -156,10 +150,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
       rushConfiguration: this.rushConfiguration,
       buildCacheConfiguration,
       projectSelection,
-      customParameterValues,
       isQuietMode: isQuietMode,
       isDebugMode: isDebugMode,
       isIncrementalBuildAllowed: this._isIncrementalBuildAllowed,
+      customParameters: this.customParameters,
       phasesToRun: phasesToRun,
       phases: this._phases
     };

--- a/common/changes/@microsoft/rush/fix-parameter-phases_2022-01-04-10-48.json
+++ b/common/changes/@microsoft/rush/fix-parameter-phases_2022-01-04-10-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

There is a mistake in the current implementation of phase/parameter associations.

## Details

The design calls for parameters to be associated with commands. If a parameter is specified when a phased command is invoked, the parameter is passed only to the phases it is associated with. The current implementation implicitly associates parameters with all commands with phases they're directly or indirectly associated with, and their values are passed on to all phases.

## How it was tested

Tested in https://github.com/elliot-nelson/rush-phased-builds-example and this repo.