### PR TITLE
[heft-node-rig] Include "dist" in the list of cached folders in heft-node-rig.

### DIFF
--- a/common/changes/@rushstack/heft-node-rig/node-rig-dist_2022-01-20-23-06.json
+++ b/common/changes/@rushstack/heft-node-rig/node-rig-dist_2022-01-20-23-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Include \"dist\" in the list of cached folders for the \"build\" and \"_phase:build\" operations.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/rigs/heft-node-rig/profiles/default/config/rush-project.json
+++ b/rigs/heft-node-rig/profiles/default/config/rush-project.json
@@ -2,11 +2,11 @@
   "operationSettings": [
     {
       "operationName": "_phase:build",
-      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
     },
     {
       "operationName": "build",
-      "outputFolderNames": ["lib", "lib-commonjs", "temp"]
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

This change includes `dist` in the list of cached folders for the "build" operations in Heft's Node rig. Our standard is to drop API Extractor rollups in the `dist` folder.