### PR TITLE
[rush] start-dev script should assume unmanaged

### DIFF
--- a/apps/rush/src/start-dev.ts
+++ b/apps/rush/src/start-dev.ts
@@ -7,7 +7,6 @@
 import * as rushLib from '@microsoft/rush-lib';
 import { PackageJsonLookup, Import } from '@rushstack/node-core-library';
 
-import { MinimalRushConfiguration } from './MinimalRushConfiguration';
 import { RushCommandSelector } from './RushCommandSelector';
 
 const builtInPluginConfigurations: rushLib._IBuiltInPluginConfiguration[] = [];
@@ -27,13 +26,9 @@ function includePlugin(pluginName: string): void {
 includePlugin('rush-amazon-s3-build-cache-plugin');
 includePlugin('rush-azure-storage-build-cache-plugin');
 
-// Load the configuration
-const configuration: MinimalRushConfiguration | undefined =
-  MinimalRushConfiguration.loadFromDefaultLocation();
-
 const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 RushCommandSelector.execute(currentPackageVersion, rushLib, {
-  isManaged: !!configuration,
+  isManaged: false,
   alreadyReportedNodeTooNewError: false,
   builtInPluginConfigurations
 });

--- a/common/changes/@microsoft/rush/enelson-ismanagedfalse_2022-01-05-22-41.json
+++ b/common/changes/@microsoft/rush/enelson-ismanagedfalse_2022-01-05-22-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Force `isManaged` to `false` in the new `start-dev` entry point.

## Details

Before the big plugin refactor, if you wanted to hack on rushstack locally and test it against your own corporate monorepo, you would use the `apps/rush-lib/lib/start.js` entry point.

That entry point probably still works fine for people who have no cloud build cache, but if you're using the Azure or S3 cloud build cache plugins, this entry point doesn't work anymore.  So I think the new "default" entry point for local hacking is probably `apps/rush/lib/start-dev.js`.

Given that, and that this entry point doesn't have an external `bin` script, I think it should do what `rush-lib/lib/start.js` does and hard-code `isManaged` to `false`.  That way whenever you're running a local copy of this entry point you get the unmanaged banner.

## How it was tested

Tested locally in corporate monorepo and in `rushstack`.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
