### PR TITLE
[rush] Experimental: task runner ASCII timeline generator

### DIFF
--- a/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
@@ -120,6 +120,10 @@ export class ProjectTaskRunner extends BaseTaskRunner {
     this._logFilenameIdentifier = phase.logFilenameIdentifier;
   }
 
+  public get phase(): IPhase {
+    return this._phase;
+  }
+
   public async executeAsync(context: ITaskRunnerContext): Promise<TaskStatus> {
     try {
       if (!this._commandToRun) {

--- a/apps/rush-lib/src/utilities/Stopwatch.ts
+++ b/apps/rush-lib/src/utilities/Stopwatch.ts
@@ -40,6 +40,14 @@ export class Stopwatch {
     return this._state;
   }
 
+  public get startTime(): number | undefined {
+    return this._startTime;
+  }
+
+  public get endTime(): number | undefined {
+    return this._endTime;
+  }
+
   /**
    * Starts the stopwatch. Note that if end() has been called,
    * reset() should be called before calling start() again.


### PR DESCRIPTION
## Summary

Once the upcoming "phased builds" feature is rolled out, monorepo maintainers will want to try it out.  I think there's two big questions that will get asked: (1) am I configuring these phases correctly? (2) am I getting enough value out of this extra configuration?

Being able to see visually what was built can often highlight questions to go explore in your own configuration, and some additional summary details can highlight what changes you might want to make to the structure of projects in the repo to get better performance out of your phases.

> This PR is an example to show the proposed output, and is not yet cleaned up.

## Details

This PR currently writes out a simple text file to contain the additional graph, but that's actually _not_ ideal, because what you really want as a maintainer is to notice a build that had a long duration yesterday, click on it, and see what happened in the timeline.  So maybe a `--timeline` option that spits it out at the end of the build to stdout would be preferred.

Example sanitized outputs:

```
========================================================================================================================
@hbo/xxx-xxxx-xxx (compile)            %%--------------------------------------------------------------------------- 0s
@hbo/xxxxxx-xxxxxx-xxxxxxxxx (compile) -%--------------------------------------------------------------------------- 0s
@hbo/xxx-xxxx-xxx (test)               -%--------------------------------------------------------------------------- 0s
@hbo/xxxxxx-xxxxxx-xxxxx (compile)     -%--------------------------------------------------------------------------- 0s
@hbo/xxxxx-xxxxxxx-xxxxxxxxx (test)    -%--------------------------------------------------------------------------- 0s
@hbo/xxxx-xxxxx (compile)              -!!!!!!!!!!!!!!!!!----------------------------------------------------------- 7s
@hbo/xxxxxx-xxxxxx-xxxxx (test)        -%--------------------------------------------------------------------------- 0s
@hbo/xxxx-xxxxx (test)                 -----------------############################################################ 26s
========================================================================================================================
LEGEND:                                                                                            Total Work:       34s
  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                             Wall Clock:       34s
                                                                                             Parallelism Used:      3/16
```

```
TIMELINE
========================================================================================================================
@hbo/hbo-node-rig (compile)            #######---------------------------------------------------------------------- 1s
@hbo/eslint-plugin-lightning (compile) ------####################--------------------------------------------------- 4s
@hbo/hbo-node-rig (test)               ------#---------------------------------------------------------------------- 0s
@hbo/eslint-config-codex (compile)     -------------------------###------------------------------------------------- 0s
@hbo/eslint-plugin-lightning (test)    -------------------------#################################################### 11s
@hbo/install-apple-profiles (compile)  ---------------------------##############------------------------------------ 2s
@hbo/eslint-config-codex (test)        ---------------------------#------------------------------------------------- 0s
@hbo/install-apple-profiles (test)     ----------------------------------------##################------------------- 3s
========================================================================================================================
LEGEND                                                                                             Total Work:       24s
  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                             Wall Clock:       17s
                                                                                             Parallelism Used:      3/16

PHASE BREAKDOWN
  _phase:compile        9s
  _phase:test          15s
```

## Alternate approaches

An alternate approach (maybe technically better) would be https://github.com/microsoft/rushstack/pull/2569.  However, to use this, you really need to configure your pipelines ahead of time to always trace and always save the trace artifact as a build output, otherwise you won't have it when you need it.  (Maybe that PR might add "--trace", and it could generate the ASCII graph in addition to the event format output?)

## How it was tested

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
