### PR TITLE
[rush-lib] Fix plugin command line

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -100,9 +100,9 @@ const DEFAULT_REBUILD_COMMAND_JSON: IBulkCommandJson = {
 
 export interface ICommandLineConfigurationOptions {
   /**
-   * If true, do not add default build, rebuild commands.
+   * If true, do not include default build and rebuild commands.
    */
-  disableDefaultBuildCommands?: boolean;
+  doNotIncludeDefaultBuildCommands?: boolean;
 }
 
 /**
@@ -141,7 +141,7 @@ export class CommandLineConfiguration {
     commandLineJson: ICommandLineJson | undefined,
     options: ICommandLineConfigurationOptions = {}
   ) {
-    const { disableDefaultBuildCommands } = options;
+    const { doNotIncludeDefaultBuildCommands: disableDefaultBuildCommands } = options;
     if (commandLineJson?.phases) {
       const phaseNameRegexp: RegExp = new RegExp(
         `^${RushConstants.phaseNamePrefix}[a-z][a-z0-9]*([-][a-z0-9]+)*$`

--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -511,12 +511,18 @@ export class CommandLineConfiguration {
    */
   public static loadFromFileOrDefault(jsonFilePath?: string): CommandLineConfiguration {
     let commandLineJson: ICommandLineJson | undefined = undefined;
-    if (jsonFilePath && FileSystem.exists(jsonFilePath)) {
-      commandLineJson = JsonFile.load(jsonFilePath);
+    if (jsonFilePath) {
+      try {
+        commandLineJson = JsonFile.load(jsonFilePath);
+      } catch (e) {
+        if (!FileSystem.isNotExistError(e as Error)) {
+          throw e;
+        }
+      }
 
       // merge commands specified in command-line.json and default (re)build settings
       // Ensure both build commands are included and preserve any other commands specified
-      if (commandLineJson && commandLineJson.commands) {
+      if (commandLineJson?.commands) {
         for (let i: number = 0; i < commandLineJson.commands.length; i++) {
           const command: CommandJson = commandLineJson.commands[i];
 

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -87,8 +87,12 @@ export abstract class PluginLoaderBase<
     if (!commandLineJsonFilePath || !FileSystem.exists(commandLineJsonFilePath)) {
       return undefined;
     }
-    const commandLineConfiguration: CommandLineConfiguration =
-      CommandLineConfiguration.loadFromFileOrDefault(commandLineJsonFilePath);
+    const commandLineConfiguration: CommandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(
+      commandLineJsonFilePath,
+      {
+        disableDefaultBuildCommands: true
+      }
+    );
     for (const additionalPathFolder of this._getCommandLineAdditionalPathFolders().reverse()) {
       commandLineConfiguration.prependAdditionalPathFolder(additionalPathFolder);
     }

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -84,18 +84,19 @@ export abstract class PluginLoaderBase<
 
   public getCommandLineConfiguration(): CommandLineConfiguration | undefined {
     const commandLineJsonFilePath: string | undefined = this._getCommandLineJsonFilePath();
-    if (!commandLineJsonFilePath || !FileSystem.exists(commandLineJsonFilePath)) {
+    if (!commandLineJsonFilePath) {
       return undefined;
     }
-    const commandLineConfiguration: CommandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(
-      commandLineJsonFilePath,
-      {
-        doNotIncludeDefaultBuildCommands: true
-      }
-    );
+    const commandLineConfiguration: CommandLineConfiguration | undefined =
+      CommandLineConfiguration.tryLoadFromFile(commandLineJsonFilePath);
+    if (!commandLineConfiguration) {
+      return undefined;
+    }
+
     for (const additionalPathFolder of this._getCommandLineAdditionalPathFolders().reverse()) {
       commandLineConfiguration.prependAdditionalPathFolder(additionalPathFolder);
     }
+
     commandLineConfiguration.shellCommandTokenContext = {
       packageFolder: this.packageFolder
     };

--- a/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -90,7 +90,7 @@ export abstract class PluginLoaderBase<
     const commandLineConfiguration: CommandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(
       commandLineJsonFilePath,
       {
-        disableDefaultBuildCommands: true
+        doNotIncludeDefaultBuildCommands: true
       }
     );
     for (const additionalPathFolder of this._getCommandLineAdditionalPathFolders().reverse()) {

--- a/common/changes/@microsoft/rush/fix-plugin-command-line_2022-01-14-07-23.json
+++ b/common/changes/@microsoft/rush/fix-plugin-command-line_2022-01-14-07-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes rush plugin error on duplicate build commands",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION

## Summary

Fixes https://github.com/microsoft/rushstack/issues/3155

## Details

Add a option named `disableDefaultBuildCommands` for `CommandLineConfiguration`, when plugin calls `CommandLineConfiguration` set up `disableDefaultBuildCommands` to true to avoid duplicate build command definitions.

## How it was tested

Local

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
