### PR TITLE
[rush-lib] Fix regression that completely broke "rush build"

### DIFF
--- a/apps/rush-lib/src/logic/ProjectTaskSelector.ts
+++ b/apps/rush-lib/src/logic/ProjectTaskSelector.ts
@@ -96,6 +96,8 @@ export class ProjectTaskSelector {
       return selectedDependencies;
     }
 
+    const taskDependencies: Map<string, Set<string>> = new Map();
+
     // Register all tasks
     // This currently does not correctly handle the scenario in which a phase is skipped.
     // If that happens, the dependency graph will have an error due to a missing task.
@@ -153,8 +155,12 @@ export class ProjectTaskSelector {
           }
         }
 
-        taskCollection.addDependencies(taskName, dependencyTasks);
+        taskDependencies.set(taskName, dependencyTasks);
       }
+    }
+
+    for (const [taskName, dependencies] of taskDependencies) {
+      taskCollection.addDependencies(taskName, dependencies);
     }
 
     return taskCollection;

--- a/common/changes/@microsoft/rush/fix-regular-build_2022-01-07-02-03.json
+++ b/common/changes/@microsoft/rush/fix-regular-build_2022-01-07-02-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes a regression that broke \"rush build\" completely when not using the \"--only\" parameter.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Previous fix broke `rush build` when not specifying `rush build -o` due to trying to add dependencies before the tasks were fully generated.

## Details
Registering dependencies requires the Task objects to have been created, therefore must run after the initial pass (or use a depth-first search, but that makes the code less readable).

## How it was tested
node ./apps/rush-lib/lib/start.js build -v
node ./apps/rush-lib/lib/start.js build -v -o terminal -o rush-lib -o node-core-library
node ./apps/rush-lib/lib/start.js build -v -t rush-lib
node ./apps/rush-lib/lib/start.js build -v -i rush-lib
node ./apps/rush-lib/lib/start.js build -v -f node-core-library