### PR TITLE
[rush] Fix an issue with adding the default options to the build and rebuild commands.

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -87,12 +87,9 @@ const DEFAULT_BUILD_COMMAND_JSON: IBulkCommandJson = {
     ' build state is tracked in a per-project folder called ".rush/temp" which should NOT be added to Git. The' +
     ' build command is tracked by the "arguments" field in the "package-deps_build.json" file contained' +
     ' therein; a full rebuild is forced whenever the command has changed (e.g. "--production" or not).',
+  safeForSimultaneousRushProcesses: false,
   enableParallelism: true,
-  ignoreMissingScript: false,
-  ignoreDependencyOrder: false,
-  incremental: true,
-  allowWarningsInSuccessfulBuild: false,
-  safeForSimultaneousRushProcesses: false
+  incremental: true
 };
 
 const DEFAULT_REBUILD_COMMAND_JSON: IBulkCommandJson = {
@@ -107,12 +104,9 @@ const DEFAULT_REBUILD_COMMAND_JSON: IBulkCommandJson = {
     ' graph for locally linked projects.  The number of simultaneous processes will be' +
     ' based on the number of machine cores unless overridden by the --parallelism flag.' +
     ' (For an incremental build, see "rush build" instead of "rush rebuild".)',
+  safeForSimultaneousRushProcesses: false,
   enableParallelism: true,
-  ignoreMissingScript: false,
-  ignoreDependencyOrder: false,
-  incremental: false,
-  allowWarningsInSuccessfulBuild: false,
-  safeForSimultaneousRushProcesses: false
+  incremental: false
 };
 
 interface ICommandLineConfigurationOptions {
@@ -539,6 +533,7 @@ export class CommandLineConfiguration {
           // Determine if we have a set of default parameters
           let commandDefaultDefinition: CommandJson | {} = {};
           switch (command.commandKind) {
+            case RushConstants.phasedCommandKind:
             case RushConstants.bulkCommandKind: {
               switch (command.name) {
                 case RushConstants.buildCommandName: {

--- a/common/changes/@microsoft/rush/fix-build-rebuild-defaults_2022-01-21-00-40.json
+++ b/common/changes/@microsoft/rush/fix-build-rebuild-defaults_2022-01-21-00-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow common/config/rush/command-line.json to specify the build command as a phased command without specifying all of the options required by the schema. The remaining options will come from the default. This is already supported when a partially-specified build command has \"commandKind\" set to \"bulk\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Rush allows a repo maintainer to specify only the options that they specifically want to override in `common/config/rush/command-line.json` for the "build" and "rebuild" commands. This is broken if the maintainer wants to make build a phased command.

This change fixes population of the summary, description, and other default options for build and rebuild by allowing these to apply to both bulk and phased commands and by eliminating the options that aren't shared between the two from the defaults (all of which were already set to the defaults for a bulk command).

## How it was tested

Tested by removing all but the `"commandKind"`, `"name"`, and `"phases"` options from `common/config/rush/command-line.json` in this branch: https://github.com/microsoft/rushstack/pull/3145