### PR TITLE
[api-documenter] Adding PowerPoint option to OfficeYamlDocumenter API set mapping

### DIFF
--- a/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
@@ -34,8 +34,9 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
   private _apiSetUrls: Record<string, string> = {
     Excel: '/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets',
     OneNote: '/office/dev/add-ins/reference/requirement-sets/onenote-api-requirement-sets',
-    Visio: '/office/dev/add-ins/reference/overview/visio-javascript-reference-overview',
     Outlook: '/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets',
+    PowerPoint: '/office/dev/add-ins/reference/requirement-sets/powerpoint-api-requirement-sets',
+    Visio: '/office/dev/add-ins/reference/overview/visio-javascript-reference-overview',
     Word: '/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets'
   };
 

--- a/common/changes/@microsoft/api-documenter/AlexJ-OfficeDocumenter_2022-02-08-00-43.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-OfficeDocumenter_2022-02-08-00-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Adding PowerPoint option to OfficeYamlDocumenter API set mapping",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
There's an override in the Office-specific DocFX YAML generator to add a link to API sets. This is done for each application, but PowerPoint was omitted from the initial list due to lack of support. This PR adds that option to reflect the current state of [PowerPoint API sets](https://docs.microsoft.com/en-us/office/dev/add-ins/reference/requirement-sets/powerpoint-api-requirement-sets).
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
This was tested in the [OfficeDev/office-js-docs-reference](https://github.com/OfficeDev/office-js-docs-reference) repo. This should be the only place using this version of ApiDocumenter.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
