### PR TITLE
[rush-lib] Optimizations for interacting with `tar` utility

### DIFF
--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -433,7 +433,7 @@ export class ProjectBuildCache {
   }
 
   private _getTarLogFilePath(): string {
-    return path.join(this._project.projectRushTempFolder, 'build-cache-tar.log');
+    return path.join(this._project.projectRushTempFolder, `${this._cacheId}.log`);
   }
 
   private static async _getCacheId(options: IProjectBuildCacheOptions): Promise<string | undefined> {

--- a/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/apps/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -6,7 +6,7 @@ import events from 'events';
 import * as crypto from 'crypto';
 import type * as stream from 'stream';
 import * as tar from 'tar';
-import { FileSystem, Path, ITerminal, FolderItem } from '@rushstack/node-core-library';
+import { Async, FileSystem, Path, ITerminal, FolderItem } from '@rushstack/node-core-library';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
@@ -358,76 +358,78 @@ export class ProjectBuildCache {
     return success;
   }
 
+  /**
+   * Walks the declared output folders of the project and collects a list of files.
+   * @returns The list of output files as project-relative paths, or `undefined` if a
+   *   symbolic link was encountered.
+   */
   private async _tryCollectPathsToCacheAsync(terminal: ITerminal): Promise<IPathsToCache | undefined> {
-    const projectFolderPath: string = this._project.projectFolder;
-    const outputFolderNamesThatExist: boolean[] = await Promise.all(
-      this._projectOutputFolderNames.map((outputFolderName) =>
-        FileSystem.existsAsync(`${projectFolderPath}/${outputFolderName}`)
-      )
-    );
-    const filteredOutputFolderNames: string[] = [];
-    for (let i: number = 0; i < outputFolderNamesThatExist.length; i++) {
-      if (outputFolderNamesThatExist[i]) {
-        filteredOutputFolderNames.push(this._projectOutputFolderNames[i]);
-      }
-    }
-
-    let encounteredEnumerationIssue: boolean = false;
-    function symbolicLinkPathCallback(entryPath: string): void {
-      terminal.writeError(`Unable to include "${entryPath}" in build cache. It is a symbolic link.`);
-      encounteredEnumerationIssue = true;
-    }
-
+    const posixPrefix: string = this._project.projectFolder;
     const outputFilePaths: string[] = [];
-    for (const filteredOutputFolderName of filteredOutputFolderNames) {
-      if (encounteredEnumerationIssue) {
-        return undefined;
-      }
+    const queue: [string, string][] = [];
 
-      const outputFilePathsForFolder: AsyncIterableIterator<string> = this._getPathsInFolder(
-        terminal,
-        symbolicLinkPathCallback,
-        filteredOutputFolderName,
-        `${projectFolderPath}/${filteredOutputFolderName}`
-      );
+    const filteredOutputFolderNames: string[] = [];
 
-      for await (const outputFilePath of outputFilePathsForFolder) {
-        outputFilePaths.push(outputFilePath);
+    let hasSymbolicLinks: boolean = false;
+
+    // Adds child directories to the queue, files to the path list, and bails on symlinks
+    function processChildren(relativePath: string, diskPath: string, children: FolderItem[]): void {
+      for (const child of children) {
+        const childRelativePath: string = `${relativePath}/${child.name}`;
+        if (child.isSymbolicLink()) {
+          terminal.writeError(
+            `Unable to include "${childRelativePath}" in build cache. It is a symbolic link.`
+          );
+          hasSymbolicLinks = true;
+        } else if (child.isDirectory()) {
+          queue.push([childRelativePath, `${diskPath}/${child.name}`]);
+        } else {
+          outputFilePaths.push(childRelativePath);
+        }
       }
     }
 
-    if (encounteredEnumerationIssue) {
+    // Handle declared output folders.
+    for (const outputFolder of this._projectOutputFolderNames) {
+      const diskPath: string = `${posixPrefix}/${outputFolder}`;
+      try {
+        const children: FolderItem[] = await FileSystem.readFolderItemsAsync(diskPath);
+        processChildren(outputFolder, diskPath, children);
+        // The folder exists, record it
+        filteredOutputFolderNames.push(outputFolder);
+      } catch (error) {
+        if (!FileSystem.isNotExistError(error as Error)) {
+          throw error;
+        }
+
+        // If the folder does not exist, ignore it.
+      }
+    }
+
+    // Walk the tree in parallel
+    await Async.forEachAsync(
+      queue,
+      async ([relativePath, diskPath]: [string, string]) => {
+        const children: FolderItem[] = await FileSystem.readFolderItemsAsync(diskPath);
+        processChildren(relativePath, diskPath, children);
+      },
+      {
+        concurrency: 10
+      }
+    );
+
+    if (hasSymbolicLinks) {
+      // Symbolic links do not round-trip safely.
       return undefined;
     }
 
-    return {
-      filteredOutputFolderNames,
-      outputFilePaths
-    };
-  }
+    // Ensure stable output path order.
+    outputFilePaths.sort();
 
-  private async *_getPathsInFolder(
-    terminal: ITerminal,
-    symbolicLinkPathCallback: (path: string) => void,
-    posixPrefix: string,
-    folderPath: string
-  ): AsyncIterableIterator<string> {
-    const folderEntries: FolderItem[] = await FileSystem.readFolderItemsAsync(folderPath);
-    for (const folderEntry of folderEntries) {
-      const entryPath: string = `${posixPrefix}/${folderEntry.name}`;
-      if (folderEntry.isSymbolicLink()) {
-        symbolicLinkPathCallback(entryPath);
-      } else if (folderEntry.isDirectory()) {
-        yield* this._getPathsInFolder(
-          terminal,
-          symbolicLinkPathCallback,
-          entryPath,
-          `${folderPath}/${folderEntry.name}`
-        );
-      } else {
-        yield entryPath;
-      }
-    }
+    return {
+      outputFilePaths,
+      filteredOutputFolderNames
+    };
   }
 
   private _getTarLogFilePath(): string {

--- a/common/changes/@microsoft/rush/optimize-tar_2021-11-09-22-50.json
+++ b/common/changes/@microsoft/rush/optimize-tar_2021-11-09-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Optimize invocation of tar to use stdin instead of a temporary file.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-00.json
+++ b/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Revise architecture of symbolic link scan to use a queue and parallel file system calls.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-27.json
+++ b/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Create separate tar logs per phase based on cache id.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-38.json
+++ b/common/changes/@microsoft/rush/tar-stdin_2022-02-02-22-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Pack tar to a temp file, then move into the cache to ensure cache integrity.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Passes input file paths via `stdin` instead of creating a temporary file.
Use multiple parallel async file system operations when scanning for symbolic links.
Create a separate log file for each phase in a project that writes to the build cache.
Modify local TAR generation to write to a temp file, then move it to the build cache, to ensure that the cache doesn't get polluted with partial entries.

## Details
Leverages`Async.forEachAsync` with a queue to scan output files.
Uses the tarball name as part of the log file path, so that each phase gets its own log file.
Logs the list of files to cache to the tar log.

## How it was tested
Local Rush builds, writing to and reading from the build cache.