### PR TITLE
[rush-lib] Add lifecycle hooks for global and phased commands

### DIFF
--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -129,7 +129,7 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
 
     this._throwPluginErrorIfNeed();
 
-    await this.rushSession.hooks.initialize.promise();
+    await this.rushSession.hooks.initialize.promise(this);
 
     return super.onExecute();
   }

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -77,7 +77,17 @@ export {
   CloudBuildCacheProviderFactory
 } from './pluginFramework/RushSession';
 
-export { RushLifecycleHooks } from './pluginFramework/RushLifeCycle';
+export {
+  RushLifecycleHooks,
+  IRushAction,
+  IGlobalScriptAction,
+  IPhasedScriptAction
+} from './pluginFramework/RushLifeCycle';
+export { PhasedScriptActionHooks } from './pluginFramework/PhasedScriptActionHooks';
+
+export { Operation } from './logic/operations/Operation';
+export { OperationStatus } from './logic/operations/OperationStatus';
+export { IOperationRunner, IOperationRunnerContext } from './logic/operations/IOperationRunner';
 
 export { IRushPlugin } from './pluginFramework/IRushPlugin';
 export { IBuiltInPluginConfiguration as _IBuiltInPluginConfiguration } from './pluginFramework/PluginLoader/BuiltInPluginLoader';

