### PR TITLE
[rush] Update rush-project.json to follow new proposed schema.

### DIFF
--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -16,18 +16,6 @@ import { OverlappingPathAnalyzer } from '../utilities/OverlappingPathAnalyzer';
  */
 export interface IRushProjectJson {
   /**
-   * A list of folder names under the project root that should be cached.
-   *
-   * These folders should not be tracked by git.
-   */
-  projectOutputFolderNames?: string[];
-
-  /**
-   * Options for individual phases.
-   */
-  phaseOptions?: IRushProjectJsonPhaseOptionsJson[];
-
-  /**
    * The incremental analyzer can skip Rush commands for projects whose input files have
    * not changed since the last build. Normally, every Git-tracked file under the project
    * folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific
@@ -37,70 +25,46 @@ export interface IRushProjectJson {
   incrementalBuildIgnoredGlobs?: string[];
 
   /**
-   * Additional project-specific options related to build caching.
-   */
-  buildCacheOptions?: IBuildCacheOptionsJson;
-}
-
-export interface IRushProjectJsonPhaseOptionsJson {
-  /**
-   * The name of the phase. This is the name that appears in command-line.json.
-   */
-  phaseName: string;
-
-  /**
-   * A list of folder names under the project root that should be cached.
-   *
-   * These folders should not be tracked by git.
-   */
-  projectOutputFolderNames?: string[];
-}
-
-export interface IBuildCacheOptionsJson extends IBuildCacheOptionsBase {
-  /**
-   * Allows for fine-grained control of cache for individual commands.
-   */
-  optionsForCommands?: ICacheOptionsForCommand[];
-}
-
-export interface IBuildCacheOptionsBase {
-  /**
    * Disable caching for this project. The project will never be restored from cache.
    * This may be useful if this project affects state outside of its folder.
    *
-   * This option is only used when the cloud build cache is enabled for the repo. You can set
-   * disableBuildCache=true to disable caching for a specific project. This is a useful workaround
+   * This option is only used when the build cache is enabled for the repo. You can set
+   * disableBuildCacheForProject=true to disable caching for a specific project. This is a useful workaround
    * if that project's build scripts violate the assumptions of the cache, for example by writing
    * files outside the project folder. Where possible, a better solution is to improve the build scripts
    * to be compatible with caching.
    */
-  disableBuildCache?: boolean;
+  disableBuildCacheForProject?: boolean;
+
+  operationSettings?: IOperationSettings[];
 }
 
