### PR TITLE
[chore] Run build using rush-lib assets after initial rebuild

### DIFF
--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -13,7 +13,13 @@ steps:
   - script: 'node common/scripts/install-run-rush.js install'
     displayName: 'Rush Install'
   - script: 'node common/scripts/install-run-rush.js rebuild --verbose --production'
-    displayName: 'Rush Rebuild'
+    displayName: 'Rush Rebuild (install-run-rush)'
+    env:
+      # Prevent time-based browserslist update warning
+      # See https://github.com/microsoft/rushstack/issues/2981
+      BROWSERSLIST_IGNORE_OLD_DATA: 1
+  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
+    displayName: 'Rush Build (rush-lib)'
     env:
       # Prevent time-based browserslist update warning
       # See https://github.com/microsoft/rushstack/issues/2981


### PR DESCRIPTION
## Summary

In order to validate that the built assets can re-construct the build graph properly, we re-run build using the newly built assets. Rebuild is unnecessary since the goal is to validate the tasks were run in the correct order.

## How it was tested

Build of this PR.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
