### PR TITLE
fix: build cache cannot be enabled for bulk build command

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -612,7 +612,6 @@ export class CommandLineConfiguration {
     const translatedCommand: IPhasedCommand = {
       ...command,
       commandKind: 'phased',
-      disableBuildCache: true,
       isSynthetic: true,
       associatedParameters: new Set<Parameter>(),
       phases: new Set([phase])

--- a/common/changes/@microsoft/rush/fix-bulk-command-build-cache_2022-01-28-15-56.json
+++ b/common/changes/@microsoft/rush/fix-bulk-command-build-cache_2022-01-28-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix: build cache cannot be enabled for bulk build command",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-bulk-command-build-cache_2022-01-28-15-56.json
+++ b/common/changes/@microsoft/rush/fix-bulk-command-build-cache_2022-01-28-15-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix: build cache cannot be enabled for bulk build command",
+      "comment": "Allow build cache to be enabled for custom bulk commands.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Build cache cannot be enabled for bulk build command.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

If bulk build command is defined in 'command-line.json', build command's `disableBuildCache` property is always true.

reproduction step:

1. defined a bulk build command in `command-line.json`

```
{
  "commands": [
    {
      "commandKind": "bulk",
      "name": "build",
      "allowWarningsInSuccessfulBuild": true,
      "summary": "Build packages.",
      "ignoreMissingScript": true,
      "enableParallelism": true
    }
  ]
}
```

2. enable `local-only` build cache(https://rushjs.io/pages/maintainer/build_cache/)
3. test build cache not work: because it is disabled


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->


## How it was tested

Test locally using my company's project which build cache cannot be enabled for bulk build command.

1. defined a bulk build command in `command-line.json`

```
{
  "commands": [
    {
      "commandKind": "bulk",
      "name": "build",
      "allowWarningsInSuccessfulBuild": true,
      "summary": "Build packages.",
      "ignoreMissingScript": true,
      "enableParallelism": true
    }
  ]
}
```

2. enable build cache(https://rushjs.io/pages/maintainer/build_cache/)
3. test build cache: it is enabled. works!

<!-----------------------------------------------------------!---------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
