### PR TITLE
Keep original version when publishing prereleases

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -236,14 +236,15 @@ export class PublishAction extends BaseRushAction {
 
     const git: Git = new Git(this.rushConfiguration);
     const publishGit: PublishGit = new PublishGit(git, this._targetBranch.value);
+    this._prereleaseToken = new PrereleaseToken(
+      this._prereleaseName.value,
+      this._suffix.value,
+      this._partialPrerelease.value
+    );
+
     if (this._includeAll.value) {
       this._publishAll(publishGit, allPackages);
     } else {
-      this._prereleaseToken = new PrereleaseToken(
-        this._prereleaseName.value,
-        this._suffix.value,
-        this._partialPrerelease.value
-      );
       this._publishChanges(git, publishGit, allPackages);
     }
 

--- a/apps/rush-lib/src/logic/test/ChangeManager.test.ts
+++ b/apps/rush-lib/src/logic/test/ChangeManager.test.ts
@@ -67,15 +67,15 @@ describe('ChangeManager', () => {
     changeManager.load(path.join(__dirname, 'rootPatchChange'), prereleaseToken);
     changeManager.apply(false);
 
-    expect(changeManager.allPackages.get('a')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('b')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('a')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('b')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('b')!.packageJson.dependencies!['a']).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
-    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('d')!.packageJson.dependencies!['c']).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
   });
 
@@ -89,10 +89,10 @@ describe('ChangeManager', () => {
     expect(changeManager.allPackages.get('a')!.packageJson.version).toEqual('1.0.0');
     expect(changeManager.allPackages.get('b')!.packageJson.version).toEqual('1.0.0');
     expect(changeManager.allPackages.get('b')!.packageJson.dependencies!['a']).toEqual('>=1.0.0 <2.0.0');
-    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('d')!.packageJson.dependencies!['c']).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
   });
 
@@ -104,16 +104,16 @@ describe('ChangeManager', () => {
     changeManager.apply(false);
 
     expect(changeManager.allPackages.get('cyclic-dep-1')!.packageJson.version).toEqual(
-      '2.0.0-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-1')!.packageJson.dependencies!['cyclic-dep-2']).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-2')!.packageJson.version).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-2')!.packageJson.dependencies!['cyclic-dep-1']).toEqual(
-      '2.0.0-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
   });
 
@@ -234,15 +234,15 @@ describe('WorkspaceChangeManager', () => {
     changeManager.load(path.join(__dirname, 'rootPatchChange'), prereleaseToken);
     changeManager.apply(false);
 
-    expect(changeManager.allPackages.get('a')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('b')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('a')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('b')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('b')!.packageJson.dependencies!['a']).toEqual(
-      'workspace:1.0.1-' + prereleaseName
+      'workspace:1.0.0-' + prereleaseName
     );
-    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('d')!.packageJson.dependencies!['c']).toEqual(
-      'workspace:1.0.1-' + prereleaseName
+      'workspace:1.0.0-' + prereleaseName
     );
   });
 
@@ -258,10 +258,10 @@ describe('WorkspaceChangeManager', () => {
     expect(changeManager.allPackages.get('b')!.packageJson.dependencies!['a']).toEqual(
       'workspace:>=1.0.0 <2.0.0'
     );
-    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
-    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.1-' + prereleaseName);
+    expect(changeManager.allPackages.get('c')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
+    expect(changeManager.allPackages.get('d')!.packageJson.version).toEqual('1.0.0-' + prereleaseName);
     expect(changeManager.allPackages.get('d')!.packageJson.dependencies!['c']).toEqual(
-      'workspace:1.0.1-' + prereleaseName
+      'workspace:1.0.0-' + prereleaseName
     );
   });
 
@@ -273,16 +273,16 @@ describe('WorkspaceChangeManager', () => {
     changeManager.apply(false);
 
     expect(changeManager.allPackages.get('cyclic-dep-1')!.packageJson.version).toEqual(
-      '2.0.0-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-1')!.packageJson.dependencies!['cyclic-dep-2']).toEqual(
-      'workspace:1.0.1-' + prereleaseName
+      'workspace:1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-2')!.packageJson.version).toEqual(
-      '1.0.1-' + prereleaseName
+      '1.0.0-' + prereleaseName
     );
     expect(changeManager.allPackages.get('cyclic-dep-2')!.packageJson.dependencies!['cyclic-dep-1']).toEqual(
-      'workspace:2.0.0-' + prereleaseName
+      'workspace:1.0.0-' + prereleaseName
     );
   });
 


### PR DESCRIPTION
When `--prerelease-name` is specified for `rush publish`, it will bump the packages before applying the prerelease suffix.
This leads to edge cases where a peerDependency selector doesn't satisfy the prereleases anymore:

 `1.0.1-something` is **not** assignable to `^1.0.0`
 `1.0.0-something` **is** assignable to `^1.0.0`

In order to solve this and make prerelease packages more usable, prereleases must not bump version numbers.

closes #3201