### PR TITLE
[heft-node/web-rig] Update the `rush-project.json` file to follow the new schema and configure the "build" command output folders for the "_phase:build" phase.

### DIFF
--- a/apps/api-extractor-model/config/rush-project.json
+++ b/apps/api-extractor-model/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/apps/api-extractor/config/rush-project.json
+++ b/apps/api-extractor/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/apps/heft/config/rush-project.json
+++ b/apps/heft/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/build-tests-samples/heft-node-basic-tutorial/config/rush-project.json
+++ b/build-tests-samples/heft-node-basic-tutorial/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests-samples/heft-node-jest-tutorial/config/rush-project.json
+++ b/build-tests-samples/heft-node-jest-tutorial/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests-samples/heft-storybook-react-tutorial/config/rush-project.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests-samples/heft-webpack-basic-tutorial/config/rush-project.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests-samples/packlets-tutorial/config/rush-project.json
+++ b/build-tests-samples/packlets-tutorial/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-documenter-test/config/rush-project.json
+++ b/build-tests/api-documenter-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-lib1-test/config/rush-project.json
+++ b/build-tests/api-extractor-lib1-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-lib2-test/config/rush-project.json
+++ b/build-tests/api-extractor-lib2-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-lib3-test/config/rush-project.json
+++ b/build-tests/api-extractor-lib3-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-scenarios/config/rush-project.json
+++ b/build-tests/api-extractor-scenarios/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-test-01/config/rush-project.json
+++ b/build-tests/api-extractor-test-01/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-test-02/config/rush-project.json
+++ b/build-tests/api-extractor-test-02/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-test-03/config/rush-project.json
+++ b/build-tests/api-extractor-test-03/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/api-extractor-test-04/config/rush-project.json
+++ b/build-tests/api-extractor-test-04/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/eslint-7-test/config/rush-project.json
+++ b/build-tests/eslint-7-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/heft-action-plugin-test/config/rush-project.json
+++ b/build-tests/heft-action-plugin-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-action-plugin/config/rush-project.json
+++ b/build-tests/heft-action-plugin/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-copy-files-test/config/rush-project.json
+++ b/build-tests/heft-copy-files-test/config/rush-project.json
@@ -1,21 +1,18 @@
 {
-  "projectOutputFolderNames": [
-    "out-all",
-
-    "out-all-except-for-images",
-
-    "out-all-linked",
-
-    "out-images-flattened",
-
-    "out-images1",
-
-    "out-images2",
-
-    "out-images3",
-
-    "out-images4",
-
-    "out-images5"
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": [
+        "out-all",
+        "out-all-except-for-images",
+        "out-all-linked",
+        "out-images-flattened",
+        "out-images1",
+        "out-images2",
+        "out-images3",
+        "out-images4",
+        "out-images5"
+      ]
+    }
   ]
 }

--- a/build-tests/heft-example-plugin-01/config/rush-project.json
+++ b/build-tests/heft-example-plugin-01/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-example-plugin-02/config/rush-project.json
+++ b/build-tests/heft-example-plugin-02/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-fastify-test/config/rush-project.json
+++ b/build-tests/heft-fastify-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-jest-reporters-test/config/rush-project.json
+++ b/build-tests/heft-jest-reporters-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-minimal-rig-test/config/rush-project.json
+++ b/build-tests/heft-minimal-rig-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-minimal-rig-usage-test/config/rush-project.json
+++ b/build-tests/heft-minimal-rig-usage-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-node-everything-esm-module-test/config/rush-project.json
+++ b/build-tests/heft-node-everything-esm-module-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-node-everything-test/config/rush-project.json
+++ b/build-tests/heft-node-everything-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-parameter-plugin-test/config/rush-project.json
+++ b/build-tests/heft-parameter-plugin-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/heft-parameter-plugin/config/rush-project.json
+++ b/build-tests/heft-parameter-plugin/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/heft-sass-test/config/rush-project.json
+++ b/build-tests/heft-sass-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-typescript-composite-test/config/rush-project.json
+++ b/build-tests/heft-typescript-composite-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib"]
+    }
+  ]
 }

--- a/build-tests/heft-webpack4-everything-test/config/rush-project.json
+++ b/build-tests/heft-webpack4-everything-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/heft-webpack5-everything-test/config/rush-project.json
+++ b/build-tests/heft-webpack5-everything-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/install-test-workspace/workspace/typescript-newest-test/config/rush-project.json
+++ b/build-tests/install-test-workspace/workspace/typescript-newest-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/install-test-workspace/workspace/typescript-v3-test/config/rush-project.json
+++ b/build-tests/install-test-workspace/workspace/typescript-v3-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/localization-plugin-test-01/config/rush-project.json
+++ b/build-tests/localization-plugin-test-01/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/localization-plugin-test-02/config/rush-project.json
+++ b/build-tests/localization-plugin-test-02/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/localization-plugin-test-03/config/rush-project.json
+++ b/build-tests/localization-plugin-test-03/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/build-tests/set-webpack-public-path-plugin-webpack4-test/config/rush-project.json
+++ b/build-tests/set-webpack-public-path-plugin-webpack4-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist-dev", "dist-prod"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist-dev", "dist-prod"]
+    }
+  ]
 }

