### PR TITLE
[rush] Remove the command associations from the build-in cache provider commands.

### DIFF
--- a/apps/rush-lib/src/schemas/rush-plugin-manifest.schema.json
+++ b/apps/rush-lib/src/schemas/rush-plugin-manifest.schema.json
@@ -32,7 +32,7 @@
             "type": "string"
           },
           "associatedCommands": {
-            "description": "Specifies associated commands with this plugin, plugin will be only installed when a associated command runs.",
+            "description": "Specifies associated commands with this plugin, plugin will be only installed when an associated command runs.",
             "type": "array",
             "items": {
               "type": "string"

--- a/common/changes/@microsoft/rush/build-cache-plugins-for-other-commands_2022-01-28-19-53.json
+++ b/common/changes/@microsoft/rush/build-cache-plugins-for-other-commands_2022-01-28-19-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the built-in cache provider plugins (rush-amazon-s3-build-cache-plugin and rush-azure-storage-build-cache-plugin) to apply for all commands, enabling cloud caching for custom phased and bulk commands.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/rush-plugin-manifest.json
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/rush-plugin-manifest.json
@@ -5,8 +5,7 @@
       "pluginName": "rush-amazon-s3-build-cache-plugin",
       "description": "Rush plugin for Amazon S3 cloud build cache",
       "entryPoint": "lib/index.js",
-      "optionsSchema": "lib/schemas/amazon-s3-config.schema.json",
-      "associatedCommands": ["build", "rebuild", "write-build-cache", "update-cloud-credentials"]
+      "optionsSchema": "lib/schemas/amazon-s3-config.schema.json"
     }
   ]
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/rush-plugin-manifest.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/rush-plugin-manifest.json
@@ -5,8 +5,7 @@
       "pluginName": "rush-azure-storage-build-cache-plugin",
       "description": "Rush plugin for Azure storage cloud build cache",
       "entryPoint": "lib/index.js",
-      "optionsSchema": "lib/schemas/azure-blob-storage-config.schema.json",
-      "associatedCommands": ["build", "rebuild", "write-build-cache", "update-cloud-credentials"]
+      "optionsSchema": "lib/schemas/azure-blob-storage-config.schema.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Currently the build-in build cache plugins only work for the `build` and `rebuild` commands. Creating a custom command in `common/config/command-line.json` does not caching on Azure or S3, and Rush gives a confusing `ERROR: Unexpected cache provider: azure-blob-storage` error message.

## Details

This change updates the build-in cache provider plugins' manifest to consider them relevant for all commands.

## How it was tested

Ran a custom phased command on a repo that has Azure Storage caching configured.