### PR TITLE
Enable the omitImportersFromPreventManualShrinkwrapChanges option.

### DIFF
--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -22,7 +22,7 @@
    * Used to allow links between workspace projects or the addition/removal of references to existing dependency versions to not
    * cause hash changes.
    */
-  // "omitImportersFromPreventManualShrinkwrapChanges": true,
+  "omitImportersFromPreventManualShrinkwrapChanges": true,
 
   /**
    * If true, the chmod field in temporary project tar headers will not be normalized.

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "257049fd804b9b063952b1a4074f99f47bf56c44",
+  "pnpmShrinkwrapHash": "912e7353f005cb1fe5038454a4f7dea57571315b",
   "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
 }


### PR DESCRIPTION
This cuts down on noise in the `repo-state.json` file.