### PR TITLE
[rush] Remove the index.mjs export from rush-sdk.

### DIFF
--- a/common/changes/@microsoft/rush/remove-mjs_2022-02-11-03-37.json
+++ b/common/changes/@microsoft/rush/remove-mjs_2022-02-11-03-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove the lib/index.mjs file from the @rushstack/rush-sdk package. This package must be CommonJS.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-sdk/config/typescript.json
+++ b/libraries/rush-sdk/config/typescript.json
@@ -1,9 +1,0 @@
-/**
- * Configures the TypeScript plugin for Heft.  This plugin also manages linting.
- */
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/heft/typescript.schema.json",
-  "extends": "@rushstack/heft-node-rig/profiles/default/config/typescript.json",
-
-  "emitMjsExtensionForESModule": true
-}

--- a/libraries/rush-sdk/package.json
+++ b/libraries/rush-sdk/package.json
@@ -9,7 +9,6 @@
   },
   "homepage": "https://rushjs.io",
   "main": "lib/index.js",
-  "module": "lib/index.mjs",
   "typings": "dist/rush-lib.d.ts",
   "scripts": {
     "build": "heft build --clean",


### PR DESCRIPTION
Because of the way `rush-sdk` re-exports `rush-lib`, it is only possible to compile it to CommonJS. We shipped an ES-style file, but webpack doesn't know what to do with the `Object.defineProperty(exports, ...)` in an ES module.