### PR TITLE
[module-minifier-plugin] Update webpack hash calculations

### DIFF
--- a/common/changes/@rushstack/module-minifier-plugin/module-minifier-hash_2022-02-16-00-50.json
+++ b/common/changes/@rushstack/module-minifier-plugin/module-minifier-hash_2022-02-16-00-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier-plugin",
+      "comment": "Include plugin state in webpack hash calculations, such that updating the plugin version or options changes the compilation and chunk hashes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier-plugin"
+}

--- a/common/changes/@rushstack/module-minifier-plugin/module-minifier-hash_2022-02-16-00-50.json
+++ b/common/changes/@rushstack/module-minifier-plugin/module-minifier-hash_2022-02-16-00-50.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/module-minifier-plugin",
-      "comment": "Include plugin state in webpack hash calculations, such that updating the plugin version or options changes the compilation and chunk hashes.",
-      "type": "patch"
+      "comment": "Include plugin state in webpack hash calculations, such that updating the plugin options changes the compilation and chunk hashes.",
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/module-minifier-plugin"

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -555,6 +555,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "serialize-javascript",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "source-map",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2149,6 +2149,7 @@ importers:
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.24
       '@types/webpack-sources': 1.4.2
+      serialize-javascript: 6.0.0
       source-map: ~0.7.3
       tapable: 1.1.3
       terser: 5.9.0
@@ -2157,6 +2158,7 @@ importers:
     dependencies:
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
+      serialize-javascript: 6.0.0
       source-map: 0.7.3
       tapable: 1.1.3
       terser: 5.9.0

--- a/common/reviews/api/module-minifier-plugin.api.md
+++ b/common/reviews/api/module-minifier-plugin.api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
-import { AsyncSeriesWaterfallHook } from 'tapable';
+import type { AsyncSeriesWaterfallHook } from 'tapable';
 import { Compiler } from 'webpack';
-import { MinifyOptions } from 'terser';
+import type { MinifyOptions } from 'terser';
 import { Plugin } from 'webpack';
 import type { RawSourceMap } from 'source-map';
-import { ReplaceSource } from 'webpack-sources';
+import type { ReplaceSource } from 'webpack-sources';
 import { Source } from 'webpack-sources';
-import { SyncWaterfallHook } from 'tapable';
+import type { SyncWaterfallHook } from 'tapable';
 import * as webpack from 'webpack';
 
 // @public
@@ -77,6 +77,12 @@ export interface ILocalMinifierOptions {
 }
 
 // @public
