### PR TITLE
[rush-lib] Add `"watchOptions"` with `watchPhases` to "phased" command kind

### DIFF
--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -46,7 +46,7 @@ export interface IPhasedCommandWithoutPhasesJson extends IBaseCommandJson {
 export interface IPhasedCommandJson extends IPhasedCommandWithoutPhasesJson {
   phases: string[];
   watchOptions?: {
-    watchForChanges: true;
+    alwaysWatch: boolean;
     watchPhases: string[];
   };
 }

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -45,6 +45,10 @@ export interface IPhasedCommandWithoutPhasesJson extends IBaseCommandJson {
  */
 export interface IPhasedCommandJson extends IPhasedCommandWithoutPhasesJson {
   phases: string[];
+  watchOptions?: {
+    watchForChanges: true;
+    watchPhases: string[];
+  };
 }
 
 /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -362,10 +362,10 @@ export class RushCommandLineParser extends CommandLineParser {
 
         enableParallelism: command.enableParallelism,
         incremental: command.incremental || false,
-        watchForChanges: command.watchForChanges || false,
         disableBuildCache: command.disableBuildCache || false,
 
-        actionPhases: command.phases,
+        initialPhases: command.phases,
+        watchPhases: command.watchPhases,
         phases: commandLineConfiguration.phases
       })
     );

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -366,7 +366,9 @@ export class RushCommandLineParser extends CommandLineParser {
 
         initialPhases: command.phases,
         watchPhases: command.watchPhases,
-        phases: commandLineConfiguration.phases
+        phases: commandLineConfiguration.phases,
+
+        alwaysWatch: command.alwaysWatch
       })
     );
   }

--- a/apps/rush-lib/src/logic/ProjectWatcher.ts
+++ b/apps/rush-lib/src/logic/ProjectWatcher.ts
@@ -15,6 +15,7 @@ export interface IProjectWatcherOptions {
   rushConfiguration: RushConfiguration;
   projectsToWatch: ReadonlySet<RushConfigurationProject>;
   terminal: ITerminal;
+  initialState?: ProjectChangeAnalyzer | undefined;
 }
 
 export interface IProjectChangeResult {
@@ -48,12 +49,21 @@ export class ProjectWatcher {
   private _previousState: ProjectChangeAnalyzer | undefined;
 
   public constructor(options: IProjectWatcherOptions) {
-    const { debounceMilliseconds = 1000, rushConfiguration, projectsToWatch, terminal } = options;
+    const {
+      debounceMilliseconds = 1000,
+      rushConfiguration,
+      projectsToWatch,
+      terminal,
+      initialState
+    } = options;
 
     this._debounceMilliseconds = debounceMilliseconds;
     this._rushConfiguration = rushConfiguration;
     this._projectsToWatch = projectsToWatch;
     this._terminal = terminal;
+
+    this._initialState = initialState;
+    this._previousState = initialState;
   }
 
   /**

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -187,6 +187,28 @@
               "items": {
                 "type": "string"
               }
+            },
+            "watchOptions": {
+              "title": "Watch Options",
+              "description": "Controls the file watching behavior of this command. If not specified, this command does not watch files.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["watchForChanges", "watchPhases"],
+              "properties": {
+                "watchForChanges": {
+                  "title": "Watch For Changes",
+                  "description": "Indicates that this command will watch for changes after the initial execution.",
+                  "enum": [true]
+                },
+                "watchPhases": {
+                  "title": "Watch Phases",
+                  "description": "List *exactly* the phases that should be run in watch mode for this command. If this property is specified and non-empty, after the phases defined in the \"phases\" property run, a file watcher will be started to watch projects for changes, and will run the phases listed in this property on changed projects.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },
@@ -202,7 +224,8 @@
 
             "enableParallelism": { "$ref": "#/definitions/anything" },
             "incremental": { "$ref": "#/definitions/anything" },
-            "phases": { "$ref": "#/definitions/anything" }
+            "phases": { "$ref": "#/definitions/anything" },
+            "watchOptions": { "$ref": "#/definitions/anything" }
           }
         }
       ]

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -193,12 +193,12 @@
               "description": "Controls the file watching behavior of this command. If not specified, this command does not watch files.",
               "type": "object",
               "additionalProperties": false,
-              "required": ["watchForChanges", "watchPhases"],
+              "required": ["alwaysWatch", "watchPhases"],
               "properties": {
-                "watchForChanges": {
-                  "title": "Watch For Changes",
-                  "description": "Indicates that this command will watch for changes after the initial execution.",
-                  "enum": [true]
+                "alwaysWatch": {
+                  "title": "Always Watch",
+                  "description": "Indicates that this command will always watch for changes after the initial execution, as if the \"--watch\" CLI flag was passed.",
+                  "type": "boolean"
                 },
                 "watchPhases": {
                   "title": "Watch Phases",

--- a/common/changes/@microsoft/rush/watch-phases_2022-01-24-22-18.json
+++ b/common/changes/@microsoft/rush/watch-phases_2022-01-24-22-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add watch mode support to \"phased\" command definitions via the \"watchOptions\" property with a subfield \"watchPhases\". This separates the initial command phases from the phases run by the file watcher, e.g. so that the initial execution can pull from cache and the watch mode execution can use a separate incremental build phase.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Adds a new property `"watchOptions"` with a subproperty `"watchPhases"` to `"commandKind": "phased"` in `command-line.json`. If `watchOptions` is specified and `watchPhases` is non-empty, then after the initial command execution, the command will boot up a file watcher and, upon detecting changes, run the phases listed in `"watchPhases"` for all affected projects.

## Details
The prior `"watchForChanges": true` option for `"commandKind": "bulk"` is now implemented by setting `watchPhases` to `phases` during command translation and `alwaysWatch` to `true`, or an empty set if `false`.

This logic change now treats the watch mode portion of command execution as a separate step after the initial execution. Build cache writes are allowed during the initial execution (since it should run all projects and is therefore "safe") but disabled during watch execution.

The expected usage is that the `"phases"` field is used to specify the set of build phases that need to be executed before any arbitrary changed project can be rebuilt, whereas the set in `"watchPhases"` are the phases used to validate a given local change. The example below runs `_phase:build` during the initial execution, then `_phase:build` and `_phase:test` in response to changes, so that a subsequent local change will get fully validated but the initial execution does the minimal necessary setup (and ideally pulls entirely from cache).

## How it was tested
Added the following to `command-line.json` temporarily:
```jsonc
    {
      "commandKind": "phased",
      "name": "start",
      "summary": "Build all projects that haven't been built or have changed since they were last built.",
      "description": "Build all projects that haven't been built or have changed since they were last built.",
      "safeForSimultaneousRushProcesses": false,

      "enableParallelism": true,
      "incremental": true,
      // Initial execution only uses the build phase so that all dependencies of watch phases have been built
      "phases": ["_phase:build"],
      "watchOptions": {
        // Act as though `--watch` is always passed. If false, adds support for passing `--watch`.
        "alwaysWatch": true
        // During watch recompilation run both build and test for affected projects
        "watchPhases": ["_phase:build", "_phase:test"]
      }
    },
```
Then ran `node ./apps/rush-lib/lib/start.js start -v` and verified the initial build of all projects (only build phase), followed by watch mode rebuilds of modified projects (build and test phases) in response to local changes.