### PR TITLE
[heft-web-rig/heft-node-rig] Bump ESLint to ~8.7.0

### DIFF
--- a/build-tests-samples/heft-node-basic-tutorial/package.json
+++ b/build-tests-samples/heft-node-basic-tutorial/package.json
@@ -16,7 +16,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/build-tests-samples/heft-node-jest-tutorial/package.json
+++ b/build-tests-samples/heft-node-jest-tutorial/package.json
@@ -15,7 +15,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/build-tests-samples/heft-storybook-react-tutorial/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/package.json
@@ -20,7 +20,7 @@
     "@types/react": "16.9.45",
     "@types/webpack-env": "1.13.0",
     "css-loader": "~4.2.1",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "heft-storybook-react-tutorial-storykit": "workspace:*",
     "html-webpack-plugin": "~5.5.0",
     "react-dom": "~16.13.1",

--- a/build-tests-samples/heft-webpack-basic-tutorial/package.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "16.9.8",
     "@types/webpack-env": "1.13.0",
     "css-loader": "~4.2.1",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "html-webpack-plugin": "~5.5.0",
     "react": "~16.13.1",
     "react-dom": "~16.13.1",

--- a/build-tests-samples/packlets-tutorial/package.json
+++ b/build-tests-samples/packlets-tutorial/package.json
@@ -13,7 +13,7 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/build-tests/heft-action-plugin/package.json
+++ b/build-tests/heft-action-plugin/package.json
@@ -13,7 +13,7 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   },
   "dependencies": {

--- a/build-tests/heft-example-plugin-01/package.json
+++ b/build-tests/heft-example-plugin-01/package.json
@@ -18,7 +18,7 @@
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
     "@types/tapable": "1.0.6",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/build-tests/heft-example-plugin-02/package.json
+++ b/build-tests/heft-example-plugin-02/package.json
@@ -22,7 +22,7 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "heft-example-plugin-01": "workspace:*",
     "typescript": "~4.5.2"
   }

