### PR TITLE
[chore] Bump @types/jest to 27.4.0

### DIFF
--- a/build-tests/api-documenter-test/package.json
+++ b/build-tests/api-documenter-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/api-documenter": "workspace:*",
     "@microsoft/api-extractor": "workspace:*",
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.24",
     "fs-extra": "~7.0.1",
     "typescript": "~4.5.2"

--- a/build-tests/api-extractor-lib2-test/package.json
+++ b/build-tests/api-extractor-lib2-test/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.24",
     "fs-extra": "~7.0.1",
     "typescript": "~4.5.2"

--- a/build-tests/api-extractor-lib3-test/package.json
+++ b/build-tests/api-extractor-lib3-test/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.24",
     "fs-extra": "~7.0.1",
     "typescript": "~4.5.2"

--- a/build-tests/api-extractor-scenarios/package.json
+++ b/build-tests/api-extractor-scenarios/package.json
@@ -12,7 +12,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@microsoft/teams-js": "1.3.0-beta.4",
     "@rushstack/node-core-library": "workspace:*",
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.24",
     "api-extractor-lib1-test": "workspace:*",
     "api-extractor-lib2-test": "workspace:*",

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -9,7 +9,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/long": "4.0.0",
     "long": "^4.0.0"
   },

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -7,7 +7,7 @@
     "build": "node build.js"
   },
   "devDependencies": {
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "@types/node": "12.20.24",
     "api-extractor-test-02": "workspace:*",
     "fs-extra": "~7.0.1",

--- a/build-tests/heft-typescript-composite-test/package.json
+++ b/build-tests/heft-typescript-composite-test/package.json
@@ -13,7 +13,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/webpack-env": "1.13.0",
-    "@types/jest": "25.2.1",
+    "@types/jest": "27.4.0",
     "eslint": "~8.3.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -4,28 +4,28 @@ importers:
 
   typescript-newest-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.44.0.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.44.2.tgz
       eslint: ~8.3.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.0.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.2.tgz
       eslint: 8.3.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
 
   typescript-v3-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.44.0.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.44.2.tgz
       eslint: ~8.3.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.0.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.2.tgz
       eslint: 8.3.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
@@ -1670,11 +1670,11 @@ packages:
       commander: 2.20.3
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz_eslint@8.3.0+typescript@4.5.2:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-2.5.0.tgz
+  file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz
     name: '@rushstack/eslint-config'
-    version: 2.5.0
+    version: 2.5.1
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=3.0.0'
@@ -1750,17 +1750,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.44.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.44.0.tgz}
+  file:../temp/tarballs/rushstack-heft-0.44.2.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.44.2.tgz}
     name: '@rushstack/heft'
-    version: 0.44.0
+    version: 0.44.2
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.7.9.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.44.2.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.6.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.10.5.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.7.11.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.0.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.7.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.10.6.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -1773,21 +1773,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.7.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.7.9.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.7.11.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.7.11.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.7.9
+    version: 0.7.11
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.44.2.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.6.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.0.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.7.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.44.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.44.2.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.45.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.45.0.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.44.2
+    version: 3.45.0
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5
@@ -1800,10 +1800,10 @@ packages:
       z-schema: 5.0.2
     dev: true
 
-  file:../temp/tarballs/rushstack-rig-package-0.3.6.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.6.tgz}
+  file:../temp/tarballs/rushstack-rig-package-0.3.7.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.7.tgz}
     name: '@rushstack/rig-package'
-    version: 0.3.6
+    version: 0.3.7
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
@@ -1815,10 +1815,10 @@ packages:
     version: 0.2.2
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.10.5.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.10.5.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.10.6.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.10.6.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.10.5
+    version: 4.10.6
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -516,14 +516,14 @@ importers:
     specifiers:
       '@microsoft/api-documenter': workspace:*
       '@microsoft/api-extractor': workspace:*
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       fs-extra: ~7.0.1
       typescript: ~4.5.2
     devDependencies:
       '@microsoft/api-documenter': link:../../apps/api-documenter
       '@microsoft/api-extractor': link:../../apps/api-extractor
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       fs-extra: 7.0.1
       typescript: 4.5.2
@@ -541,13 +541,13 @@ importers:
   ../../build-tests/api-extractor-lib2-test:
     specifiers:
       '@microsoft/api-extractor': workspace:*
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       fs-extra: ~7.0.1
       typescript: ~4.5.2
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       fs-extra: 7.0.1
       typescript: 4.5.2
@@ -555,7 +555,7 @@ importers:
   ../../build-tests/api-extractor-lib3-test:
     specifiers:
       '@microsoft/api-extractor': workspace:*
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       api-extractor-lib1-test: workspace:*
       fs-extra: ~7.0.1
@@ -564,7 +564,7 @@ importers:
       api-extractor-lib1-test: link:../api-extractor-lib1-test
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       fs-extra: 7.0.1
       typescript: 4.5.2
