### PR TITLE
[node-core-library] Expose and consume a FileSystem.readFolderWithTypes and FileSystem.readFolderWithTypesAsync API

### DIFF
--- a/apps/api-documenter/src/cli/BaseAction.ts
+++ b/apps/api-documenter/src/cli/BaseAction.ts
@@ -58,7 +58,7 @@ export abstract class BaseAction extends CommandLineAction {
     const outputFolder: string = this._outputFolderParameter.value || `./${this.actionName}`;
     FileSystem.ensureFolder(outputFolder);
 
-    for (const filename of FileSystem.readFolder(inputFolder)) {
+    for (const filename of FileSystem.readFolderItemNames(inputFolder)) {
       if (filename.match(/\.api\.json$/i)) {
         console.log(`Reading ${filename}`);
         const filenamePath: string = path.join(inputFolder, filename);

--- a/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
+++ b/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
@@ -29,7 +29,7 @@ function convert(inputPath: string, outputPath: string): void {
     return;
   }
 
-  FileSystem.readFolder(inputPath).forEach((name) => {
+  FileSystem.readFolderItemNames(inputPath).forEach((name) => {
     const fpath: string = path.join(inputPath, name);
     if (FileSystem.getStatistics(fpath).isFile()) {
       // only convert yaml

--- a/apps/heft/src/plugins/ProjectValidatorPlugin.ts
+++ b/apps/heft/src/plugins/ProjectValidatorPlugin.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as fs from 'fs';
-import { FileSystem, LegacyAdapters, Path } from '@rushstack/node-core-library';
+import { FileSystem, Path, FolderItem } from '@rushstack/node-core-library';
 
 import { HeftConfiguration } from '../configuration/HeftConfiguration';
 import { Constants } from '../utilities/Constants';
@@ -99,17 +98,9 @@ export class ProjectValidatorPlugin implements IHeftPlugin {
     logger: ScopedLogger,
     heftConfiguration: HeftConfiguration
   ): Promise<void> {
-    // TODO: Replace this with a FileSystem API
-    let heftDataFolderContents: fs.Dirent[];
+    let heftDataFolderContents: FolderItem[];
     try {
-      // Use this instead of fs.promises to avoid a warning in older versions of Node
-      heftDataFolderContents = await LegacyAdapters.convertCallbackToPromise(
-        fs.readdir,
-        heftConfiguration.projectHeftDataFolder,
-        {
-          withFileTypes: true
-        }
-      );
+      heftDataFolderContents = await FileSystem.readFolderItemsAsync(heftConfiguration.projectHeftDataFolder);
     } catch (e) {
       if (!FileSystem.isNotExistError(e as Error)) {
         throw e;

--- a/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
+++ b/apps/heft/src/utilities/fileSystem/TypeScriptCachedFileSystem.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as fs from 'fs';
 import {
   Encoding,
   Text,
@@ -12,7 +11,8 @@ import {
   IFileSystemCreateLinkOptions,
   FileSystem,
   FileSystemStats,
-  Sort
+  Sort,
+  FolderItem
 } from '@rushstack/node-core-library';
 
 export interface IReadFolderFilesAndDirectoriesResult {
@@ -163,15 +163,14 @@ export class TypeScriptCachedFileSystem {
     return this._withCaching(
       folderPath,
       (path: string) => {
-        // TODO: Replace this with a FileSystem API
-        const folderEntries: fs.Dirent[] = fs.readdirSync(path, { withFileTypes: true });
+        const folderEntries: FolderItem[] = FileSystem.readFolderItems(path);
         return this._sortFolderEntries(folderEntries);
       },
       this._readFolderCache
     );
   };
 
-  private _sortFolderEntries(folderEntries: fs.Dirent[]): IReadFolderFilesAndDirectoriesResult {
+  private _sortFolderEntries(folderEntries: FolderItem[]): IReadFolderFilesAndDirectoriesResult {
     // TypeScript expects entries sorted ordinally by name
     // In practice this might not matter
     folderEntries.sort((a, b) => Sort.compareByValue(a, b));

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -965,7 +965,7 @@ export class RushConfiguration {
       return;
     }
 
-    for (const filename of FileSystem.readFolder(commonRushConfigFolder)) {
+    for (const filename of FileSystem.readFolderItemNames(commonRushConfigFolder)) {
       // Ignore things that aren't actual files
       const stat: FileSystemStats = FileSystem.getLinkStatistics(path.join(commonRushConfigFolder, filename));
       if (!stat.isFile() && !stat.isSymbolicLink()) {

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -4,7 +4,6 @@
 /* eslint max-lines: off */
 
 import * as path from 'path';
-import * as fs from 'fs';
 import * as semver from 'semver';
 import {
   JsonFile,
@@ -12,7 +11,8 @@ import {
   JsonNull,
   Path,
   FileSystem,
-  PackageNameParser
+  PackageNameParser,
+  FileSystemStats
 } from '@rushstack/node-core-library';
 import { trueCasePathSync } from 'true-case-path';
 
@@ -967,7 +967,7 @@ export class RushConfiguration {
 
     for (const filename of FileSystem.readFolder(commonRushConfigFolder)) {
       // Ignore things that aren't actual files
-      const stat: fs.Stats = FileSystem.getLinkStatistics(path.join(commonRushConfigFolder, filename));
+      const stat: FileSystemStats = FileSystem.getLinkStatistics(path.join(commonRushConfigFolder, filename));
       if (!stat.isFile() && !stat.isSymbolicLink()) {
         continue;
       }

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -124,7 +124,7 @@ export class InitAction extends BaseConfiglessRushAction {
       return false;
     }
 
-    for (const itemName of FileSystem.readFolder(initFolder)) {
+    for (const itemName of FileSystem.readFolderItemNames(initFolder)) {
       if (itemName.substr(0, 1) === '.') {
         // Ignore any items that start with ".", for example ".git"
         continue;

--- a/apps/rush-lib/src/cli/actions/InitAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAction.ts
@@ -2,14 +2,20 @@
 // See LICENSE in the project root for license information.
 
 import colors from 'colors/safe';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { BaseConfiglessRushAction } from './BaseRushAction';
-import { FileSystem, NewlineKind, InternalError, AlreadyReportedError } from '@rushstack/node-core-library';
+import {
+  FileSystem,
+  NewlineKind,
+  InternalError,
+  AlreadyReportedError,
+  FileSystemStats
+} from '@rushstack/node-core-library';
 import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+
 import { Rush } from '../../api/Rush';
 
 export class InitAction extends BaseConfiglessRushAction {
@@ -126,7 +132,7 @@ export class InitAction extends BaseConfiglessRushAction {
 
       const itemPath: string = path.join(initFolder, itemName);
 
-      const stats: fs.Stats = FileSystem.getStatistics(itemPath);
+      const stats: FileSystemStats = FileSystem.getStatistics(itemPath);
       // Ignore any loose files in the current folder, e.g. "README.md"
       // or "CONTRIBUTING.md"
       if (stats.isDirectory()) {

--- a/apps/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/apps/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -42,7 +42,7 @@ export class InitAutoinstallerAction extends BaseRushAction {
 
     if (FileSystem.exists(autoinstaller.folderFullPath)) {
       // It's okay if the folder is empty
-      if (FileSystem.readFolder(autoinstaller.folderFullPath).length > 0) {
+      if (FileSystem.readFolderItemNames(autoinstaller.folderFullPath).length > 0) {
         throw new Error('The target folder already exists: ' + autoinstaller.folderFullPath);
       }
     }

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import { once } from 'events';
-import { Path, ITerminal } from '@rushstack/node-core-library';
+import { Path, ITerminal, FileSystemStats, FileSystem } from '@rushstack/node-core-library';
 
 import { ProjectChangeAnalyzer } from './ProjectChangeAnalyzer';
 import { RushConfiguration } from '../api/RushConfiguration';
@@ -144,7 +144,7 @@ export class ProjectWatcher {
 
         const addWatcher = (
           watchedPath: string,
-          listener: (event: string, fileName: string | Buffer) => void
+          listener: (event: string, fileName: string) => void
         ): void => {
           const watcher: fs.FSWatcher = fs.watch(
             watchedPath,
@@ -161,7 +161,7 @@ export class ProjectWatcher {
           });
         };
 
-        const changeListener = (event: string, fileName: string | Buffer): void => {
+        const changeListener = (event: string, fileName: string): void => {
           try {
             if (terminated) {
               return;
@@ -174,7 +174,7 @@ export class ProjectWatcher {
 
               if (normalizedName && !watchers.has(normalizedName)) {
                 try {
-                  const stat: fs.Stats = fs.statSync(fileName);
+                  const stat: FileSystemStats = FileSystem.getStatistics(fileName);
                   if (stat.isDirectory()) {
                     addWatcher(normalizedName, changeListener);
                   }

--- a/apps/rush-lib/src/logic/SetupChecks.ts
+++ b/apps/rush-lib/src/logic/SetupChecks.ts
@@ -120,7 +120,7 @@ export class SetupChecks {
       const nodeModulesFolder: string = path.join(folder, RushConstants.nodeModulesFolderName);
       if (FileSystem.exists(nodeModulesFolder)) {
         // Collect the names of files/folders in that node_modules folder
-        const filenames: string[] = FileSystem.readFolder(nodeModulesFolder).filter(
+        const filenames: string[] = FileSystem.readFolderItemNames(nodeModulesFolder).filter(
           (x) => !x.startsWith('.')
         );
 

--- a/apps/rush-lib/src/logic/Telemetry.ts
+++ b/apps/rush-lib/src/logic/Telemetry.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as fs from 'fs';
 import * as path from 'path';
-import { FileSystem, Import } from '@rushstack/node-core-library';
+import { FileSystem, FileSystemStats, Import } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { Rush } from '../api/Rush';
@@ -74,7 +73,7 @@ export class Telemetry {
         const sortedFiles: string[] = files
           .map((fileName) => {
             const filePath: string = path.join(this._dataFolder, fileName);
-            const stats: fs.Stats = FileSystem.getStatistics(filePath);
+            const stats: FileSystemStats = FileSystem.getStatistics(filePath);
             return {
               filePath: filePath,
               modifiedTime: stats.mtime.getTime(),

--- a/apps/rush-lib/src/logic/Telemetry.ts
+++ b/apps/rush-lib/src/logic/Telemetry.ts
@@ -68,7 +68,7 @@ export class Telemetry {
    */
   private _cleanUp(): void {
     if (FileSystem.exists(this._dataFolder)) {
-      const files: string[] = FileSystem.readFolder(this._dataFolder);
+      const files: string[] = FileSystem.readFolderItemNames(this._dataFolder);
       if (files.length > MAX_FILE_COUNT) {
         const sortedFiles: string[] = files
           .map((fileName) => {

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -447,7 +447,7 @@ export abstract class BaseInstallManager {
     const hookDestination: string | undefined = git.getHooksFolder();
 
     if (FileSystem.exists(hookSource) && hookDestination) {
-      const allHookFilenames: string[] = FileSystem.readFolder(hookSource);
+      const allHookFilenames: string[] = FileSystem.readFolderItemNames(hookSource);
       // Ignore the ".sample" file(s) in this folder.
       const hookFilenames: string[] = allHookFilenames.filter((x) => !/\.sample$/.test(x));
       if (hookFilenames.length > 0) {

--- a/apps/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -3,7 +3,6 @@
 
 import colors from 'colors/safe';
 import * as fetch from 'node-fetch';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
@@ -12,7 +11,8 @@ import {
   JsonFile,
   PosixModeBits,
   NewlineKind,
-  AlreadyReportedError
+  AlreadyReportedError,
+  FileSystemStats
 } from '@rushstack/node-core-library';
 import { PrintUtilities } from '@rushstack/terminal';
 
@@ -203,7 +203,7 @@ export abstract class BaseInstallManager {
     // Allow us to defer the file read until we need it
     const canSkipInstall: () => boolean = () => {
       // Based on timestamps, can we skip this install entirely?
-      const outputStats: fs.Stats = FileSystem.getStatistics(this._commonTempInstallFlag.path);
+      const outputStats: FileSystemStats = FileSystem.getStatistics(this._commonTempInstallFlag.path);
       return this.canSkipInstall(outputStats.mtime);
     };
 

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -140,7 +140,7 @@ export abstract class BaseLinkManager {
       // If there are children, then we need to symlink each item in the folder individually
       Utilities.createFolderWithRetry(localPackage.folderPath);
 
-      for (const filename of FileSystem.readFolder(localPackage.symlinkTargetFolderPath)) {
+      for (const filename of FileSystem.readFolderItemNames(localPackage.symlinkTargetFolderPath)) {
         if (filename.toLowerCase() !== 'node_modules') {
           // Create the symlink
           let symlinkKind: SymlinkKind = SymlinkKind.File;

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -2,11 +2,15 @@
 // See LICENSE in the project root for license information.
 
 import colors from 'colors/safe';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { FileSystem, IFileSystemCreateLinkOptions, InternalError } from '@rushstack/node-core-library';
+import {
+  FileSystem,
+  FileSystemStats,
+  IFileSystemCreateLinkOptions,
+  InternalError
+} from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { Utilities } from '../../utilities/Utilities';
@@ -40,7 +44,7 @@ export abstract class BaseLinkManager {
       targetPath = options.linkTargetPath;
     } else {
       // Link to the relative path, to avoid going outside containers such as a Docker image
-      targetPath = path.relative(fs.realpathSync(newLinkFolder), options.linkTargetPath);
+      targetPath = path.relative(FileSystem.getRealPath(newLinkFolder), options.linkTargetPath);
     }
 
     if (process.platform === 'win32') {
@@ -144,10 +148,10 @@ export abstract class BaseLinkManager {
           const linkSource: string = path.join(localPackage.folderPath, filename);
           let linkTarget: string = path.join(localPackage.symlinkTargetFolderPath, filename);
 
-          const linkStats: fs.Stats = FileSystem.getLinkStatistics(linkTarget);
+          const linkStats: FileSystemStats = FileSystem.getLinkStatistics(linkTarget);
 
           if (linkStats.isSymbolicLink()) {
-            const targetStats: fs.Stats = FileSystem.getStatistics(FileSystem.getRealPath(linkTarget));
+            const targetStats: FileSystemStats = FileSystem.getStatistics(FileSystem.getRealPath(linkTarget));
             if (targetStats.isDirectory()) {
               // Neither a junction nor a directory-symlink can have a directory-symlink
               // as its target; instead, we must obtain the real physical path.

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -6,8 +6,7 @@ import events from 'events';
 import * as crypto from 'crypto';
 import type * as stream from 'stream';
 import * as tar from 'tar';
-import { FileSystem, LegacyAdapters, Path, ITerminal } from '@rushstack/node-core-library';
-import * as fs from 'fs';
+import { FileSystem, Path, ITerminal, FolderItem } from '@rushstack/node-core-library';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
@@ -410,9 +409,7 @@ export class ProjectBuildCache {
     posixPrefix: string,
     folderPath: string
   ): AsyncIterableIterator<string> {
-    const folderEntries: fs.Dirent[] = await LegacyAdapters.convertCallbackToPromise(fs.readdir, folderPath, {
-      withFileTypes: true
-    });
+    const folderEntries: FolderItem[] = await FileSystem.readFolderItemsAsync(folderPath);
     for (const folderEntry of folderEntries) {
       const entryPath: string = `${posixPrefix}/${folderEntry.name}`;
       if (folderEntry.isSymbolicLink()) {

--- a/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployArchiver.ts
@@ -30,7 +30,7 @@ export class DeployArchiver {
   private static _getFilePathsRecursively(dir: string): string[] {
     // returns a flat array of absolute paths of all files recursively contained in the dir
     let results: string[] = [];
-    const list: string[] = FileSystem.readFolder(dir);
+    const list: string[] = FileSystem.readFolderItemNames(dir);
 
     if (!list.length) return results;
 

--- a/apps/rush-lib/src/logic/deploy/DeployManager.ts
+++ b/apps/rush-lib/src/logic/deploy/DeployManager.ts
@@ -756,7 +756,7 @@ export class DeployManager {
     FileSystem.ensureFolder(targetRootFolder);
 
     // Is the target folder empty?
-    if (FileSystem.readFolder(targetRootFolder).length > 0) {
+    if (FileSystem.readFolderItemNames(targetRootFolder).length > 0) {
       if (overwriteExisting) {
         console.log('Deleting target folder contents because "--overwrite" was specified...');
         FileSystem.ensureEmptyFolder(targetRootFolder);

--- a/apps/rush-lib/src/utilities/AsyncRecycler.ts
+++ b/apps/rush-lib/src/utilities/AsyncRecycler.ts
@@ -89,7 +89,7 @@ export class AsyncRecycler {
 
     const excludeSet: Set<string> = new Set<string>((membersToExclude || []).map((x) => x.toUpperCase()));
 
-    for (const memberPath of FileSystem.readFolder(resolvedFolderPath, { absolutePaths: true })) {
+    for (const memberPath of FileSystem.readFolderItemNames(resolvedFolderPath, { absolutePaths: true })) {
       const normalizedMemberName: string = path.basename(memberPath).toUpperCase();
       if (!excludeSet.has(normalizedMemberName)) {
         let shouldMove: boolean = false;
@@ -166,7 +166,7 @@ export class AsyncRecycler {
 
       // child_process.spawn() doesn't expand wildcards.  To be safe, we will do it manually
       // rather than rely on an unknown shell.
-      for (const filename of FileSystem.readFolder(this.recyclerFolder)) {
+      for (const filename of FileSystem.readFolderItemNames(this.recyclerFolder)) {
         // The "." and ".." are supposed to be excluded, but let's be safe
         if (filename !== '.' && filename !== '..') {
           args.push(path.join(this.recyclerFolder, filename));

--- a/apps/rush-lib/src/utilities/AsyncRecycler.ts
+++ b/apps/rush-lib/src/utilities/AsyncRecycler.ts
@@ -2,11 +2,10 @@
 // See LICENSE in the project root for license information.
 
 import * as child_process from 'child_process';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { Text, Path, FileSystem } from '@rushstack/node-core-library';
+import { Text, Path, FileSystem, FileSystemStats } from '@rushstack/node-core-library';
 
 import { Utilities } from './Utilities';
 
@@ -95,7 +94,7 @@ export class AsyncRecycler {
       if (!excludeSet.has(normalizedMemberName)) {
         let shouldMove: boolean = false;
         try {
-          const stats: fs.Stats = FileSystem.getLinkStatistics(memberPath);
+          const stats: FileSystemStats = FileSystem.getLinkStatistics(memberPath);
           shouldMove = stats.isDirectory();
         } catch (error) {
           // If we fail to access the item, assume it's not a folder

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -2,10 +2,15 @@
 // See LICENSE in the project root for license information.
 
 import * as child_process from 'child_process';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { JsonFile, IPackageJson, FileSystem, FileConstants } from '@rushstack/node-core-library';
+import {
+  JsonFile,
+  IPackageJson,
+  FileSystem,
+  FileConstants,
+  FileSystemStats
+} from '@rushstack/node-core-library';
 import type * as stream from 'stream';
 import { CommandLineHelper } from '@rushstack/ts-command-line';
 
@@ -235,7 +240,7 @@ export class Utilities {
     let exists: boolean = false;
 
     try {
-      const lstat: fs.Stats = FileSystem.getLinkStatistics(filePath);
+      const lstat: FileSystemStats = FileSystem.getLinkStatistics(filePath);
       exists = lstat.isFile();
     } catch (e) {
       /* no-op */
@@ -251,7 +256,7 @@ export class Utilities {
     let exists: boolean = false;
 
     try {
-      const lstat: fs.Stats = FileSystem.getLinkStatistics(directoryPath);
+      const lstat: FileSystemStats = FileSystem.getLinkStatistics(directoryPath);
       exists = lstat.isDirectory();
     } catch (e) {
       /* no-op */
@@ -299,7 +304,7 @@ export class Utilities {
         return false;
       }
 
-      const inputStats: fs.Stats = FileSystem.getStatistics(inputFilename);
+      const inputStats: FileSystemStats = FileSystem.getStatistics(inputFilename);
       if (dateToCompare < inputStats.mtime) {
         return false;
       }

--- a/build-tests/api-extractor-scenarios/src/runScenarios.ts
+++ b/build-tests/api-extractor-scenarios/src/runScenarios.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as fs from 'fs';
 import * as path from 'path';
-import { JsonFile } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile } from '@rushstack/node-core-library';
 import {
   Extractor,
   ExtractorConfig,
@@ -26,7 +25,7 @@ export function runScenarios(buildConfigPath: string): void {
     entryPoints.push(entryPoint);
 
     const overridesPath = path.resolve(`./src/${scenarioFolderName}/config/api-extractor-overrides.json`);
-    const apiExtractorJsonOverrides = fs.existsSync(overridesPath) ? JsonFile.load(overridesPath) : {};
+    const apiExtractorJsonOverrides = FileSystem.exists(overridesPath) ? JsonFile.load(overridesPath) : {};
     const apiExtractorJson = {
       $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
 

--- a/build-tests/install-test-workspace/build.js
+++ b/build-tests/install-test-workspace/build.js
@@ -106,7 +106,7 @@ const dotPnpmFolderPath = path.resolve(__dirname, 'workspace/node_modules/.pnpm'
 
 console.log('\nCleaning cached tarballs...');
 if (FileSystem.exists(dotPnpmFolderPath)) {
-  for (const filename of FileSystem.readFolder(dotPnpmFolderPath)) {
+  for (const filename of FileSystem.readFolderItemNames(dotPnpmFolderPath)) {
     if (filename.startsWith('local+')) {
       const filePath = path.join(dotPnpmFolderPath, filename);
       console.log('  Deleting ' + filePath);

--- a/common/changes/@microsoft/api-documenter/readdir-with-types_2022-01-05-03-42.json
+++ b/common/changes/@microsoft/api-documenter/readdir-with-types_2022-01-05-03-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/rush/readdir-with-types_2022-01-05-02-00.json
+++ b/common/changes/@microsoft/rush/readdir-with-types_2022-01-05-02-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft/readdir-with-types_2022-01-05-02-00.json
+++ b/common/changes/@rushstack/heft/readdir-with-types_2022-01-05-02-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/readdir-with-types_2022-01-05-02-00.json
+++ b/common/changes/@rushstack/node-core-library/readdir-with-types_2022-01-05-02-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Expose a FileSystem.readFolderItems and FileSystem.readFolderItemsAsync API to get folder entries with types in a single API call.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/readdir-with-types_2022-01-05-03-42.json
+++ b/common/changes/@rushstack/node-core-library/readdir-with-types_2022-01-05-03-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Deprecate FileSystem.readFolder in favor of FileSystem.readFolderItemNames.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -233,8 +233,12 @@ export class FileSystem {
     static readFileAsync(filePath: string, options?: IFileSystemReadFileOptions): Promise<string>;
     static readFileToBuffer(filePath: string): Buffer;
     static readFileToBufferAsync(filePath: string): Promise<Buffer>;
+    // @deprecated (undocumented)
     static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): string[];
+    // @deprecated (undocumented)
     static readFolderAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]>;
+    static readFolderItemNames(folderPath: string, options?: IFileSystemReadFolderOptions): string[];
+    static readFolderItemNamesAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]>;
     static readFolderItems(folderPath: string, options?: IFileSystemReadFolderOptions): FolderItem[];
     static readFolderItemsAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<FolderItem[]>;
     static readLink(path: string): string;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -235,6 +235,8 @@ export class FileSystem {
     static readFileToBufferAsync(filePath: string): Promise<Buffer>;
     static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): string[];
     static readFolderAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<string[]>;
+    static readFolderItems(folderPath: string, options?: IFileSystemReadFolderOptions): FolderItem[];
+    static readFolderItemsAsync(folderPath: string, options?: IFileSystemReadFolderOptions): Promise<FolderItem[]>;
     static readLink(path: string): string;
     static readLinkAsync(path: string): Promise<string>;
     static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
@@ -265,6 +267,9 @@ export enum FolderConstants {
     Git = ".git",
     NodeModules = "node_modules"
 }
+
+// @public
+export type FolderItem = fs.Dirent;
 
 // @public
 export interface IAnsiEscapeConvertForTestsOptions {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -596,12 +596,31 @@ export class FileSystem {
   }
 
   /**
-   * Reads the contents of the folder, not including "." or "..".
+   * @deprecated
+   * Use {@link FileSystem.readFolderItemNames} instead.
+   */
+  public static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): string[] {
+    return FileSystem.readFolderItemNames(folderPath, options);
+  }
+
+  /**
+   * @deprecated
+   * Use {@link FileSystem.readFolderItemNamesAsync} instead.
+   */
+  public static async readFolderAsync(
+    folderPath: string,
+    options?: IFileSystemReadFolderOptions
+  ): Promise<string[]> {
+    return await FileSystem.readFolderItemNamesAsync(folderPath, options);
+  }
+
+  /**
+   * Reads the names of folder entries, not including "." or "..".
    * Behind the scenes it uses `fs.readdirSync()`.
    * @param folderPath - The absolute or relative path to the folder which should be read.
    * @param options - Optional settings that can change the behavior. Type: `IReadFolderOptions`
    */
-  public static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): string[] {
+  public static readFolderItemNames(folderPath: string, options?: IFileSystemReadFolderOptions): string[] {
     return FileSystem._wrapException(() => {
       options = {
         ...READ_FOLDER_DEFAULT_OPTIONS,
@@ -618,9 +637,9 @@ export class FileSystem {
   }
 
   /**
-   * An async version of {@link FileSystem.readFolder}.
+   * An async version of {@link FileSystem.readFolderItemNames}.
    */
-  public static async readFolderAsync(
+  public static async readFolderItemNamesAsync(
     folderPath: string,
     options?: IFileSystemReadFolderOptions
   ): Promise<string[]> {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -7,6 +7,7 @@ import * as fsx from 'fs-extra';
 
 import { Text, NewlineKind, Encoding } from './Text';
 import { PosixModeBits } from './PosixModeBits';
+import { LegacyAdapters } from './LegacyAdapters';
 
 /**
  * An alias for the Node.js `fs.Stats` object.
@@ -16,6 +17,15 @@ import { PosixModeBits } from './PosixModeBits';
  * @public
  */
 export type FileSystemStats = fs.Stats;
+
+/**
+ * An alias for the Node.js `fs.Dirent` object.
+ *
+ * @remarks
+ * This avoids the need to import the `fs` package when using the {@link FileSystem} API.
+ * @public
+ */
+export type FolderItem = fs.Dirent;
 
 // The PosixModeBits are intended to be used with bitwise operations.
 /* eslint-disable no-bitwise */
@@ -598,7 +608,6 @@ export class FileSystem {
         ...options
       };
 
-      // @todo: Update this to use Node 10's `withFileTypes: true` option when we drop support for Node 8
       const fileNames: string[] = fsx.readdirSync(folderPath);
       if (options.absolutePaths) {
         return fileNames.map((fileName) => nodeJsPath.resolve(folderPath, fileName));
@@ -621,12 +630,66 @@ export class FileSystem {
         ...options
       };
 
-      // @todo: Update this to use Node 10's `withFileTypes: true` option when we drop support for Node 8
       const fileNames: string[] = await fsx.readdir(folderPath);
       if (options.absolutePaths) {
         return fileNames.map((fileName) => nodeJsPath.resolve(folderPath, fileName));
       } else {
         return fileNames;
+      }
+    });
+  }
+
+  /**
+   * Reads the contents of the folder, not including "." or "..", returning objects including the
+   * entry names and types.
+   * Behind the scenes it uses `fs.readdirSync()`.
+   * @param folderPath - The absolute or relative path to the folder which should be read.
+   * @param options - Optional settings that can change the behavior. Type: `IReadFolderOptions`
+   */
+  public static readFolderItems(folderPath: string, options?: IFileSystemReadFolderOptions): FolderItem[] {
+    return FileSystem._wrapException(() => {
+      options = {
+        ...READ_FOLDER_DEFAULT_OPTIONS,
+        ...options
+      };
+
+      const folderEntries: FolderItem[] = fsx.readdirSync(folderPath, { withFileTypes: true });
+      if (options.absolutePaths) {
+        return folderEntries.map((folderEntry) => {
+          folderEntry.name = nodeJsPath.resolve(folderPath, folderEntry.name);
+          return folderEntry;
+        });
+      } else {
+        return folderEntries;
+      }
+    });
+  }
+
+  /**
+   * An async version of {@link FileSystem.readFolderItems}.
+   */
+  public static async readFolderItemsAsync(
+    folderPath: string,
+    options?: IFileSystemReadFolderOptions
+  ): Promise<FolderItem[]> {
+    return await FileSystem._wrapExceptionAsync(async () => {
+      options = {
+        ...READ_FOLDER_DEFAULT_OPTIONS,
+        ...options
+      };
+
+      const folderEntries: FolderItem[] = await LegacyAdapters.convertCallbackToPromise(
+        fs.readdir,
+        folderPath,
+        { withFileTypes: true }
+      );
+      if (options.absolutePaths) {
+        return folderEntries.map((folderEntry) => {
+          folderEntry.name = nodeJsPath.resolve(folderPath, folderEntry.name);
+          return folderEntry;
+        });
+      } else {
+        return folderEntries;
       }
     });
   }
@@ -936,7 +999,7 @@ export class FileSystem {
       ...options
     };
 
-    if (FileSystem.getStatistics(options.sourcePath).isDirectory()) {
+    if ((await FileSystem.getStatisticsAsync(options.sourcePath)).isDirectory()) {
       throw new Error(
         'The specified path refers to a folder; this operation expects a file object:\n' + options.sourcePath
       );

--- a/libraries/node-core-library/src/LockFile.ts
+++ b/libraries/node-core-library/src/LockFile.ts
@@ -270,7 +270,7 @@ export class LockFile {
       let smallestBirthTimePid: string = pid.toString();
 
       // now, scan the directory for all lockfiles
-      const files: string[] = FileSystem.readFolder(resourceFolder);
+      const files: string[] = FileSystem.readFolderItemNames(resourceFolder);
 
       // look for anything ending with # then numbers and ".lock"
       const lockFileRegExp: RegExp = /^(.+)#([0-9]+)\.lock$/;

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -63,6 +63,7 @@ export {
   FileSystem,
   FileSystemCopyFilesAsyncFilter,
   FileSystemCopyFilesFilter,
+  FolderItem,
   FileSystemStats,
   IFileSystemCopyFileBaseOptions,
   IFileSystemCopyFileOptions,


### PR DESCRIPTION
## Summary

This PR exposes a `FileSystem` API that uses the `fs.readdir(path, { withFileTypes: true })` API.

## How it was tested

This is now used in places that previously used the `withFileTypes: true` option in the repo.