+export interface IMinifierConnection {
+    configHash: string;
+    disconnect(): Promise<void>;
+}
+
+// @public
 export interface IModuleInfo {
     module: IExtendedModule;
     source: Source;
@@ -120,9 +126,8 @@ export interface IModuleMinificationSuccessResult {
 
 // @public
 export interface IModuleMinifier {
-    // (undocumented)
+    connect(): Promise<IMinifierConnection>;
     minify: IModuleMinifierFunction;
-    ref?(): () => Promise<void>;
 }
 
 // @public
@@ -182,6 +187,8 @@ export interface IWorkerPoolMinifierOptions {
 // @public
 export class LocalMinifier implements IModuleMinifier {
     constructor(options: ILocalMinifierOptions);
+    // (undocumented)
+    connect(): Promise<IMinifierConnection>;
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
 }
 
@@ -204,6 +211,8 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
 
 // @public
 export class NoopMinifier implements IModuleMinifier {
+    // (undocumented)
+    connect(): Promise<IMinifierConnection>;
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
 }
 
@@ -227,11 +236,11 @@ export const STAGE_BEFORE: -100;
 export class WorkerPoolMinifier implements IModuleMinifier {
     constructor(options: IWorkerPoolMinifierOptions);
     // (undocumented)
+    connect(): Promise<IMinifierConnection>;
+    // (undocumented)
     get maxThreads(): number;
     set maxThreads(threads: number);
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
-    // (undocumented)
-    ref(): () => Promise<void>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/webpack/module-minifier-plugin/README.md
+++ b/webpack/module-minifier-plugin/README.md
@@ -13,6 +13,9 @@ This improves minification time by:
 - Handing smaller code chunks to the minifier at a time (AST analysis is superlinear in size of the AST)
 - Even single asset builds will likely still contain multiple modules in the final output, which can be split across available CPU cores
 
+## Use with `[hash]` and `[contenthash]` tokens
+The plugin will do its best to update webpack hashes if changing the direct inputs (`useSourceMap`, `compressAsyncImports` or `usePortableModules`) to the plugin, but if altering the `minifier` property itself, you may need to use the `output.hashSalt` property to force a change to the hashes, especially if leverging the `MessagePortMinifier` or similar, since it has no direct access to the configuration of the minifier.
+
 ## Parallel execution
 If running on node 10, you will need to ensure that the `--experimental-workers` flag is enabled.
 

--- a/webpack/module-minifier-plugin/package.json
+++ b/webpack/module-minifier-plugin/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@types/node": "12.20.24",
     "@types/tapable": "1.0.6",
+    "serialize-javascript": "6.0.0",
     "source-map": "~0.7.3",
     "tapable": "1.1.3",
     "terser": "5.9.0"

--- a/webpack/module-minifier-plugin/src/MessagePortMinifier.ts
+++ b/webpack/module-minifier-plugin/src/MessagePortMinifier.ts
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { once } from 'events';
+import { MessagePort } from 'worker_threads';
+
 import {
+  IMinifierConnection,
   IModuleMinificationCallback,
   IModuleMinificationRequest,
   IModuleMinificationResult,
   IModuleMinifier
 } from './ModuleMinifierPlugin.types';
-import { MessagePort } from 'worker_threads';
 
 /**
  * Minifier implementation that outsources requests to the other side of a MessagePort
@@ -20,18 +23,7 @@ export class MessagePortMinifier implements IModuleMinifier {
 
   public constructor(port: MessagePort) {
     this.port = port;
-
-    const callbacks: Map<string, IModuleMinificationCallback[]> = (this._callbacks = new Map());
-
-    port.on('message', (message: IModuleMinificationResult | number | false) => {
-      if (typeof message === 'object') {
-        const callbacksForRequest: IModuleMinificationCallback[] = callbacks.get(message.hash)!;
-        callbacks.delete(message.hash);
-        for (const callback of callbacksForRequest) {
-          callback(message);
-        }
-      }
-    });
+    this._callbacks = new Map();
   }
 
   /**
@@ -51,5 +43,32 @@ export class MessagePortMinifier implements IModuleMinifier {
     this._callbacks.set(hash, [callback]);
 
     this.port.postMessage(request);
+  }
+
+  public async connect(): Promise<IMinifierConnection> {
+    const configHashPromise: Promise<string> = once(this.port, 'message') as unknown as Promise<string>;
+    this.port.postMessage('initialize');
+    const configHash: string = await configHashPromise;
+
+    const callbacks: Map<string, IModuleMinificationCallback[]> = this._callbacks;
+
+    function handler(message: IModuleMinificationResult | number | false): void {
+      if (typeof message === 'object') {
+        const callbacksForRequest: IModuleMinificationCallback[] = callbacks.get(message.hash)!;
+        callbacks.delete(message.hash);
+        for (const callback of callbacksForRequest) {
+          callback(message);
+        }
+      }
+    }
+
+    this.port.on('message', handler);
+    return {
+      configHash,
+      disconnect: async () => {
+        this.port.off('message', handler);
+        this.port.close();
+      }
+    };
   }
 }

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { createHash, Hash } from 'crypto';
+
 import {
   CachedSource,
   ConcatSource,
@@ -12,6 +13,7 @@ import {
 } from 'webpack-sources';
 import * as webpack from 'webpack';
 import { AsyncSeriesWaterfallHook, SyncHook, SyncWaterfallHook, TapOptions } from 'tapable';
+
 import {
   CHUNK_MODULES_TOKEN,
   MODULE_WRAPPER_PREFIX,
@@ -21,6 +23,7 @@ import {
 } from './Constants';
 import { getIdentifier } from './MinifiedIdentifier';
 import {
+  IMinifierConnection,
   IModuleMinifier,
   IModuleMinifierPluginOptions,
   IModuleMinificationResult,
@@ -39,10 +42,12 @@ import { rehydrateAsset } from './RehydrateAsset';
 import { AsyncImportCompressionPlugin } from './AsyncImportCompressionPlugin';
 import { PortableMinifierModuleIdsPlugin } from './PortableMinifierIdsPlugin';
 
-const { version: pluginVersion } = require('../package.json');
-
 // The name of the plugin, for use in taps
 const PLUGIN_NAME: 'ModuleMinifierPlugin' = 'ModuleMinifierPlugin';
+
+// Monotonically increasing identifier to be incremented any time the code generation logic changes
+// Will be applied to the webpack hash.
+const CODE_GENERATION_REVISION: number = 1;
 
 const TAP_BEFORE: TapOptions<'promise'> = {
   name: PLUGIN_NAME,
@@ -68,6 +73,11 @@ interface IExtendedParser extends webpack.compilation.normalModuleFactory.Parser
 
 interface IExtendedModuleTemplate extends webpack.compilation.ModuleTemplate {
   render: (module: IExtendedModule, dependencyTemplates: unknown, options: unknown) => Source;
+}
+
+interface IOptionsForHash extends Omit<IModuleMinifierPluginOptions, 'minifier'> {
+  revision: number;
+  minifier: undefined;
 }
 
 /**
@@ -136,7 +146,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
   private readonly _enhancers: webpack.Plugin[];
   private readonly _sourceMap: boolean | undefined;
 
-  private readonly _optionsForHash: Omit<IModuleMinifierPluginOptions, 'minifier' | 'sourceMap'>;
+  private readonly _optionsForHash: IOptionsForHash;
 
   public constructor(options: IModuleMinifierPluginOptions) {
     this.hooks = {
@@ -150,8 +160,9 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
     const { minifier, sourceMap, usePortableModules = false, compressAsyncImports = false } = options;
 
     this._optionsForHash = {
-      usePortableModules,
-      compressAsyncImports
+      ...options,
+      minifier: undefined,
+      revision: CODE_GENERATION_REVISION
     };
 
     this._enhancers = [];
@@ -185,6 +196,9 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
         : typeof devtool === 'string'
         ? devtool.endsWith('source-map')
         : mode === 'production' && devtool !== false;
+
+    this._optionsForHash.sourceMap = useSourceMaps;
+    const binaryConfig: Uint8Array = Buffer.from(JSON.stringify(this._optionsForHash), 'utf-8');
 
     compiler.hooks.thisCompilation.tap(
       PLUGIN_NAME,
@@ -242,7 +256,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
 
         const { minifier } = this;
 
-        const cleanupMinifier: (() => Promise<void>) | undefined = minifier.ref?.();
+        let minifierConnection: IMinifierConnection | undefined;
 
         const requestShortener: webpack.compilation.RequestShortener =
           compilation.runtimeTemplate.requestShortener;
@@ -371,8 +385,10 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
           .javascript as IExtendedModuleTemplate;
         const innerRender: IExtendedModuleTemplate['render'] = jsTemplate.render.bind(jsTemplate);
 
-        // Reset cache if more processing is needed
-        compilation.hooks.seal.tap(PLUGIN_NAME, () => {
+        // The optimizeTree hook is the last async hook that occurs before chunk rendering
+        compilation.hooks.optimizeTree.tapPromise(PLUGIN_NAME, async () => {
+          minifierConnection = await minifier.connect();
+
           submittedModules.clear();
 
           const cache: WeakSet<IExtendedModule> = new WeakSet();
@@ -530,9 +546,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
             }
 
             // Handle any error from the minifier.
-            if (cleanupMinifier) {
-              await cleanupMinifier();
-            }
+            await minifierConnection?.disconnect();
 
             // All assets and modules have been minified, hand them off to be rehydrated
             await this.hooks.rehydrateAssets.promise(
@@ -545,20 +559,13 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
           }
         );
 
-        const { usePortableModules, compressAsyncImports } = this._optionsForHash;
-
         function updateChunkHash(hash: Hash, chunk: webpack.compilation.Chunk): void {
-          // For now, automatically assume that any change to this plugin will alter the hash.
-          hash.update(pluginVersion as string);
-          // Using vs. not using source maps might affect output
-          hash.update(`${useSourceMaps}`);
-          // Portable modules will affect output
-          hash.update(`${usePortableModules}`);
-          // Async import compression will affect output
-          hash.update(`${compressAsyncImports}`);
-
-          // Ideally should also include the configuration of the minifier itself, but that needs design to account for that
-          // the minifier config can include arbitrary JavaScript, e.g. the nth-identifier function.
+          // Apply the options hash
+          hash.update(binaryConfig);
+          // Apply the hash from the minifier
+          if (minifierConnection) {
+            hash.update(minifierConnection.configHash, 'utf8');
+          }
         }
 
         // Need to update chunk hashes with information from this plugin

--- a/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
+++ b/webpack/module-minifier-plugin/src/ModuleMinifierPlugin.types.ts
@@ -2,9 +2,9 @@
 // See LICENSE in the project root for license information.
 
 import type { RawSourceMap } from 'source-map';
-import { AsyncSeriesWaterfallHook, SyncWaterfallHook } from 'tapable';
-import * as webpack from 'webpack';
-import { ReplaceSource, Source } from 'webpack-sources';
+import type { AsyncSeriesWaterfallHook, SyncWaterfallHook } from 'tapable';
+import type * as webpack from 'webpack';
+import type { ReplaceSource, Source } from 'webpack-sources';
 
 /**
  * Request to the minifier
@@ -245,18 +245,36 @@ export interface IModuleMinifierFunction {
 }
 
 /**
+ * Metadata from the minifier for the plugin
+ * @public
+ */
+export interface IMinifierConnection {
+  /**
+   * Hash of the configuration of this minifier, to be applied to the webpack chunk and compilation hashes.
+   */
+  configHash: string;
+  /**
+   * Callback to be invoked when done with the minifier
+   */
+  disconnect(): Promise<void>;
+}
+
+/**
  * Object that can be invoked to minify code.
  * @public
  */
 export interface IModuleMinifier {
+  /**
+   * Asynchronously minify a module
+   */
   minify: IModuleMinifierFunction;
 
   /**
-   * Prevents the minifier from shutting down until the returned callback is invoked.
+   * Prevents the minifier from shutting down until the returned `disconnect()` callback is invoked.
    * The callback may be used to surface errors encountered by the minifier that may not be relevant to a specific file.
    * It should be called to allow the minifier to cleanup
    */
-  ref?(): () => Promise<void>;
+  connect(): Promise<IMinifierConnection>;
 }
 
 /**

--- a/webpack/module-minifier-plugin/src/NoopMinifier.ts
+++ b/webpack/module-minifier-plugin/src/NoopMinifier.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import {
+  IMinifierConnection,
   IModuleMinificationCallback,
   IModuleMinificationRequest,
   IModuleMinifier
@@ -37,5 +38,15 @@ export class NoopMinifier implements IModuleMinifier {
           }
         : undefined
     });
+  }
+
+  public async connect(): Promise<IMinifierConnection> {
+    return {
+      configHash: NoopMinifier.name,
+
+      disconnect: async () => {
+        // Do nothing.
+      }
+    };
   }
 }


### PR DESCRIPTION
## Summary
Ensures that `@rushstack/module-minifier-plugin` is accounted for in the webpack chunk hash and compilation hash.

## Details
Includes the plugin version and all top-level options as part of the webpack chunk hash calculation. Added documentation about leveraging the webpack `output.hashSalt` field if necessary to change the hash for changes to, e.g. the minifier configuration, since that is out of the direct scope of information readily processable by this plugin.

## How it was tested
Verified that the compilation hash changed with the updated plugin. Unfortunately the compilation and chunk hashes without the plugin appear to already be unstable (several runs yielded distinct hashes).