### PR TITLE
[rush-lib] Add publish command line arg tag to git tag

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -371,7 +371,7 @@ export class PublishAction extends BaseRushAction {
             return;
           }
 
-          git.addTag(!!this._publish.value, packageName, packageVersion, this._commitId.value);
+          git.addTag(!!this._publish.value, packageName, packageVersion, this._commitId.value, this._npmTag.value);
           updated = true;
         };
 
@@ -405,7 +405,8 @@ export class PublishAction extends BaseRushAction {
           !!this._publish.value && !this._registryUrl.value,
           change.packageName,
           change.newVersion!,
-          this._commitId.value
+          this._commitId.value,
+          this._npmTag.value
         );
       }
     }

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -371,7 +371,7 @@ export class PublishAction extends BaseRushAction {
             return;
           }
 
-          git.addTag(!!this._publish.value, packageName, packageVersion, this._commitId.value, this._npmTag.value);
+          git.addTag(!!this._publish.value, packageName, packageVersion, this._commitId.value, this._prereleaseName.value);
           updated = true;
         };
 
@@ -406,7 +406,7 @@ export class PublishAction extends BaseRushAction {
           change.packageName,
           change.newVersion!,
           this._commitId.value,
-          this._npmTag.value
+          this._prereleaseName.value
         );
       }
     }

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -91,7 +91,7 @@ export class PublishGit {
     packageName: string,
     packageVersion: string,
     commitId: string | undefined,
-    npmTag?: string
+    preReleaseName?: string
   ): void {
     // Tagging only happens if we're publishing to real NPM and committing to git.
     const tagName: string = PublishUtilities.createTagname(
@@ -102,9 +102,9 @@ export class PublishGit {
     PublishUtilities.execCommand(!!this._targetBranch && shouldExecute, this._gitPath, [
       'tag',
       '-a',
-      npmTag ? `${tagName}-${npmTag}` : tagName,
+      preReleaseName ? `${tagName}-${preReleaseName}` : tagName,
       '-m',
-      npmTag ? `${packageName} v${packageVersion}-${npmTag}` : `${packageName} v${packageVersion}`,
+      preReleaseName ? `${packageName} v${packageVersion}-${preReleaseName}` : `${packageName} v${packageVersion}`,
       ...(commitId ? [commitId] : [])
     ]);
   }

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -90,7 +90,8 @@ export class PublishGit {
     shouldExecute: boolean,
     packageName: string,
     packageVersion: string,
-    commitId: string | undefined
+    commitId: string | undefined,
+    npmTag?: string
   ): void {
     // Tagging only happens if we're publishing to real NPM and committing to git.
     const tagName: string = PublishUtilities.createTagname(
@@ -101,9 +102,9 @@ export class PublishGit {
     PublishUtilities.execCommand(!!this._targetBranch && shouldExecute, this._gitPath, [
       'tag',
       '-a',
-      tagName,
+      npmTag ? `${tagName}-${npmTag}` : tagName,
       '-m',
-      `${packageName} v${packageVersion}`,
+      npmTag ? `${packageName} v${packageVersion}-${npmTag}` : `${packageName} v${packageVersion}`,
       ...(commitId ? [commitId] : [])
     ]);
   }

--- a/apps/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/apps/rush-lib/src/logic/test/PublishGit.test.ts
@@ -25,7 +25,7 @@ describe('PublishGit Test', () => {
       'project1',
       '2',
       undefined,
-      undefined // This is undefined to simulate `rush publish ...` without --tag
+      undefined // This is undefined to simulate `rush publish ...` without --prerelease-name
     )
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(
@@ -54,7 +54,7 @@ describe('PublishGit Test', () => {
       'project1',
       '2',
       undefined,
-      'new_version_tag' // Simulates `rush publish ... --tag new_version_tag`
+      'new_version_prerelease' // Simulates `rush publish ... --prerelease-name new_version_tag`
     )
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(

--- a/apps/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/apps/rush-lib/src/logic/test/PublishGit.test.ts
@@ -5,7 +5,7 @@ import { PublishGit } from "../PublishGit";
 import { PublishUtilities } from '../PublishUtilities';
 
 describe('PublishGit Test', () => {
-  it('Test Git Tag', () => {
+  it('Test git with no command line arg tag', () => {
     const execCommand = jest.fn()
     PublishUtilities.execCommand = execCommand
 
@@ -19,7 +19,36 @@ describe('PublishGit Test', () => {
       'project1',
       '2',
       undefined,
-      'new_version_tag'
+      undefined // This is undefined to simulate `rush publish ...` without --tag
+    )
+    expect(execCommand).toBeCalledTimes(1)
+    expect(execCommand).toBeCalledWith(
+      false,
+      '/usr/local/bin/git',
+      [
+        'tag',
+        '-a',
+        `project1_v2`,
+        '-m',
+        'project1 v2',
+    ])
+  })
+
+  it('Test git with command line arg tag', () => {
+    const execCommand = jest.fn()
+    PublishUtilities.execCommand = execCommand
+
+    const rushFilename: string = path.resolve(__dirname, '../../api/test/repo', 'rush-npm.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+    const git: Git = new Git(rushConfiguration);
+    const publishGit: PublishGit = new PublishGit(git, 'test');
+
+    publishGit.addTag(
+      false,
+      'project1',
+      '2',
+      undefined,
+      'new_version_tag' // Simulates `rush publish ... --tag new_version_tag`
     )
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(

--- a/apps/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/apps/rush-lib/src/logic/test/PublishGit.test.ts
@@ -1,25 +1,34 @@
 import * as path from 'path';
-import { RushConfiguration } from "../..";
+
+import { RushConfiguration } from "../../api/RushConfiguration";
 import { Git } from "../Git";
 import { PublishGit } from "../PublishGit";
 import { PublishUtilities } from '../PublishUtilities';
 
 describe('PublishGit Test', () => {
   let gitPath: string
+  let execCommand: jest.SpyInstance
+  let publishGit: PublishGit
+
   beforeAll(() => {
     gitPath = '/usr/bin/git'
     process.env.RUSH_GIT_BINARY_PATH = gitPath
   })
 
-  it('Test git with no command line arg tag', () => {
-    const execCommand = jest.fn()
-    PublishUtilities.execCommand = execCommand
+  beforeEach(() => {
+    execCommand = jest.spyOn(PublishUtilities, 'execCommand').mockImplementation(() => { /* no-op */ });
 
-    const rushFilename: string = path.resolve(__dirname, '../../api/test/repo', 'rush-npm.json');
+    const rushFilename: string = path.resolve(__dirname, '../../api/test/repo/rush-npm.json');
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
     const git: Git = new Git(rushConfiguration);
-    const publishGit: PublishGit = new PublishGit(git, 'test');
+    publishGit = new PublishGit(git, 'test');
+  })
 
+  afterEach(() => {
+    execCommand.mockClear()
+  })
+
+  it('Test git with no command line arg tag', () => {
     publishGit.addTag(
       false,
       'project1',
@@ -41,20 +50,12 @@ describe('PublishGit Test', () => {
   })
 
   it('Test git with command line arg tag', () => {
-    const execCommand = jest.fn()
-    PublishUtilities.execCommand = execCommand
-
-    const rushFilename: string = path.resolve(__dirname, '../../api/test/repo', 'rush-npm.json');
-    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
-    const git: Git = new Git(rushConfiguration);
-    const publishGit: PublishGit = new PublishGit(git, 'test');
-
     publishGit.addTag(
       false,
       'project1',
       '2',
       undefined,
-      'new_version_prerelease' // Simulates `rush publish ... --prerelease-name new_version_tag`
+      'new_version_prerelease' // Simulates `rush publish ... --prerelease-name new_version_prerelease`
     )
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(
@@ -63,9 +64,9 @@ describe('PublishGit Test', () => {
       [
         'tag',
         '-a',
-        `project1_v2-new_version_tag`,
+        `project1_v2-new_version_prerelease`,
         '-m',
-        'project1 v2-new_version_tag',
+        'project1 v2-new_version_prerelease',
     ])
   })
 })

--- a/apps/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/apps/rush-lib/src/logic/test/PublishGit.test.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import { RushConfiguration } from "../..";
+import { Git } from "../Git";
+import { PublishGit } from "../PublishGit";
+import { PublishUtilities } from '../PublishUtilities';
+
+describe('PublishGit Test', () => {
+  it('Test Git Tag', () => {
+    const execCommand = jest.fn()
+    PublishUtilities.execCommand = execCommand
+
+    const rushFilename: string = path.resolve(__dirname, '../../api/test/repo', 'rush-npm.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+    const git: Git = new Git(rushConfiguration);
+    const publishGit: PublishGit = new PublishGit(git, 'test');
+
+    publishGit.addTag(
+      false,
+      'project1',
+      '2',
+      undefined,
+      'new_version_tag'
+    )
+    expect(execCommand).toBeCalledTimes(1)
+    expect(execCommand).toBeCalledWith(
+      false,
+      '/usr/local/bin/git',
+      [
+        'tag',
+        '-a',
+        `project1_v2-new_version_tag`,
+        '-m',
+        'project1 v2-new_version_tag',
+    ])
+  })
+})

--- a/apps/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/apps/rush-lib/src/logic/test/PublishGit.test.ts
@@ -5,6 +5,12 @@ import { PublishGit } from "../PublishGit";
 import { PublishUtilities } from '../PublishUtilities';
 
 describe('PublishGit Test', () => {
+  let gitPath: string
+  beforeAll(() => {
+    gitPath = '/usr/bin/git'
+    process.env.RUSH_GIT_BINARY_PATH = gitPath
+  })
+
   it('Test git with no command line arg tag', () => {
     const execCommand = jest.fn()
     PublishUtilities.execCommand = execCommand
@@ -24,7 +30,7 @@ describe('PublishGit Test', () => {
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(
       false,
-      '/usr/local/bin/git',
+      gitPath,
       [
         'tag',
         '-a',
@@ -53,7 +59,7 @@ describe('PublishGit Test', () => {
     expect(execCommand).toBeCalledTimes(1)
     expect(execCommand).toBeCalledWith(
       false,
-      '/usr/local/bin/git',
+      gitPath,
       [
         'tag',
         '-a',

--- a/common/changes/@microsoft/rush/fix-git-tagging_2022-02-09-23-28.json
+++ b/common/changes/@microsoft/rush/fix-git-tagging_2022-02-09-23-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "change git tag to use passed in tag argument",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-git-tagging_2022-02-09-23-28.json
+++ b/common/changes/@microsoft/rush/fix-git-tagging_2022-02-09-23-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "change git tag to use passed in tag argument",
+      "comment": "Fix an issue where the git tag would not include the prerelease portion of the version, which will cause subsequent publishes of the same version to not be tagged.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Linked issue: https://github.com/microsoft/rushstack/issues/3222

These changes address the bug here (in part 4): https://github.com/microsoft/rushstack/issues/2536
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This PR fixes how git tags are added after a `prerelease` is published.

If the publish command was: `rush publish --apply --publish --tag beta --prerelease-name beta`

The old git tag would be:
`projectName_projectVersion`

With this change the tag will be:
`projectName_projectVersion-beta`

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

This is a problem because it can cause conflicting git tags, which could cause pipelines to fail before they finish building.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

- [ ] Unit tests
- [ ] Integration tests

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
