### PR TITLE
[rush-lib]: getChangedFiles should not only show added files

### DIFF
--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -267,8 +267,7 @@ export class Git {
       'diff',
       `${targetBranch}...`,
       '--name-only',
-      '--no-renames',
-      '--diff-filter=A'
+      '--no-renames'
     ]);
     return output
       .split('\n')

--- a/common/changes/@microsoft/rush/fix-getChangedFiles_2022-01-27-10-49.json
+++ b/common/changes/@microsoft/rush/fix-getChangedFiles_2022-01-27-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "rush-lib getChangedFiles should not only show added files",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

`getChangedFiles` should not only show added files

## Details

delete `--diff-filter=A` params

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Verified that rush build still works.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
