### PR TITLE
[rush-lib] Don't load the PowerShell Profile for the AsyncRecycler task

### DIFF
--- a/apps/rush-lib/src/utilities/AsyncRecycler.ts
+++ b/apps/rush-lib/src/utilities/AsyncRecycler.ts
@@ -150,7 +150,7 @@ export class AsyncRecycler {
       args = [
         '/c',
         '"' +
-          'PowerShell.exe -Version 3.0 -NoLogo -NonInteractive -WindowStyle Hidden -Command' +
+          'PowerShell.exe -Version 3.0 -NoLogo -NonInteractive -NoProfile -WindowStyle Hidden -Command' +
           ` Get-ChildItem -Force '${escapedRecyclerFolder}'` +
           // The "^|" here prevents cmd.exe from interpreting the "|" symbol
           ` ^| ForEach ($_) { Remove-Item -ErrorAction Ignore -Force -Recurse "\\\\?\\$($_.FullName)" }` +

--- a/common/changes/@microsoft/rush/sachinjoseph-no-powershell-profile_2022-02-14-19-20.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-no-powershell-profile_2022-02-14-19-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Do not load the PowerShell User Profile for running the AsyncRecycler task",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
The AsyncRecycler task on Windows uses PowerShell to delete files, and PowerShell command by default loads the User Profile which usually does things like loading modules like PoshGit which are unnecessary for AsyncRecycler.

This PR prevents loading the PowerShell User Profile and hence prevents some unnecessary code from being run.