--- a/build-tests/ts-command-line-test/config/rush-project.json
+++ b/build-tests/ts-command-line-test/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/common/changes/@microsoft/api-extractor-model/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@microsoft/api-extractor-model/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@microsoft/api-extractor/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/eslint-config/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/eslint-config/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-patch/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/eslint-patch/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/eslint-plugin-security/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/eslint-plugin/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/heft-config-file/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/heft-jest-plugin/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-node-rig/phasify-rigs_2022-01-07-03-12.json
+++ b/common/changes/@rushstack/heft-node-rig/phasify-rigs_2022-01-07-03-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-node-rig",
-      "comment": "Add a \"_phase:build\" cache configuration to config/rush-project.json.",
+      "comment": "Update the `rush-project.json` file to follow the new schema and configure the \"build\" command output folders for the \"_phase:build\" phase.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-node-rig/phasify-rigs_2022-01-07-03-12.json
+++ b/common/changes/@rushstack/heft-node-rig/phasify-rigs_2022-01-07-03-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Add a \"_phase:build\" cache configuration to config/rush-project.json.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-web-rig/phasify-rigs_2022-01-07-03-12.json
+++ b/common/changes/@rushstack/heft-web-rig/phasify-rigs_2022-01-07-03-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Add a \"_phase:build\" cache configuration to config/rush-project.json.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/changes/@rushstack/heft-web-rig/phasify-rigs_2022-01-07-03-12.json
+++ b/common/changes/@rushstack/heft-web-rig/phasify-rigs_2022-01-07-03-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-web-rig",
-      "comment": "Add a \"_phase:build\" cache configuration to config/rush-project.json.",
+      "comment": "Update the `rush-project.json` file to follow the new schema and configure the \"build\" command output folders for the \"_phase:build\" phase.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/heft/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/node-core-library/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/rig-package/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/rig-package/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rig-package",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rig-package"
+}

--- a/common/changes/@rushstack/tree-pattern/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/tree-pattern/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/tree-pattern",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern"
+}

--- a/common/changes/@rushstack/ts-command-line/phasify-rigs_2022-01-18-19-49.json
+++ b/common/changes/@rushstack/ts-command-line/phasify-rigs_2022-01-18-19-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -18,11 +18,12 @@ steps:
       # Prevent time-based browserslist update warning
       # See https://github.com/microsoft/rushstack/issues/2981
       BROWSERSLIST_IGNORE_OLD_DATA: 1
-  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
-    displayName: 'Rush Build (rush-lib)'
-    env:
-      # Prevent time-based browserslist update warning
-      # See https://github.com/microsoft/rushstack/issues/2981
-      BROWSERSLIST_IGNORE_OLD_DATA: 1
-  - script: 'node repo-scripts/repo-toolbox/lib/start.js readme --verify'
-    displayName: 'Ensure repo README is up-to-date'
+  # TEMPORARY - Put these back once Rush is published and updated in rush.json
+  # - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
+  #   displayName: 'Rush Build (rush-lib)'
+  #   env:
+  #     # Prevent time-based browserslist update warning
+  #     # See https://github.com/microsoft/rushstack/issues/2981
+  #     BROWSERSLIST_IGNORE_OLD_DATA: 1
+  # - script: 'node repo-scripts/repo-toolbox/lib/start.js readme --verify'
+  #   displayName: 'Ensure repo README is up-to-date'

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -16,14 +16,13 @@ steps:
     displayName: 'Rush Rebuild (install-run-rush)'
     env:
       # Prevent time-based browserslist update warning
-      # See https://github.com/microsoft/rushstack/issues/2981 
+      # See https://github.com/microsoft/rushstack/issues/2981
       BROWSERSLIST_IGNORE_OLD_DATA: 1
-# Re-enable after the schema changes to rush-project.json are published and pulled in
-#  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
-#    displayName: 'Rush Build (rush-lib)'
-#    env:
-#      # Prevent time-based browserslist update warning
-#      # See https://github.com/microsoft/rushstack/issues/2981
-#      BROWSERSLIST_IGNORE_OLD_DATA: 1
+  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
+    displayName: 'Rush Build (rush-lib)'
+    env:
+      # Prevent time-based browserslist update warning
+      # See https://github.com/microsoft/rushstack/issues/2981
+      BROWSERSLIST_IGNORE_OLD_DATA: 1
   - script: 'node repo-scripts/repo-toolbox/lib/start.js readme --verify'
     displayName: 'Ensure repo README is up-to-date'

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1036,14 +1036,6 @@ importers:
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.5.2
       typescript: 4.5.2
 
