### PR TITLE
[rush-lib] Fix git-hooks error when drive letter casing does not match

### DIFF
--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -7,6 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as url from 'url';
 import colors from 'colors/safe';
+import { trueCasePathSync } from 'true-case-path';
 import { Executable, AlreadyReportedError, Path, ITerminal } from '@rushstack/node-core-library';
 import { ensureGitMinimumVersion } from '@rushstack/package-deps-hash';
 
@@ -155,7 +156,13 @@ export class Git {
       // This should have never been called in a non-Git environment
       return true;
     }
-    const defaultHooksPath: string = path.resolve(repoInfo.commonGitDir, 'hooks');
+    let commonGitDir: string = repoInfo.commonGitDir;
+    try {
+      commonGitDir = trueCasePathSync(commonGitDir);
+    } catch (error) {
+      /* ignore errors from true-case-path */
+    }
+    const defaultHooksPath: string = path.resolve(commonGitDir, 'hooks');
     const hooksResult: IResultOrError<string> = this._tryGetGitHooksPath();
     if (hooksResult.error) {
       console.log(

--- a/common/changes/@microsoft/rush/user-danade-FixDriveCasingGitHooks_2022-02-05-00-26.json
+++ b/common/changes/@microsoft/rush/user-danade-FixDriveCasingGitHooks_2022-02-05-00-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix git-hooks folder check failing when compared paths have different drive letter casing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Node can sometimes be inconsistent with drive letter casing. The library we obtain the `.git` directory from can sometimes provide the incorrect drive letter casing when running on Windows, which breaks our comparison to the (correctly cased) path to the Rush repo. This check ensures that the drive letter casing from the library matches the true drive letter casing.