### PR TITLE
[module-minifier-plugin] Async import compression

### DIFF
--- a/build-tests/localization-plugin-test-02/webpack.config.js
+++ b/build-tests/localization-plugin-test-02/webpack.config.js
@@ -46,7 +46,8 @@ function generateConfiguration(mode, outputFolderName) {
             verbose: true
           }),
           sourceMap: true,
-          usePortableModules: true
+          usePortableModules: true,
+          compressAsyncImports: true
         })
       ]
     },

--- a/common/changes/@rushstack/module-minifier-plugin/async-import-compression_2022-01-19-00-28.json
+++ b/common/changes/@rushstack/module-minifier-plugin/async-import-compression_2022-01-19-00-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Add support for `compressAsyncImports` flag. Modify `usePortableModules` option to use `module.identifier()` instead of `module.resource` so that loader configuration is accounted for during deduplication. Switch to overriding the render function on the JavaScript module template to deduplicate rendering across chunks.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin"
+}

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -62,6 +62,7 @@ export const IDENTIFIER_TRAILING_DIGITS: string;
 // @public
 export interface IExtendedModule extends webpack.compilation.Module {
     external?: boolean;
+    hasDependencies(callback: (dep: webpack.compilation.Dependency) => boolean | void): boolean;
     id: string | number | null;
     identifier(): string;
     modules?: IExtendedModule[];
@@ -132,13 +133,14 @@ export interface IModuleMinifierFunction {
 
 // @public
 export interface IModuleMinifierPluginHooks {
-    finalModuleId: SyncWaterfallHook<string | number | undefined>;
-    postProcessCodeFragment: SyncWaterfallHook<ReplaceSource, string>;
+    finalModuleId: SyncWaterfallHook<string | number | undefined, webpack.compilation.Compilation>;
+    postProcessCodeFragment: SyncWaterfallHook<ReplaceSource, IPostProcessFragmentContext>;
     rehydrateAssets: AsyncSeriesWaterfallHook<IDehydratedAssets, webpack.compilation.Compilation>;
 }
 
 // @public
 export interface IModuleMinifierPluginOptions {
+    compressAsyncImports?: boolean;
     minifier: IModuleMinifier;
     sourceMap?: boolean;
     usePortableModules?: boolean;
@@ -155,6 +157,13 @@ export interface _INormalModuleFactoryModuleData {
         descriptionFileRoot?: string;
         relativePath?: string;
     };
+}
+
+// @public
+export interface IPostProcessFragmentContext {
+    compilation: webpack.compilation.Compilation;
+    loggingName: string;
+    module: webpack.compilation.Module | undefined;
 }
 
 // @internal

--- a/webpack/module-minifier-plugin/src/AsyncImportCompressionPlugin.ts
+++ b/webpack/module-minifier-plugin/src/AsyncImportCompressionPlugin.ts
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import webpack, { Compiler, Plugin } from 'webpack';
+import { ReplaceSource } from 'webpack-sources';
+import { Tapable, TapOptions } from 'tapable';
+
+import Template from 'webpack/lib/Template';
+
+import { STAGE_AFTER } from './Constants';
+import {
+  IExtendedModule,
+  IModuleMinifierPluginHooks,
+  IPostProcessFragmentContext
+} from './ModuleMinifierPlugin.types';
+
+const PLUGIN_NAME: 'AsyncImportCompressionPlugin' = 'AsyncImportCompressionPlugin';
+
+const TAP_AFTER: TapOptions<'sync'> = {
+  name: PLUGIN_NAME,
+  stage: STAGE_AFTER
+};
+
+const ASYNC_IMPORT_PREFIX: '__IMPORT_ASYNC' = '__IMPORT_ASYNC';
+const ASYNC_IMPORT_REGEX: RegExp = /__IMPORT_ASYNC[^\)]+/g;
+
+declare class WebpackImportDependency extends webpack.compilation.Dependency {
+  public module: webpack.compilation.Module;
+  public block: {
+    chunkGroup: webpack.compilation.ChunkGroup;
+    range: [number, number];
+  };
+}
+
+interface IAsyncImportMetadata {
+  chunkCount: number;
+  chunkIds: number[];
+  count: number;
+  index: number;
+}
+
+interface ILocalImportMetadata {
+  meta: IAsyncImportMetadata;
+  module: webpack.compilation.Module;
+}
+
+function getImportDependency(compilation: webpack.compilation.Compilation): typeof WebpackImportDependency {
+  for (const key of compilation.dependencyTemplates.keys()) {
+    if (key.name === 'ImportDependency') {
+      return key as unknown as typeof WebpackImportDependency;
+    }
+  }
+
+  throw new Error(`Could not find ImportDependency!`);
+}
+
+function getImportTypeExpression(
+  module: webpack.compilation.Module,
+  originModule: webpack.compilation.Module
+): string {
+  const exportsType: string | undefined = module.buildMeta?.exportsType;
+  const strict: boolean | undefined = originModule.buildMeta?.strictHarmonyModule;
+
+  if (exportsType === 'namespace') {
+    return '';
+  } else if (exportsType === 'named') {
+    return ',3';
+  } else if (strict) {
+    return ',1';
+  } else {
+    return ',7';
+  }
+}
+
+function needChunkOnDemandLoadingCode(chunk: webpack.compilation.Chunk): boolean {
+  for (const chunkGroup of chunk.groupsIterable) {
+    if (chunkGroup.getNumberOfChildren() > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Plugin that replaces `Promise.all([__webpack_require__.e(1), __webpack_require__,e(12)]).then(__webpack_require__.t.bind(123,7))`
+ * with more concise expressions like `__webpack_require__.ee([1,12],123,7)`, etc.
+ *
+ * Also ensures that the code seen by the minifier does not contain chunk ids, and is therefore portable across chunks/compilations.
+ */
+export class AsyncImportCompressionPlugin implements Plugin {
+  private readonly _minifierHooks: IModuleMinifierPluginHooks;
+
+  public constructor(minifierHooks: IModuleMinifierPluginHooks) {
+    this._minifierHooks = minifierHooks;
+  }
+
+  public apply(compiler: Compiler): void {
+    const asyncImportMap: Map<webpack.compilation.Module, Map<string, ILocalImportMetadata>> = new Map();
+    const asyncImportGroups: Map<string, IAsyncImportMetadata> = new Map();
+    let rankedImportGroups: IAsyncImportMetadata[] | undefined;
+
+    this._minifierHooks.postProcessCodeFragment.tap(
+      {
+        name: PLUGIN_NAME,
+        stage: -1
+      },
+      (source: ReplaceSource, context: IPostProcessFragmentContext) => {
+        const code: string = source.original().source() as string;
+
+        let localImports: Map<string, ILocalImportMetadata> | undefined;
+
+        ASYNC_IMPORT_REGEX.lastIndex = -1;
+        // RegExp.exec uses null or an array as the return type, explicitly
+        let match: RegExpExecArray | null = null;
+        while ((match = ASYNC_IMPORT_REGEX.exec(code))) {
+          const token: string = match[0];
+
+          if (!localImports) {
+            if (!context.module) {
+              context.compilation.errors.push(
+                new Error(`Unexpected async import ${token} in non-module context ${context.loggingName}`)
+              );
+              return source;
+            }
+
+            localImports = asyncImportMap.get(context.module);
+            if (!localImports) {
+              context.compilation.errors.push(
+                new Error(`Unexpected async import ${token} in module ${context.loggingName}`)
+              );
+              return source;
+            }
+          }
+
+          const localImport: ILocalImportMetadata | undefined = localImports.get(token);
+          if (!localImport) {
+            context.compilation.errors.push(
+              new Error(`Missing metadata for ${token} in module ${context.loggingName}`)
+            );
+            return source;
+          }
+          const { meta, module } = localImport;
+
+          const chunkExpression: string = meta.index < 0 ? JSON.stringify(meta.chunkIds) : `${meta.index}`;
+
+          const mapped: string | number | undefined = this._minifierHooks.finalModuleId.call(
+            module.id!,
+            context.compilation
+          );
+          const idExpr: string | number = mapped === undefined ? module.id! : mapped;
+
+          // Replace with a reference or array of ideas, the target module id, and the type of import
+          source.replace(
+            match.index,
+            ASYNC_IMPORT_REGEX.lastIndex - 1,
+            `${chunkExpression},${JSON.stringify(idExpr)}${getImportTypeExpression(module, context.module!)}`
+          );
+        }
+
+        return source;
+      }
+    );
+
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation: webpack.compilation.Compilation) => {
+      asyncImportMap.clear();
+      asyncImportGroups.clear();
+
+      compilation.hooks.beforeChunkAssets.tap(TAP_AFTER, () => {
+        const ImportDependency: typeof WebpackImportDependency = getImportDependency(compilation);
+
+        for (const module of compilation.modules) {
+          const toProcess: IExtendedModule[] = module.modules || [module];
+
+          for (const child of toProcess) {
+            child.hasDependencies((dep: webpack.compilation.Dependency) => {
+              if (dep instanceof ImportDependency) {
+                const { module: targetModule } = dep;
+
+                let localAsyncImports: Map<string, ILocalImportMetadata> | undefined =
+                  asyncImportMap.get(module);
+                if (!localAsyncImports) {
+                  asyncImportMap.set(module, (localAsyncImports = new Map()));
+                }
+
+                const chunkGroup: webpack.compilation.ChunkGroup = dep.block.chunkGroup;
+                const chunkIds: number[] = chunkGroup
+                  ? chunkGroup.chunks.map((chunk) => chunk.id!).sort()
+                  : [];
+                const idString: string = chunkIds.join(';');
+
+                let meta: IAsyncImportMetadata | undefined = asyncImportGroups.get(idString);
+                if (!meta) {
+                  asyncImportGroups.set(
+                    idString,
+                    (meta = {
+                      chunkCount: chunkIds.length,
+                      chunkIds: chunkIds,
+                      count: 0,
+                      index: -1
+                    })
+                  );
+                }
+                meta.count++;
+
+                const stringKey: string = `${targetModule.id}`.replace(/[^A-Za-z0-9_$]/g, '_');
+
+                const key: string = `${ASYNC_IMPORT_PREFIX}${stringKey}`;
+                localAsyncImports.set(key, {
+                  meta,
+                  module: targetModule
+                });
+              }
+            });
+          }
+        }
+
+        const rankedImports: [string, IAsyncImportMetadata][] = [...asyncImportGroups]
+          .filter((x) => x[1].count > 1)
+          .sort((x, y) => {
+            let diff: number = y[1].count - x[1].count;
+            if (!diff) {
+              diff = y[1].chunkCount - x[1].chunkCount;
+            }
+
+            if (!diff) {
+              diff = x[0] > y[0] ? 1 : x[0] < y[0] ? -1 : 0;
+            }
+
+            return diff;
+          });
+
+        for (let i: number = 0, len: number = rankedImports.length; i < len; i++) {
+          rankedImports[i][1].index = i;
+          // console.log(rankedImports[i]);
+        }
+
+        rankedImportGroups = rankedImports.map((x) => x[1]);
+
+        // Have to do this after the official plugin in order to override
+        compilation.dependencyTemplates.set(ImportDependency, {
+          apply(dep: WebpackImportDependency, source: ReplaceSource): void {
+            const stringKey: string = `${dep.module.id}`.replace(/[^A-Za-z0-9_$]/g, '_');
+            const key: string = `${ASYNC_IMPORT_PREFIX}${stringKey}`;
+            const content: string = `__webpack_require__.ee(${key})`;
+            source.replace(dep.block.range[0], dep.block.range[1] - 1, content);
+          }
+          // Typings in webpack are incorrect. This is a DependencyTemplate object
+        } as unknown as Tapable);
+      });
+
+      compilation.mainTemplate.hooks.requireExtensions.tap(
+        PLUGIN_NAME,
+        (source: string, chunk: webpack.compilation.Chunk) => {
+          if (!needChunkOnDemandLoadingCode(chunk)) {
+            return source;
+          }
+
+          const { requireFn } = compilation.mainTemplate;
+          return Template.asString([
+            `var asyncImportChunkGroups = [`,
+            rankedImportGroups
+              ? rankedImportGroups.map((x) => Template.indent(JSON.stringify(x.chunkIds))).join(',\n')
+              : '',
+            `];`,
+            `${requireFn}.ee = function (groupOrId, moduleId, importType) {`,
+            Template.indent([
+              `return Promise.all((Array.isArray(groupOrId) ? groupOrId : asyncImportChunkGroups[groupOrId]).map(function (x) { return ${requireFn}.e(x); }))`,
+              `.then(importType ? ${requireFn}.t.bind(0,moduleId,importType) : ${requireFn}.bind(0,moduleId));`
+            ]),
+            `};`,
+            source
+          ]);
+        }
+      );
+    });
+  }
+}

--- a/webpack/module-minifier-plugin/src/AsyncImportCompressionPlugin.ts
+++ b/webpack/module-minifier-plugin/src/AsyncImportCompressionPlugin.ts
@@ -61,13 +61,19 @@ function getImportTypeExpression(
   const exportsType: string | undefined = module.buildMeta?.exportsType;
   const strict: boolean | undefined = originModule.buildMeta?.strictHarmonyModule;
 
+  // Logic translated from:
+  // https://github.com/webpack/webpack/blob/3956274f1eada621e105208dcab4608883cdfdb2/lib/RuntimeTemplate.js#L110-L122
   if (exportsType === 'namespace') {
+    // Use the raw module directly
     return '';
   } else if (exportsType === 'named') {
+    // Create a new namespace object and forward all exports
     return ',3';
   } else if (strict) {
+    // Synthetic default export
     return ',1';
   } else {
+    // If modules is marked __esModule, return raw module, otherwise create a new namespace object and forward all exports
     return ',7';
   }
 }
@@ -82,7 +88,7 @@ function needChunkOnDemandLoadingCode(chunk: webpack.compilation.Chunk): boolean
 }
 
 /**
- * Plugin that replaces `Promise.all([__webpack_require__.e(1), __webpack_require__,e(12)]).then(__webpack_require__.t.bind(123,7))`
+ * Plugin that replaces `Promise.all([__webpack_require__.e(1), __webpack_require__.e(12)]).then(__webpack_require__.t.bind(123,7))`
  * with more concise expressions like `__webpack_require__.ee([1,12],123,7)`, etc.
  *
  * Also ensures that the code seen by the minifier does not contain chunk ids, and is therefore portable across chunks/compilations.

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -525,15 +525,10 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
             }
 
             // All assets and modules have been minified, hand them off to be rehydrated
-
-            // Clone the maps for safety, even though we won't be using them in the plugin anymore
-            const assets: IAssetMap = new Map(minifiedAssets);
-            const modules: IModuleMap = new Map(minifiedModules);
-
             await this.hooks.rehydrateAssets.promise(
               {
-                assets,
-                modules
+                assets: minifiedAssets,
+                modules: minifiedModules
               },
               compilation
             );


### PR DESCRIPTION
## Summary
Adds an option `compressAsyncImports: true` to `ModuleMinifierPlugin` that, if specified, reduces the API call size of webpack async import expressions by combining all chunk imports and the final module import into a single call to the webpack runtime. Also creates a lookup table of frequently used chunk sets to further reduce code size.

## Details
Converts expressions like `Promise.resolve([__webpack_require__.e(1), __webpack_require__.e(2)]).then(__webpack_require__.bind(23))` to the more concise `__webpack_require__.ee([1,2 ], 23)`

## How it was tested
Build test project `localization-plugin-test-02`
Linking inside a private repo with a large quantity of async imports.