### PR TITLE
[rush] Fix an issue with folder iteration during caching.

### DIFF
--- a/common/changes/@microsoft/rush/fix-file-collector_2022-02-06-03-42.json
+++ b/common/changes/@microsoft/rush/fix-file-collector_2022-02-06-03-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where cache entries in certain circumstances would be missing files in nested subfolders. For full details see https://github.com/microsoft/rushstack/pull/3211.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Currently, there is an issue with the algorithm that iterates through files that will be passed to `tar`. If there are fewer than 10 (the folder iteration concurrency) subfolders inside the folders that are to be cached, folders more than two levels deep will not be iterated through, so their files will not be cached. This happens because the iterator completes before any of the tertiary-level folders are added to the queue.

## Details

This PR fixes the issue by iterating through each folder level serially instead of trying to add all subfolders to the same queue. This can result in slightly less parallelism, but it will always capture all folders.

## How it was tested

Tested on a project with four subfolders inside its `lib` folder and files more than three levels deep that produced cache entries that are missing files. 