### PR TITLE
docs: Fix property name in rush-project.json to match schema

### DIFF
--- a/apps/rush/UPGRADING.md
+++ b/apps/rush/UPGRADING.md
@@ -44,7 +44,7 @@ are essentially the same.
 {
   "incrementalBuildIgnoredGlobs": ["temp/**"],
 
-  "disableBuildCache": false,  // formerly buildCacheOptions.disableBuildCache
+  "disableBuildCacheForProject": false,  // formerly buildCacheOptions.disableBuildCache
 
   "operationSettings": [  // formerly phaseOptions
     {


### PR DESCRIPTION


## Summary
This updates the property name in the UPGRADING.md guide to match the [corresponding schema](https://github.com/microsoft/rushstack/blob/master/apps/rush-lib/src/schemas/rush-project.schema.json#L27)

## Details
If using the property name currently present in the UPGRADING.md an operation fails with the following error:

```
JSON validation failed:
/drone/src/site-server/common/tools/api-documenter/config/rush-project.json

Error: #/ (For use with the Rush tool, this file...)
       Additional properties not allowed: disableBuildCache
```

Due to the rush-project.json not validating against the schema.

## How it was tested
I changed the property name in my own rush project after seeing the error, and the error no longer occurred.