### PR TITLE
[rush-lib] fix bug in `rush change --verify` for nested Rush repos

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -366,7 +366,7 @@ export class ChangeAction extends BaseRushAction {
 
   private _getChangeFiles(): string[] {
     const repoRoot = getRepoRoot(this.rushConfiguration.rushJsonFolder);
-    const relativeChangesFolder = path.relative(this.rushConfiguration.changesFolder, repoRoot);
+    const relativeChangesFolder = path.relative(repoRoot, this.rushConfiguration.changesFolder);
     return this._git
       .getChangedFiles(this._targetBranch, this._terminal, true, relativeChangesFolder)
       .map((relativePath) => {

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -365,8 +365,8 @@ export class ChangeAction extends BaseRushAction {
   }
 
   private _getChangeFiles(): string[] {
-    const repoRoot = getRepoRoot(this.rushConfiguration.rushJsonFolder);
-    const relativeChangesFolder = path.relative(repoRoot, this.rushConfiguration.changesFolder);
+    const repoRoot: string = getRepoRoot(this.rushConfiguration.rushJsonFolder);
+    const relativeChangesFolder: string = path.relative(repoRoot, this.rushConfiguration.changesFolder);
     return this._git
       .getChangedFiles(this._targetBranch, this._terminal, true, relativeChangesFolder)
       .map((relativePath) => {

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -19,6 +19,7 @@ import {
   ITerminal,
   ConsoleTerminalProvider
 } from '@rushstack/node-core-library';
+import { getRepoRoot } from '@rushstack/package-deps-hash';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { IChangeFile, IChangeInfo, ChangeType } from '../../api/ChangeManagement';
@@ -364,8 +365,10 @@ export class ChangeAction extends BaseRushAction {
   }
 
   private _getChangeFiles(): string[] {
+    const repoRoot = getRepoRoot(this.rushConfiguration.rushJsonFolder);
+    const relativeChangesFolder = path.relative(this.rushConfiguration.changesFolder, repoRoot);
     return this._git
-      .getChangedFiles(this._targetBranch, this._terminal, true, this.rushConfiguration.changesFolder)
+      .getChangedFiles(this._targetBranch, this._terminal, true, relativeChangesFolder)
       .map((relativePath) => {
         return path.join(this.rushConfiguration.rushJsonFolder, relativePath);
       });

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -365,7 +365,7 @@ export class ChangeAction extends BaseRushAction {
 
   private _getChangeFiles(): string[] {
     return this._git
-      .getChangedFiles(this._targetBranch, this._terminal, true, `common/changes/`)
+      .getChangedFiles(this._targetBranch, this._terminal, true, this.rushConfiguration.changesFolder)
       .map((relativePath) => {
         return path.join(this.rushConfiguration.rushJsonFolder, relativePath);
       });

--- a/common/changes/@microsoft/rush/rf-nested-rush-change-verify_2022-02-09-22-07.json
+++ b/common/changes/@microsoft/rush/rf-nested-rush-change-verify_2022-02-09-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix bug in `rush change --verify` for Rush repos not at the root of a git repo",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/rf-nested-rush-change-verify_2022-02-09-22-07.json
+++ b/common/changes/@microsoft/rush/rf-nested-rush-change-verify_2022-02-09-22-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix bug in `rush change --verify` for Rush repos not at the root of a git repo",
+      "comment": "Fix a bug where `rush change --verify` would not find the correct `common/changes` folder if the `rush.json` is not in the Git repo's root folder.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
This command would fail before for nested Rush repos (Rush repos that aren't at the root of the git repo) even after adding changelogs -- the code gathering the changed projects worked properly but the code gathering the changelogs did not.  It was using a hardcoded `common/changes` path from the git repo root.  Instead we pull the resolved changes folder off the Rush configuration.

Not sure how to test this exactly but hoping the bug and fix are obvious to maintainers.