@@ -574,7 +574,7 @@ importers:
       '@microsoft/api-extractor': workspace:*
       '@microsoft/teams-js': 1.3.0-beta.4
       '@rushstack/node-core-library': workspace:*
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       api-extractor-lib1-test: workspace:*
       api-extractor-lib2-test: workspace:*
@@ -586,7 +586,7 @@ importers:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@microsoft/teams-js': 1.3.0-beta.4
       '@rushstack/node-core-library': link:../../libraries/node-core-library
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       api-extractor-lib1-test: link:../api-extractor-lib1-test
       api-extractor-lib2-test: link:../api-extractor-lib2-test
@@ -599,14 +599,14 @@ importers:
     specifiers:
       '@microsoft/api-extractor': workspace:*
       '@types/heft-jest': 1.0.1
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/long': 4.0.0
       '@types/node': 12.20.24
       fs-extra: ~7.0.1
       long: ^4.0.0
       typescript: ~4.5.2
     dependencies:
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/long': 4.0.0
       long: 4.0.0
     devDependencies:
@@ -637,13 +637,13 @@ importers:
 
   ../../build-tests/api-extractor-test-03:
     specifiers:
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       api-extractor-test-02: workspace:*
       fs-extra: ~7.0.1
       typescript: ~4.5.2
     devDependencies:
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/node': 12.20.24
       api-extractor-test-02: link:../api-extractor-test-02
       fs-extra: 7.0.1
@@ -952,7 +952,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/webpack-env': 1.13.0
       eslint: ~8.3.0
       tslint: ~5.20.1
@@ -963,7 +963,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
       '@types/webpack-env': 1.13.0
       eslint: 8.3.0
       tslint: 5.20.1_typescript@4.5.2
@@ -4301,6 +4301,7 @@ packages:
       '@types/istanbul-reports': 1.1.2
       '@types/yargs': 15.0.14
       chalk: 3.0.0
+    dev: true
 
   /@jest/types/26.6.2:
     resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
@@ -6375,7 +6376,7 @@ packages:
   /@types/heft-jest/1.0.1:
     resolution: {integrity: sha512-cF2iEUpvGh2WgLowHVAdjI05xuDo+GwCA8hGV3Q5PBl8apjd6BTcpPFQ2uPlfUM7BLpgur2xpYo8VeBXopMI4A==}
     dependencies:
-      '@types/jest': 25.2.1
+      '@types/jest': 27.4.0
     dev: true
 
   /@types/html-minifier-terser/5.1.2:
@@ -6414,17 +6415,18 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
 
   /@types/istanbul-reports/3.0.1:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
 
-  /@types/jest/25.2.1:
-    resolution: {integrity: sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==}
+  /@types/jest/27.4.0:
+    resolution: {integrity: sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==}
     dependencies:
-      jest-diff: 25.5.0
-      pretty-format: 25.5.0
+      jest-diff: 27.4.2
+      pretty-format: 27.4.2
 
   /@types/jju/1.4.1:
     resolution: {integrity: sha512-LFt+YA7Lv2IZROMwokZKiPNORAV5N3huMs3IKnzlE430HWhWYZ8b+78HiwJXJJP1V2IEjinyJURuRJfGoaFSIA==}
@@ -6799,6 +6801,7 @@ packages:
     resolution: {integrity: sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==}
     dependencies:
       '@types/yargs-parser': 20.2.1
+    dev: true
 
   /@types/yargs/16.0.4:
     resolution: {integrity: sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==}
@@ -8663,6 +8666,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
 
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -9586,6 +9590,7 @@ packages:
   /diff-sequences/25.2.6:
     resolution: {integrity: sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==}
     engines: {node: '>= 8.3'}
+    dev: true
 
   /diff-sequences/27.4.0:
     resolution: {integrity: sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==}
@@ -12779,6 +12784,7 @@ packages:
       diff-sequences: 25.2.6
       jest-get-type: 25.2.6
       pretty-format: 25.5.0
+    dev: true
 
   /jest-diff/27.4.2:
     resolution: {integrity: sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==}
@@ -12913,6 +12919,7 @@ packages:
   /jest-get-type/25.2.6:
     resolution: {integrity: sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==}
     engines: {node: '>= 8.3'}
+    dev: true
 
   /jest-get-type/27.4.0:
     resolution: {integrity: sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==}
@@ -15749,6 +15756,7 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 4.3.0
       react-is: 16.13.1
+    dev: true
 
   /pretty-format/27.4.2:
     resolution: {integrity: sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "bb7c90e284febcc7531af0f4c81381fc194a5b6a",
+  "pnpmShrinkwrapHash": "f12214a1ca307d5f3529088a4a4f0ff66db0f03d",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }


### PR DESCRIPTION
## Summary

Bump `@types/jest` to `27.4.0`, the current latest version.

## How it was tested

Rebuild