--- a/build-tests/heft-fastify-test/package.json
+++ b/build-tests/heft-fastify-test/package.json
@@ -16,7 +16,7 @@
     "@rushstack/heft": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   },
   "dependencies": {

--- a/build-tests/heft-jest-reporters-test/package.json
+++ b/build-tests/heft-jest-reporters-test/package.json
@@ -16,7 +16,7 @@
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/build-tests/heft-node-everything-esm-module-test/package.json
+++ b/build-tests/heft-node-everything-esm-module-test/package.json
@@ -18,7 +18,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",

--- a/build-tests/heft-node-everything-test/package.json
+++ b/build-tests/heft-node-everything-test/package.json
@@ -17,7 +17,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",

--- a/build-tests/heft-parameter-plugin/package.json
+++ b/build-tests/heft-parameter-plugin/package.json
@@ -13,7 +13,7 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   },
   "dependencies": {

--- a/build-tests/heft-sass-test/package.json
+++ b/build-tests/heft-sass-test/package.json
@@ -21,7 +21,7 @@
     "@types/webpack-env": "1.13.0",
     "autoprefixer": "~9.8.0",
     "css-loader": "~4.2.1",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "html-webpack-plugin": "~5.5.0",
     "node-sass": "6.0.1",
     "postcss": "7.0.32",

--- a/build-tests/heft-typescript-composite-test/package.json
+++ b/build-tests/heft-typescript-composite-test/package.json
@@ -16,7 +16,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/webpack-env": "1.13.0",
     "@types/jest": "27.4.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~4.5.2"

--- a/build-tests/heft-webpack4-everything-test/package.json
+++ b/build-tests/heft-webpack4-everything-test/package.json
@@ -17,7 +17,7 @@
     "@rushstack/heft-webpack4-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/webpack-env": "1.13.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "file-loader": "~6.0.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -17,7 +17,7 @@
     "@rushstack/heft-webpack5-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/webpack-env": "1.13.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~4.5.2"

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -6,13 +6,13 @@ importers:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.1.tgz
       '@rushstack/heft': file:rushstack-heft-0.44.2.tgz
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.7.0+typescript@4.5.2
       '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.2.tgz
-      eslint: 8.3.0
+      eslint: 8.7.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
 
@@ -20,13 +20,13 @@ importers:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.1.tgz
       '@rushstack/heft': file:rushstack-heft-0.44.2.tgz
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.5.2
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.7.0+typescript@4.5.2
       '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.2.tgz
-      eslint: 8.3.0
+      eslint: 8.7.0
       tslint: 5.20.1_typescript@4.5.2
       typescript: 4.5.2
 
@@ -50,13 +50,13 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@eslint/eslintrc/1.0.4:
-    resolution: {integrity: sha1-3+D/e6JwhI0Qxa3QcV4ElkwDSzE=}
+  /@eslint/eslintrc/1.0.5:
+    resolution: {integrity: sha1-M/G4ONvx+SO/pRfgCDYreN278xg=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.3
-      espree: 9.1.0
+      espree: 9.3.0
       globals: 13.10.0
       ignore: 4.0.6
       import-fresh: 3.3.0
@@ -67,23 +67,23 @@ packages:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array/0.6.0:
-    resolution: {integrity: sha1-tWIf2zsyMJ0tFldUVsvCd/qPAho=}
+  /@humanwhocodes/config-array/0.9.2:
+    resolution: {integrity: sha1-aL5VxzcCMAnfxf4kXVEYG7ZHaRQ=}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 1.2.0
+      '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.3
       minimatch: 3.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@humanwhocodes/object-schema/1.2.0:
-    resolution: {integrity: sha1-h956+cIxgm/daKxyWPd8Qp4OX88=}
+  /@humanwhocodes/object-schema/1.2.1:
+    resolution: {integrity: sha1-tSBSnsIdjllFoYUd/Rwy6U45/0U=}
     dev: true
 
   /@microsoft/tsdoc-config/0.15.2:
-    resolution: {integrity: sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==}
+    resolution: {integrity: sha1-6zU8k/O2KrdL3Jq29Kgrz4AUDxQ=}
     dependencies:
       '@microsoft/tsdoc': 0.13.2
       ajv: 6.12.6
@@ -92,11 +92,11 @@ packages:
     dev: true
 
   /@microsoft/tsdoc/0.13.2:
-    resolution: {integrity: sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==}
+    resolution: {integrity: sha1-Ow77bTkDvUntsHNpb2DpDfCO+yY=}
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    resolution: {integrity: sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=}
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -104,12 +104,12 @@ packages:
     dev: true
 
   /@nodelib/fs.stat/2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    resolution: {integrity: sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=}
     engines: {node: '>= 8'}
     dev: true
 
   /@nodelib/fs.walk/1.2.7:
-    resolution: {integrity: sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==}
+    resolution: {integrity: sha1-lMI9sY7kZT4Smr0m+wb4cKyeHuI=}
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
@@ -117,23 +117,23 @@ packages:
     dev: true
 
   /@types/argparse/1.0.38:
-    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    resolution: {integrity: sha1-qB/YYG1IH4c6OADG665PHXaKVqk=}
     dev: true
 
   /@types/json-schema/7.0.9:
-    resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
+    resolution: {integrity: sha1-l+3JA36gw4WFMgsolk3eOznkZg0=}
     dev: true
 
   /@types/node/12.20.24:
-    resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
+    resolution: {integrity: sha1-w3rGnLKUivtM75X0JPoAN5camlw=}
     dev: true
 
   /@types/tapable/1.0.6:
-    resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==}
+    resolution: {integrity: sha1-qcpLcKGLJwzLK8Cqr+/R1Ia36nQ=}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.6.0_7d727cadaff2de2813cd41f6e2d8a801:
-    resolution: {integrity: sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==}
+  /@typescript-eslint/eslint-plugin/5.6.0_d466ed60638eced99d543a223feeb14a:
+    resolution: {integrity: sha1-79hmiz1mJ8Rs5yLCr+gTko/hIKA=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -143,13 +143,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/scope-manager': 5.6.0
       debug: 4.3.3
-      eslint: 8.3.0
+      eslint: 8.7.0
       functional-red-black-tree: 1.0.1
-      ignore: 5.1.8
+      ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.5.2
@@ -158,8 +158,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.3.0+typescript@4.5.2:
-    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
+  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.7.0+typescript@4.5.2:
+    resolution: {integrity: sha1-86WWDyAEq9yse7gUErr8FWCEHCM=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -168,16 +168,16 @@ packages:
       '@typescript-eslint/scope-manager': 5.6.0
       '@typescript-eslint/types': 5.6.0
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.3.0
+      eslint-utils: 3.0.0_eslint@8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.6.0_eslint@8.3.0+typescript@4.5.2:
-    resolution: {integrity: sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==}
+  /@typescript-eslint/parser/5.6.0_eslint@8.7.0+typescript@4.5.2:
+    resolution: {integrity: sha1-EWdzJGWWQUANZTJTwD3PvtRo0Zk=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -190,14 +190,14 @@ packages:
       '@typescript-eslint/types': 5.6.0
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
       debug: 4.3.3
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
   /@typescript-eslint/scope-manager/5.6.0:
-    resolution: {integrity: sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==}
+    resolution: {integrity: sha1-ndfwB9yPOjTN/2959eqrJ64FFX4=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.6.0
@@ -205,12 +205,12 @@ packages:
     dev: true
 
   /@typescript-eslint/types/5.6.0:
-    resolution: {integrity: sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==}
+    resolution: {integrity: sha1-dFyxtZ2q3MHzL3vpXw9orM84r90=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.2:
-    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
+    resolution: {integrity: sha1-37sZyTB/3YG9nGUMZ+g5eCHX+vA=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -231,23 +231,23 @@ packages:
     dev: true
 
   /@typescript-eslint/visitor-keys/5.6.0:
-    resolution: {integrity: sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==}
+    resolution: {integrity: sha1-PjZQnhA/6XE9jwNayXcjX9Y8tuY=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.6.0
-      eslint-visitor-keys: 3.1.0
+      eslint-visitor-keys: 3.2.0
     dev: true
 
-  /acorn-jsx/5.3.1_acorn@8.6.0:
+  /acorn-jsx/5.3.1_acorn@8.7.0:
     resolution: {integrity: sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.6.0
+      acorn: 8.7.0
     dev: true
 
-  /acorn/8.6.0:
-    resolution: {integrity: sha1-42kroOsaDIPqpPN/X6c2jdcUKJU=}
+  /acorn/8.7.0:
+    resolution: {integrity: sha1-kJUf3g+PCd+TVJSB5fwUFEW3kc8=}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -259,11 +259,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
-
-  /ansi-colors/4.1.1:
-    resolution: {integrity: sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=}
-    engines: {node: '>=6'}
     dev: true
 
   /ansi-regex/5.0.1:
@@ -286,7 +281,7 @@ packages:
     dev: true
 
   /anymatch/3.1.2:
-    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    resolution: {integrity: sha1-wFV8CWrzLxBhmPT04qODU343hxY=}
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
@@ -294,7 +289,7 @@ packages:
     dev: true
 
   /argparse/1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    resolution: {integrity: sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=}
     dependencies:
       sprintf-js: 1.0.3
     dev: true
@@ -304,7 +299,7 @@ packages:
     dev: true
 
   /array-includes/3.1.4:
-    resolution: {integrity: sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==}
+    resolution: {integrity: sha1-9bSTFix2DzU5Yx8AW6K7Rqy0W6k=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -315,12 +310,12 @@ packages:
     dev: true
 
   /array-union/2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    resolution: {integrity: sha1-t5hCCtvrHego2ErNii4j0+/oXo0=}
     engines: {node: '>=8'}
     dev: true
 
   /array.prototype.flatmap/1.2.5:
-    resolution: {integrity: sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==}
+    resolution: {integrity: sha1-kI3ILYpAaTD984WY1R50EdGNREY=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -333,7 +328,7 @@ packages:
     dev: true
 
   /binary-extensions/2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    resolution: {integrity: sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=}
     engines: {node: '>=8'}
     dev: true
 
@@ -345,7 +340,7 @@ packages:
     dev: true
 
   /braces/3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    resolution: {integrity: sha1-NFThpGLujVmeI23zNs2epPiv4Qc=}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
@@ -357,7 +352,7 @@ packages:
     dev: true
 
   /call-bind/1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    resolution: {integrity: sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=}
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.1
@@ -386,7 +381,7 @@ packages:
     dev: true
 
   /chokidar/3.4.3:
-    resolution: {integrity: sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==}
+    resolution: {integrity: sha1-wd84IxRI5FykrFiObHlXO6alfVs=}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.2
@@ -422,7 +417,7 @@ packages:
     dev: true
 
   /colors/1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
+    resolution: {integrity: sha1-icetmjdLwDDfgBMkH2gTbtiDWvw=}
     engines: {node: '>=0.1.90'}
     dev: true
 
@@ -444,7 +439,7 @@ packages:
     dev: true
 
   /debug/4.3.3:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
+    resolution: {integrity: sha1-BCZuC3CpjURi5uKI44JZITMytmQ=}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -460,7 +455,7 @@ packages:
     dev: true
 
   /define-properties/1.1.3:
-    resolution: {integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==}
+    resolution: {integrity: sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=}
     engines: {node: '>= 0.4'}
     dependencies:
       object-keys: 1.1.1
@@ -472,14 +467,14 @@ packages:
     dev: true
 
   /dir-glob/3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    resolution: {integrity: sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
     dev: true
 
   /doctrine/2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    resolution: {integrity: sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=}
     engines: {node: '>=0.10.0'}
     dependencies:
       esutils: 2.0.3
@@ -492,15 +487,8 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /enquirer/2.3.6:
-    resolution: {integrity: sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=}
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: 4.1.1
-    dev: true
-
   /es-abstract/1.19.1:
-    resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==}
+    resolution: {integrity: sha1-1IhXlodpFpWd547aoN9FZicRXsM=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -526,7 +514,7 @@ packages:
     dev: true
 
   /es-to-primitive/1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    resolution: {integrity: sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=}
     engines: {node: '>= 0.4'}
     dependencies:
       is-callable: 1.2.4
@@ -544,17 +532,17 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-plugin-promise/6.0.0_eslint@8.3.0:
-    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+  /eslint-plugin-promise/6.0.0_eslint@8.7.0:
+    resolution: {integrity: sha1-AXZSwHyYFkE6QeEcMK3ELD1V/xg=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.3.0
+      eslint: 8.7.0
     dev: true
 
-  /eslint-plugin-react/7.27.1_eslint@8.3.0:
-    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
+  /eslint-plugin-react/7.27.1_eslint@8.7.0:
+    resolution: {integrity: sha1-RpICRCUGYW93qFTZG6uq4ewXS0U=}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -562,7 +550,7 @@ packages:
       array-includes: 3.1.4
       array.prototype.flatmap: 1.2.5
       doctrine: 2.1.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       estraverse: 5.3.0
       jsx-ast-utils: 2.4.1
       minimatch: 3.0.4
@@ -577,14 +565,14 @@ packages:
     dev: true
 
   /eslint-plugin-tsdoc/0.2.14:
-    resolution: {integrity: sha512-fJ3fnZRsdIoBZgzkQjv8vAj6NeeOoFkTfgosj6mKsFjX70QV256sA/wq+y/R2+OL4L8E79VVaVWrPeZnKNe8Ng==}
+    resolution: {integrity: sha1-4y58HfivezAJwlJZC+wHoQMK+/I=}
     dependencies:
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
     dev: true
 
   /eslint-scope/5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    resolution: {integrity: sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=}
     engines: {node: '>=8.0.0'}
     dependencies:
       esrecurse: 4.3.0
@@ -596,47 +584,46 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
-      estraverse: 5.2.0
+      estraverse: 5.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.3.0:
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+  /eslint-utils/3.0.0_eslint@8.7.0:
+    resolution: {integrity: sha1-iuuvrOc0W7M1WdsKHxOh0tSMNnI=}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.3.0
+      eslint: 8.7.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
   /eslint-visitor-keys/2.1.0:
-    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    resolution: {integrity: sha1-9lMoJZMFknOSyTjtROsKXJsr0wM=}
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-visitor-keys/3.1.0:
-    resolution: {integrity: sha1-7uSs6okYFM2men2IEtlkfdAXmvI=}
+  /eslint-visitor-keys/3.2.0:
+    resolution: {integrity: sha1-b7sWameY7lmRNYvC2qG6dswSVKE=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.3.0:
-    resolution: {integrity: sha1-o8JAlQdAPBx/bEKSYRHWy++8PoU=}
+  /eslint/8.7.0:
+    resolution: {integrity: sha1-IuA2hC7lt8+HsD/iN3MWdbTTYzw=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.0.4
-      '@humanwhocodes/config-array': 0.6.0
+      '@eslint/eslintrc': 1.0.5
+      '@humanwhocodes/config-array': 0.9.2
       ajv: 6.12.6
       chalk: 4.1.1
       cross-spawn: 7.0.3
       debug: 4.3.3
       doctrine: 3.0.0
-      enquirer: 2.3.6
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.0
-      eslint-utils: 3.0.0_eslint@8.3.0
-      eslint-visitor-keys: 3.1.0
-      espree: 9.1.0
+      eslint-utils: 3.0.0_eslint@8.7.0
+      eslint-visitor-keys: 3.2.0
+      espree: 9.3.0
       esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -644,10 +631,10 @@ packages:
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
       globals: 13.10.0
-      ignore: 4.0.6
+      ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
-      is-glob: 4.0.1
+      is-glob: 4.0.3
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -655,9 +642,7 @@ packages:
       minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
-      progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.3.5
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       text-table: 0.2.0
@@ -666,13 +651,13 @@ packages:
       - supports-color
     dev: true
 
-  /espree/9.1.0:
-    resolution: {integrity: sha1-up08mzTuriBXJBJOMd5FQ9Wfv3Q=}
+  /espree/9.3.0:
+    resolution: {integrity: sha1-wSQNeRg7cqrubM+lqQvJER3whag=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.6.0
-      acorn-jsx: 5.3.1_acorn@8.6.0
-      eslint-visitor-keys: 3.1.0
+      acorn: 8.7.0
+      acorn-jsx: 5.3.1_acorn@8.7.0
+      eslint-visitor-keys: 3.2.0
     dev: true
 
   /esprima/4.0.1:
@@ -685,33 +670,28 @@ packages:
     resolution: {integrity: sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=}
     engines: {node: '>=0.10'}
     dependencies:
-      estraverse: 5.2.0
+      estraverse: 5.3.0
     dev: true
 
   /esrecurse/4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    resolution: {integrity: sha1-eteWTWeauyi+5yzsY3WLHF0smSE=}
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
     dev: true
 
   /estraverse/4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: true
-
-  /estraverse/5.2.0:
-    resolution: {integrity: sha1-MH30JUfmzHMk088DwVXVzbjFOIA=}
+    resolution: {integrity: sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=}
     engines: {node: '>=4.0'}
     dev: true
 
   /estraverse/5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    resolution: {integrity: sha1-LupSkHAvJquP5TcDcP+GyWXSESM=}
     engines: {node: '>=4.0'}
     dev: true
 
   /esutils/2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    resolution: {integrity: sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -720,7 +700,7 @@ packages:
     dev: true
 
   /fast-glob/3.2.5:
-    resolution: {integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==}
+    resolution: {integrity: sha1-eTmvKmVt55pPGQGQPuityqfLlmE=}
     engines: {node: '>=8'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -740,7 +720,7 @@ packages:
     dev: true
 
   /fastq/1.11.0:
-    resolution: {integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==}
+    resolution: {integrity: sha1-u5+5VaBxMKkY62PB9RYcwypdCFg=}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -753,7 +733,7 @@ packages:
     dev: true
 
   /fill-range/7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    resolution: {integrity: sha1-GRmmp8df44ssfHflGYU12prN2kA=}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
@@ -772,7 +752,7 @@ packages:
     dev: true
 
   /fs-extra/7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    resolution: {integrity: sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
       graceful-fs: 4.2.6
@@ -785,15 +765,14 @@ packages:
     dev: true
 
   /fsevents/2.1.3:
-    resolution: {integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==}
+    resolution: {integrity: sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    deprecated: '"Please update to latest v2.3 or v2.2"'
     dev: true
     optional: true
 
   /function-bind/1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    resolution: {integrity: sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=}
     dev: true
 
   /functional-red-black-tree/1.0.1:
@@ -801,7 +780,7 @@ packages:
     dev: true
 
   /get-intrinsic/1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
+    resolution: {integrity: sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -809,7 +788,7 @@ packages:
     dev: true
 
   /get-symbol-description/1.0.0:
-    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+    resolution: {integrity: sha1-f9uByQAQH71WTdXxowr1qtweWNY=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -822,7 +801,7 @@ packages:
     dev: true
 
   /glob-parent/5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    resolution: {integrity: sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=}
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
@@ -865,23 +844,23 @@ packages:
     dev: true
 
   /globby/11.0.4:
-    resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
+    resolution: {integrity: sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=}
     engines: {node: '>=10'}
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.5
-      ignore: 5.1.8
+      ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
 
   /graceful-fs/4.2.6:
-    resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==}
+    resolution: {integrity: sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=}
     dev: true
 
   /has-bigints/1.0.1:
-    resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
+    resolution: {integrity: sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=}
     dev: true
 
   /has-flag/3.0.0:
@@ -895,19 +874,19 @@ packages:
     dev: true
 
   /has-symbols/1.0.2:
-    resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==}
+    resolution: {integrity: sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=}
     engines: {node: '>= 0.4'}
     dev: true
 
   /has-tostringtag/1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
+    resolution: {integrity: sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.2
     dev: true
 
   /has/1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    resolution: {integrity: sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
@@ -918,8 +897,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /ignore/5.1.8:
-    resolution: {integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==}
+  /ignore/5.2.0:
+    resolution: {integrity: sha1-bTusj6f+DUXZ+b57rC/CeVd+NFo=}
     engines: {node: '>= 4'}
     dev: true
 
@@ -932,7 +911,7 @@ packages:
     dev: true
 
   /import-lazy/4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    resolution: {integrity: sha1-6OtidIOgpD2jwD8+NVSL5csMwVM=}
     engines: {node: '>=8'}
     dev: true
 
@@ -949,11 +928,11 @@ packages:
     dev: true
 
   /inherits/2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution: {integrity: sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=}
     dev: true
 
   /internal-slot/1.0.3:
-    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
+    resolution: {integrity: sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=}
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.1.1
@@ -962,36 +941,36 @@ packages:
     dev: true
 
   /is-bigint/1.0.2:
-    resolution: {integrity: sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==}
+    resolution: {integrity: sha1-/7OBRCUDI1rSReqJ5Fs9v/BA7lo=}
     dev: true
 
   /is-binary-path/2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    resolution: {integrity: sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
     dev: true
 
   /is-boolean-object/1.1.1:
-    resolution: {integrity: sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==}
+    resolution: {integrity: sha1-PAh48DXLghIo01DS4eNnGXFqPeg=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
     dev: true
 
   /is-callable/1.2.4:
-    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
+    resolution: {integrity: sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-core-module/2.4.0:
-    resolution: {integrity: sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==}
+    resolution: {integrity: sha1-jp/I4VAnsBFBgCbpjw5vTYYwXME=}
     dependencies:
       has: 1.0.3
     dev: true
 
   /is-date-object/1.0.4:
-    resolution: {integrity: sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==}
+    resolution: {integrity: sha1-VQz8wDr62gXuo90wmBx7CVUfc+U=}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -1000,37 +979,30 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-glob/4.0.1:
-    resolution: {integrity: sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 2.1.1
-    dev: true
-
   /is-glob/4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    resolution: {integrity: sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
     dev: true
 
   /is-negative-zero/2.0.1:
-    resolution: {integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==}
+    resolution: {integrity: sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-number-object/1.0.5:
-    resolution: {integrity: sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==}
+    resolution: {integrity: sha1-bt+u7XlQz/Ga/tzp+/yp7m3Sies=}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-number/7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    resolution: {integrity: sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=}
     engines: {node: '>=0.12.0'}
     dev: true
 
   /is-regex/1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
+    resolution: {integrity: sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1038,25 +1010,25 @@ packages:
     dev: true
 
   /is-shared-array-buffer/1.0.1:
-    resolution: {integrity: sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==}
+    resolution: {integrity: sha1-l7DIX72stZycRG/mU7gs8rW3z+Y=}
     dev: true
 
   /is-string/1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    resolution: {integrity: sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: true
 
   /is-symbol/1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
+    resolution: {integrity: sha1-ptrJO2NbBjymhyI23oiRClevE5w=}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.2
     dev: true
 
   /is-weakref/1.0.1:
-    resolution: {integrity: sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==}
+    resolution: {integrity: sha1-hC26TsF/qayYUN8tbvvBc3J08qI=}
     dependencies:
       call-bind: 1.0.2
     dev: true
@@ -1070,7 +1042,7 @@ packages:
     dev: true
 
   /js-tokens/4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution: {integrity: sha1-GSA/tZmR35jjoocFDUZHzerzJJk=}
     dev: true
 
   /js-yaml/3.14.1:
@@ -1103,12 +1075,12 @@ packages:
     dev: true
 
   /jsonpath-plus/4.0.0:
-    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
+    resolution: {integrity: sha1-lUtp+qPYsH8wri+eYBF2pLDSgG4=}
     engines: {node: '>=10.0'}
     dev: true
 
   /jsx-ast-utils/2.4.1:
-    resolution: {integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==}
+    resolution: {integrity: sha1-ERSkwSCUgdsGxpDCtPSIzGZfZX4=}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.4
@@ -1136,26 +1108,26 @@ packages:
     dev: true
 
   /loose-envify/1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    resolution: {integrity: sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=}
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
     dev: true
 
   /lru-cache/6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    resolution: {integrity: sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
     dev: true
 
   /merge2/1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    resolution: {integrity: sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=}
     engines: {node: '>= 8'}
     dev: true
 
   /micromatch/4.0.4:
-    resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
+    resolution: {integrity: sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.2
@@ -1180,7 +1152,7 @@ packages:
     dev: true
 
   /ms/2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    resolution: {integrity: sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=}
     dev: true
 
   /natural-compare/1.4.0:
@@ -1188,7 +1160,7 @@ packages:
     dev: true
 
   /normalize-path/3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    resolution: {integrity: sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -1198,16 +1170,16 @@ packages:
     dev: true
 
   /object-inspect/1.11.0:
-    resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
+    resolution: {integrity: sha1-nc6xRs7dQUig2eUauI00z1CZIrE=}
     dev: true
 
   /object-keys/1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    resolution: {integrity: sha1-HEfyct8nfzsdrwYWd9nILiMixg4=}
     engines: {node: '>= 0.4'}
     dev: true
 
   /object.assign/4.1.2:
-    resolution: {integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==}
+    resolution: {integrity: sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1217,7 +1189,7 @@ packages:
     dev: true
 
   /object.entries/1.1.5:
-    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==}
+    resolution: {integrity: sha1-4azdF8TeLNltWghIfPuduE2IGGE=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1226,7 +1198,7 @@ packages:
     dev: true
 
   /object.fromentries/2.0.5:
-    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
+    resolution: {integrity: sha1-ezeyBRCcIedB5gVyf+iwrV+gglE=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1235,14 +1207,14 @@ packages:
     dev: true
 
   /object.hasown/1.1.0:
-    resolution: {integrity: sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==}
+    resolution: {integrity: sha1-cjLtJm800ZfRXKxYgCMvekeQr+U=}
     dependencies:
       define-properties: 1.1.3
       es-abstract: 1.19.1
     dev: true
 
   /object.values/1.1.5:
-    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==}
+    resolution: {integrity: sha1-lZ9j486e8QhyAzMIITHkpFm3Fqw=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1286,16 +1258,16 @@ packages:
     dev: true
 
   /path-parse/1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution: {integrity: sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=}
     dev: true
 
   /path-type/4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    resolution: {integrity: sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=}
     engines: {node: '>=8'}
     dev: true
 
   /picomatch/2.3.0:
-    resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
+    resolution: {integrity: sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=}
     engines: {node: '>=8.6'}
     dev: true
 
@@ -1305,18 +1277,13 @@ packages:
     dev: true
 
   /prettier/2.3.1:
-    resolution: {integrity: sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==}
+    resolution: {integrity: sha1-dpA8P4xESbyaxZes76JNxa1MvqY=}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
 
-  /progress/2.0.3:
-    resolution: {integrity: sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=}
-    engines: {node: '>=0.4.0'}
-    dev: true
-
   /prop-types/15.7.2:
-    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==}
+    resolution: {integrity: sha1-UsQedbjIfnK52TYOAga5ncv/psU=}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -1329,22 +1296,22 @@ packages:
     dev: true
 
   /queue-microtask/1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution: {integrity: sha1-SSkii7xyTfrEPg77BYyve2z7YkM=}
     dev: true
 
   /react-is/16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    resolution: {integrity: sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=}
     dev: true
 
   /readdirp/3.5.0:
-    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
+    resolution: {integrity: sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=}
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.0
     dev: true
 
   /regexp.prototype.flags/1.3.1:
-    resolution: {integrity: sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==}
+    resolution: {integrity: sha1-fvNSro0VnnWMDq3Kb4/LTu8HviY=}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1352,7 +1319,7 @@ packages:
     dev: true
 
   /regexpp/3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
+    resolution: {integrity: sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=}
     engines: {node: '>=8'}
     dev: true
 
@@ -1362,13 +1329,13 @@ packages:
     dev: true
 
   /resolve/1.17.0:
-    resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
+    resolution: {integrity: sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=}
     dependencies:
       path-parse: 1.0.7
     dev: true
 
   /resolve/1.19.0:
-    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
+    resolution: {integrity: sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=}
     dependencies:
       is-core-module: 2.4.0
       path-parse: 1.0.7
@@ -1382,14 +1349,14 @@ packages:
     dev: true
 
   /resolve/2.0.0-next.3:
-    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==}
+    resolution: {integrity: sha1-1BAWKT1KhYajnKXZtfFcvqH1XkY=}
     dependencies:
       is-core-module: 2.4.0
       path-parse: 1.0.7
     dev: true
 
   /reusify/1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    resolution: {integrity: sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
@@ -1401,7 +1368,7 @@ packages:
     dev: true
 
   /run-parallel/1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution: {integrity: sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=}
     dependencies:
       queue-microtask: 1.2.3
     dev: true
@@ -1412,12 +1379,12 @@ packages:
     dev: true
 
   /semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    resolution: {integrity: sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=}
     hasBin: true
     dev: true
 
   /semver/7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
+    resolution: {integrity: sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -1437,7 +1404,7 @@ packages:
     dev: true
 
   /side-channel/1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    resolution: {integrity: sha1-785cj9wQTudRslxY1CkAEfpeos8=}
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
@@ -1445,7 +1412,7 @@ packages:
     dev: true
 
   /slash/3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    resolution: {integrity: sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=}
     engines: {node: '>=8'}
     dev: true
 
@@ -1454,12 +1421,12 @@ packages:
     dev: true
 
   /string-argv/0.3.1:
-    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+    resolution: {integrity: sha1-leL77AQnrhkYSTX4FtdKqkxcGdo=}
     engines: {node: '>=0.6.19'}
     dev: true
 
   /string.prototype.matchall/4.0.6:
-    resolution: {integrity: sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==}
+    resolution: {integrity: sha1-Wrtdq8lMew6iOA9lumELOlRLFfo=}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
@@ -1472,14 +1439,14 @@ packages:
     dev: true
 
   /string.prototype.trimend/1.0.4:
-    resolution: {integrity: sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==}
+    resolution: {integrity: sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
     dev: true
 
   /string.prototype.trimstart/1.0.4:
-    resolution: {integrity: sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==}
+    resolution: {integrity: sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
@@ -1493,7 +1460,7 @@ packages:
     dev: true
 
   /strip-json-comments/3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    resolution: {integrity: sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=}
     engines: {node: '>=8'}
     dev: true
 
@@ -1512,7 +1479,7 @@ packages:
     dev: true
 
   /tapable/1.1.3:
-    resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
+    resolution: {integrity: sha1-ofzMBrWNth/XpF2i2kT186Pme6I=}
     engines: {node: '>=6'}
     dev: true
 
@@ -1525,14 +1492,14 @@ packages:
     dev: true
 
   /to-regex-range/5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    resolution: {integrity: sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
 
   /true-case-path/2.2.1:
-    resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
+    resolution: {integrity: sha1-xb8EpbvsP9EYvkCERhs6J8TXlr8=}
     dev: true
 
   /tslib/1.14.1:
@@ -1572,7 +1539,7 @@ packages:
     dev: true
 
   /tsutils/3.21.0_typescript@4.5.2:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    resolution: {integrity: sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
@@ -1600,7 +1567,7 @@ packages:
     dev: true
 
   /unbox-primitive/1.0.1:
-    resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==}
+    resolution: {integrity: sha1-CF4hViXsMWJXTciFmr7nilmxRHE=}
     dependencies:
       function-bind: 1.1.1
       has-bigints: 1.0.1
@@ -1609,7 +1576,7 @@ packages:
     dev: true
 
   /universalify/0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    resolution: {integrity: sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=}
     engines: {node: '>= 4.0.0'}
     dev: true
 
@@ -1624,12 +1591,12 @@ packages:
     dev: true
 
   /validator/13.7.0:
-    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
+    resolution: {integrity: sha1-T5ZYuhO6jz2C7ogdNRZInqhcCFc=}
     engines: {node: '>= 0.10'}
     dev: true
 
   /which-boxed-primitive/1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
+    resolution: {integrity: sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=}
     dependencies:
       is-bigint: 1.0.2
       is-boolean-object: 1.1.1
@@ -1656,11 +1623,11 @@ packages:
     dev: true
 
   /yallist/4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    resolution: {integrity: sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=}
     dev: true
 
   /z-schema/5.0.2:
-    resolution: {integrity: sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==}
+    resolution: {integrity: sha1-9BA5Syyfy57a9qdRFJHAu06JpQQ=}
     engines: {node: '>=8.0.0'}
     hasBin: true
     dependencies:
@@ -1671,7 +1638,7 @@ packages:
       commander: 2.20.3
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.3.0+typescript@4.5.2:
+  file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz_eslint@8.7.0+typescript@4.5.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz}
     id: file:../temp/tarballs/rushstack-eslint-config-2.5.1.tgz
     name: '@rushstack/eslint-config'
@@ -1681,16 +1648,16 @@ packages:
       typescript: '>=3.0.0'
     dependencies:
       '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.1.0.tgz
-      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz_eslint@8.3.0+typescript@4.5.2
-      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz_eslint@8.3.0+typescript@4.5.2
-      '@typescript-eslint/eslint-plugin': 5.6.0_7d727cadaff2de2813cd41f6e2d8a801
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz_eslint@8.7.0+typescript@4.5.2
+      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz_eslint@8.7.0+typescript@4.5.2
+      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz_eslint@8.7.0+typescript@4.5.2
+      '@typescript-eslint/eslint-plugin': 5.6.0_d466ed60638eced99d543a223feeb14a
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
-      eslint-plugin-promise: 6.0.0_eslint@8.3.0
-      eslint-plugin-react: 7.27.1_eslint@8.3.0
+      eslint: 8.7.0
+      eslint-plugin-promise: 6.0.0_eslint@8.7.0
+      eslint-plugin-react: 7.27.1_eslint@8.7.0
       eslint-plugin-tsdoc: 0.2.14
       typescript: 4.5.2
     transitivePeerDependencies:
@@ -1703,7 +1670,7 @@ packages:
     version: 1.1.0
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz_eslint@8.3.0+typescript@4.5.2:
+  file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz_eslint@8.7.0+typescript@4.5.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-0.8.4.tgz
     name: '@rushstack/eslint-plugin'
@@ -1712,14 +1679,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.2.tgz
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      eslint: 8.3.0
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      eslint: 8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz_eslint@8.3.0+typescript@4.5.2:
+  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz_eslint@8.7.0+typescript@4.5.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.4.tgz
     name: '@rushstack/eslint-plugin-packlets'
@@ -1728,14 +1695,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.2.tgz
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      eslint: 8.3.0
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      eslint: 8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz_eslint@8.3.0+typescript@4.5.2:
+  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz_eslint@8.7.0+typescript@4.5.2:
     resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz}
     id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.4.tgz
     name: '@rushstack/eslint-plugin-security'
@@ -1744,8 +1711,8 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../temp/tarballs/rushstack-tree-pattern-0.2.2.tgz
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      eslint: 8.3.0
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      eslint: 8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/build-tests/install-test-workspace/workspace/typescript-newest-test/package.json
+++ b/build-tests/install-test-workspace/workspace/typescript-newest-test/package.json
@@ -13,6 +13,6 @@
     "@rushstack/heft": "*",
     "typescript": "~4.5.2",
     "tslint": "~5.20.1",
-    "eslint": "~8.3.0"
+    "eslint": "~8.7.0"
   }
 }

--- a/build-tests/install-test-workspace/workspace/typescript-v3-test/package.json
+++ b/build-tests/install-test-workspace/workspace/typescript-v3-test/package.json
@@ -13,6 +13,6 @@
     "@rushstack/heft": "*",
     "typescript": "~4.5.2",
     "tslint": "~5.20.1",
-    "eslint": "~8.3.0"
+    "eslint": "~8.7.0"
   }
 }

--- a/build-tests/set-webpack-public-path-plugin-webpack4-test/package.json
+++ b/build-tests/set-webpack-public-path-plugin-webpack4-test/package.json
@@ -16,7 +16,7 @@
     "@rushstack/set-webpack-public-path-plugin": "workspace:*",
     "html-webpack-plugin": "~4.5.0",
     "@types/webpack-env": "1.13.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/common/changes/@rushstack/eslint-config/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-config/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/eslint-plugin-security/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/eslint-plugin-security/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/eslint-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/changes/@rushstack/eslint-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/eslint-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-node-rig/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/heft-node-rig/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Upgrade ESLint to ~8.7.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
+++ b/common/changes/@rushstack/heft-sass-plugin/user-danade-BumpEslint_2022-01-24-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/heft-sass-plugin/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-web-rig/user-danade-BumpEslint_2022-01-24-17-38.json
+++ b/common/changes/@rushstack/heft-web-rig/user-danade-BumpEslint_2022-01-24-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Upgrade ESLint to ~8.7.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -31,7 +31,7 @@
     "typescript": "~4.5.2",
 
     // Workaround for https://github.com/microsoft/rushstack/issues/1466
-    "eslint": "~8.3.0"
+    "eslint": "~8.7.0"
   },
 
   /**

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -329,7 +329,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -337,7 +337,7 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests-samples/heft-node-jest-tutorial:
@@ -347,7 +347,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -355,7 +355,7 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests-samples/heft-node-rig-tutorial:
@@ -384,7 +384,7 @@ importers:
       '@types/react-dom': 16.9.8
       '@types/webpack-env': 1.13.0
       css-loader: ~4.2.1
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       heft-storybook-react-tutorial-storykit: workspace:*
       html-webpack-plugin: ~5.5.0
       react: ~16.13.1
@@ -404,7 +404,7 @@ importers:
       '@types/react-dom': 16.9.8
       '@types/webpack-env': 1.13.0
       css-loader: 4.2.2_webpack@4.44.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       heft-storybook-react-tutorial-storykit: link:../heft-storybook-react-tutorial-storykit
       html-webpack-plugin: 5.5.0_webpack@4.44.2
       react: 16.13.1
@@ -471,7 +471,7 @@ importers:
       '@types/react-dom': 16.9.8
       '@types/webpack-env': 1.13.0
       css-loader: ~4.2.1
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       html-webpack-plugin: ~5.5.0
       react: ~16.13.1
       react-dom: ~16.13.1
@@ -489,7 +489,7 @@ importers:
       '@types/react-dom': 16.9.8
       '@types/webpack-env': 1.13.0
       css-loader: 4.2.2_webpack@4.44.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       html-webpack-plugin: 5.5.0_webpack@4.44.2
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -503,13 +503,13 @@ importers:
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/api-documenter-test:
@@ -683,7 +683,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -691,7 +691,7 @@ importers:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/heft-action-plugin-test:
@@ -714,7 +714,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       tapable: 1.1.3
       typescript: ~4.5.2
     dependencies:
@@ -724,7 +724,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/heft-example-plugin-02:
@@ -732,14 +732,14 @@ importers:
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       heft-example-plugin-01: workspace:*
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       heft-example-plugin-01: link:../heft-example-plugin-01
       typescript: 4.5.2
 
@@ -749,7 +749,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       fastify: ~3.16.1
       typescript: ~4.5.2
     dependencies:
@@ -759,7 +759,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/heft-jest-reporters-test:
@@ -770,7 +770,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     devDependencies:
       '@jest/reporters': 27.4.2
@@ -779,7 +779,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/heft-minimal-rig-test:
@@ -814,7 +814,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       heft-example-plugin-01: workspace:*
       heft-example-plugin-02: workspace:*
       tslint: ~5.20.1
@@ -827,7 +827,7 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
       tslint: 5.20.1_typescript@4.5.2
@@ -842,7 +842,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       heft-example-plugin-01: workspace:*
       heft-example-plugin-02: workspace:*
       tslint: ~5.20.1
@@ -855,7 +855,7 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
       tslint: 5.20.1_typescript@4.5.2
@@ -868,7 +868,7 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -876,7 +876,7 @@ importers:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../build-tests/heft-parameter-plugin-test:
@@ -909,7 +909,7 @@ importers:
       autoprefixer: ~9.8.0
       buttono: ~1.0.2
       css-loader: ~4.2.1
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       html-webpack-plugin: ~5.5.0
       node-sass: 6.0.1
       postcss: 7.0.32
@@ -934,7 +934,7 @@ importers:
       '@types/webpack-env': 1.13.0
       autoprefixer: 9.8.8
       css-loader: 4.2.2_webpack@4.44.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       html-webpack-plugin: 5.5.0_webpack@4.44.2
       node-sass: 6.0.1
       postcss: 7.0.32
@@ -954,7 +954,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/jest': 27.4.0
       '@types/webpack-env': 1.13.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
       typescript: ~4.5.2
@@ -965,7 +965,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/jest': 27.4.0
       '@types/webpack-env': 1.13.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       tslint: 5.20.1_typescript@4.5.2
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.5.2
       typescript: 4.5.2
@@ -989,7 +989,7 @@ importers:
       '@rushstack/heft-webpack4-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       file-loader: ~6.0.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
@@ -1003,7 +1003,7 @@ importers:
       '@rushstack/heft-webpack4-plugin': link:../../heft-plugins/heft-webpack4-plugin
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       file-loader: 6.0.0_webpack@4.44.2
       tslint: 5.20.1_typescript@4.5.2
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.5.2
@@ -1019,7 +1019,7 @@ importers:
       '@rushstack/heft-webpack5-plugin': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
       typescript: ~4.5.2
@@ -1031,7 +1031,7 @@ importers:
       '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.13.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       tslint: 5.20.1_typescript@4.5.2
       tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.5.2
       typescript: 4.5.2
@@ -1154,7 +1154,7 @@ importers:
       '@rushstack/heft-webpack4-plugin': workspace:*
       '@rushstack/set-webpack-public-path-plugin': workspace:*
       '@types/webpack-env': 1.13.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       html-webpack-plugin: ~4.5.0
       typescript: ~4.5.2
     devDependencies:
@@ -1163,7 +1163,7 @@ importers:
       '@rushstack/heft-webpack4-plugin': link:../../heft-plugins/heft-webpack4-plugin
       '@rushstack/set-webpack-public-path-plugin': link:../../webpack/set-webpack-public-path-plugin
       '@types/webpack-env': 1.13.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       html-webpack-plugin: 4.5.2
       typescript: 4.5.2
 
@@ -1189,7 +1189,7 @@ importers:
       '@typescript-eslint/experimental-utils': ~5.6.0
       '@typescript-eslint/parser': ~5.6.0
       '@typescript-eslint/typescript-estree': ~5.6.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       eslint-plugin-promise: ~6.0.0
       eslint-plugin-react: ~7.27.1
       eslint-plugin-tsdoc: ~0.2.14
@@ -1199,15 +1199,15 @@ importers:
       '@rushstack/eslint-plugin': link:../eslint-plugin
       '@rushstack/eslint-plugin-packlets': link:../eslint-plugin-packlets
       '@rushstack/eslint-plugin-security': link:../eslint-plugin-security
-      '@typescript-eslint/eslint-plugin': 5.6.0_7d727cadaff2de2813cd41f6e2d8a801
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/eslint-plugin': 5.6.0_d466ed60638eced99d543a223feeb14a
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint-plugin-promise: 6.0.0_eslint@8.3.0
-      eslint-plugin-react: 7.27.1_eslint@8.3.0
+      eslint-plugin-promise: 6.0.0_eslint@8.7.0
+      eslint-plugin-react: 7.27.1_eslint@8.7.0
       eslint-plugin-tsdoc: 0.2.14
     devDependencies:
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../eslint/eslint-patch:
@@ -1232,11 +1232,11 @@ importers:
       '@typescript-eslint/experimental-utils': ~5.6.0
       '@typescript-eslint/parser': ~5.6.0
       '@typescript-eslint/typescript-estree': ~5.6.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
     devDependencies:
       '@rushstack/heft': 0.44.2
       '@rushstack/heft-node-rig': 1.6.0_@rushstack+heft@0.44.2
@@ -1244,9 +1244,9 @@ importers:
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../eslint/eslint-plugin-packlets:
@@ -1261,11 +1261,11 @@ importers:
       '@typescript-eslint/experimental-utils': ~5.6.0
       '@typescript-eslint/parser': ~5.6.0
       '@typescript-eslint/typescript-estree': ~5.6.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
     devDependencies:
       '@rushstack/heft': 0.44.2
       '@rushstack/heft-node-rig': 1.6.0_@rushstack+heft@0.44.2
@@ -1273,9 +1273,9 @@ importers:
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../eslint/eslint-plugin-security:
@@ -1290,11 +1290,11 @@ importers:
       '@typescript-eslint/experimental-utils': ~5.6.0
       '@typescript-eslint/parser': ~5.6.0
       '@typescript-eslint/typescript-estree': ~5.6.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       typescript: ~4.5.2
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
     devDependencies:
       '@rushstack/heft': 0.44.2
       '@rushstack/heft-node-rig': 1.6.0_@rushstack+heft@0.44.2
@@ -1302,9 +1302,9 @@ importers:
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
 
   ../../heft-plugins/heft-dev-cert-plugin:
@@ -1318,7 +1318,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/webpack-dev-server': 4.0.0
-      eslint: ~8.3.0
+      eslint: ~8.7.0
     dependencies:
       '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -1330,7 +1330,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/webpack-dev-server': 4.0.0
-      eslint: 8.3.0
+      eslint: 8.7.0
 
   ../../heft-plugins/heft-jest-plugin:
     specifiers:
@@ -1346,7 +1346,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 12.20.24
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       jest-config: ~27.4.2
       jest-environment-node: ~27.4.2
       jest-resolve: ~27.4.2
@@ -1372,7 +1372,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 12.20.24
-      eslint: 8.3.0
+      eslint: 8.7.0
       jest-environment-node: 27.4.2
       jest-watch-select-projects: 2.0.0
       typescript: 4.5.2
@@ -1389,7 +1389,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/node-sass': 4.11.2
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       node-sass: 6.0.1
       postcss: 7.0.32
       postcss-modules: ~1.5.0
@@ -1408,7 +1408,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/node-sass': 4.11.2
-      eslint: 8.3.0
+      eslint: 8.7.0
 
   ../../heft-plugins/heft-storybook-plugin:
     specifiers:
@@ -1813,13 +1813,13 @@ importers:
       '@microsoft/api-extractor': workspace:*
       '@rushstack/heft': workspace:*
       '@rushstack/heft-jest-plugin': workspace:*
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       jest-environment-node: ~27.4.2
       typescript: ~4.5.2
     dependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
-      eslint: 8.3.0
+      eslint: 8.7.0
       jest-environment-node: 27.4.2
       typescript: 4.5.2
     devDependencies:
@@ -1832,7 +1832,7 @@ importers:
       '@rushstack/heft-jest-plugin': workspace:*
       '@rushstack/heft-sass-plugin': workspace:*
       '@rushstack/heft-webpack4-plugin': workspace:*
-      eslint: ~8.3.0
+      eslint: ~8.7.0
       jest-environment-jsdom: ~27.4.2
       typescript: ~4.5.2
     dependencies:
@@ -1840,7 +1840,7 @@ importers:
       '@rushstack/heft-jest-plugin': link:../../heft-plugins/heft-jest-plugin
       '@rushstack/heft-sass-plugin': link:../../heft-plugins/heft-sass-plugin
       '@rushstack/heft-webpack4-plugin': link:../../heft-plugins/heft-webpack4-plugin
-      eslint: 8.3.0
+      eslint: 8.7.0
       jest-environment-jsdom: 27.4.3
       typescript: 4.5.2
     devDependencies:
@@ -3723,6 +3723,23 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eslint/eslintrc/1.0.5:
+    resolution: {integrity: sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.3
+      espree: 9.3.0
+      globals: 13.12.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.0.4
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   /@fastify/ajv-compiler/1.1.0:
     resolution: {integrity: sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==}
@@ -3759,6 +3776,17 @@ packages:
 
   /@humanwhocodes/config-array/0.6.0:
     resolution: {integrity: sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.3
+      minimatch: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/config-array/0.9.2:
+    resolution: {integrity: sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -6638,7 +6666,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.6.0_7d727cadaff2de2813cd41f6e2d8a801:
+  /@typescript-eslint/eslint-plugin/5.6.0_d466ed60638eced99d543a223feeb14a:
     resolution: {integrity: sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6649,11 +6677,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.3.0+typescript@4.5.2
-      '@typescript-eslint/parser': 5.6.0_eslint@8.3.0+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.7.0+typescript@4.5.2
+      '@typescript-eslint/parser': 5.6.0_eslint@8.7.0+typescript@4.5.2
       '@typescript-eslint/scope-manager': 5.6.0_typescript@4.5.2
       debug: 4.3.3
-      eslint: 8.3.0
+      eslint: 8.7.0
       functional-red-black-tree: 1.0.1
       ignore: 5.1.9
       regexpp: 3.2.0
@@ -6700,7 +6728,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.3.0+typescript@4.5.2:
+  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.7.0+typescript@4.5.2:
     resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6710,9 +6738,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.6.0_typescript@4.5.2
       '@typescript-eslint/types': 5.6.0_typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
-      eslint: 8.3.0
+      eslint: 8.7.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.3.0
+      eslint-utils: 3.0.0_eslint@8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6757,7 +6785,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.6.0_eslint@8.3.0+typescript@4.5.2:
+  /@typescript-eslint/parser/5.6.0_eslint@8.7.0+typescript@4.5.2:
     resolution: {integrity: sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6771,7 +6799,7 @@ packages:
       '@typescript-eslint/types': 5.6.0_typescript@4.5.2
       '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
       debug: 4.3.3
-      eslint: 8.3.0
+      eslint: 8.7.0
       typescript: 4.5.2
     transitivePeerDependencies:
       - supports-color
@@ -7285,6 +7313,14 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.6.0
+    dev: true
+
+  /acorn-jsx/5.3.2_acorn@8.7.0:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.7.0
 
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
@@ -7302,6 +7338,11 @@ packages:
 
   /acorn/8.6.0:
     resolution: {integrity: sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn/8.7.0:
+    resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -7417,6 +7458,7 @@ packages:
   /ansi-colors/4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
+    dev: true
 
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -9641,6 +9683,7 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
+    dev: true
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -9783,13 +9826,13 @@ packages:
       eslint: 7.30.0
     dev: true
 
-  /eslint-plugin-promise/6.0.0_eslint@8.3.0:
+  /eslint-plugin-promise/6.0.0_eslint@8.7.0:
     resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.3.0
+      eslint: 8.7.0
     dev: false
 
   /eslint-plugin-react/7.27.1_eslint@7.30.0:
@@ -9815,7 +9858,7 @@ packages:
       string.prototype.matchall: 4.0.6
     dev: true
 
-  /eslint-plugin-react/7.27.1_eslint@8.3.0:
+  /eslint-plugin-react/7.27.1_eslint@8.7.0:
     resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9824,7 +9867,7 @@ packages:
       array-includes: 3.1.4
       array.prototype.flatmap: 1.2.5
       doctrine: 2.1.0
-      eslint: 8.3.0
+      eslint: 8.7.0
       estraverse: 5.3.0
       jsx-ast-utils: 2.4.1
       minimatch: 3.0.4
@@ -9890,6 +9933,16 @@ packages:
     dependencies:
       eslint: 8.3.0
       eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /eslint-utils/3.0.0_eslint@8.7.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.7.0
+      eslint-visitor-keys: 2.1.0
 
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
@@ -9902,6 +9955,10 @@ packages:
 
   /eslint-visitor-keys/3.1.0:
     resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /eslint-visitor-keys/3.2.0:
+    resolution: {integrity: sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /eslint/7.30.0:
@@ -9998,6 +10055,50 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /eslint/8.7.0:
+    resolution: {integrity: sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint/eslintrc': 1.0.5
+      '@humanwhocodes/config-array': 0.9.2
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.3
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.1.0
+      eslint-utils: 3.0.0_eslint@8.7.0
+      eslint-visitor-keys: 3.2.0
+      espree: 9.3.0
+      esquery: 1.4.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 6.0.2
+      globals: 13.12.0
+      ignore: 5.2.0
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.0.4
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      regexpp: 3.2.0
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   /espree/7.3.1:
     resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
@@ -10015,6 +10116,15 @@ packages:
       acorn: 8.6.0
       acorn-jsx: 5.3.2_acorn@8.6.0
       eslint-visitor-keys: 3.1.0
+    dev: true
+
+  /espree/9.3.0:
+    resolution: {integrity: sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.7.0
+      acorn-jsx: 5.3.2_acorn@8.7.0
+      eslint-visitor-keys: 3.2.0
 
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -11603,6 +11713,10 @@ packages:
 
   /ignore/5.1.9:
     resolution: {integrity: sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==}
+    engines: {node: '>= 4'}
+
+  /ignore/5.2.0:
+    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
 
   /immediate/3.0.6:
@@ -14997,6 +15111,7 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
@@ -17044,31 +17159,6 @@ packages:
       - acorn
     dev: true
 
-  /terser-webpack-plugin/5.2.5_acorn@8.6.0+webpack@5.35.1:
-    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      jest-worker: 27.4.5
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@8.6.0
-      webpack: 5.35.1
-    transitivePeerDependencies:
-      - acorn
-
   /terser-webpack-plugin/5.2.5_acorn@8.6.0+webpack@5.64.4:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
     engines: {node: '>= 10.13.0'}
@@ -17094,6 +17184,31 @@ packages:
     transitivePeerDependencies:
       - acorn
     dev: true
+
+  /terser-webpack-plugin/5.2.5_acorn@8.7.0+webpack@5.35.1:
+    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      jest-worker: 27.4.5
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      source-map: 0.6.1
+      terser: 5.10.0_acorn@8.7.0
+      webpack: 5.35.1
+    transitivePeerDependencies:
+      - acorn
 
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -17145,6 +17260,22 @@ packages:
         optional: true
     dependencies:
       acorn: 8.6.0
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /terser/5.10.0_acorn@8.7.0:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 8.7.0
       commander: 2.20.3
       source-map: 0.7.3
       source-map-support: 0.5.21
@@ -18284,7 +18415,7 @@ packages:
       '@webassemblyjs/ast': 1.11.0
       '@webassemblyjs/wasm-edit': 1.11.0
       '@webassemblyjs/wasm-parser': 1.11.0
-      acorn: 8.6.0
+      acorn: 8.7.0
       browserslist: 4.18.1
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.8.3
@@ -18299,7 +18430,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_acorn@8.6.0+webpack@5.35.1
+      terser-webpack-plugin: 5.2.5_acorn@8.7.0+webpack@5.35.1
       watchpack: 2.3.0
       webpack-sources: 2.3.1
     transitivePeerDependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "912e7353f005cb1fe5038454a4f7dea57571315b",
-  "preferredVersionsHash": "87aab8e8f0a6545cb9d0ea30194ba68279d285a8"
+  "pnpmShrinkwrapHash": "ddcf3fce3389dc423f22d161b9aeb366d96ac62a",
+  "preferredVersionsHash": "d2a5d015a5e5f4861bc36581c3c08cb789ed7fab"
 }

--- a/eslint/eslint-config/package.json
+++ b/eslint/eslint-config/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-tsdoc": "~0.2.14"
   },
   "devDependencies": {
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/eslint/eslint-plugin-packlets/package.json
+++ b/eslint/eslint-plugin-packlets/package.json
@@ -38,7 +38,7 @@
     "@types/node": "12.20.24",
     "@typescript-eslint/parser": "~5.6.0",
     "@typescript-eslint/typescript-estree": "~5.6.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/eslint/eslint-plugin-security/package.json
+++ b/eslint/eslint-plugin-security/package.json
@@ -37,7 +37,7 @@
     "@types/node": "12.20.24",
     "@typescript-eslint/parser": "~5.6.0",
     "@typescript-eslint/typescript-estree": "~5.6.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/eslint/eslint-plugin/package.json
+++ b/eslint/eslint-plugin/package.json
@@ -41,7 +41,7 @@
     "@types/node": "12.20.24",
     "@typescript-eslint/parser": "~5.6.0",
     "@typescript-eslint/typescript-estree": "~5.6.0",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "typescript": "~4.5.2"
   }
 }

--- a/heft-plugins/heft-dev-cert-plugin/package.json
+++ b/heft-plugins/heft-dev-cert-plugin/package.json
@@ -32,6 +32,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
     "@types/webpack-dev-server": "4.0.0",
-    "eslint": "~8.3.0"
+    "eslint": "~8.7.0"
   }
 }

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -39,7 +39,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",
     "@types/node": "12.20.24",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "jest-environment-node": "~27.4.2",
     "jest-watch-select-projects": "2.0.0",
     "typescript": "~4.5.2"

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -36,6 +36,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
     "@types/node-sass": "4.11.2",
-    "eslint": "~8.3.0"
+    "eslint": "~8.7.0"
   }
 }

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "jest-environment-node": "~27.4.2",
     "typescript": "~4.5.2"
   },

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -20,7 +20,7 @@
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@rushstack/heft-sass-plugin": "workspace:*",
     "@rushstack/heft-webpack4-plugin": "workspace:*",
-    "eslint": "~8.3.0",
+    "eslint": "~8.7.0",
     "jest-environment-jsdom": "~27.4.2",
     "typescript": "~4.5.2"
   },


### PR DESCRIPTION
## Summary

Updates the version of ESLint used to lint projects within Rushstack to `~8.7.0`. The rig packages have been upgraded as well, which provide ESLint for Heft tooling

## How it was tested

Ensured successful build ran `eslint@8.7.0`.
