### PR TITLE
[rush-serve-plugin] Add stub project for rush-serve-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ These GitHub repositories provide supplementary resources for Rush Stack:
 | [/repo-scripts/generate-api-docs](./repo-scripts/generate-api-docs/) | Used to generate API docs for the rushstack.io website |
 | [/repo-scripts/repo-toolbox](./repo-scripts/repo-toolbox/) | Used to execute various operations specific to this repo |
 | [/rush-plugins/rush-litewatch-plugin](./rush-plugins/rush-litewatch-plugin/) | An experimental alternative approach for multi-project watch mode |
+| [/rush-plugins/rush-serve-plugin](./rush-plugins/rush-serve-plugin/) | A Rush plugin that hooks into a rush action and serves output folders from all projects in the repository. |
 <!-- GENERATED PROJECT SUMMARY END -->
 
 ## Contributor Notice

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -15,11 +15,11 @@
       "allowedCategories": [ "tests" ]
     },
     {
-      "name": "@jest/create-cache-key-function",
+      "name": "@jest/core",
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "@jest/core",
+      "name": "@jest/create-cache-key-function",
       "allowedCategories": [ "libraries" ]
     },
     {
@@ -332,6 +332,10 @@
     },
     {
       "name": "eslint-plugin-tsdoc",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "express",
       "allowedCategories": [ "libraries" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1919,6 +1919,29 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
 
+  ../../rush-plugins/rush-serve-plugin:
+    specifiers:
+      '@rushstack/eslint-config': workspace:*
+      '@rushstack/heft': workspace:*
+      '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/node-core-library': workspace:*
+      '@rushstack/rush-sdk': workspace:*
+      '@types/express': 4.17.13
+      '@types/heft-jest': 1.0.1
+      '@types/node': 12.20.24
+      express: 4.17.1
+    dependencies:
+      '@rushstack/node-core-library': link:../../libraries/node-core-library
+      '@rushstack/rush-sdk': link:../../libraries/rush-sdk
+      express: 4.17.1
+    devDependencies:
+      '@rushstack/eslint-config': link:../../eslint/eslint-config
+      '@rushstack/heft': link:../../apps/heft
+      '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@types/express': 4.17.13
+      '@types/heft-jest': 1.0.1
+      '@types/node': 12.20.24
+
   ../../webpack/loader-load-themed-styles:
     specifiers:
       '@microsoft/load-themed-styles': workspace:*
@@ -2088,13 +2111,15 @@ packages:
       '@types/node-fetch': 2.5.12
       '@types/tunnel': 0.0.1
       form-data: 3.0.1
-      node-fetch: 2.6.2
+      node-fetch: 2.6.7
       process: 0.11.10
       tough-cookie: 4.0.0
       tslib: 2.3.1
       tunnel: 0.0.6
       uuid: 8.3.2
       xml2js: 0.4.23
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@azure/core-lro/1.0.5:
@@ -2106,6 +2131,8 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.11
       events: 3.3.0
       tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@azure/core-paging/1.2.0:
@@ -2155,6 +2182,8 @@ packages:
       qs: 6.10.1
       tslib: 1.14.1
       uuid: 3.4.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@azure/logger/1.0.3:
@@ -2176,6 +2205,8 @@ packages:
       '@opentelemetry/api': 0.10.2
       events: 3.3.0
       tslib: 2.3.1
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@babel/code-frame/7.10.4:
@@ -14024,11 +14055,6 @@ packages:
     dependencies:
       minimatch: 3.0.4
     dev: true
-
-  /node-fetch/2.6.2:
-    resolution: {integrity: sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==}
-    engines: {node: 4.x || >=6.0.0}
-    dev: false
 
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d1db070ee27d66f05a954e7b3df919068ab539dd",
+  "pnpmShrinkwrapHash": "5435004dde5c43cc078865ba45d97272186ba315",
   "preferredVersionsHash": "d2a5d015a5e5f4861bc36581c3c08cb789ed7fab"
 }

--- a/rush-plugins/rush-serve-plugin/.eslintrc.js
+++ b/rush-plugins/rush-serve-plugin/.eslintrc.js
@@ -1,0 +1,11 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: [
+    '@rushstack/eslint-config/profile/node',
+    '@rushstack/eslint-config/mixins/friendly-locals',
+    '@rushstack/eslint-config/mixins/tsdoc'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname }
+};

--- a/rush-plugins/rush-serve-plugin/.npmignore
+++ b/rush-plugins/rush-serve-plugin/.npmignore
@@ -1,0 +1,30 @@
+# THIS IS A STANDARD TEMPLATE FOR .npmignore FILES IN THIS REPO.
+
+# Ignore all files by default, to avoid accidentally publishing unintended files.
+*
+
+# Use negative patterns to bring back the specific things we want to publish.
+!/bin/**
+!/lib/**
+!/lib-*/**
+!/dist/**
+!ThirdPartyNotice.txt
+
+# Ignore certain patterns that should not get published.
+/dist/*.stats.*
+/lib/**/test/
+/lib-*/**/test/
+*.test.js
+
+# NOTE: These don't need to be specified, because NPM includes them automatically.
+#
+# package.json
+# README (and its variants)
+# CHANGELOG (and its variants)
+# LICENSE / LICENCE
+
+#--------------------------------------------
+# DO NOT MODIFY THE TEMPLATE ABOVE THIS LINE
+#--------------------------------------------
+
+# (Add your project-specific overrides here)

