### PR TITLE
[package-deps-hash] Reduce minimum git version to 2.20.0, fix working tree state computation

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-07.json
+++ b/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Fix incorrect parsing in `parseGitStatus`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-42.json
+++ b/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/package-deps-hash",
-      "comment": "Remove `--merge-base` from `getRepoChanges` and document need to manually acquire merge-base commit if comparing against a separate branch.\nReduce minimum Git version to 2.20.",
+      "comment": "Remove `--merge-base` from `getRepoChanges` and document the need to manually acquire merge-base commit if comparing against a separate branch.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-42.json
+++ b/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Remove `--merge-base` from `getRepoChanges` and document need to manually acquire merge-base commit if comparing against a separate branch.\nReduce minimum Git version to 2.20.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-43.json
+++ b/common/changes/@rushstack/package-deps-hash/package-deps-fixes_2022-01-20-22-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Reduce minimum Git version to 2.20.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -12,7 +12,7 @@ export interface IGitVersion {
 
 const MINIMUM_GIT_VERSION: IGitVersion = {
   major: 2,
-  minor: 30,
+  minor: 20,
   patch: 0
 };
 
@@ -280,6 +280,7 @@ export function getRepoState(currentWorkingDirectory: string, gitPath?: string):
  * Find all changed files tracked by Git, their current hashes, and the nature of the change. Only useful if all changes are staged or committed.
  * @param currentWorkingDirectory - The working directory. Only used to find the repository root.
  * @param revision - The Git revision specifier to detect changes relative to. Defaults to HEAD (i.e. will compare staged vs. committed)
+ *   If comparing against a different branch, call `git merge-base` first to find the target commit.
  * @param gitPath - The path to the Git executable
  * @returns A map from the Git file path to the corresponding file change metadata
  * @beta
@@ -298,8 +299,6 @@ export function getRepoChanges(
       'diff-index',
       '--color=never',
       '--no-renames',
-      // rush change targets origin/main with this, and usually the current branch is not synced, so use the merge-base
-      '--merge-base',
       '--no-commit-id',
       '--cached',
       '-z',

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -3,7 +3,7 @@
 
 import { parseGitStatus, parseGitVersion } from '../getRepoState';
 
-describe('parseGitVersion', () => {
+describe(parseGitVersion.name, () => {
   it('Can parse valid git version responses', () => {
     expect(parseGitVersion('git version 2.30.2.windows.1')).toEqual({
       major: 2,
@@ -38,7 +38,7 @@ describe('parseGitVersion', () => {
   });
 });
 
-describe('parseGitStatus', () => {
+describe(parseGitStatus.name, () => {
   it('Finds index entries', () => {
     const files: string[] = [`A.ts`, `B.ts`, `C.ts`];
     const input: string = [`A  ${files[0]}`, `D  ${files[1]}`, `M  ${files[2]}`, ''].join('\0');

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { parseGitVersion } from '../getRepoState';
+import { parseGitStatus, parseGitVersion } from '../getRepoState';
 
-describe('getRepoState', () => {
+describe('parseGitVersion', () => {
   it('Can parse valid git version responses', () => {
     expect(parseGitVersion('git version 2.30.2.windows.1')).toEqual({
       major: 2,
@@ -35,5 +35,55 @@ describe('getRepoState', () => {
     expect(() => parseGitVersion('git version .2.30')).toThrowErrorMatchingInlineSnapshot(
       `"While validating the Git installation, the \\"git version\\" command produced unexpected output: \\"git version .2.30\\""`
     );
+  });
+});
+
+describe('parseGitStatus', () => {
+  it('Finds index entries', () => {
+    const files: string[] = [`A.ts`, `B.ts`, `C.ts`];
+    const input: string = [`A  ${files[0]}`, `D  ${files[1]}`, `M  ${files[2]}`, ''].join('\0');
+
+    const result: Map<string, boolean> = parseGitStatus(input);
+
+    expect(result.size).toEqual(3);
+    expect(result.get(files[0])).toEqual(true);
+    expect(result.get(files[1])).toEqual(false);
+    expect(result.get(files[2])).toEqual(true);
+  });
+
+  it('Finds working tree entries', () => {
+    const files: string[] = [`A.ts`, `B.ts`, `C.ts`];
+    const input: string = [` A ${files[0]}`, ` D ${files[1]}`, ` M ${files[2]}`, ''].join('\0');
+
+    const result: Map<string, boolean> = parseGitStatus(input);
+
+    expect(result.size).toEqual(3);
+    expect(result.get(files[0])).toEqual(true);
+    expect(result.get(files[1])).toEqual(false);
+    expect(result.get(files[2])).toEqual(true);
+  });
+
+  it('Can handle untracked files', () => {
+    const files: string[] = [`A.ts`, `B.ts`, `C.ts`];
+    const input: string = [`?? ${files[0]}`, `?? ${files[1]}`, `?? ${files[2]}`, ''].join('\0');
+
+    const result: Map<string, boolean> = parseGitStatus(input);
+
+    expect(result.size).toEqual(3);
+    expect(result.get(files[0])).toEqual(true);
+    expect(result.get(files[1])).toEqual(true);
+    expect(result.get(files[2])).toEqual(true);
+  });
+
+  it('Can handle files modified in both index and working tree', () => {
+    const files: string[] = [`A.ts`, `B.ts`, `C.ts`];
+    const input: string = [`D  ${files[0]}`, `AD ${files[1]}`, `DA ${files[2]}`, ''].join('\0');
+
+    const result: Map<string, boolean> = parseGitStatus(input);
+
+    expect(result.size).toEqual(3);
+    expect(result.get(files[0])).toEqual(false);
+    expect(result.get(files[1])).toEqual(false);
+    expect(result.get(files[2])).toEqual(true);
   });
 });


### PR DESCRIPTION
## Summary
Fixes #3163 
Fixes #3109

## Details
Reduces the minimum version of Git required by `getRepoState` to `2.20.0` by removing `--merge-base` from `getRepoChanges` and documenting the behavior change.

Fixes a bug in `getRepoState` with regards to parsing the output of `git status`. Added unit tests for `parseGitStatus`.

## How it was tested
New unit tests for `parseGitStatus` covering a range of statuses.
Verified that `node ./apps/rush-lib/lib/start.js build -o git:HEAD` correctly handles a file being renamed in the index.