### PR TITLE
[rush-lib] Fix regression in bulk commands with unsafe selectors

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -24,6 +24,7 @@ import { SelectionParameterSet } from '../SelectionParameterSet';
 import { CommandLineConfiguration, IPhase, IPhasedCommand } from '../../api/CommandLineConfiguration';
 import { IProjectTaskSelectorOptions, ProjectTaskSelector } from '../../logic/ProjectTaskSelector';
 import { IFlagParameterJson } from '../../api/CommandLineJson';
+import { Selection } from '../../logic/Selection';
 
 /**
  * Constructor parameters for BulkScriptAction.
@@ -233,11 +234,17 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
         terminal.writeLine(`    ${colors.cyan(name)}`);
       }
 
+      // Account for consumer relationships
+      const projectSelection: Set<RushConfigurationProject> = Selection.intersection(
+        Selection.expandAllConsumers(changedProjects),
+        projectsToWatch
+      );
+
       const executeOptions: IExecuteInternalOptions = {
         taskSelectorOptions: {
           ...options.taskSelectorOptions,
           // Revise down the set of projects to execute the command on
-          projectSelection: changedProjects,
+          projectSelection,
           // Pass the ProjectChangeAnalyzer from the state differ to save a bit of overhead
           projectChangeAnalyzer: state
         },

--- a/apps/rush-lib/src/logic/ProjectTaskSelector.ts
+++ b/apps/rush-lib/src/logic/ProjectTaskSelector.ts
@@ -112,7 +112,7 @@ export class ProjectTaskSelector {
         );
         if (commandToRun === undefined && !phase.ignoreMissingScript) {
           throw new Error(
-            `The project [${project.packageName}] does not define a '${phase.name}' command in the 'scripts' section of its package.json`
+            `The project '${project.packageName}' does not define a '${phase.name}' command in the 'scripts' section of its package.json`
           );
         }
 

--- a/apps/rush-lib/src/logic/ProjectTaskSelector.ts
+++ b/apps/rush-lib/src/logic/ProjectTaskSelector.ts
@@ -70,84 +70,94 @@ export class ProjectTaskSelector {
     const projects: ReadonlySet<RushConfigurationProject> = this._options.projectSelection;
     const taskCollection: TaskCollection = new TaskCollection();
 
+    const selectedDependenciesCache: Map<RushConfigurationProject, Set<RushConfigurationProject>> = new Map();
+    function getSelectedDependencies(project: RushConfigurationProject): Set<RushConfigurationProject> {
+      let selectedDependencies: Set<RushConfigurationProject> | undefined =
+        selectedDependenciesCache.get(project);
+      if (selectedDependencies) {
+        return selectedDependencies;
+      }
+
+      selectedDependencies = new Set();
+      selectedDependenciesCache.set(project, selectedDependencies);
+
+      for (const dependency of project.dependencyProjects) {
+        if (projects.has(dependency)) {
+          // The tasks for this project are part of the set. Preserve dependency as-is
+          selectedDependencies.add(dependency);
+        } else {
+          // This project is not part of the set, but some of its dependencies could be.
+          for (const indirectDependency of getSelectedDependencies(dependency)) {
+            selectedDependencies.add(indirectDependency);
+          }
+        }
+      }
+
+      return selectedDependencies;
+    }
+
     // Register all tasks
+    // This currently does not correctly handle the scenario in which a phase is skipped.
+    // If that happens, the dependency graph will have an error due to a missing task.
     for (const phaseName of this._phasesToRun) {
       const phase: IPhase = this._getPhaseByName(phaseName);
-      for (const rushProject of projects) {
-        this._registerProjectPhaseTask(rushProject, phase, taskCollection);
+      for (const project of projects) {
+        const taskName: string = this._getPhaseDisplayNameForProject(phase, project);
+
+        const customParameterValues: string[] = this._getCustomParameterValuesForPhase(phase);
+        const commandToRun: string | undefined = ProjectTaskSelector.getScriptToRun(
+          project,
+          phase.name,
+          customParameterValues
+        );
+        if (commandToRun === undefined && !phase.ignoreMissingScript) {
+          throw new Error(
+            `The project [${project.packageName}] does not define a '${phase.name}' command in the 'scripts' section of its package.json`
+          );
+        }
+
+        taskCollection.addTask(
+          new ProjectTaskRunner({
+            rushProject: project,
+            taskName,
+            rushConfiguration: this._options.rushConfiguration,
+            buildCacheConfiguration: this._options.buildCacheConfiguration,
+            commandToRun: commandToRun || '',
+            isIncrementalBuildAllowed: this._options.isIncrementalBuildAllowed,
+            projectChangeAnalyzer: this._projectChangeAnalyzer,
+            phase
+          })
+        );
+
+        const dependencyTasks: Set<string> = new Set();
+        if (phase.dependencies?.self) {
+          for (const dependencyPhaseName of phase.dependencies.self) {
+            const dependencyPhase: IPhase = this._getPhaseByName(dependencyPhaseName);
+            const dependencyTaskName: string = this._getPhaseDisplayNameForProject(dependencyPhase, project);
+
+            dependencyTasks.add(dependencyTaskName);
+          }
+        }
+
+        if (phase.dependencies?.upstream) {
+          for (const dependencyPhaseName of phase.dependencies.upstream) {
+            const dependencyPhase: IPhase = this._getPhaseByName(dependencyPhaseName);
+            for (const dependencyProject of getSelectedDependencies(project)) {
+              const dependencyTaskName: string = this._getPhaseDisplayNameForProject(
+                dependencyPhase,
+                dependencyProject
+              );
+
+              dependencyTasks.add(dependencyTaskName);
+            }
+          }
+        }
+
+        taskCollection.addDependencies(taskName, dependencyTasks);
       }
     }
 
     return taskCollection;
-  }
-
-  private _registerProjectPhaseTask(
-    project: RushConfigurationProject,
-    phase: IPhase,
-    taskCollection: TaskCollection
-  ): string {
-    const taskName: string = this._getPhaseDisplayNameForProject(phase, project);
-    if (taskCollection.hasTask(taskName)) {
-      return taskName;
-    }
-
-    const customParameterValues: string[] = this._getCustomParameterValuesForPhase(phase);
-    const commandToRun: string | undefined = ProjectTaskSelector.getScriptToRun(
-      project,
-      phase.name,
-      customParameterValues
-    );
-    if (commandToRun === undefined && !phase.ignoreMissingScript) {
-      throw new Error(
-        `The project [${project.packageName}] does not define a '${phase.name}' command in the 'scripts' section of its package.json`
-      );
-    }
-
-    taskCollection.addTask(
-      new ProjectTaskRunner({
-        rushProject: project,
-        taskName,
-        rushConfiguration: this._options.rushConfiguration,
-        buildCacheConfiguration: this._options.buildCacheConfiguration,
-        commandToRun: commandToRun || '',
-        isIncrementalBuildAllowed: this._options.isIncrementalBuildAllowed,
-        projectChangeAnalyzer: this._projectChangeAnalyzer,
-        phase
-      })
-    );
-
-    const dependencyTasks: Set<string> = new Set();
-    if (phase.dependencies?.self) {
-      for (const dependencyPhaseName of phase.dependencies.self) {
-        const dependencyPhase: IPhase = this._getPhaseByName(dependencyPhaseName);
-        const dependencyTaskName: string = this._registerProjectPhaseTask(
-          project,
-          dependencyPhase,
-          taskCollection
-        );
-
-        dependencyTasks.add(dependencyTaskName);
-      }
-    }
-
-    if (phase.dependencies?.upstream) {
-      for (const dependencyPhaseName of phase.dependencies.upstream) {
-        const dependencyPhase: IPhase = this._getPhaseByName(dependencyPhaseName);
-        for (const dependencyProject of project.dependencyProjects) {
-          const dependencyTaskName: string = this._registerProjectPhaseTask(
-            dependencyProject,
-            dependencyPhase,
-            taskCollection
-          );
-
-          dependencyTasks.add(dependencyTaskName);
-        }
-      }
-    }
-
-    taskCollection.addDependencies(taskName, dependencyTasks);
-
-    return taskName;
   }
 
   private _getPhaseByName(phaseName: string): IPhase {

--- a/common/changes/@microsoft/rush/fix-unsafe-selectors-in-phased-commands_2022-01-07-00-28.json
+++ b/common/changes/@microsoft/rush/fix-unsafe-selectors-in-phased-commands_2022-01-07-00-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes a regression in bulk command execution when using \"unsafe\" selector parameters, e.g. \"--only\". Ensures that only the projects selected by the parameters get included in the build, rather that forcibly including all dependencies.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes behavior of the unsafe `--only` `--impacted-by` and `--impacted-by-except` selection parameters with respect to the task selector. A regression was introduced during the phased command implementation that project dependencies were forcibly included.

## Details
Restores the filtering of the project graph to elide projects that are not included by the selection.

## How it was tested
Verified `node ./apps/rush-lib/lib/start.js build -o module-minifier-plugin` selects exactly one project