### PR TITLE
[rush] Pass down builtInPluginConfigurations

### DIFF
--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -43,17 +43,9 @@ export class RushCommandSelector {
             ` which does not support the "rushx" command`
         );
       }
-      Rush.launchRushX(launcherVersion, {
-        isManaged: options.isManaged,
-        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
-        builtInPluginConfigurations: options.builtInPluginConfigurations
-      });
+      Rush.launchRushX(launcherVersion, options);
     } else {
-      Rush.launch(launcherVersion, {
-        isManaged: options.isManaged,
-        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
-        builtInPluginConfigurations: options.builtInPluginConfigurations
-      });
+      Rush.launch(launcherVersion, options);
     }
   }
 

--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -45,12 +45,14 @@ export class RushCommandSelector {
       }
       Rush.launchRushX(launcherVersion, {
         isManaged: options.isManaged,
-        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError
+        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
+        builtInPluginConfigurations: options.builtInPluginConfigurations
       });
     } else {
       Rush.launch(launcherVersion, {
         isManaged: options.isManaged,
-        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError
+        alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
+        builtInPluginConfigurations: options.builtInPluginConfigurations
       });
     }
   }

--- a/common/changes/@microsoft/rush/enelson-fix-builtin-option_2022-01-05-17-09.json
+++ b/common/changes/@microsoft/rush/enelson-fix-builtin-option_2022-01-05-17-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Pass builtin plugins to the internal Rush launcher",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/enelson-fix-builtin-option_2022-01-05-17-09.json
+++ b/common/changes/@microsoft/rush/enelson-fix-builtin-option_2022-01-05-17-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Pass builtin plugins to the internal Rush launcher",
+      "comment": "",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary

Fix a small issue discovered while attempting to run the new `lib/start-dev` script from another monorepo.

## Details

The `start-dev.js` script adds in the built-in plugins so that they'll be automatically loaded by PluginManager, but the options weren't being passed down all the way.  This caused issues when used in a repo other than rushstack.

## How it was tested

 - Tested locally both inside and outside rushstack.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