-export interface IBuildCacheOptions extends IBuildCacheOptionsBase {
+export interface IOperationSettings {
   /**
-   * Allows for fine-grained control of cache for individual commands.
+   * The name of the operation. This should be a key in the `package.json`'s `scripts` object.
    */
-  optionsForCommandsByName: Map<string, ICacheOptionsForCommand>;
-}
-
-export interface ICacheOptionsForCommand {
-  /**
-   * The command name.
-   */
-  name: string;
+  operationName: string;
 
   /**
-   * Disable caching for this command.
-   * This may be useful if this command for this project affects state outside of this project folder.
+   * Specify the folders where this operation writes its output files. If enabled, the Rush build
+   * cache will restore these folders from the cache. The strings are folder names under the project
+   * root folder.
    *
-   * This option is only used when the cloud build cache is enabled for the repo. You can set
-   * disableBuildCache=true to disable caching for a command in a specific project. This is a useful workaround
-   * if that project's build scripts violate the assumptions of the cache, for example by writing
-   * files outside the project folder. Where possible, a better solution is to improve the build scripts
-   * to be compatible with caching.
+   * These folders should not be tracked by Git. They must not contain symlinks.
    */
-  disableBuildCache?: boolean;
+  outputFolderNames?: string[];
+
+  /**
+   * Disable caching for this operation. The operation will never be restored from cache.
+   * This may be useful if this operation affects state outside of its folder.
+   *
+   * This option is only used when the build cache is enabled for the repo. You can set
+   * disableBuildCacheForOperation=true to disable caching for a specific project operation.
+   * This is a useful workaround if that project's build scripts violate the assumptions of the cache,
+   * for example by writing files outside the project folder. Where possible, a better solution is to improve
+   * the build scripts to be compatible with caching.
+   */
+  disableBuildCacheForOperation?: boolean;
 }
 
 export const RUSH_PROJECT_CONFIGURATION_FILE: ConfigurationFile<IRushProjectJson> =
@@ -108,95 +72,71 @@ export const RUSH_PROJECT_CONFIGURATION_FILE: ConfigurationFile<IRushProjectJson
     projectRelativeFilePath: `config/${RushConstants.rushProjectConfigFilename}`,
     jsonSchemaPath: path.resolve(__dirname, '..', 'schemas', 'rush-project.schema.json'),
     propertyInheritance: {
-      projectOutputFolderNames: {
-        inheritanceType: InheritanceType.append
-      },
-      phaseOptions: {
+      operationSettings: {
         inheritanceType: InheritanceType.custom,
         inheritanceFunction: (
-          child: IRushProjectJsonPhaseOptionsJson[] | undefined,
-          parent: IRushProjectJsonPhaseOptionsJson[] | undefined
+          child: IOperationSettings[] | undefined,
+          parent: IOperationSettings[] | undefined
         ) => {
           if (!child) {
             return parent;
           } else if (!parent) {
             return child;
           } else {
-            // Merge the projectOutputFolderNames arrays
-
-            const resultPhaseOptionsByPhaseName: Map<string, IRushProjectJsonPhaseOptionsJson> = new Map();
-            for (const parentPhaseOptions of parent) {
-              resultPhaseOptionsByPhaseName.set(parentPhaseOptions.phaseName, parentPhaseOptions);
+            // Merge the outputFolderNames arrays
+            const resultOperationSettingsByOperationName: Map<string, IOperationSettings> = new Map();
+            for (const parentOperationSettings of parent) {
+              resultOperationSettingsByOperationName.set(
+                parentOperationSettings.operationName,
+                parentOperationSettings
+              );
             }
 
-            const childEncounteredPhaseNames: Set<string> = new Set();
-            for (const childPhaseOptions of child) {
-              const phaseName: string = childPhaseOptions.phaseName;
-              if (childEncounteredPhaseNames.has(phaseName)) {
-                // If the phase options already exist, but didn't come from the parent, then
+            const childEncounteredOperationNames: Set<string> = new Set();
+            for (const childOperationSettings of child) {
+              const operationName: string = childOperationSettings.operationName;
+              if (childEncounteredOperationNames.has(operationName)) {
+                // If the operation settings already exist, but didn't come from the parent, then
                 // it shows up multiple times in the child.
                 const childSourceFilePath: string =
                   RUSH_PROJECT_CONFIGURATION_FILE.getObjectSourceFilePath(child)!;
                 throw new Error(
-                  `The phase "${phaseName}" occurs multiple times in the "phaseOptions" array ` +
+                  `The operation "${operationName}" occurs multiple times in the "operationSettings" array ` +
                     `in "${childSourceFilePath}".`
                 );
               }
 
-              childEncounteredPhaseNames.add(phaseName);
+              childEncounteredOperationNames.add(operationName);
 
-              let mergedPhaseOptions: IRushProjectJsonPhaseOptionsJson | undefined =
-                resultPhaseOptionsByPhaseName.get(phaseName);
-              if (mergedPhaseOptions) {
-                // The parent phase options object already exists, so append to the projectOutputFolderNames
-                const projectOutputFolderNames: string[] | undefined =
-                  mergedPhaseOptions.projectOutputFolderNames && childPhaseOptions.projectOutputFolderNames
+              let mergedOperationSettings: IOperationSettings | undefined =
+                resultOperationSettingsByOperationName.get(operationName);
+              if (mergedOperationSettings) {
+                // The parent operation settings object already exists, so append to the outputFolderNames
+                const outputFolderNames: string[] | undefined =
+                  mergedOperationSettings.outputFolderNames && childOperationSettings.outputFolderNames
                     ? [
-                        ...mergedPhaseOptions.projectOutputFolderNames,
-                        ...childPhaseOptions.projectOutputFolderNames
+                        ...mergedOperationSettings.outputFolderNames,
+                        ...childOperationSettings.outputFolderNames
                       ]
-                    : mergedPhaseOptions.projectOutputFolderNames ||
-                      childPhaseOptions.projectOutputFolderNames;
+                    : mergedOperationSettings.outputFolderNames || childOperationSettings.outputFolderNames;
 
-                mergedPhaseOptions = {
-                  ...mergedPhaseOptions,
-                  ...childPhaseOptions,
-                  projectOutputFolderNames
+                mergedOperationSettings = {
+                  ...mergedOperationSettings,
+                  ...childOperationSettings,
+                  outputFolderNames
                 };
-                resultPhaseOptionsByPhaseName.set(phaseName, mergedPhaseOptions);
+                resultOperationSettingsByOperationName.set(operationName, mergedOperationSettings);
               } else {
-                resultPhaseOptionsByPhaseName.set(phaseName, childPhaseOptions);
+                resultOperationSettingsByOperationName.set(operationName, childOperationSettings);
               }
             }
 
-            return Array.from(resultPhaseOptionsByPhaseName.values());
+            return Array.from(resultOperationSettingsByOperationName.values());
           }
         }
       },
       incrementalBuildIgnoredGlobs: {
         inheritanceType: InheritanceType.replace
-      },
-      buildCacheOptions: {
-        inheritanceType: InheritanceType.custom,
-        inheritanceFunction: (
-          current: IBuildCacheOptionsJson | undefined,
-          parent: IBuildCacheOptionsJson | undefined
-        ): IBuildCacheOptionsJson | undefined => {
-          if (!current) {
-            return parent;
-          } else if (!parent) {
-            return current;
-          } else {
-            return {
-              ...parent,
-              ...current,
-              optionsForCommands: [
-                ...(parent.optionsForCommands || []),
-                ...(current.optionsForCommands || [])
-              ]
-            };
-          }
-        }
       }
     }
   });
@@ -214,53 +154,26 @@ export class RushProjectConfiguration {
   public readonly project: RushConfigurationProject;
 
   /**
-   * A list of folder names under the project root that should be cached for each phase.
-   *
-   * These folders should not be tracked by git.
-   *
-   * @remarks
-   * The `projectOutputFolderNames` property is populated in a "build" entry
+   * {@inheritdoc IRushProjectJson.incrementalBuildIgnoredGlobs}
    */
-  public readonly projectOutputFolderNamesForPhases: ReadonlyMap<string, ReadonlyArray<string>>;
+  public readonly incrementalBuildIgnoredGlobs: ReadonlyArray<string>;
 
   /**
-   * The incremental analyzer can skip Rush commands for projects whose input files have
-   * not changed since the last build. Normally, every Git-tracked file under the project
-   * folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific
-   * files, specified as globs relative to the project folder. The list of file globs will
-   * be interpreted the same way your .gitignore file is.
+   * {@inheritdoc IRushProjectJson.disableBuildCacheForProject}
    */
-  public readonly incrementalBuildIgnoredGlobs?: ReadonlyArray<string>;
+  public readonly disableBuildCacheForProject: boolean;
 
-  /**
-   * Project-specific cache options.
-   */
-  public readonly cacheOptions: IBuildCacheOptions;
+  public readonly operationSettingsByOperationName: ReadonlyMap<string, Readonly<IOperationSettings>>;
 
   private constructor(
     project: RushConfigurationProject,
     rushProjectJson: IRushProjectJson,
-    projectOutputFolderNamesForPhases: ReadonlyMap<string, ReadonlyArray<string>>
+    operationSettingsByOperationName: ReadonlyMap<string, IOperationSettings>
   ) {
     this.project = project;
-
-    this.projectOutputFolderNamesForPhases = projectOutputFolderNamesForPhases;
-
-    this.incrementalBuildIgnoredGlobs = rushProjectJson.incrementalBuildIgnoredGlobs;
-
-    const optionsForCommandsByName: Map<string, ICacheOptionsForCommand> = new Map<
-      string,
-      ICacheOptionsForCommand
-    >();
-    if (rushProjectJson.buildCacheOptions?.optionsForCommands) {
-      for (const cacheOptionsForCommand of rushProjectJson.buildCacheOptions.optionsForCommands) {
-        optionsForCommandsByName.set(cacheOptionsForCommand.name, cacheOptionsForCommand);
-      }
-    }
-    this.cacheOptions = {
-      disableBuildCache: rushProjectJson.buildCacheOptions?.disableBuildCache,
-      optionsForCommandsByName
-    };
+    this.incrementalBuildIgnoredGlobs = rushProjectJson.incrementalBuildIgnoredGlobs || [];
+    this.disableBuildCacheForProject = rushProjectJson.disableBuildCacheForProject || false;
+    this.operationSettingsByOperationName = operationSettingsByOperationName;
   }
 
   /**
@@ -342,163 +255,79 @@ export class RushProjectConfiguration {
     repoCommandLineConfiguration: CommandLineConfiguration,
     terminal: ITerminal
   ): RushProjectConfiguration {
-    if (rushProjectJson.projectOutputFolderNames) {
-      const overlappingPathAnalyzer: OverlappingPathAnalyzer<boolean> =
-        new OverlappingPathAnalyzer<boolean>();
-
-      const invalidFolderNames: string[] = [];
-      for (const projectOutputFolder of rushProjectJson.projectOutputFolderNames) {
-        if (projectOutputFolder.match(/[\\]/)) {
-          invalidFolderNames.push(projectOutputFolder);
-        }
-
-        const overlaps: boolean = !!overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(
-          projectOutputFolder,
-          true
-        );
-        if (overlaps) {
-          terminal.writeErrorLine(
-            `The project output folder name "${projectOutputFolder}" is invalid because it overlaps with another folder name.`
-          );
-          throw new AlreadyReportedError();
-        }
-      }
-
-      if (invalidFolderNames.length > 0) {
-        terminal.writeErrorLine(
-          `Invalid project configuration for project "${project.packageName}". Entries in ` +
-            '"projectOutputFolderNames" must not contain backslashes and the following entries do: ' +
-            invalidFolderNames.join(', ')
-        );
-      }
-    }
-
-    const duplicateCommandNames: Set<string> = new Set<string>();
-    const invalidCommandNames: string[] = [];
-    if (rushProjectJson.buildCacheOptions?.optionsForCommands) {
-      const commandNames: Set<string> = new Set<string>();
-      for (const [commandName, command] of repoCommandLineConfiguration.commands) {
-        if (command.commandKind === RushConstants.phasedCommandKind) {
-          commandNames.add(commandName);
-        }
-      }
-
-      const alreadyEncounteredCommandNames: Set<string> = new Set<string>();
-      for (const cacheOptionsForCommand of rushProjectJson.buildCacheOptions.optionsForCommands) {
-        const commandName: string = cacheOptionsForCommand.name;
-        if (!commandNames.has(commandName)) {
-          invalidCommandNames.push(commandName);
-        } else if (alreadyEncounteredCommandNames.has(commandName)) {
-          duplicateCommandNames.add(commandName);
-        } else {
-          alreadyEncounteredCommandNames.add(commandName);
-        }
-      }
-    }
-
-    if (invalidCommandNames.length > 0) {
-      terminal.writeErrorLine(
-        `Invalid project configuration fpr project "${project.packageName}". The following ` +
-          'command names in cacheOptions.optionsForCommands are not specified in this repo: ' +
-          invalidCommandNames.join(', ')
-      );
-    }
-
-    if (duplicateCommandNames.size > 0) {
-      terminal.writeErrorLine(
-        `Invalid project configuration fpr project "${project.packageName}". The following ` +
-          'command names in cacheOptions.optionsForCommands are specified more than once: ' +
-          Array.from(duplicateCommandNames).join(', ')
-      );
-    }
-
-    const projectOutputFolderNamesForPhases: Map<string, string[]> = new Map<string, string[]>();
-    if (rushProjectJson.projectOutputFolderNames) {
-      projectOutputFolderNamesForPhases.set(
-        RushConstants.buildCommandName,
-        rushProjectJson.projectOutputFolderNames
-      );
-    }
-
-    if (rushProjectJson.phaseOptions) {
+    const operationSettingsByOperationName: Map<string, IOperationSettings> = new Map<
+      string,
+      IOperationSettings
+    >();
+    if (rushProjectJson.operationSettings) {
       const overlappingPathAnalyzer: OverlappingPathAnalyzer<string> = new OverlappingPathAnalyzer<string>();
-      const phaseOptionsByPhase: Map<string, IRushProjectJsonPhaseOptionsJson> = new Map<
-        string,
-        IRushProjectJsonPhaseOptionsJson
-      >();
-      for (const phaseOptions of rushProjectJson.phaseOptions) {
-        const phaseName: string = phaseOptions.phaseName;
-        const existingPhaseOptions: IRushProjectJsonPhaseOptionsJson | undefined =
-          phaseOptionsByPhase.get(phaseName);
-        if (existingPhaseOptions) {
-          const existingPhaseOptionsJsonPath: string | undefined =
-            RUSH_PROJECT_CONFIGURATION_FILE.getObjectSourceFilePath(existingPhaseOptions);
-          const phaseOptionsJsonPath: string | undefined =
-            RUSH_PROJECT_CONFIGURATION_FILE.getObjectSourceFilePath(phaseOptions);
+      for (const operationSettings of rushProjectJson.operationSettings) {
+        const operationName: string = operationSettings.operationName;
+        const existingOperationSettings: IOperationSettings | undefined =
+          operationSettingsByOperationName.get(operationName);
+        if (existingOperationSettings) {
+          const existingOperationSettingsJsonPath: string | undefined =
+            RUSH_PROJECT_CONFIGURATION_FILE.getObjectSourceFilePath(existingOperationSettings);
+          const operationSettingsJsonPath: string | undefined =
+            RUSH_PROJECT_CONFIGURATION_FILE.getObjectSourceFilePath(operationSettings);
           let errorMessage: string =
-            `The phase "${phaseName}" appears multiple times in the "${project.packageName}" project's ` +
+            `The operation "${operationName}" appears multiple times in the "${project.packageName}" project's ` +
             `${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath} file's ` +
-            'phaseOptions property.';
-          if (existingPhaseOptionsJsonPath && phaseOptionsJsonPath) {
-            if (existingPhaseOptionsJsonPath !== phaseOptionsJsonPath) {
+            'operationSettings property.';
+          if (existingOperationSettingsJsonPath && operationSettingsJsonPath) {
+            if (existingOperationSettingsJsonPath !== operationSettingsJsonPath) {
               errorMessage +=
-                ` It first appears in "${existingPhaseOptionsJsonPath}" and again ` +
-                `in "${phaseOptionsJsonPath}".`;
+                ` It first appears in "${existingOperationSettingsJsonPath}" and again ` +
+                `in "${operationSettingsJsonPath}".`;
             } else if (
-              !Path.convertToSlashes(existingPhaseOptionsJsonPath).startsWith(
+              !Path.convertToSlashes(existingOperationSettingsJsonPath).startsWith(
                 Path.convertToSlashes(project.projectFolder)
               )
             ) {
-              errorMessage += ` It appears multiple times in "${phaseOptionsJsonPath}".`;
+              errorMessage += ` It appears multiple times in "${operationSettingsJsonPath}".`;
             }
           }
 
           terminal.writeErrorLine(errorMessage);
-        } else if (!repoCommandLineConfiguration.phases.has(phaseName)) {
+        } else if (!repoCommandLineConfiguration.phases.has(operationName)) {
           terminal.writeErrorLine(
             `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}"` +
-              ` for project "${project.packageName}". Phase "${phaseName}" is not defined in the repo's ${RushConstants.commandLineFilename}.`
+              ` for project "${project.packageName}". Operation "${operationName}" is not defined in the repo's ${RushConstants.commandLineFilename}.`
           );
         } else {
-          phaseOptionsByPhase.set(phaseOptions.phaseName, phaseOptions);
-          if (phaseOptions.projectOutputFolderNames) {
-            projectOutputFolderNamesForPhases.set(
-              phaseOptions.phaseName,
-              phaseOptions.projectOutputFolderNames
-            );
-          }
+          operationSettingsByOperationName.set(operationName, operationSettings);
         }
 
-        if (phaseOptions.projectOutputFolderNames) {
-          for (const projectOutputFolderName of phaseOptions.projectOutputFolderNames) {
-            const overlappingPhaseNames: string[] | undefined =
-              overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(projectOutputFolderName, phaseName);
-            if (overlappingPhaseNames) {
-              const overlapsWithOwnPhase: boolean = overlappingPhaseNames?.includes(phaseName);
-              if (overlapsWithOwnPhase) {
-                if (overlappingPhaseNames.length === 1) {
+        if (operationSettings.outputFolderNames) {
+          for (const outputFolderName of operationSettings.outputFolderNames) {
+            const overlappingOperationNames: string[] | undefined =
+              overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(outputFolderName, operationName);
+            if (overlappingOperationNames) {
+              const overlapsWithOwnOperation: boolean = overlappingOperationNames?.includes(operationName);
+              if (overlapsWithOwnOperation) {
+                if (overlappingOperationNames.length === 1) {
                   terminal.writeErrorLine(
                     `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                      `for project "${project.packageName}". The project output folder name "${projectOutputFolderName}" in ` +
-                      `phase ${phaseName} overlaps with another folder name in the same phase.`
+                      `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                      `operation ${operationName} overlaps with another folder name in the same operation.`
                   );
                 } else {
-                  const otherPhaseNames: string[] = overlappingPhaseNames.filter(
-                    (overlappingPhaseName) => overlappingPhaseName !== phaseName
+                  const otherOperationNames: string[] = overlappingOperationNames.filter(
+                    (overlappingOperationName) => overlappingOperationName !== operationName
                   );
                   terminal.writeErrorLine(
                     `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                      `for project "${project.packageName}". The project output folder name "${projectOutputFolderName}" in ` +
-                      `phase ${phaseName} overlaps with other folder names in the same phase and with ` +
-                      `folder names in the following other phases: ${otherPhaseNames.join(', ')}.`
+                      `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                      `operation ${operationName} overlaps with other folder names in the same operation and with ` +
+                      `folder names in the following other operations: ${otherOperationNames.join(', ')}.`
                   );
                 }
               } else {
                 terminal.writeErrorLine(
                   `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                    `for project "${project.packageName}". The project output folder name "${projectOutputFolderName}" in ` +
-                    `phase ${phaseName} overlaps with other folder name(s) in the following other phases: ` +
-                    `${overlappingPhaseNames.join(', ')}.`
+                    `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                    `operation ${operationName} overlaps with other folder name(s) in the following other operations: ` +
+                    `${overlappingOperationNames.join(', ')}.`
                 );
               }
 
@@ -509,6 +338,6 @@ export class RushProjectConfiguration {
       }
     }
 
-    return new RushProjectConfiguration(project, rushProjectJson, projectOutputFolderNamesForPhases);
+    return new RushProjectConfiguration(project, rushProjectJson, operationSettingsByOperationName);
   }
 }

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -289,11 +289,6 @@ export class RushProjectConfiguration {
           }
 
           terminal.writeErrorLine(errorMessage);
-        } else if (!repoCommandLineConfiguration.phases.has(operationName)) {
-          terminal.writeErrorLine(
-            `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}"` +
-              ` for project "${project.packageName}". Operation "${operationName}" is not defined in the repo's ${RushConstants.commandLineFilename}.`
-          );
         } else {
           operationSettingsByOperationName.set(operationName, operationSettings);
         }

--- a/apps/rush-lib/src/api/test/RushProjectConfiguration.test.ts
+++ b/apps/rush-lib/src/api/test/RushProjectConfiguration.test.ts
@@ -11,29 +11,23 @@ describe(RushProjectConfiguration.name, () => {
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
     const rushProjectJson: IRushProjectJson =
       await RUSH_PROJECT_CONFIGURATION_FILE.loadConfigurationFileForProjectAsync(terminal, testFolder);
-    expect(rushProjectJson.projectOutputFolderNames).toMatchInlineSnapshot(`
-      Array [
-        "a",
-        "b",
-      ]
-    `);
-    expect(rushProjectJson.phaseOptions?.length).toEqual(2);
-    expect(rushProjectJson.phaseOptions?.[0].phaseName).toMatchInlineSnapshot(`"_phase:a"`);
-    expect(rushProjectJson.phaseOptions?.[0].projectOutputFolderNames).toMatchInlineSnapshot(`
+    expect(rushProjectJson.operationSettings?.length).toEqual(2);
+    expect(rushProjectJson.operationSettings?.[0].operationName).toMatchInlineSnapshot(`"_phase:a"`);
+    expect(rushProjectJson.operationSettings?.[0].outputFolderNames).toMatchInlineSnapshot(`
       Array [
         "a-a",
         "a-b",
       ]
     `);
-    expect(rushProjectJson.phaseOptions?.[1].phaseName).toMatchInlineSnapshot(`"_phase:b"`);
-    expect(rushProjectJson.phaseOptions?.[1].projectOutputFolderNames).toMatchInlineSnapshot(`
+    expect(rushProjectJson.operationSettings?.[1].operationName).toMatchInlineSnapshot(`"_phase:b"`);
+    expect(rushProjectJson.operationSettings?.[1].outputFolderNames).toMatchInlineSnapshot(`
       Array [
         "b-a",
       ]
     `);
   });
 
-  it('throws an error when loading a rush-project.json config that lists a phase twice', async () => {
+  it('throws an error when loading a rush-project.json config that lists an operation twice', async () => {
     const testFolder: string = `${__dirname}/jsonFiles/test-project-b`;
     const terminal: Terminal = new Terminal(new StringBufferTerminalProvider());
     try {
@@ -44,7 +38,7 @@ describe(RushProjectConfiguration.name, () => {
         .replace(/\\/g, '/')
         .replace(testFolder.replace(/\\/g, '/'), '<testFolder>');
       expect(errorMessage).toMatchInlineSnapshot(
-        `"The phase \\"_phase:a\\" occurs multiple times in the \\"phaseOptions\\" array in \\"<testFolder>/config/rush-project.json\\"."`
+        `"The operation \\"_phase:a\\" occurs multiple times in the \\"operationSettings\\" array in \\"<testFolder>/config/rush-project.json\\"."`
       );
     }
   });

--- a/apps/rush-lib/src/api/test/jsonFiles/rush-project-base.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/rush-project-base.json
@@ -1,14 +1,12 @@
 {
-  "projectOutputFolderNames": ["a"],
-
-  "phaseOptions": [
+  "operationSettings": [
     {
-      "phaseName": "_phase:a",
-      "projectOutputFolderNames": ["a-a"]
+      "operationName": "_phase:a",
+      "outputFolderNames": ["a-a"]
     },
     {
-      "phaseName": "_phase:b",
-      "projectOutputFolderNames": ["b-a"]
+      "operationName": "_phase:b",
+      "outputFolderNames": ["b-a"]
     }
   ]
 }

--- a/apps/rush-lib/src/api/test/jsonFiles/test-project-a/config/rush-project.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/test-project-a/config/rush-project.json
@@ -1,11 +1,10 @@
 {
   "extends": "../../rush-project-base.json",
-  "projectOutputFolderNames": ["b"],
 
-  "phaseOptions": [
+  "operationSettings": [
     {
-      "phaseName": "_phase:a",
-      "projectOutputFolderNames": ["a-b"]
+      "operationName": "_phase:a",
+      "outputFolderNames": ["a-b"]
     }
   ]
 }

--- a/apps/rush-lib/src/api/test/jsonFiles/test-project-b/config/rush-project.json
+++ b/apps/rush-lib/src/api/test/jsonFiles/test-project-b/config/rush-project.json
@@ -1,15 +1,14 @@
 {
   "extends": "../../rush-project-base.json",
-  "projectOutputFolderNames": ["b"],
 
-  "phaseOptions": [
+  "operationSettings": [
     {
-      "phaseName": "_phase:a",
-      "projectOutputFolderNames": ["a-b"]
+      "operationName": "_phase:a",
+      "outputFolderNames": ["a-b"]
     },
     {
-      "phaseName": "_phase:a",
-      "projectOutputFolderNames": ["a-c"]
+      "operationName": "_phase:a",
+      "outputFolderNames": ["a-c"]
     }
   ]
 }

--- a/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
@@ -34,7 +34,7 @@ import { BaseTaskRunner, ITaskRunnerContext } from './BaseTaskRunner';
 import { ProjectLogWritable } from './ProjectLogWritable';
 import { ProjectBuildCache } from '../buildCache/ProjectBuildCache';
 import type { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
-import { ICacheOptionsForCommand, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { CollatedTerminalProvider } from '../../utilities/CollatedTerminalProvider';
 import type { CommandLineConfiguration, IPhase } from '../../api/CommandLineConfiguration';
 import { RushConstants } from '../RushConstants';
@@ -413,18 +413,18 @@ export class ProjectTaskRunner extends BaseTaskRunner {
             terminal
           );
         if (projectConfiguration) {
-          if (projectConfiguration.cacheOptions?.disableBuildCache) {
+          if (projectConfiguration.disableBuildCacheForProject) {
             terminal.writeVerboseLine('Caching has been disabled for this project.');
           } else {
-            const commandOptions: ICacheOptionsForCommand | undefined =
-              projectConfiguration.cacheOptions.optionsForCommandsByName.get(this._commandName);
-            if (commandOptions?.disableBuildCache) {
+            const operationSettings: IOperationSettings | undefined =
+              projectConfiguration.operationSettingsByOperationName.get(this._commandName);
+            if (operationSettings?.disableBuildCacheForOperation) {
               terminal.writeVerboseLine(
                 `Caching has been disabled for this project's "${this._commandName}" command.`
               );
             } else {
               const projectOutputFolderNames: ReadonlyArray<string> =
-                projectConfiguration.projectOutputFolderNamesForPhases.get(this._phase.name) || [];
+                operationSettings?.outputFolderNames || [];
               this._projectBuildCache = await ProjectBuildCache.tryGetProjectBuildCache({
                 projectConfiguration,
                 projectOutputFolderNames,

--- a/apps/rush-lib/src/schemas/anything.schema.json
+++ b/apps/rush-lib/src/schemas/anything.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema that matches anything",
+
+  "oneOf": [
+    {
+      "type": "array"
+    },
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "integer"
+    },
+    {
+      "type": "null"
+    },
+    {
+      "type": "number"
+    },
+    {
+      "type": "object"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/apps/rush-lib/src/schemas/rush-project.schema.json
+++ b/apps/rush-lib/src/schemas/rush-project.schema.json
@@ -4,6 +4,7 @@
   "description": "For use with the Rush tool, this file provides per-project configuration options. See http://rushjs.io for details.",
 
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
@@ -15,45 +16,6 @@
       "type": "string"
     },
 
-    "buildCacheOptions": {
-      "type": "object",
-      "properties": {
-        "disableBuildCache": {
-          "description": "Selectively disables the build cache for this project. The project will never be restored from cache. This is a useful workaround if that project's build scripts violate the assumptions of the cache, for example by writing files outside the project folder. Where possible, a better solution is to improve the build scripts to be compatible with caching.",
-          "type": "boolean"
-        },
-
-        "optionsForCommands": {
-          "description": "Allows for fine-grained control of cache for individual Rush commands.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["name"],
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "The Rush command name, as defined in custom-commands.json"
-              },
-
-              "disableBuildCache": {
-                "description": "Selectively disables the build cache for this come. The project will never be restored from cache. This is a useful workaround if that project's build scripts violate the assumptions of the cache, for example by writing files outside the project folder. Where possible, a better solution is to improve the build scripts to be compatible with caching.",
-                "type": "boolean"
-              }
-            }
-          }
-        }
-      }
-    },
-
-    "projectOutputFolderNames": {
-      "type": "array",
-      "description": "Specify the folders where your toolchain writes its output files. If enabled, the Rush build cache will restore these folders from the cache. The strings are folder names under the project root folder. These folders should not be tracked by Git. They must not contain symlinks.",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-
     "incrementalBuildIgnoredGlobs": {
       "type": "array",
       "description": "The incremental analyzer can skip Rush commands for projects whose input files have not changed since the last build. Normally, every Git-tracked file under the project folder is assumed to be an input. Set incrementalBuildIgnoredGlobs to ignore specific files, specified as globs relative to the project folder. The list of file globs will be interpreted the same way your .gitignore file is.",
@@ -62,25 +24,36 @@
       }
     },
 
-    "phaseOptions": {
+    "disableBuildCacheForProject": {
+      "description": "Disable caching for this project. The project will never be restored from cache. This may be useful if this project affects state outside of its folder.",
+      "type": "boolean"
+    },
+
+    "operationSettings": {
       "type": "array",
-      "description": "Options for individual phases.",
+      "description": "Options for individual commands and phases.",
       "items": {
         "type": "object",
-        "required": ["phaseName"],
+        "additionalProperties": false,
+        "required": ["operationName"],
         "properties": {
-          "phaseName": {
+          "operationName": {
             "type": "string",
-            "description": "The name of the phase. This is the name that appears in command-line.json."
+            "description": "The name of the operation. This should be a key in the `package.json`'s `scripts` object."
           },
 
-          "projectOutputFolderNames": {
+          "outputFolderNames": {
             "type": "array",
-            "description": "Specify the folders where this phase writes its output files. If enabled, the Rush build cache will restore these folders from the cache. The strings are folder names under the project root folder. These folders should not be tracked by Git. They must not contain symlinks.",
+            "description": "Specify the folders where this operation writes its output files. If enabled, the Rush build cache will restore these folders from the cache. The strings are folder names under the project root folder. These folders should not be tracked by Git. They must not contain symlinks.",
             "items": {
               "type": "string"
             },
             "uniqueItems": true
+          },
+
+          "disableBuildCacheForOperation": {
+            "description": "Disable caching for this operation. The operation will never be restored from cache. This may be useful if this operation affects state outside of its folder.",
+            "type": "boolean"
           }
         }
       }

--- a/apps/rush/UPGRADING.md
+++ b/apps/rush/UPGRADING.md
@@ -2,49 +2,67 @@
 
 ### Rush 5.60.0
 
-This release of Rush changed the schema of the `<project-root>/config/rush-project.json` file.
-The new schema introduces a concept of "operations" and an `operationSettings` property. An operation
+This release of Rush includes a breaking change for the experiment build cache feature. It only affects
+monorepos with `buildCacheEnabled=true` in `experiments.json`.
+
+The `<project-root>/config/rush-project.json` file format has changed. The new schema introduces
+a concept of "operations" and an `operationSettings` property. An operation
 is a command or phase that is invoked in a project. The top-level `projectOutputFolderNames` property
 has been removed in favor of a per-operation `outputFolderNames` property. The `phaseOptions` and
 `buildCacheOptions` properties have also been removed in favor of a per-operation properties.
-Below is an example diff between an old and new `rush-project.json` file:
 
-```diff JSON
+Converting to the new format: Although JSON fields have been moved/renamed, their meanings
+are essentially the same.
+
+**`rush-project.json`** (OLD)
+
+```js
 {
   "incrementalBuildIgnoredGlobs": ["temp/**"],
--  "projectOutputFolderNames": ["output-folder-1", "output-folder-2"],
--  "phaseOptions" [
--    {
--      "phaseName": "_phase:build",
--      "projectOutputFolderNames": ["output-folder-a", "output-folder-b"]
--    }
--  ]
--  "buildCacheOptions": {
--    "disableBuildCache": false,
--    "optionsForCommands" [
--      {
--        "commandName": "test",
--        "disableBuildCache": true
--      }
--    ]
--  }
-+  "disableBuildCache": false,
-+  "operationSettings": [
-+    {
-+      "operationName": "build",
-+      // The "build" operation's output folder names were previously defined
-+      // in the top-level `projectOutputFolderNames` property.
-+      "outputFolderNames": ["output-folder-1", "output-folder-2"]
-+    },
-+    {
-+      "operationName": "_phase:build",
-+      "outputFolderNames": ["output-folder-a", "output-folder-b"]
-+    },
-+    {
-+      "operationName": "test",
-+      "disableBuildCacheForOperation": true
-+    }
-+  ]
+  "projectOutputFolderNames": ["output-folder-1", "output-folder-2"],
+  "phaseOptions": [
+    {
+      "phaseName": "_phase:build",
+      "projectOutputFolderNames": ["output-folder-a", "output-folder-b"]
+    }
+  ],
+  "buildCacheOptions": {
+    "disableBuildCache": false,
+    "optionsForCommands": [
+      {
+        "commandName": "test",
+        "disableBuildCache": true
+      }
+    ]
+  }
+}
+```
+
+**`rush-project.json`** (NEW)
+
+```js
+{
+  "incrementalBuildIgnoredGlobs": ["temp/**"],
+
+  "disableBuildCache": false,  // formerly buildCacheOptions.disableBuildCache
+
+  "operationSettings": [  // formerly phaseOptions
+    {
+      "operationName": "build",
+
+      // The "build" operation's output folder names were previously defined
+      // in the top-level `projectOutputFolderNames` property.
+      "outputFolderNames": ["output-folder-1", "output-folder-2"]
+    },
+    {
+      "operationName": "_phase:build",  // formerly phaseName
+      "outputFolderNames": ["output-folder-a", "output-folder-b"]
+    },
+    {
+      "operationName": "test",
+      "disableBuildCacheForOperation": true
+    }
+  ]
 }
 ```
 

--- a/apps/rush/UPGRADING.md
+++ b/apps/rush/UPGRADING.md
@@ -1,0 +1,51 @@
+# Upgrade notes for @microsoft/rush
+
+### Rush 5.60.0
+
+This release of Rush changed the schema of the `<project-root>/config/rush-project.json` file.
+The new schema introduces a concept of "operations" and an `operationSettings` property. An operation
+is a command or phase that is invoked in a project. The top-level `projectOutputFolderNames` property
+has been removed in favor of a per-operation `outputFolderNames` property. The `phaseOptions` and
+`buildCacheOptions` properties have also been removed in favor of a per-operation properties.
+Below is an example diff between an old and new `rush-project.json` file:
+
+```diff JSON
+{
+  "incrementalBuildIgnoredGlobs": ["temp/**"],
+-  "projectOutputFolderNames": ["output-folder-1", "output-folder-2"],
+-  "phaseOptions" [
+-    {
+-      "phaseName": "_phase:build",
+-      "projectOutputFolderNames": ["output-folder-a", "output-folder-b"]
+-    }
+-  ]
+-  "buildCacheOptions": {
+-    "disableBuildCache": false,
+-    "optionsForCommands" [
+-      {
+-        "commandName": "test",
+-        "disableBuildCache": true
+-      }
+-    ]
+-  }
++  "disableBuildCache": false,
++  "operationSettings": [
++    {
++      "operationName": "build",
++      // The "build" operation's output folder names were previously defined
++      // in the top-level `projectOutputFolderNames` property.
++      "outputFolderNames": ["output-folder-1", "output-folder-2"]
++    },
++    {
++      "operationName": "_phase:build",
++      "outputFolderNames": ["output-folder-a", "output-folder-b"]
++    },
++    {
++      "operationName": "test",
++      "disableBuildCacheForOperation": true
++    }
++  ]
+}
+```
+
+See design notes [here](https://github.com/microsoft/rushstack/issues/2300#issuecomment-1012622369).

--- a/apps/rush/UPGRADING.md
+++ b/apps/rush/UPGRADING.md
@@ -48,4 +48,4 @@ Below is an example diff between an old and new `rush-project.json` file:
 }
 ```
 
-See design notes [here](https://github.com/microsoft/rushstack/issues/2300#issuecomment-1012622369).
+For details see [issue #2300](https://github.com/microsoft/rushstack/issues/2300#issuecomment-1012622369).

--- a/common/changes/@microsoft/rush/update-rush-project.json_2022-01-15-17-49.json
+++ b/common/changes/@microsoft/rush/update-rush-project.json_2022-01-15-17-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING CHANGE) Update the schema of \"<project-root>/config/rush-project.json\". The \"projectOutputFolderNames\", \"phaseOptions\", and \"buildCacheOptions\" properties have been removed in favor of a new \"operationSettings\" property that is used to define settings for commands and phases and a \"disableBuildCacheForProject\" property that disables caching for the whole project.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/update-rush-project.json_2022-01-15-17-49.json
+++ b/common/changes/@microsoft/rush/update-rush-project.json_2022-01-15-17-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "(BREAKING CHANGE) Update the schema of \"<project-root>/config/rush-project.json\". The \"projectOutputFolderNames\", \"phaseOptions\", and \"buildCacheOptions\" properties have been removed in favor of a new \"operationSettings\" property that is used to define settings for commands and phases and a \"disableBuildCacheForProject\" property that disables caching for the whole project.",
+      "comment": "(BREAKING CHANGE) Some experimental fields have been renamed in \"config/rush-project.json\". Please see UPGRADING.md for details.",
       "type": "none"
     }
   ],

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -16,13 +16,14 @@ steps:
     displayName: 'Rush Rebuild (install-run-rush)'
     env:
       # Prevent time-based browserslist update warning
-      # See https://github.com/microsoft/rushstack/issues/2981
+      # See https://github.com/microsoft/rushstack/issues/2981 
       BROWSERSLIST_IGNORE_OLD_DATA: 1
-  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
-    displayName: 'Rush Build (rush-lib)'
-    env:
-      # Prevent time-based browserslist update warning
-      # See https://github.com/microsoft/rushstack/issues/2981
-      BROWSERSLIST_IGNORE_OLD_DATA: 1
+# Re-enable after the schema changes to rush-project.json are published and pulled in
+#  - script: 'node apps/rush-lib/lib/start.js build --verbose --production'
+#    displayName: 'Rush Build (rush-lib)'
+#    env:
+#      # Prevent time-based browserslist update warning
+#      # See https://github.com/microsoft/rushstack/issues/2981
+#      BROWSERSLIST_IGNORE_OLD_DATA: 1
   - script: 'node repo-scripts/repo-toolbox/lib/start.js readme --verify'
     displayName: 'Ensure repo README is up-to-date'


### PR DESCRIPTION
## Summary

This PR updates the schema of `rush-project.json` to follow the proposal here: https://github.com/microsoft/rushstack/issues/2300#issuecomment-1012622369

Note that this change removes the validation step that ensures phases/operations are defined in the repo's `command-line.json`

## How it was tested

https://github.com/elliot-nelson/rush-phased-builds-example/pull/7