### PR TITLE
[rush] Only check for overlapping output folders within operations that will be invoked as part of the same command.

### DIFF
--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -333,7 +333,7 @@ export class RushProjectConfiguration {
       // For each phased command, check if any of its phases' output folders overlap.
       for (const command of repoCommandLineConfiguration.commands.values()) {
         if (command.commandKind === 'phased') {
-          const phasesOverlappingPathAnalyzer: OverlappingPathAnalyzer<string> =
+          const overlappingPathAnalyzer: OverlappingPathAnalyzer<string> =
             new OverlappingPathAnalyzer<string>();
 
           for (const operationName of command.phases) {
@@ -343,7 +343,7 @@ export class RushProjectConfiguration {
               if (operationSettings.outputFolderNames) {
                 for (const outputFolderName of operationSettings.outputFolderNames) {
                   const overlappingOperationNames: string[] | undefined =
-                    phasesOverlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(
+                    overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(
                       outputFolderName,
                       operationName
                     );
@@ -351,30 +351,21 @@ export class RushProjectConfiguration {
                     const overlapsWithOwnOperation: boolean =
                       overlappingOperationNames?.includes(operationName);
                     if (overlapsWithOwnOperation) {
-                      if (overlappingOperationNames.length === 1) {
-                        terminal.writeErrorLine(
-                          `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                            `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                            `operation "${operationName}" overlaps with another folder name in the same operation.`
-                        );
-                      } else {
-                        const otherOperationNames: string[] = overlappingOperationNames.filter(
-                          (overlappingOperationName) => overlappingOperationName !== operationName
-                        );
-                        terminal.writeErrorLine(
-                          `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                            `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                            `operation "${operationName}" overlaps with other folder names in the same operation and with ` +
-                            'folder names in the following other operations invoked by the ' +
-                            `"${command.name}" command: ${otherOperationNames.join(', ')}.`
-                        );
-                      }
+                      terminal.writeErrorLine(
+                        `The "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" config file in the ` +
+                          `"${project.packageName}" project defines an operation "${operationName}" with a path ` +
+                          `("${outputFolderName}") in "outputFolderNames" that overlaps with another path in the ` +
+                          'same operation.'
+                      );
                     } else {
                       terminal.writeErrorLine(
-                        `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                          `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                          `operation "${operationName}" overlaps with other folder name(s) in the following other operations ` +
-                          `invoked by the "${command.name}" command: ${overlappingOperationNames.join(', ')}.`
+                        `The "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" config file in the ` +
+                          `"${project.packageName}" project defines two potentially simultaneous operations whose ` +
+                          '"outputFolderNames" would overlap. Simultaneous operations should not delete each ' +
+                          "other's output." +
+                          `\n\n` +
+                          `The "${outputFolderName}" path overlaps across these operations: ` +
+                          overlappingOperationNames.map((operationName) => `"${operationName}"`).join(', ')
                       );
                     }
 

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -297,7 +297,6 @@ export class RushProjectConfiguration {
       IOperationSettings
     >();
     if (rushProjectJson.operationSettings) {
-      const overlappingPathAnalyzer: OverlappingPathAnalyzer<string> = new OverlappingPathAnalyzer<string>();
       for (const operationSettings of rushProjectJson.operationSettings) {
         const operationName: string = operationSettings.operationName;
         const existingOperationSettings: IOperationSettings | undefined =
@@ -329,41 +328,60 @@ export class RushProjectConfiguration {
         } else {
           operationSettingsByOperationName.set(operationName, operationSettings);
         }
+      }
 
-        if (operationSettings.outputFolderNames) {
-          for (const outputFolderName of operationSettings.outputFolderNames) {
-            const overlappingOperationNames: string[] | undefined =
-              overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(outputFolderName, operationName);
-            if (overlappingOperationNames) {
-              const overlapsWithOwnOperation: boolean = overlappingOperationNames?.includes(operationName);
-              if (overlapsWithOwnOperation) {
-                if (overlappingOperationNames.length === 1) {
-                  terminal.writeErrorLine(
-                    `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                      `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                      `operation ${operationName} overlaps with another folder name in the same operation.`
-                  );
-                } else {
-                  const otherOperationNames: string[] = overlappingOperationNames.filter(
-                    (overlappingOperationName) => overlappingOperationName !== operationName
-                  );
-                  terminal.writeErrorLine(
-                    `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                      `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                      `operation ${operationName} overlaps with other folder names in the same operation and with ` +
-                      `folder names in the following other operations: ${otherOperationNames.join(', ')}.`
-                  );
+      // For each phased command, check if any of its phases' output folders overlap.
+      for (const [, command] of repoCommandLineConfiguration.commands) {
+        if (command.commandKind === 'phased') {
+          const phasesOverlappingPathAnalyzer: OverlappingPathAnalyzer<string> =
+            new OverlappingPathAnalyzer<string>();
+
+          for (const operationName of command.phases) {
+            const operationSettings: IOperationSettings | undefined =
+              operationSettingsByOperationName.get(operationName);
+            if (operationSettings) {
+              if (operationSettings.outputFolderNames) {
+                for (const outputFolderName of operationSettings.outputFolderNames) {
+                  const overlappingOperationNames: string[] | undefined =
+                    phasesOverlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(
+                      outputFolderName,
+                      operationName
+                    );
+                  if (overlappingOperationNames) {
+                    const overlapsWithOwnOperation: boolean =
+                      overlappingOperationNames?.includes(operationName);
+                    if (overlapsWithOwnOperation) {
+                      if (overlappingOperationNames.length === 1) {
+                        terminal.writeErrorLine(
+                          `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
+                            `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                            `operation "${operationName}" overlaps with another folder name in the same operation.`
+                        );
+                      } else {
+                        const otherOperationNames: string[] = overlappingOperationNames.filter(
+                          (overlappingOperationName) => overlappingOperationName !== operationName
+                        );
+                        terminal.writeErrorLine(
+                          `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
+                            `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                            `operation "${operationName}" overlaps with other folder names in the same operation and with ` +
+                            'folder names in the following other operations invoked by the ' +
+                            `"${command.name}" command: ${otherOperationNames.join(', ')}.`
+                        );
+                      }
+                    } else {
+                      terminal.writeErrorLine(
+                        `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
+                          `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
+                          `operation "${operationName}" overlaps with other folder name(s) in the following other operations ` +
+                          `invoked by the "${command.name}" command: ${overlappingOperationNames.join(', ')}.`
+                      );
+                    }
+
+                    throw new AlreadyReportedError();
+                  }
                 }
-              } else {
-                terminal.writeErrorLine(
-                  `Invalid "${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" ` +
-                    `for project "${project.packageName}". The project output folder name "${outputFolderName}" in ` +
-                    `operation ${operationName} overlaps with other folder name(s) in the following other operations: ` +
-                    `${overlappingOperationNames.join(', ')}.`
-                );
               }
-
-              throw new AlreadyReportedError();
             }
           }
         }

--- a/apps/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/apps/rush-lib/src/api/RushProjectConfiguration.ts
@@ -331,7 +331,7 @@ export class RushProjectConfiguration {
       }
 
       // For each phased command, check if any of its phases' output folders overlap.
-      for (const [, command] of repoCommandLineConfiguration.commands) {
+      for (const command of repoCommandLineConfiguration.commands.values()) {
         if (command.commandKind === 'phased') {
           const phasesOverlappingPathAnalyzer: OverlappingPathAnalyzer<string> =
             new OverlappingPathAnalyzer<string>();

--- a/common/changes/@microsoft/rush/fix-overlapping-paths-check_2022-01-18-20-35.json
+++ b/common/changes/@microsoft/rush/fix-overlapping-paths-check_2022-01-18-20-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

This issue was found when testing Rush@5.60.0-rc.0. If a `rush-project.json` has matching lists of folders for `build` and `_phase:build` operations, validation will fail. This change checks for overlapping folders only among operations that will be invoked by a single command. For example, if `rush build` invokes `_phase:build` and `_phase:test`, and `_phase:build` and `_phase:lint` have overlapping output folders, there is no error because `_phase:build` and `_phase:lint` aren't invoked by the same command.

## How it was tested

Confirmed https://github.com/microsoft/rushstack/pull/3144 is fixed, and introduced an issue in a phased repo to confirm the expected behavior.