-  ../../build-tests/install-test-workspace:
-    specifiers:
-      '@microsoft/rush-lib': workspace:*
-      '@rushstack/node-core-library': workspace:*
-    devDependencies:
-      '@microsoft/rush-lib': link:../../apps/rush-lib
-      '@rushstack/node-core-library': link:../../libraries/node-core-library
-
   ../../build-tests/localization-plugin-test-01:
     specifiers:
       '@rushstack/localization-plugin': workspace:*

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f12214a1ca307d5f3529088a4a4f0ff66db0f03d",
+  "pnpmShrinkwrapHash": "c20c0967f9e8c9f41c244a45666d68e7d651beae",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }

--- a/eslint/eslint-config/config/rush-project.json
+++ b/eslint/eslint-config/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/eslint/eslint-patch/config/rush-project.json
+++ b/eslint/eslint-patch/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/eslint/eslint-plugin-packlets/config/rush-project.json
+++ b/eslint/eslint-plugin-packlets/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/eslint/eslint-plugin-security/config/rush-project.json
+++ b/eslint/eslint-plugin-security/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/eslint/eslint-plugin/config/rush-project.json
+++ b/eslint/eslint-plugin/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/heft-plugins/heft-jest-plugin/config/rush-project.json
+++ b/heft-plugins/heft-jest-plugin/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/libraries/heft-config-file/config/rush-project.json
+++ b/libraries/heft-config-file/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/libraries/node-core-library/config/rush-project.json
+++ b/libraries/node-core-library/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/libraries/rig-package/config/rush-project.json
+++ b/libraries/rig-package/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/libraries/tree-pattern/config/rush-project.json
+++ b/libraries/tree-pattern/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/libraries/ts-command-line/config/rush-project.json
+++ b/libraries/ts-command-line/config/rush-project.json
@@ -1,0 +1,8 @@
+{
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    }
+  ]
+}

--- a/repo-scripts/generate-api-docs/config/rush-project.json
+++ b/repo-scripts/generate-api-docs/config/rush-project.json
@@ -1,3 +1,8 @@
 {
-  "projectOutputFolderNames": ["lib", "dist"]
+  "operationSettings": [
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
 }

--- a/rigs/heft-node-rig/profiles/default/config/rush-project.json
+++ b/rigs/heft-node-rig/profiles/default/config/rush-project.json
@@ -1,3 +1,10 @@
 {
-  "projectOutputFolderNames": ["dist", "lib", "temp"]
+  "projectOutputFolderNames": ["dist", "lib", "temp"],
+
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:build",
+      "projectOutputFolderNames": ["dist", "lib", "temp"]
+    }
+  ]
 }

--- a/rigs/heft-node-rig/profiles/default/config/rush-project.json
+++ b/rigs/heft-node-rig/profiles/default/config/rush-project.json
@@ -1,10 +1,12 @@
 {
-  "projectOutputFolderNames": ["dist", "lib", "temp"],
-
-  "phaseOptions": [
+  "operationSettings": [
     {
-      "phaseName": "_phase:build",
-      "projectOutputFolderNames": ["dist", "lib", "temp"]
+      "operationName": "_phase:build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+    },
+    {
+      "operationName": "build",
+      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
     }
   ]
 }

--- a/rigs/heft-web-rig/profiles/library/config/rush-project.json
+++ b/rigs/heft-web-rig/profiles/library/config/rush-project.json
@@ -1,10 +1,12 @@
 {
-  "projectOutputFolderNames": ["dist", "lib", "lib-commonjs", "temp"],
-
-  "phaseOptions": [
+  "operationSettings": [
     {
-      "phaseName": "_phase:build",
-      "projectOutputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
+      "operationName": "_phase:build",
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
+    },
+    {
+      "operationName": "build",
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
     }
   ]
 }

--- a/rigs/heft-web-rig/profiles/library/config/rush-project.json
+++ b/rigs/heft-web-rig/profiles/library/config/rush-project.json
@@ -1,3 +1,10 @@
 {
-  "projectOutputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
+  "projectOutputFolderNames": ["dist", "lib", "lib-commonjs", "temp"],
+
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:build",
+      "projectOutputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
+    }
+  ]
 }

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.57.1",
+  "rushVersion": "5.60.0-rc.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.60.0-rc.0",
+  "rushVersion": "5.60.0-rc.1",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/rush.json
+++ b/rush.json
@@ -747,12 +747,12 @@
       "shouldPublish": false
     },
 
-    {
-      "packageName": "install-test-workspace",
-      "projectFolder": "build-tests/install-test-workspace",
-      "reviewCategory": "tests",
-      "shouldPublish": false
-    },
+    // {
+    //   "packageName": "install-test-workspace",
+    //   "projectFolder": "build-tests/install-test-workspace",
+    //   "reviewCategory": "tests",
+    //   "shouldPublish": false
+    // },
     {
       "packageName": "localization-plugin-test-01",
       "projectFolder": "build-tests/localization-plugin-test-01",


### PR DESCRIPTION
Adds a `_phase:build` output entry to `rush-project.json` in the rigs.