--- a/apps/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -5,20 +5,37 @@ import type { StdioSummarizer } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
-import type { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 
+/**
+ * Information passed to the executing `IOperationRunner`
+ *
+ * @beta
+ */
 export interface IOperationRunnerContext {
-  repoCommandLineConfiguration: CommandLineConfiguration;
+  /**
+   * The writer into which this `IOperationRunner` should write its logs.
+   */
   collatedWriter: CollatedWriter;
-  stdioSummarizer: StdioSummarizer;
-  quietMode: boolean;
+  /**
+   * If Rush was invoked with `--debug`
+   */
   debugMode: boolean;
+  /**
+   * Defaults to `true`. Will be `false` if Rush was invoked with `--verbose`.
+   */
+  quietMode: boolean;
+  /**
+   * Object used to report a summary at the end of the Rush invocation.
+   */
+  stdioSummarizer: StdioSummarizer;
 }
 
 /**
  * The `Operation` class is a node in the dependency graph of work that needs to be scheduled by the
  * `OperationExecutionManager`. Each `Operation` has a `runner` member of type `IOperationRunner`, whose
  * implementation manages the actual process for running a single operation.
+ *
+ * @beta
  */
 export interface IOperationRunner {
   /**
@@ -32,10 +49,9 @@ export interface IOperationRunner {
   isSkipAllowed: boolean;
 
   /**
-   * Assigned by execute().  True if the script was an empty string.  Operationally an empty string is
-   * like a shell command that succeeds instantly, but e.g. it would be odd to report time statistics for it.
+   * Indicates that this runner does nothing. Will be used to skip time statistics.
    */
-  hadEmptyScript: boolean;
+  isNoop: boolean;
 
   /**
    * If set to true, a warning result should not make Rush exit with a nonzero

--- a/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
@@ -1,30 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { OperationStatus } from './OperationStatus';
-import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import type { OperationStatus } from './OperationStatus';
+import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
 
 /**
  * Implementation of `IOperationRunner` for operations that require no work, such as empty scripts,
- * or operations that are skipped by filters.
+ * skipped operations, or blocked operations.
  */
 export class NullOperationRunner implements IOperationRunner {
-  private readonly _result: OperationStatus;
   public readonly name: string;
-  public readonly hadEmptyScript: boolean = true;
-  // The operation may never be skipped; it doesn't do anything anyway
-  public isSkipAllowed: boolean = false;
-  // The operation is a no-op, so skip writing an empty cache entry
-  public isCacheWriteAllowed: boolean = false;
+  public readonly isNoop: boolean = true;
+  // The operation may be skipped; it doesn't do anything anyway
+  public isSkipAllowed: boolean = true;
+  // The operation is a no-op, so is cacheable.
+  public isCacheWriteAllowed: boolean = true;
   // Nothing will get logged, no point allowing warnings
   public readonly warningsAreAllowed: boolean = false;
 
+  public readonly result: OperationStatus;
+
   public constructor(name: string, result: OperationStatus) {
     this.name = name;
-    this._result = result;
+    this.result = result;
   }
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
-    return this._result;
+    return this.result;
   }
 }

--- a/apps/rush-lib/src/logic/operations/Operation.ts
+++ b/apps/rush-lib/src/logic/operations/Operation.ts
@@ -1,18 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { StdioSummarizer } from '@rushstack/terminal';
-import { CollatedWriter } from '@rushstack/stream-collator';
-
-import { Stopwatch } from '../../utilities/Stopwatch';
-import { OperationStatus } from './OperationStatus';
-import { OperationError } from './OperationError';
 import { IOperationRunner } from './IOperationRunner';
 
 /**
  * The `Operation` class is a node in the dependency graph of work that needs to be scheduled by the
  * `OperationExecutionManager`. Each `Operation` has a `runner` member of type `IOperationRunner`, whose
  * implementation manages the actual process of running a single operation.
+ *
+ * The graph of `Operation` instances will be cloned into a separate execution graph after processing.
+ *
+ * @beta
  */
 export class Operation {
   /**
@@ -22,76 +20,25 @@ export class Operation {
   public runner: IOperationRunner;
 
   /**
-   * The current execution status of an operation. Operations start in the 'ready' state,
-   * but can be 'blocked' if an upstream operation failed. It is 'executing' when
-   * the operation is executing. Once execution is complete, it is either 'success' or
-   * 'failure'.
-   */
-  public status: OperationStatus;
-
-  /**
    * A set of all dependencies which must be executed before this operation is complete.
-   * When dependencies finish execution, they are removed from this list.
    */
-  public dependencies: Set<Operation> = new Set<Operation>();
+  public readonly dependencies: Set<Operation> = new Set<Operation>();
 
   /**
-   * The inverse of dependencies, lists all projects which are directly dependent on this one.
+   * The weight for this operation. This scalar is the contribution of this operation to the
+   * `criticalPathLength` calculation above. Modify to indicate the following:
+   * - `weight` === 1: indicates that this operation has an average duration
+   * - `weight` &gt; 1: indicates that this operation takes longer than average and so the scheduler
+   *     should try to favor starting it over other, shorter operations. An example might be an operation that
+   *     bundles an entire application and runs whole-program optimization.
+   * - `weight` &lt; 1: indicates that this operation takes less time than average and so the scheduler
+   *     should favor other, longer operations over it. An example might be an operation to unpack a cached
+   *     output, or an operation using NullOperationRunner, which might use a value of 0.
    */
-  public dependents: Set<Operation> = new Set<Operation>();
+  public weight: number = 1;
 
-  /**
-   * This number represents how far away this Operation is from the furthest "root" project (i.e.
-   * a project with no dependents). This helps us to calculate the critical path (i.e. the
-   * longest chain of projects which must be executed in order, thereby limiting execution speed
-   * of the entire operation tree.
-   *
-   * This number is calculated via a memoized depth-first search, and when choosing the next
-   * operation to execute, the operation with the highest criticalPathLength is chosen.
-   *
-   * Example:
-   *        (0) A
-   *             \
-   *          (1) B     C (0)         (applications)
-   *               \   /|\
-   *                \ / | \
-   *             (2) D  |  X (1)      (utilities)
-   *                    | / \
-   *                    |/   \
-   *                (2) Y     Z (2)   (other utilities)
-   *
-   * All roots (A & C) have a criticalPathLength of 0.
-   * B has a score of 1, since A depends on it.
-   * D has a score of 2, since we look at the longest chain (e.g D->B->A is longer than D->C)
-   * X has a score of 1, since the only package which depends on it is A
-   * Z has a score of 2, since only X depends on it, and X has a score of 1
-   * Y has a score of 2, since the chain Y->X->C is longer than Y->C
-   *
-   * The algorithm is implemented in AsyncOperationQueue.ts as calculateCriticalPathLength()
-   */
-  public criticalPathLength: number | undefined;
-
-  /**
-   * The error which occurred while executing this operation, this is stored in case we need
-   * it later (for example to re-print errors at end of execution).
-   */
-  public error: OperationError | undefined;
-
-  /**
-   * The operation writer which contains information from the output streams of this operation
-   */
-  public collatedWriter!: CollatedWriter;
-
-  public stdioSummarizer!: StdioSummarizer;
-
-  /**
-   * The stopwatch which measures how long it takes the operation to execute
-   */
-  public stopwatch!: Stopwatch;
-
-  public constructor(runner: IOperationRunner, initialStatus: OperationStatus) {
+  public constructor(runner: IOperationRunner) {
     this.runner = runner;
-    this.status = initialStatus;
   }
 
   public get name(): string {

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -4,7 +4,6 @@
 import * as os from 'os';
 import colors from 'colors/safe';
 import {
-  StdioSummarizer,
   TerminalWritable,
   StdioWritable,
   TerminalChunkKind,
@@ -13,12 +12,10 @@ import {
 import { StreamCollator, CollatedTerminal, CollatedWriter } from '@rushstack/stream-collator';
 import { AlreadyReportedError, NewlineKind, InternalError, Sort } from '@rushstack/node-core-library';
 
-import { Stopwatch } from '../../utilities/Stopwatch';
 import { AsyncOperationQueue, IOperationSortFunction } from './AsyncOperationQueue';
 import { Operation } from './Operation';
 import { OperationStatus } from './OperationStatus';
-import { IOperationRunnerContext } from './IOperationRunner';
-import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
+import { IOperationExecutionRecordContext, OperationExecutionRecord } from './OperationExecutionRecord';
 import { OperationError } from './OperationError';
 
 export interface IOperationExecutionManagerOptions {
@@ -26,7 +23,6 @@ export interface IOperationExecutionManagerOptions {
   debugMode: boolean;
   parallelism: string | undefined;
   changedProjectsOnly: boolean;
-  repoCommandLineConfiguration: CommandLineConfiguration;
   destination?: TerminalWritable;
 }
 
@@ -42,12 +38,10 @@ const ASCII_HEADER_WIDTH: number = 79;
  * tasks are complete, or prematurely fails if any of the tasks fail.
  */
 export class OperationExecutionManager {
-  private readonly _operations: Set<Operation>;
   private readonly _changedProjectsOnly: boolean;
+  private readonly _executionRecords: Set<OperationExecutionRecord>;
   private readonly _quietMode: boolean;
-  private readonly _debugMode: boolean;
   private readonly _parallelism: number;
-  private readonly _repoCommandLineConfiguration: CommandLineConfiguration;
   private readonly _totalOperations: number;
 
   private readonly _outputWritable: TerminalWritable;
@@ -62,22 +56,19 @@ export class OperationExecutionManager {
   private _completedOperations: number;
 
   public constructor(operations: Set<Operation>, options: IOperationExecutionManagerOptions) {
-    const { quietMode, debugMode, parallelism, changedProjectsOnly, repoCommandLineConfiguration } = options;
-    this._operations = operations;
+    const { quietMode, debugMode, parallelism, changedProjectsOnly } = options;
     this._completedOperations = 0;
     this._totalOperations = operations.size;
     this._quietMode = quietMode;
-    this._debugMode = debugMode;
     this._hasAnyFailures = false;
     this._hasAnyNonAllowedWarnings = false;
     this._changedProjectsOnly = changedProjectsOnly;
-    this._repoCommandLineConfiguration = repoCommandLineConfiguration;
 
     // TERMINAL PIPELINE:
     //
     // streamCollator --> colorsNewlinesTransform --> StdioWritable
     //
-    this._outputWritable = options.destination ? options.destination : StdioWritable.instance;
+    this._outputWritable = options.destination || StdioWritable.instance;
     this._colorsNewlinesTransform = new TextRewriterTransform({
       destination: this._outputWritable,
       normalizeNewlines: NewlineKind.OsDefault,
@@ -88,6 +79,32 @@ export class OperationExecutionManager {
       onWriterActive: this._streamCollator_onWriterActive
     });
     this._terminal = this._streamCollator.terminal;
+
+    // Convert the developer graph to the mutable execution graph
+    const executionRecordContext: IOperationExecutionRecordContext = {
+      streamCollator: this._streamCollator,
+      debugMode,
+      quietMode
+    };
+
+    const executionRecords: Map<Operation, OperationExecutionRecord> = new Map();
+    for (const operation of operations) {
+      executionRecords.set(operation, new OperationExecutionRecord(operation, executionRecordContext));
+    }
+
+    for (const [operation, consumer] of executionRecords) {
+      for (const dependency of operation.dependencies) {
+        const dependencyRecord: OperationExecutionRecord | undefined = executionRecords.get(dependency);
+        if (!dependencyRecord) {
+          throw new Error(
+            `Operation "${consumer.name}" declares a dependency on operation "${dependency.name}" that is not in the set of operations to execute.`
+          );
+        }
+        consumer.dependencies.add(dependencyRecord);
+        dependencyRecord.consumers.add(consumer);
+      }
+    }
+    this._executionRecords = new Set(executionRecords.values());
 
     const numberOfCores: number = os.cpus().length;
 
@@ -159,13 +176,13 @@ export class OperationExecutionManager {
    */
   public async executeAsync(): Promise<void> {
     this._completedOperations = 0;
-    const totalTasks: number = this._totalOperations;
+    const totalOperations: number = this._totalOperations;
 
     if (!this._quietMode) {
-      const plural: string = totalTasks === 1 ? '' : 's';
-      this._terminal.writeStdoutLine(`Selected ${totalTasks} project${plural}:`);
+      const plural: string = totalOperations === 1 ? '' : 's';
+      this._terminal.writeStdoutLine(`Selected ${totalOperations} operation${plural}:`);
       this._terminal.writeStdoutLine(
-        Array.from(this._operations, (x) => `  ${x.name}`)
+        Array.from(this._executionRecords, (x) => `  ${x.name}`)
           .sort()
           .join('\n')
       );
@@ -174,22 +191,14 @@ export class OperationExecutionManager {
 
     this._terminal.writeStdoutLine(`Executing a maximum of ${this._parallelism} simultaneous processes...`);
 
-    const maxParallelism: number = Math.min(totalTasks, this._parallelism);
-    const prioritySort: IOperationSortFunction = (a: Operation, b: Operation): number => {
-      let diff: number = a.criticalPathLength! - b.criticalPathLength!;
-      if (diff) {
-        return diff;
-      }
-
-      diff = a.dependents.size - b.dependents.size;
-      if (diff) {
-        return diff;
-      }
-
-      // No further default considerations.
-      return 0;
+    const maxParallelism: number = Math.min(totalOperations, this._parallelism);
+    const prioritySort: IOperationSortFunction = (
+      a: OperationExecutionRecord,
+      b: OperationExecutionRecord
+    ): number => {
+      return a.criticalPathLength! - b.criticalPathLength!;
     };
-    const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(this._operations, prioritySort);
+    const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(this._executionRecords, prioritySort);
 
     // Iterate in parallel with maxParallelism concurrent lanes
     await Promise.all(
@@ -208,182 +217,128 @@ export class OperationExecutionManager {
     this._printOperationStatus();
 
     if (this._hasAnyFailures) {
-      this._terminal.writeStderrLine(colors.red('Projects failed to build.') + '\n');
+      this._terminal.writeStderrLine(colors.red('Operations failed.') + '\n');
       throw new AlreadyReportedError();
     } else if (this._hasAnyNonAllowedWarnings) {
-      this._terminal.writeStderrLine(colors.yellow('Projects succeeded with warnings.') + '\n');
+      this._terminal.writeStderrLine(colors.yellow('Operations succeeded with warnings.') + '\n');
       throw new AlreadyReportedError();
     }
   }
 
-  private async _executeOperationAsync(operation: Operation, tid: number): Promise<void> {
-    operation.status = OperationStatus.Executing;
-    operation.stopwatch = Stopwatch.start();
-    operation.collatedWriter = this._streamCollator.registerTask(operation.name);
-    operation.stdioSummarizer = new StdioSummarizer();
-
-    const context: IOperationRunnerContext = {
-      repoCommandLineConfiguration: this._repoCommandLineConfiguration,
-      stdioSummarizer: operation.stdioSummarizer,
-      collatedWriter: operation.collatedWriter,
-      quietMode: this._quietMode,
-      debugMode: this._debugMode
-    };
+  private async _executeOperationAsync(operation: OperationExecutionRecord, tid: number): Promise<void> {
+    let result: OperationStatus = (operation.status = OperationStatus.Executing);
+    operation.stopwatch.start();
 
     try {
-      const result: OperationStatus = await operation.runner.executeAsync(context);
+      result = await operation.runner.executeAsync(operation);
 
-      operation.stopwatch.stop();
-      operation.stdioSummarizer.close();
-
-      switch (result) {
-        case OperationStatus.Success:
-          this._markAsSuccess(operation);
-          break;
-        case OperationStatus.SuccessWithWarning:
-          this._hasAnyNonAllowedWarnings =
-            this._hasAnyNonAllowedWarnings || !operation.runner.warningsAreAllowed;
-          this._markAsSuccessWithWarning(operation);
-          break;
-        case OperationStatus.FromCache:
-          this._markAsFromCache(operation);
-          break;
-        case OperationStatus.Skipped:
-          this._markAsSkipped(operation);
-          break;
-        case OperationStatus.Failure:
-          this._hasAnyFailures = true;
-          this._markAsFailed(operation);
-          break;
-      }
+      // Only perform global state updates. Internal state updates are handled by Operation itself.
+      this._handleOperationResult(operation, result);
     } catch (error) {
-      operation.stdioSummarizer.close();
-
-      this._hasAnyFailures = true;
-
-      // eslint-disable-next-line require-atomic-updates
+      const status: OperationStatus = OperationStatus.Failure;
       operation.error = error as OperationError;
-
-      this._markAsFailed(operation);
-    }
-
-    operation.collatedWriter.close();
-  }
-
-  /**
-   * Marks an operation as having failed and marks each of its dependents as blocked
-   */
-  private _markAsFailed(operation: Operation): void {
-    if (operation.error) {
-      operation.collatedWriter.terminal.writeStderrLine(operation.error.message);
-    }
-    operation.collatedWriter.terminal.writeStderrLine(colors.red(`"${operation.name}" failed to build.`));
-    operation.status = OperationStatus.Failure;
-    operation.dependents.forEach((dependent: Operation) => {
-      this._markAsBlocked(dependent, operation);
-    });
-  }
-
-  /**
-   * Marks an operation and all its dependents as blocked
-   */
-  private _markAsBlocked(blockedOperation: Operation, failedOperation: Operation): void {
-    if (blockedOperation.status === OperationStatus.Ready) {
-      this._completedOperations++;
-
-      // Note: We cannot write to blockedOperation.collatedWriter because "blockedOperation" will be skipped
-      failedOperation.collatedWriter.terminal.writeStdoutLine(
-        `"${blockedOperation.name}" is blocked by "${failedOperation.name}".`
-      );
-      blockedOperation.status = OperationStatus.Blocked;
-      blockedOperation.dependents.forEach((dependent: Operation) => {
-        this._markAsBlocked(dependent, failedOperation);
-      });
+      this._handleOperationResult(operation, status);
+    } finally {
+      operation.collatedWriter.close();
+      operation.stdioSummarizer.close();
+      operation.stopwatch.stop();
     }
   }
 
   /**
-   * Marks an operation as being completed, and removes it from the dependencies list of all its dependents
+   * Applies the new status to an OperationExecutionRecord and propagates any relevant effects.
    */
-  private _markAsSuccess(operation: Operation): void {
-    if (operation.runner.hadEmptyScript) {
-      operation.collatedWriter.terminal.writeStdoutLine(
-        colors.green(`"${operation.name}" had an empty script.`)
-      );
-    } else {
-      operation.collatedWriter.terminal.writeStdoutLine(
-        colors.green(`"${operation.name}" completed successfully in ${operation.stopwatch.toString()}.`)
-      );
-    }
-    operation.status = OperationStatus.Success;
+  private _handleOperationResult(record: OperationExecutionRecord, result: OperationStatus): void {
+    record.status = result;
 
-    operation.dependents.forEach((dependent: Operation) => {
-      if (!this._changedProjectsOnly) {
-        dependent.runner.isSkipAllowed = false;
+    const {
+      collatedWriter: { terminal },
+      runner,
+      name
+    } = record;
+
+    let blockCacheWrite: boolean = !runner.isCacheWriteAllowed;
+    let blockSkip: boolean = !runner.isSkipAllowed;
+
+    switch (result) {
+      /**
+       * This operation failed. Mark it as such and all reachable dependents as blocked.
+       */
+      case OperationStatus.Failure:
+        const message: string | undefined = record.error?.message;
+        if (message) {
+          terminal.writeStderrLine(message);
+        }
+        terminal.writeStderrLine(colors.red(`"${name}" failed to build.`));
+        const blockedQueue: Set<OperationExecutionRecord> = new Set(record.consumers);
+        for (const blockedRecord of blockedQueue) {
+          if (blockedRecord.status === OperationStatus.Ready) {
+            this._completedOperations++;
+
+            terminal.writeStdoutLine(`"${blockedRecord.name}" is blocked by "${name}".`);
+            blockedRecord.status = OperationStatus.Blocked;
+
+            for (const dependent of blockedRecord.consumers) {
+              blockedQueue.add(dependent);
+            }
+          }
+        }
+        this._hasAnyFailures = true;
+        break;
+      /**
+       * This operation was restored from the build cache.
+       */
+      case OperationStatus.FromCache:
+        terminal.writeStdoutLine(colors.green(`"${name}" was restored from the build cache.`));
+        break;
+      /**
+       * This operation was skipped via legacy change detection.
+       */
+      case OperationStatus.Skipped:
+        terminal.writeStdoutLine(colors.green(`"${name}" was skipped.`));
+        // Skipping means cannot guarantee integrity, so prevent cache writes in dependents.
+        blockCacheWrite = true;
+        break;
+      case OperationStatus.Success:
+        terminal.writeStdoutLine(
+          colors.green(`"${name}" completed successfully in ${record.stopwatch.toString()}.`)
+        );
+        // Legacy incremental build, if asked, prevent skip in dependents if the operation executed.
+        blockSkip ||= !this._changedProjectsOnly;
+        break;
+      case OperationStatus.SuccessWithWarning:
+        terminal.writeStderrLine(
+          colors.yellow(`"${name}" completed with warnings in ${record.stopwatch.toString()}.`)
+        );
+        // Legacy incremental build, if asked, prevent skip in dependents if the operation executed.
+        blockSkip ||= !this._changedProjectsOnly;
+        this._hasAnyNonAllowedWarnings = this._hasAnyNonAllowedWarnings || !runner.warningsAreAllowed;
+        break;
+    }
+
+    // Apply status changes to direct dependents
+    for (const item of record.consumers) {
+      if (blockCacheWrite) {
+        item.runner.isCacheWriteAllowed = false;
       }
-      dependent.dependencies.delete(operation);
-    });
-  }
 
-  /**
-   * Marks an operation as being completed, but with warnings written to stderr, and removes it from the dependencies
-   * list of all its dependents
-   */
-  private _markAsSuccessWithWarning(operation: Operation): void {
-    operation.collatedWriter.terminal.writeStderrLine(
-      colors.yellow(`"${operation.name}" completed with warnings in ${operation.stopwatch.toString()}.`)
-    );
-    operation.status = OperationStatus.SuccessWithWarning;
-    operation.dependents.forEach((dependent: Operation) => {
-      if (!this._changedProjectsOnly) {
-        dependent.runner.isSkipAllowed = false;
+      if (blockSkip) {
+        item.runner.isSkipAllowed = false;
       }
-      dependent.dependencies.delete(operation);
-    });
-  }
 
-  /**
-   * Marks an operation as skipped.
-   */
-  private _markAsSkipped(operation: Operation): void {
-    operation.collatedWriter.terminal.writeStdoutLine(colors.green(`${operation.name} was skipped.`));
-    operation.status = OperationStatus.Skipped;
-    operation.dependents.forEach((dependent: Operation) => {
-      dependent.dependencies.delete(operation);
-    });
-
-    const invalidationQueue: Set<Operation> = new Set(operation.dependents);
-    for (const consumer of invalidationQueue) {
-      // If an operation is skipped, state is not guaranteed in downstream tasks, so block cache write
-      consumer.runner.isCacheWriteAllowed = false;
-
-      // Propagate through the entire build queue applying cache write prevention.
-      for (const indirectConsumer of consumer.dependents) {
-        invalidationQueue.add(indirectConsumer);
-      }
+      // Remove this operation from the dependencies, to unblock the scheduler
+      item.dependencies.delete(record);
     }
-  }
-
-  /**
-   * Marks an operation as provided by cache.
-   */
-  private _markAsFromCache(operation: Operation): void {
-    operation.collatedWriter.terminal.writeStdoutLine(
-      colors.green(`${operation.name} was restored from the build cache.`)
-    );
-    operation.status = OperationStatus.FromCache;
-    operation.dependents.forEach((dependent: Operation) => {
-      dependent.dependencies.delete(operation);
-    });
   }
 
   /**
    * Prints out a report of the status of each project
    */
   private _printOperationStatus(): void {
-    const operationsByStatus: Record<string, Operation[]> = {};
-    for (const operation of this._operations) {
-      switch (operation.status) {
+    const operationsByStatus: Map<OperationStatus, OperationExecutionRecord[]> = new Map();
+    for (const operation of this._executionRecords) {
+      const { status } = operation;
+      switch (status) {
         // These are the sections that we will report below
         case OperationStatus.Skipped:
         case OperationStatus.FromCache:
@@ -394,13 +349,14 @@ export class OperationExecutionManager {
           break;
         default:
           // This should never happen
-          throw new InternalError('Unexpected task status: ' + operation.status);
+          throw new InternalError(`Unexpected task status: ${status}`);
       }
 
-      if (operationsByStatus[operation.status]) {
-        operationsByStatus[operation.status].push(operation);
+      const collection: OperationExecutionRecord[] | undefined = operationsByStatus.get(status);
+      if (collection) {
+        collection.push(operation);
       } else {
-        operationsByStatus[operation.status] = [operation];
+        operationsByStatus.set(status, [operation]);
       }
     }
 
@@ -452,7 +408,7 @@ export class OperationExecutionManager {
 
   private _writeCondensedSummary(
     status: OperationStatus,
-    operationsByStatus: Record<string, Operation[]>,
+    recordsByStatus: Map<OperationStatus, OperationExecutionRecord[]>,
     headingColor: (text: string) => string,
     preamble: string
   ): void {
@@ -465,7 +421,7 @@ export class OperationExecutionManager {
     //   e
     //   k
 
-    const operations: Operation[] | undefined = operationsByStatus[status];
+    const operations: OperationExecutionRecord[] | undefined = recordsByStatus.get(status);
     if (!operations || operations.length === 0) {
       return;
     }
@@ -478,8 +434,8 @@ export class OperationExecutionManager {
 
     for (const operation of operations) {
       if (
-        operation.stopwatch &&
-        !operation.runner.hadEmptyScript &&
+        operation.stopwatch.duration !== 0 &&
+        !operation.runner.isNoop &&
         operation.status !== OperationStatus.Skipped
       ) {
         const time: string = operation.stopwatch.toString();
@@ -494,7 +450,7 @@ export class OperationExecutionManager {
 
   private _writeDetailedSummary(
     status: OperationStatus,
-    operationsByStatus: Record<string, Operation[]>,
+    recordsByStatus: Map<OperationStatus, OperationExecutionRecord[]>,
     headingColor: (text: string) => string,
     shortStatusName?: string
   ): void {
@@ -506,7 +462,7 @@ export class OperationExecutionManager {
     //
     // [eslint] Warning: src/logic/operations/OperationsExecutionManager.ts:393:3 ...
 
-    const operations: Operation[] | undefined = operationsByStatus[status];
+    const operations: OperationExecutionRecord[] | undefined = recordsByStatus.get(status);
     if (!operations || operations.length === 0) {
       return;
     }
@@ -556,18 +512,18 @@ export class OperationExecutionManager {
 
   private _writeSummaryHeader(
     status: OperationStatus,
-    operations: Operation[],
+    records: OperationExecutionRecord[],
     headingColor: (text: string) => string
   ): void {
     // Format a header like this
     //
-    // ==[ FAILED: 2 projects ]================================================
+    // ==[ FAILED: 2 operations ]================================================
 
-    // "2 projects"
-    const projectsText: string = `${operations.length}${operations.length === 1 ? ' project' : ' projects'}`;
+    // "2 operations"
+    const projectsText: string = `${records.length}${records.length === 1 ? ' operation' : ' operations'}`;
     const headingText: string = `${status}: ${projectsText}`;
 
-    // leftPart: "==[ FAILED: 2 projects "
+    // leftPart: "==[ FAILED: 2 operations "
     const leftPart: string = `${colors.gray('==[')} ${headingColor(headingText)} `;
     const leftPartLength: number = 3 + 1 + headingText.length + 1;
 

--- a/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { StdioSummarizer } from '@rushstack/terminal';
+import { CollatedWriter, StreamCollator } from '@rushstack/stream-collator';
+
+import { OperationStatus } from './OperationStatus';
+import { OperationError } from './OperationError';
+import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import { Operation } from './Operation';
+import { Stopwatch } from '../../utilities/Stopwatch';
+
+export interface IOperationExecutionRecordContext {
+  streamCollator: StreamCollator;
+
+  debugMode: boolean;
+  quietMode: boolean;
+}
+
+/**
+ * Internal class representing everything about executing an operation
+ */
+export class OperationExecutionRecord implements IOperationRunnerContext {
+  /**
+   * The current execution status of an operation. Operations start in the 'ready' state,
+   * but can be 'blocked' if an upstream operation failed. It is 'executing' when
+   * the operation is executing. Once execution is complete, it is either 'success' or
+   * 'failure'.
+   */
+  public status: OperationStatus = OperationStatus.Ready;
+
+  /**
+   * The error which occurred while executing this operation, this is stored in case we need
+   * it later (for example to re-print errors at end of execution).
+   */
+  public error: OperationError | undefined = undefined;
+
+  /**
+   * This number represents how far away this Operation is from the furthest "root" operation (i.e.
+   * an operation with no consumers). This helps us to calculate the critical path (i.e. the
+   * longest chain of projects which must be executed in order, thereby limiting execution speed
+   * of the entire operation tree.
+   *
+   * This number is calculated via a memoized depth-first search, and when choosing the next
+   * operation to execute, the operation with the highest criticalPathLength is chosen.
+   *
+   * Example:
+   *        (0) A
+   *             \
+   *          (1) B     C (0)         (applications)
+   *               \   /|\
+   *                \ / | \
+   *             (2) D  |  X (1)      (utilities)
+   *                    | / \
+   *                    |/   \
+   *                (2) Y     Z (2)   (other utilities)
+   *
+   * All roots (A & C) have a criticalPathLength of 0.
+   * B has a score of 1, since A depends on it.
+   * D has a score of 2, since we look at the longest chain (e.g D->B->A is longer than D->C)
+   * X has a score of 1, since the only package which depends on it is A
+   * Z has a score of 2, since only X depends on it, and X has a score of 1
+   * Y has a score of 2, since the chain Y->X->C is longer than Y->C
+   *
+   * The algorithm is implemented in AsyncOperationQueue.ts as calculateCriticalPathLength()
+   */
+  public criticalPathLength: number | undefined = undefined;
+
+  /**
+   * The set of operations that must complete before this operation executes.
+   */
+  public readonly dependencies: Set<OperationExecutionRecord> = new Set();
+  /**
+   * The set of operations that depend on this operation.
+   */
+  public readonly consumers: Set<OperationExecutionRecord> = new Set();
+
+  public readonly stopwatch: Stopwatch = new Stopwatch();
+  public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer();
+
+  public readonly runner: IOperationRunner;
+  public readonly weight: number;
+
+  private readonly _context: IOperationExecutionRecordContext;
+
+  private _collatedWriter: CollatedWriter | undefined = undefined;
+
+  public constructor(operation: Operation, context: IOperationExecutionRecordContext) {
+    this.runner = operation.runner;
+    this.weight = operation.weight;
+    this._context = context;
+  }
+
+  public get name(): string {
+    return this.runner.name;
+  }
+
+  public get debugMode(): boolean {
+    return this._context.debugMode;
+  }
+
+  public get quietMode(): boolean {
+    return this._context.quietMode;
+  }
+
+  public get collatedWriter(): CollatedWriter {
+    // Lazy instantiate because the registerTask() call affects display ordering
+    if (!this._collatedWriter) {
+      this._collatedWriter = this._context.streamCollator.registerTask(this.name);
+    }
+    return this._collatedWriter;
+  }
+}

--- a/apps/rush-lib/src/logic/operations/OperationSelector.ts
+++ b/apps/rush-lib/src/logic/operations/OperationSelector.ts
@@ -166,7 +166,6 @@ export class OperationSelector {
       if (deps.operations) {
         for (const dependencyOperation of deps.operations) {
           record.operation.dependencies.add(dependencyOperation);
-          dependencyOperation.dependents.add(record.operation);
         }
       }
 

--- a/apps/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/apps/rush-lib/src/logic/operations/OperationStatus.ts
@@ -2,15 +2,40 @@
 // See LICENSE in the project root for license information.
 
 /**
- * Enumeration defining potential states of an operation: not started, executing, or completed
+ * Enumeration defining potential states of an operation
+ * @beta
  */
 export enum OperationStatus {
+  /**
+   * The Operation is on the queue, ready to execute (but may be waiting for dependencies)
+   */
   Ready = 'READY',
+  /**
+   * The Operation is currently executing
+   */
   Executing = 'EXECUTING',
+  /**
+   * The Operation completed successfully and did not write to standard output
+   */
   Success = 'SUCCESS',
+  /**
+   * The Operation completed successfully, but wrote to standard output
+   */
   SuccessWithWarning = 'SUCCESS WITH WARNINGS',
+  /**
+   * The Operation was skipped via the legacy incremental build logic
+   */
   Skipped = 'SKIPPED',
+  /**
+   * The Operation had its outputs restored from the build cache
+   */
   FromCache = 'FROM CACHE',
+  /**
+   * The Operation failed
+   */
   Failure = 'FAILURE',
+  /**
+   * The Operation could not be executed because one or more of its dependencies failed
+   */
   Blocked = 'BLOCKED'
 }

--- a/apps/rush-lib/src/logic/operations/ShellOperationFactory.ts
+++ b/apps/rush-lib/src/logic/operations/ShellOperationFactory.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
-import type { IPhase } from '../../api/CommandLineConfiguration';
+import type { CommandLineConfiguration, IPhase } from '../../api/CommandLineConfiguration';
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { IRegisteredCustomParameter } from '../../cli/scriptActions/BaseScriptAction';
@@ -18,6 +18,7 @@ import { OperationStatus } from './OperationStatus';
 export interface IOperationFactoryOptions {
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration?: BuildCacheConfiguration | undefined;
+  commandLineConfiguration: CommandLineConfiguration;
   isIncrementalBuildAllowed: boolean;
   customParameters: Iterable<IRegisteredCustomParameter>;
   projectChangeAnalyzer: ProjectChangeAnalyzer;
@@ -59,6 +60,7 @@ export class OperationFactory implements IOperationFactory {
           displayName,
           rushConfiguration: factoryOptions.rushConfiguration,
           buildCacheConfiguration: factoryOptions.buildCacheConfiguration,
+          commandLineConfiguration: factoryOptions.commandLineConfiguration,
           commandToRun: commandToRun || '',
           isIncrementalBuildAllowed: factoryOptions.isIncrementalBuildAllowed,
           projectChangeAnalyzer: factoryOptions.projectChangeAnalyzer,
@@ -66,7 +68,7 @@ export class OperationFactory implements IOperationFactory {
         })
       : new NullOperationRunner(displayName, OperationStatus.FromCache);
 
-    const operation: Operation = new Operation(runner, OperationStatus.Ready);
+    const operation: Operation = new Operation(runner);
 
     return operation;
   }

--- a/apps/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -49,6 +49,7 @@ export interface IOperationRunnerOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration: BuildCacheConfiguration | undefined;
+  commandLineConfiguration: CommandLineConfiguration;
   commandToRun: string;
   isIncrementalBuildAllowed: boolean;
   projectChangeAnalyzer: ProjectChangeAnalyzer;
@@ -78,15 +79,16 @@ function _areShallowEqual(object1: JsonObject, object2: JsonObject): boolean {
 export class ShellOperationRunner implements IOperationRunner {
   public readonly name: string;
 
-  public readonly isSkipAllowed: boolean;
-  public hadEmptyScript: boolean = false;
-  public readonly warningsAreAllowed: boolean;
   public isCacheWriteAllowed: boolean = false;
+  public isSkipAllowed: boolean;
+  public readonly isNoop: boolean = false;
+  public readonly warningsAreAllowed: boolean;
 
   private readonly _rushProject: RushConfigurationProject;
   private readonly _phase: IPhase;
   private readonly _rushConfiguration: RushConfiguration;
   private readonly _buildCacheConfiguration: BuildCacheConfiguration | undefined;
+  private readonly _commandLineConfiguration: CommandLineConfiguration;
   private readonly _commandName: string;
   private readonly _commandToRun: string;
   private readonly _isCacheReadAllowed: boolean;
@@ -108,6 +110,7 @@ export class ShellOperationRunner implements IOperationRunner {
     this._phase = phase;
     this._rushConfiguration = options.rushConfiguration;
     this._buildCacheConfiguration = options.buildCacheConfiguration;
+    this._commandLineConfiguration = options.commandLineConfiguration;
     this._commandName = phase.name;
     this._commandToRun = options.commandToRun;
     this._isCacheReadAllowed = options.isIncrementalBuildAllowed;
@@ -121,9 +124,6 @@ export class ShellOperationRunner implements IOperationRunner {
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
     try {
-      if (!this._commandToRun) {
-        this.hadEmptyScript = true;
-      }
       return await this._executeAsync(context);
     } catch (error) {
       throw new OperationError('executing', (error as Error).message);
@@ -260,8 +260,7 @@ export class ShellOperationRunner implements IOperationRunner {
       if (this._isCacheReadAllowed) {
         const projectBuildCache: ProjectBuildCache | undefined = await this._tryGetProjectBuildCacheAsync(
           terminal,
-          trackedFiles,
-          context.repoCommandLineConfiguration
+          trackedFiles
         );
 
         buildCacheReadAttempted = !!projectBuildCache;
@@ -369,13 +368,9 @@ export class ShellOperationRunner implements IOperationRunner {
         // If the command is successful, we can calculate project hash, and no dependencies were skipped,
         // write a new cache entry.
         const setCacheEntryPromise: Promise<boolean> | undefined = this.isCacheWriteAllowed
-          ? (
-              await this._tryGetProjectBuildCacheAsync(
-                terminal,
-                trackedFiles,
-                context.repoCommandLineConfiguration
-              )
-            )?.trySetCacheEntryAsync(terminal)
+          ? (await this._tryGetProjectBuildCacheAsync(terminal, trackedFiles))?.trySetCacheEntryAsync(
+              terminal
+            )
           : undefined;
 
         const [, cacheWriteSuccess] = await Promise.all([writeProjectStatePromise, setCacheEntryPromise]);
@@ -403,8 +398,7 @@ export class ShellOperationRunner implements IOperationRunner {
 
   private async _tryGetProjectBuildCacheAsync(
     terminal: ITerminal,
-    trackedProjectFiles: string[] | undefined,
-    commandLineConfiguration: CommandLineConfiguration
+    trackedProjectFiles: string[] | undefined
   ): Promise<ProjectBuildCache | undefined> {
     if (this._projectBuildCache === UNINITIALIZED) {
       this._projectBuildCache = undefined;
@@ -413,7 +407,7 @@ export class ShellOperationRunner implements IOperationRunner {
         const projectConfiguration: RushProjectConfiguration | undefined =
           await RushProjectConfiguration.tryLoadForProjectAsync(
             this._rushProject,
-            commandLineConfiguration,
+            this._commandLineConfiguration,
             terminal
           );
         if (projectConfiguration) {

--- a/apps/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
@@ -2,26 +2,29 @@
 // See LICENSE in the project root for license information.
 
 import { Operation } from '../Operation';
-import { OperationStatus } from '../OperationStatus';
+import { IOperationExecutionRecordContext, OperationExecutionRecord } from '../OperationExecutionRecord';
 import { MockOperationRunner } from './MockOperationRunner';
 import { AsyncOperationQueue, IOperationSortFunction } from '../AsyncOperationQueue';
 
-function addDependency(dependent: Operation, dependency: Operation): void {
-  dependent.dependencies.add(dependency);
+function addDependency(consumer: OperationExecutionRecord, dependency: OperationExecutionRecord): void {
+  consumer.dependencies.add(dependency);
+  dependency.consumers.add(consumer);
 }
 
-function nullSort(a: Operation, b: Operation): number {
+function nullSort(a: OperationExecutionRecord, b: OperationExecutionRecord): number {
   return 0;
+}
+
+function createRecord(name: string): OperationExecutionRecord {
+  return new OperationExecutionRecord(
+    new Operation(new MockOperationRunner(name)),
+    {} as unknown as IOperationExecutionRecordContext
+  );
 }
 
 describe('AsyncOperationQueue', () => {
   it('iterates operations in topological order', async () => {
-    const operations = [
-      new Operation(new MockOperationRunner('a')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('b')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('c')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('d')!, OperationStatus.Ready)
-    ];
+    const operations = [createRecord('a'), createRecord('b'), createRecord('c'), createRecord('d')];
 
     addDependency(operations[0], operations[2]);
     addDependency(operations[3], operations[1]);
@@ -32,8 +35,8 @@ describe('AsyncOperationQueue', () => {
     const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, nullSort);
     for await (const operation of queue) {
       actualOrder.push(operation);
-      for (const dependent of operation.dependents) {
-        dependent.dependencies.delete(operation);
+      for (const consumer of operation.consumers) {
+        consumer.dependencies.delete(operation);
       }
     }
 
@@ -41,24 +44,22 @@ describe('AsyncOperationQueue', () => {
   });
 
   it('respects the sort predicate', async () => {
-    const operations = [
-      new Operation(new MockOperationRunner('a')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('b')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('c')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('d')!, OperationStatus.Ready)
-    ];
+    const operations = [createRecord('a'), createRecord('b'), createRecord('c'), createRecord('d')];
 
     const expectedOrder = [operations[2], operations[0], operations[1], operations[3]];
     const actualOrder = [];
-    const customSort: IOperationSortFunction = (a: Operation, b: Operation): number => {
+    const customSort: IOperationSortFunction = (
+      a: OperationExecutionRecord,
+      b: OperationExecutionRecord
+    ): number => {
       return expectedOrder.indexOf(b) - expectedOrder.indexOf(a);
     };
 
     const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, customSort);
     for await (const operation of queue) {
       actualOrder.push(operation);
-      for (const dependent of operation.dependents) {
-        dependent.dependencies.delete(operation);
+      for (const consumer of operation.consumers) {
+        consumer.dependencies.delete(operation);
       }
     }
 
@@ -66,12 +67,7 @@ describe('AsyncOperationQueue', () => {
   });
 
   it('detects cyles', async () => {
-    const operations = [
-      new Operation(new MockOperationRunner('a')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('b')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('c')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('d')!, OperationStatus.Ready)
-    ];
+    const operations = [createRecord('a'), createRecord('b'), createRecord('c'), createRecord('d')];
 
     addDependency(operations[0], operations[2]);
     addDependency(operations[2], operations[3]);
@@ -85,11 +81,11 @@ describe('AsyncOperationQueue', () => {
 
   it('handles concurrent iteration', async () => {
     const operations = [
-      new Operation(new MockOperationRunner('a')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('b')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('c')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('d')!, OperationStatus.Ready),
-      new Operation(new MockOperationRunner('e')!, OperationStatus.Ready)
+      createRecord('a'),
+      createRecord('b'),
+      createRecord('c'),
+      createRecord('d'),
+      createRecord('e')
     ];
 
     // Set up to allow (0,1) -> (2) -> (3,4)
@@ -106,7 +102,7 @@ describe('AsyncOperationQueue', () => {
       [operations[4], 2]
     ]);
 
-    const actualConcurrency: Map<Operation, number> = new Map();
+    const actualConcurrency: Map<OperationExecutionRecord, number> = new Map();
     const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, nullSort);
     let concurrency: number = 0;
 
@@ -121,8 +117,8 @@ describe('AsyncOperationQueue', () => {
 
           await Promise.resolve();
 
-          for (const dependent of operation.dependents) {
-            dependent.dependencies.delete(operation);
+          for (const consumer of operation.consumers) {
+            consumer.dependencies.delete(operation);
           }
 
           --concurrency;

--- a/apps/rush-lib/src/logic/operations/test/MockOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/test/MockOperationRunner.ts
@@ -9,7 +9,7 @@ import { IOperationRunner, IOperationRunnerContext } from '../IOperationRunner';
 export class MockOperationRunner implements IOperationRunner {
   private readonly _action: ((terminal: CollatedTerminal) => Promise<OperationStatus>) | undefined;
   public readonly name: string;
-  public readonly hadEmptyScript: boolean = false;
+  public readonly isNoop: boolean = false;
   public isSkipAllowed: boolean = false;
   public isCacheWriteAllowed: boolean = false;
   public readonly warningsAreAllowed: boolean;

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -32,7 +32,7 @@ function createExecutionManager(
   executionManagerOptions: IOperationExecutionManagerOptions,
   operationRunner: IOperationRunner
 ): OperationExecutionManager {
-  const operation: Operation = new Operation(operationRunner, OperationStatus.Ready);
+  const operation: Operation = new Operation(operationRunner);
 
   return new OperationExecutionManager(new Set([operation]), executionManagerOptions);
 }
@@ -69,8 +69,7 @@ describe(OperationExecutionManager.name, () => {
             debugMode: false,
             parallelism: 'tequila',
             changedProjectsOnly: false,
-            destination: mockWritable,
-            repoCommandLineConfiguration: undefined!
+            destination: mockWritable
           })
       ).toThrowErrorMatchingSnapshot();
     });
@@ -83,8 +82,7 @@ describe(OperationExecutionManager.name, () => {
         debugMode: false,
         parallelism: '1',
         changedProjectsOnly: false,
-        destination: mockWritable,
-        repoCommandLineConfiguration: undefined!
+        destination: mockWritable
       };
     });
 
@@ -140,8 +138,7 @@ describe(OperationExecutionManager.name, () => {
           debugMode: false,
           parallelism: '1',
           changedProjectsOnly: false,
-          destination: mockWritable,
-          repoCommandLineConfiguration: undefined!
+          destination: mockWritable
         };
       });
 
@@ -175,8 +172,7 @@ describe(OperationExecutionManager.name, () => {
           debugMode: false,
           parallelism: '1',
           changedProjectsOnly: false,
-          destination: mockWritable,
-          repoCommandLineConfiguration: undefined!
+          destination: mockWritable
         };
       });
 

--- a/apps/rush-lib/src/logic/operations/test/OperationSelector.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationSelector.test.ts
@@ -10,7 +10,6 @@ import { IOperationOptions, IOperationFactory, OperationSelector } from '../Oper
 import { Operation } from '../Operation';
 import { ICommandLineJson } from '../../../api/CommandLineJson';
 import { RushConstants } from '../../RushConstants';
-import { OperationStatus } from '../OperationStatus';
 import { MockOperationRunner } from './MockOperationRunner';
 
 interface ISerializedOperation {
@@ -40,7 +39,7 @@ describe(OperationSelector.name, () => {
         RushConstants.phaseNamePrefix.length
       )})`;
 
-      return new Operation(new MockOperationRunner(name), OperationStatus.Ready);
+      return new Operation(new MockOperationRunner(name));
     }
   };
 

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -8,7 +8,7 @@ exports[`OperationExecutionManager Error logging printedStderrAfterError 2`] = `
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -71,7 +71,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 project[default] [gray]]=======================================================[default]
+    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
 ",
   },
   Object {
@@ -97,7 +97,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Projects failed to build.[default]
+    "text": "[red]Operations failed.[default]
 
 ",
   },
@@ -110,7 +110,7 @@ exports[`OperationExecutionManager Error logging printedStdoutAfterErrorWithEmpt
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -173,7 +173,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 project[default] [gray]]=======================================================[default]
+    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
 ",
   },
   Object {
@@ -199,7 +199,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Projects failed to build.[default]
+    "text": "[red]Operations failed.[default]
 
 ",
   },
@@ -212,7 +212,7 @@ exports[`OperationExecutionManager Warning logging Fail on warning Logs warnings
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -275,7 +275,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 project[default] [gray]]=========================================[default]
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
 ",
   },
   Object {
@@ -285,7 +285,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -301,7 +301,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]Projects succeeded with warnings.[default]
+    "text": "[yellow]Operations succeeded with warnings.[default]
 
 ",
   },
@@ -312,7 +312,7 @@ exports[`OperationExecutionManager Warning logging Success on warning Logs warni
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -375,7 +375,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 project[default] [gray]]=========================================[default]
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
 ",
   },
   Object {
@@ -385,7 +385,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
 
 ",
   },

--- a/apps/rush-lib/src/pluginFramework/PhasedScriptActionHooks.ts
+++ b/apps/rush-lib/src/pluginFramework/PhasedScriptActionHooks.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { AsyncSeriesHook, AsyncSeriesWaterfallHook } from 'tapable';
+import { Operation } from '../logic/operations/Operation';
+
+/**
+ * Hooks usable by rush plugins to modify the behavior of a phased script action.
+ * @beta
+ */
+export class PhasedScriptActionHooks {
+  /**
+   * The hook to run after the initial run completes.
+   */
+  public afterRun: AsyncSeriesHook<void> = new AsyncSeriesHook<void>(undefined, 'afterRun');
+  /**
+   * The hook to run after a watch-mode run completes.
+   */
+  public afterWatchRun: AsyncSeriesHook<void> = new AsyncSeriesHook<void>(undefined, 'afterWatchRun');
+  /**
+   * The hook to run after calculating the set of operations to include but before executing them for the initial run.
+   * Allows a plugin to modify the execution graph.
+   */
+  public prepareOperations: AsyncSeriesWaterfallHook<Set<Operation>> = new AsyncSeriesWaterfallHook<
+    Set<Operation>
+  >(['operations'], 'prepareOperations');
+  /**
+   * The hook to run after calculating the set of operations to include but before executing them for a watch-mode run.
+   * Allows a plugin to modify the execution graph.
+   */
+  public prepareWatchOperations: AsyncSeriesWaterfallHook<Set<Operation>> = new AsyncSeriesWaterfallHook<
+    Set<Operation>
+  >(['operations'], 'prepareWatchOperations');
+}

--- a/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -1,14 +1,76 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AsyncSeriesHook } from 'tapable';
+import { AsyncSeriesHook, HookMap } from 'tapable';
+import { PhasedScriptActionHooks } from './PhasedScriptActionHooks';
 
 /**
+ * Information about the currently executing action provided to plugins.
+ * @beta
+ */
+export interface IRushAction {
+  /**
+   * The name of this action, as seen on the command line
+   */
+  readonly actionName: string;
+}
+
+/**
+ * Information about the currently executing global script action (as defined in command-line.json) provided to plugins.
+ * @beta
+ */
+export interface IGlobalScriptAction extends IRushAction {
+  // Nothing added.
+}
+
+/**
+ * Information about the currently executing phased script action (as defined in command-line.json, or default "build" or "rebuild") provided to plugins.
+ * @beta
+ */
+export interface IPhasedScriptAction extends IRushAction {
+  /**
+   * Hooks into the lifecyle of this action's execution
+   */
+  readonly hooks: PhasedScriptActionHooks;
+}
+
+/**
+ * Hooks into the lifecycle of the Rush process invocation that plugins may tap into.
+ *
  * @beta
  */
 export class RushLifecycleHooks {
   /**
-   * The hook to run when all rush plugins is initialized.
+   * The hook to run before executing any Rush CLI Command.
    */
-  public initialize: AsyncSeriesHook<void> = new AsyncSeriesHook<void>();
+  public initialize: AsyncSeriesHook<IRushAction> = new AsyncSeriesHook<IRushAction>(
+    ['action'],
+    'initialize'
+  );
+
+  /**
+   * The hook to run before executing any global Rush CLI Command (as defined in command-line.json).
+   */
+  public anyGlobalScriptCommand: AsyncSeriesHook<IGlobalScriptAction> =
+    new AsyncSeriesHook<IGlobalScriptAction>(['action'], 'anyGlobalScriptCommand');
+
+  /**
+   * A hook map to allow plugins to hook specific named global script commands before execution.
+   */
+  public globalScriptCommand: HookMap<AsyncSeriesHook<IGlobalScriptAction>> = new HookMap((key: string) => {
+    return new AsyncSeriesHook<IGlobalScriptAction>(['action'], key);
+  }, 'globalScriptCommand');
+
+  /**
+   * The hook to run before executing any phased Rush CLI Command (as defined in command-line.json, or the default "build" or "rebuild").
+   */
+  public anyPhasedScriptComamnd: AsyncSeriesHook<IPhasedScriptAction> =
+    new AsyncSeriesHook<IPhasedScriptAction>(['action'], 'anyPhasedScriptCommand');
+
+  /**
+   * A hook map to allow plugins to hook specific named phased script commands before execution.
+   */
+  public phasedScriptCommand: HookMap<AsyncSeriesHook<IPhasedScriptAction>> = new HookMap((key: string) => {
+    return new AsyncSeriesHook<IPhasedScriptAction>(['action'], key);
+  }, 'phasedScriptCommand');
 }

--- a/common/changes/@microsoft/rush/operation-execution-record_2022-02-10-02-09.json
+++ b/common/changes/@microsoft/rush/operation-execution-record_2022-02-10-02-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add new hooks for plugins to interact with global and phased commands. Add hooks into the phased command execution lifecycle for initial and watch runs. Expose relevant API surface for customizing the operation graph and injecting custom operation runners before execution.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1633,6 +1633,8 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-node-rig': workspace:*
       '@rushstack/node-core-library': workspace:*
+      '@rushstack/stream-collator': workspace:*
+      '@rushstack/terminal': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node-fetch': 1.6.9
       '@types/semver': 7.3.5
@@ -1640,6 +1642,8 @@ importers:
       tapable: 2.2.1
     dependencies:
       '@rushstack/node-core-library': link:../node-core-library
+      '@rushstack/stream-collator': link:../stream-collator
+      '@rushstack/terminal': link:../terminal
       '@types/node-fetch': 1.6.9
       tapable: 2.2.1
     devDependencies:

--- a/libraries/rush-sdk/package.json
+++ b/libraries/rush-sdk/package.json
@@ -19,6 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
+    "@rushstack/stream-collator": "workspace:*",
+    "@rushstack/terminal": "workspace:*",
     "@types/node-fetch": "1.6.9",
     "tapable": "2.2.1"
   },


### PR DESCRIPTION
## Summary
Adds new Rush lifecycle hooks for the execution of specific and general global and phased commands.
Adds new lifecycle hooks to phased command execution.

## Details
Adds top-level Rush lifecycle hooks that will be invoked after `initialize` when invoking any global script command, or any phased script command.
Adds hook maps in Rush that can be used to tap specific global script commands or phased script commands by name,

Adds hooks to phased command execution for modifying the Operation Graph prior to execution for both the initial pass and watch-mode runs.
Adds hooks to phased command execution that will be invoked after execution of the initial pass, and after execution of watch-mode runs.

Refactors internals to avoid confusion in the public API surface, e.g. by removing execution-time metadata from the Operation Graph and rerouting global configuration away from the `executeAsync` method of `IOperationRunner`.

## How it was tested
Local builds and unit tests to ensure consistency of behavior in `rush build`. Using the hooks to make changes currently left to a subsequent PR.