### PR TITLE
feat(rush-lib): settings change for pnpm lockfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,7 +36,7 @@
 
 # Don't allow people to merge changes to these generated files, because the result
 # may be invalid.  You need to run "rush update" again.
-pnpm-lock.yaml               merge=binary
+pnpm-lock.yaml               merge=text
 shrinkwrap.yaml              merge=binary
 npm-shrinkwrap.json          merge=binary
 yarn.lock                    merge=binary

--- a/apps/rush-lib/assets/rush-init/[dot]gitattributes
+++ b/apps/rush-lib/assets/rush-init/[dot]gitattributes
@@ -1,6 +1,6 @@
 # Don't allow people to merge changes to these generated files, because the result
 # may be invalid.  You need to run "rush update" again.
-pnpm-lock.yaml               merge=binary
+pnpm-lock.yaml               merge=text
 shrinkwrap.yaml              merge=binary
 npm-shrinkwrap.json          merge=binary
 yarn.lock                    merge=binary

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -110,7 +110,7 @@
      *
      * This option is experimental. The default value is false.
      */
-    /*[LINE "HYPOTHETICAL"]*/ "useWorkspaces": true
+    "useWorkspaces": true
   },
 
   /**

--- a/common/changes/@microsoft/rush/feat-pnpm-lock-conflict_2022-01-06-08-44.json
+++ b/common/changes/@microsoft/rush/feat-pnpm-lock-conflict_2022-01-06-08-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Change pnpm-lock.yaml to text in gitattributes & set useWorkspaces to true",
+      "comment": "Update the \"rush init\" template to enable pnpm workspaces and to merge the pnpm-lock.yaml file as text.",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/rush/feat-pnpm-lock-conflict_2022-01-06-08-44.json
+++ b/common/changes/@microsoft/rush/feat-pnpm-lock-conflict_2022-01-06-08-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Change pnpm-lock.yaml to text in gitattributes & set useWorkspaces to true",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION

## Summary

1. turn on `useWorkspaces` in `rush init` template.
2. set `pnpm-lock.yaml` merge driver to `text` in this repo and `rush init` template.

## Details

This was one of the topics discussed in October's Rush Hour. Everyone agreed that PNPM 6 lockfiles can be safely merged as text. Microsoft said they have been running this way for some time without any conflicts.



## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
