### PR TITLE
Fix the "allowWarningsInSuccessfulBuild" option in command-line.json

### DIFF
--- a/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskExecution/ProjectTaskRunner.ts
@@ -52,7 +52,6 @@ export interface IProjectTaskRunnerOptions {
   commandToRun: string;
   isIncrementalBuildAllowed: boolean;
   projectChangeAnalyzer: ProjectChangeAnalyzer;
-  allowWarningsInSuccessfulBuild?: boolean;
   taskName: string;
   phase: IPhase;
 }
@@ -114,9 +113,7 @@ export class ProjectTaskRunner extends BaseTaskRunner {
     this._projectChangeAnalyzer = options.projectChangeAnalyzer;
     this._packageDepsFilename = `package-deps_${phase.logFilenameIdentifier}.json`;
     this.warningsAreAllowed =
-      EnvironmentConfiguration.allowWarningsInSuccessfulBuild ||
-      options.allowWarningsInSuccessfulBuild ||
-      false;
+      EnvironmentConfiguration.allowWarningsInSuccessfulBuild || phase.allowWarningsOnSuccess || false;
     this._logFilenameIdentifier = phase.logFilenameIdentifier;
   }
 

--- a/common/changes/@microsoft/rush/fix-warningsInSuccessfulBuild_2022-01-18-16-07.json
+++ b/common/changes/@microsoft/rush/fix-warningsInSuccessfulBuild_2022-01-18-16-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix the \"allowWarningsInSuccessfulBuild\" option in bulk commands defined in common/config/command-line.json.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3165.

## Details

This was regressed in https://github.com/microsoft/rushstack/pull/3113

## How it was tested

Ran `rush test` in https://github.com/gesiu/rush-warnings