### PR TITLE
[rush] Merge the phase projectOutputFolderNames arrays in rush-project.json config files.

### DIFF
--- a/apps/rush-lib/src/api/test/RushProjectConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/RushProjectConfiguration.test.ts
@@ -1,0 +1,51 @@
+import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
+import {
+  RUSH_PROJECT_CONFIGURATION_FILE,
+  RushProjectConfiguration,
+  IRushProjectJson
+} from '../RushProjectConfiguration';
+
+describe(RushProjectConfiguration.name, () => {
+  it('loads a rush-project.json config that extends another config file', async () => {
+    const testFolder: string = `${__dirname}/jsonFiles/test-project-a`;
+    const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
+    const rushProjectJson: IRushProjectJson =
+      await RUSH_PROJECT_CONFIGURATION_FILE.loadConfigurationFileForProjectAsync(terminal, testFolder);
+    expect(rushProjectJson.projectOutputFolderNames).toMatchInlineSnapshot(`
+      Array [
+        "a",
+        "b",
+      ]
+    `);
+    expect(rushProjectJson.phaseOptions?.length).toEqual(2);
+    expect(rushProjectJson.phaseOptions?.[0].phaseName).toMatchInlineSnapshot(`"_phase:a"`);
+    expect(rushProjectJson.phaseOptions?.[0].projectOutputFolderNames).toMatchInlineSnapshot(`
+      Array [
+        "a-a",
+        "a-b",
+      ]
+    `);
+    expect(rushProjectJson.phaseOptions?.[1].phaseName).toMatchInlineSnapshot(`"_phase:b"`);
+    expect(rushProjectJson.phaseOptions?.[1].projectOutputFolderNames).toMatchInlineSnapshot(`
+      Array [
+        "b-a",
+      ]
+    `);
+  });
+
+  it('throws an error when loading a rush-project.json config that lists a phase twice', async () => {
+    const testFolder: string = `${__dirname}/jsonFiles/test-project-b`;
+    const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
+    try {
+      await RUSH_PROJECT_CONFIGURATION_FILE.loadConfigurationFileForProjectAsync(terminal, testFolder);
+      fail('Expected to throw');
+    } catch (e) {
+      const errorMessage: string = (e as Error).message
+        .replace(/\\/g, '/')
+        .replace(testFolder.replace(/\\/g, '/'), '<testFolder>');
+      expect(errorMessage).toMatchInlineSnapshot(
+        `"The phase \\"_phase:a\\" occurs multiple times in the \\"phaseOptions\\" array in \\"<testFolder>/config/rush-project.json\\"."`
+      );
+    }
+  });
+});

--- a/apps/rush-lib/src/api/test/jsonFiles/rush-project-base.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/rush-project-base.json
@@ -1,0 +1,14 @@
+{
+  "projectOutputFolderNames": ["a"],
+
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:a",
+      "projectOutputFolderNames": ["a-a"]
+    },
+    {
+      "phaseName": "_phase:b",
+      "projectOutputFolderNames": ["b-a"]
+    }
+  ]
+}

--- a/apps/rush-lib/src/api/test/jsonFiles/test-project-a/config/rush-project.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/test-project-a/config/rush-project.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../rush-project-base.json",
+  "projectOutputFolderNames": ["b"],
+
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:a",
+      "projectOutputFolderNames": ["a-b"]
+    }
+  ]
+}

--- a/apps/rush-lib/src/api/test/jsonFiles/test-project-b/config/rush-project.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/test-project-b/config/rush-project.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../rush-project-base.json",
+  "projectOutputFolderNames": ["b"],
+
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:a",
+      "projectOutputFolderNames": ["a-b"]
+    },
+    {
+      "phaseName": "_phase:a",
+      "projectOutputFolderNames": ["a-c"]
+    }
+  ]
+}

--- a/common/changes/@microsoft/rush/extend-phase-projectOutputFolderNames_2022-01-06-07-41.json
+++ b/common/changes/@microsoft/rush/extend-phase-projectOutputFolderNames_2022-01-06-07-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

The `config/rush-project.json` file contains a `projectOutputFolderNames` property that is appended to when the config file extends another file containing that property. There is a similar property (the `projectOutputFolderNames` array) defined per phase in the items of the `phaseOptions` property, but this array doesn't currently support concatenation from a parent file. This change adds support for that.

## How it was tested

Added a unit test.