### PR TITLE
Fix some instances of "confusable" characters.

### DIFF
--- a/apps/heft/README.md
+++ b/apps/heft/README.md
@@ -26,7 +26,7 @@ Ultimately, you'll want to define a small set of stereotypical project types
 overriding the rig configuration. Being consistent ensures that any person can easily contribute to any project.
 Heft is a ready-made implementation of all these concepts.
 
-You don’t need a monorepo to use Heft, however. It also works well for small standalone projects. Compared to other
+You don't need a monorepo to use Heft, however. It also works well for small standalone projects. Compared to other
 similar systems, Heft has some unique design goals:
 
 - **Scalable**: Heft interfaces with the [Rush Stack](https://rushstack.io/) family of tools, which are tailored

--- a/common/changes/@rushstack/debug-certificate-manager/fix-special-chars_2022-01-06-00-13.json
+++ b/common/changes/@rushstack/debug-certificate-manager/fix-special-chars_2022-01-06-00-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix an incorrect argument passed to the command to repair the certificate store on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/heft/fix-special-chars_2022-01-06-00-13.json
+++ b/common/changes/@rushstack/heft/fix-special-chars_2022-01-06-00-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -423,8 +423,8 @@ export class CertificateManager {
       await FileSystem.writeFileAsync(friendlyNamePath, friendlyNameFile);
 
       const repairStoreResult: IRunResult = await runAsync(CERTUTIL_EXE_NAME, [
-        '–repairstore',
-        '–user',
+        '-repairstore',
+        '-user',
         'root',
         SERIAL_NUMBER,
         friendlyNamePath


### PR DESCRIPTION
VSCode called out a character ([here](https://github.com/microsoft/rushstack/blob/master/libraries/debug-certificate-manager/src/CertificateManager.ts#L426)) that is "ambiguous," which is an actual bug. I wrote a little script to replace those in a repo: https://gist.github.com/iclanton/6956d1a0e98737393d70c5d7f70484ec

This PR replaces them across the repo.