### PR TITLE
[heft-config-file] Ensure newlines in an invalid JSON file are normalized before parsing.

### DIFF
--- a/common/changes/@rushstack/heft-config-file/clean-up-test-newlines_2022-01-05-00-32.json
+++ b/common/changes/@rushstack/heft-config-file/clean-up-test-newlines_2022-01-05-00-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -494,12 +494,10 @@ describe('ConfigurationFile', () => {
         projectRelativeFilePath: 'config/notExist.json',
         jsonSchemaPath: schemaPath
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, projectFolder, rigConfig);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, projectFolder, rigConfig)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
   });
 
@@ -517,12 +515,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it("returns undefined when the file doesn't exist for tryLoadConfigurationFileForProjectAsync", async () => {
@@ -536,9 +532,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      expect(
-        await configFileLoader.tryLoadConfigurationFileForProjectAsync(terminal, __dirname)
-      ).toBeUndefined();
+
+      await expect(
+        configFileLoader.tryLoadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).resolves.toBeUndefined();
     });
 
     it("Throws an error when the file isn't valid JSON", async () => {
@@ -552,12 +549,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it("Throws an error for a file that doesn't match its schema", async () => {
@@ -571,12 +566,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it('Throws an error when there is a circular reference in "extends" properties', async () => {
@@ -590,12 +583,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it('Throws an error when an "extends" property points to a file that cannot be resolved', async () => {
@@ -609,12 +600,10 @@ describe('ConfigurationFile', () => {
           'config.schema.json'
         )
       });
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it("Throws an error when a combined config file doesn't match the schema", async () => {
@@ -629,12 +618,9 @@ describe('ConfigurationFile', () => {
         )
       });
 
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it("Throws an error when a requested file doesn't exist", async () => {
@@ -648,12 +634,9 @@ describe('ConfigurationFile', () => {
         )
       });
 
-      try {
-        await configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname);
-        fail();
-      } catch (e) {
-        expect(e).toMatchSnapshot();
-      }
+      await expect(
+        configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
   });
 });

--- a/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
+++ b/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
@@ -121,11 +121,11 @@ Object {
 `;
 
 exports[`ConfigurationFile error cases Throws an error for a file that doesn't match its schema 1`] = `
-[Error: JSON validation failed:
+"JSON validation failed:
 <project root>/src/test/errorCases/invalidType/config.json
 
 Error: #/filePaths
-       Expected type array but found type string]
+       Expected type array but found type string"
 `;
 
 exports[`ConfigurationFile error cases Throws an error for a file that doesn't match its schema 2`] = `
@@ -139,7 +139,7 @@ Object {
 `;
 
 exports[`ConfigurationFile error cases Throws an error when a combined config file doesn't match the schema 1`] = `
-[Error: Resolved configuration object does not match schema: Error: JSON validation failed:
+"Resolved configuration object does not match schema: Error: JSON validation failed:
 <project root>/src/test/errorCases/invalidCombinedFile/config1.json
 
 Error: #/
@@ -147,7 +147,7 @@ Error: #/
   Error: #/
          Additional properties not allowed: folderPaths
   Error: #/
-         Additional properties not allowed: filePaths]
+         Additional properties not allowed: filePaths"
 `;
 
 exports[`ConfigurationFile error cases Throws an error when a combined config file doesn't match the schema 2`] = `
@@ -160,7 +160,7 @@ Object {
 }
 `;
 
-exports[`ConfigurationFile error cases Throws an error when a requested file doesn't exist 1`] = `[Error: File does not exist: <project root>/src/test/errorCases/folderThatDoesntExist/config.json]`;
+exports[`ConfigurationFile error cases Throws an error when a requested file doesn't exist 1`] = `"File does not exist: <project root>/src/test/errorCases/folderThatDoesntExist/config.json"`;
 
 exports[`ConfigurationFile error cases Throws an error when a requested file doesn't exist 2`] = `
 Object {
@@ -172,7 +172,7 @@ Object {
 }
 `;
 
-exports[`ConfigurationFile error cases Throws an error when an "extends" property points to a file that cannot be resolved 1`] = `[Error: In file "<project root>/src/test/errorCases/extendsNotExist/config.json", file referenced in "extends" property ("./config2.json") cannot be resolved.]`;
+exports[`ConfigurationFile error cases Throws an error when an "extends" property points to a file that cannot be resolved 1`] = `"In file \\"<project root>/src/test/errorCases/extendsNotExist/config.json\\", file referenced in \\"extends\\" property (\\"./config2.json\\") cannot be resolved."`;
 
 exports[`ConfigurationFile error cases Throws an error when an "extends" property points to a file that cannot be resolved 2`] = `
 Object {
@@ -185,9 +185,9 @@ Object {
 `;
 
 exports[`ConfigurationFile error cases Throws an error when the file isn't valid JSON 1`] = `
-[Error: In config file "<project root>/src/test/errorCases/invalidJson/config.json": SyntaxError: Unexpected token '}' at 2:19
-  "filePaths": "A
-                 ^]
+"In config file \\"<project root>/src/test/errorCases/invalidJson/config.json\\": SyntaxError: Unexpected token '}' at 2:19
+  \\"filePaths\\": \\"A
+                 ^"
 `;
 
 exports[`ConfigurationFile error cases Throws an error when the file isn't valid JSON 2`] = `
@@ -200,7 +200,7 @@ Object {
 }
 `;
 
-exports[`ConfigurationFile error cases Throws an error when there is a circular reference in "extends" properties 1`] = `[Error: A loop has been detected in the "extends" properties of configuration file at "<project root>/src/test/errorCases/circularReference/config1.json".]`;
+exports[`ConfigurationFile error cases Throws an error when there is a circular reference in "extends" properties 1`] = `"A loop has been detected in the \\"extends\\" properties of configuration file at \\"<project root>/src/test/errorCases/circularReference/config1.json\\"."`;
 
 exports[`ConfigurationFile error cases Throws an error when there is a circular reference in "extends" properties 2`] = `
 Object {
@@ -222,7 +222,7 @@ Object {
 }
 `;
 
-exports[`ConfigurationFile error cases throws an error when the file doesn't exist 1`] = `[Error: File does not exist: <project root>/src/test/errorCases/invalidType/notExist.json]`;
+exports[`ConfigurationFile error cases throws an error when the file doesn't exist 1`] = `"File does not exist: <project root>/src/test/errorCases/invalidType/notExist.json"`;
 
 exports[`ConfigurationFile error cases throws an error when the file doesn't exist 2`] = `
 Object {
@@ -254,7 +254,7 @@ Object {
 }
 `;
 
-exports[`ConfigurationFile loading a rig throws an error when a config file doesn't exist in a project referencing a rig, which also doesn't have the file 1`] = `[Error: File does not exist: <project root>/src/test/project-referencing-rig/config/notExist.json]`;
+exports[`ConfigurationFile loading a rig throws an error when a config file doesn't exist in a project referencing a rig, which also doesn't have the file 1`] = `"File does not exist: <project root>/src/test/project-referencing-rig/config/notExist.json"`;
 
 exports[`ConfigurationFile loading a rig throws an error when a config file doesn't exist in a project referencing a rig, which also doesn't have the file 2`] = `
 Object {


### PR DESCRIPTION
## Summary

We recently changed the newlines in this repo's `.gitattributes` from always CRLF to use the Git config's defaults. This broke a test that has a snapshot of an error thrown when parsing an invalid JSON file. The test was updated, but now Windows users who have old clones of the repo that don't have re-normalized newlines are expecting the previous state of the test. This PR updates the test to normalize newlines in the invalid JSON file before it is parsed to ensure a consistent error message.

This PR also cleans up the test code.

## How it was tested

Ran the test.