### PR TITLE
[rush] Fix project change detection for new projects using PNPM

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
@@ -24,6 +24,11 @@ export class PnpmProjectShrinkwrapFile extends BaseProjectShrinkwrapFile {
   }
 
   public hasChanges(otherShrinkwrap: PnpmProjectShrinkwrapFile): boolean {
+    if (!otherShrinkwrap.shrinkwrapFile.isWorkspaceCompatible && !otherShrinkwrap.shrinkwrapFile.getTempProjectDependencyKey(this.project.tempProjectName)) {
+      // The project is new to the shrinkwrap file.
+      return true;
+    }
+
     const otherMap: Map<string, string> | undefined = otherShrinkwrap.generateProjectShrinkwrapMap();
     const thisMap: Map<string, string> | undefined = this.generateProjectShrinkwrapMap();
 

--- a/common/changes/@microsoft/rush/stekycz-bugfix-pnpm-git-diff_2022-01-21-14-08.json
+++ b/common/changes/@microsoft/rush/stekycz-bugfix-pnpm-git-diff_2022-01-21-14-08.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix project change detection for new projects using PNPM",
+      "comment": "Fix project change detection when a new project is added to a repo using PNPM in non-workspace mode.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/stekycz-bugfix-pnpm-git-diff_2022-01-21-14-08.json
+++ b/common/changes/@microsoft/rush/stekycz-bugfix-pnpm-git-diff_2022-01-21-14-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix project change detection for new projects using PNPM",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Using PNPM and subset selection with git fails when new project is added in the diff commits.

## Details

I wanted to list affected projects by changes in my branch. The change was addition of a new project. Therefore, I wanted to use `rush list --impacted-by git:<hash>` command.  However, it failed with `Cannot get dependency key for temp project: <project_name>`.

Considerations:
1. The change should not (negatively) impact any other use cases.
2. I do not want to remove throwing the error because the error might be important in other use cases. Therefore, return `undefined` from `generateLegacyProjectShrinkwrapMap` is not possible.
3. I might be able to detect it in `ProjectChangeAnalyzer`, however, it would not fix it for other `hasChanges` calls.
4. It make sense to me to say the project has changes when the project did not exist before.

## How it was tested

I have manually ran `rush list --impacted-by git:<hash>` the same as it was failing before. It returned affected projects as expected.