--- a/rush-plugins/rush-serve-plugin/LICENSE
+++ b/rush-plugins/rush-serve-plugin/LICENSE
@@ -1,0 +1,24 @@
+@rushstack/rush-litewatch-plugin
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rush-plugins/rush-serve-plugin/README.md
+++ b/rush-plugins/rush-serve-plugin/README.md
@@ -1,5 +1,7 @@
 # @rushstack/rush-serve-plugin
 
+UNDER DEVELOPMENT
+
 A Rush plugin that hooks into action execution and runs an express server to serve project outputs. Meant for use with watch-mode commands.
 
 ```

--- a/rush-plugins/rush-serve-plugin/README.md
+++ b/rush-plugins/rush-serve-plugin/README.md
@@ -1,0 +1,14 @@
+# @rushstack/rush-serve-plugin
+
+A Rush plugin that hooks into action execution and runs an express server to serve project outputs. Meant for use with watch-mode commands.
+
+```
+# The user invokes this command
+$ rush start
+```
+
+What happens:
+- Rush scans for riggable `rush-serve.json` config files in all projects
+- Rush uses the configuration in the aforementioned files to configure an Express server to serve project outputs as static (but not cached) content
+- When a change happens to a source file, Rush's normal watch-mode machinery will rebuild all affected project phases, resulting in new files on disk
+- The next time one of these files is requested, Rush will serve the new version. Optionally, may support signals for automatic refresh.

--- a/rush-plugins/rush-serve-plugin/config/jest.config.json
+++ b/rush-plugins/rush-serve-plugin/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@rushstack/heft-node-rig/profiles/default/config/jest.config.json"
+}

--- a/rush-plugins/rush-serve-plugin/config/rig.json
+++ b/rush-plugins/rush-serve-plugin/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "@rushstack/heft-node-rig"
+}

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@rushstack/rush-serve-plugin",
+  "version": "0.0.0",
+  "description": "A Rush plugin that hooks into a rush action and serves output folders from all projects in the repository.",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/microsoft/rushstack.git",
+    "type": "git",
+    "directory": "rush-plugins/rush-serve-plugin"
+  },
+  "main": "lib/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "heft test --clean",
+    "_phase:build": "heft build --clean",
+    "_phase:test": "heft test --no-build"
+  },
+  "dependencies": {
+    "@rushstack/node-core-library": "workspace:*",
+    "@rushstack/rush-sdk": "workspace:*",
+    "express": "4.17.1"
+  },
+  "devDependencies": {
+    "@rushstack/eslint-config": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@rushstack/heft-node-rig": "workspace:*",
+    "@types/express": "4.17.13",
+    "@types/heft-jest": "1.0.1",
+    "@types/node": "12.20.24"
+  }
+}

--- a/rush-plugins/rush-serve-plugin/src/index.ts
+++ b/rush-plugins/rush-serve-plugin/src/index.ts
@@ -1,0 +1,1 @@
+throw new Error('Not implemented yet!');

--- a/rush-plugins/rush-serve-plugin/src/schemas/rush-serve.schema.json
+++ b/rush-plugins/rush-serve-plugin/src/schemas/rush-serve.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Configuration for the @rushstack/rush-serve-plugin.",
+  "description": "For use with the Rush tool, this file provides per-project configuration options. See http://rushjs.io for details.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+
+    "extends": {
+      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects.",
+      "type": "string"
+    },
+
+    "routing": {
+      "type": "array",
+      "description": "Routing rules",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["projectRelativeFolder", "servePath"],
+        "properties": {
+          "projectRelativeFolder": {
+            "type": "string",
+            "description": "The folder from which to read assets, relative to the root of the current project."
+          },
+
+          "servePath": {
+            "type": "string",
+            "description": "The server path at which to serve the assets in \"projectRelativeFolder\"."
+          },
+
+          "immutable": {
+            "type": "boolean",
+            "description": "Enables or disables the `immutable` directive in the `Cache-Control` resoponse header. See (https://expressjs.com/en/4x/api.html#express.static).",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/rush-plugins/rush-serve-plugin/src/test/Server.test.ts
+++ b/rush-plugins/rush-serve-plugin/src/test/Server.test.ts
@@ -1,0 +1,5 @@
+describe('Server', () => {
+  it('Is not implemented yet.', () => {
+    // Do nothing.
+  });
+});

--- a/rush-plugins/rush-serve-plugin/tsconfig.json
+++ b/rush-plugins/rush-serve-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+
+  "compilerOptions": {
+    "types": ["heft-jest", "node"]
+  }
+}

--- a/rush.json
+++ b/rush.json
@@ -959,6 +959,12 @@
       "reviewCategory": "libraries",
       "shouldPublish": false
     },
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "projectFolder": "rush-plugins/rush-serve-plugin",
+      "reviewCategory": "libraries",
+      "shouldPublish": false
+    },
 
     // "webpack" folder (alphabetical order)
     {


### PR DESCRIPTION
## Summary
Creates a new stub project for a Rush plugin that uses an `express` server to serve project outputs.

## Details
Empty project.

## How it was tested
Verified that `rush build` still works. Plugin is not yet expected to do anything.