### PR TITLE
[rush-lib] Disable implicit expansion of included phases

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -273,25 +273,11 @@ export class CommandLineConfiguration {
               commandPhases.add(phase);
             }
 
-            // Apply implicit phase dependency expansion
-            // The equivalent of the "--to" operator used for projects
-            // Appending to the set while iterating it accomplishes a full breadth-first search
-            for (const phase of commandPhases) {
-              for (const dependency of phase.phaseDependencies.self) {
-                commandPhases.add(dependency);
-              }
-
-              for (const dependency of phase.phaseDependencies.upstream) {
-                commandPhases.add(dependency);
-              }
-            }
-
             const { watchOptions } = command;
 
             if (watchOptions) {
               normalizedCommand.alwaysWatch = watchOptions.alwaysWatch;
 
-              // No implicit phase dependency expansion for watch mode.
               for (const phaseName of watchOptions.watchPhases) {
                 const phase: IPhase | undefined = this.phases.get(phaseName);
                 if (!phase) {

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -182,7 +182,7 @@
             },
             "phases": {
               "title": "Phases",
-              "description": "List the phases associated with this command. Note that phases with dependencies will be implicitly included even if they aren't explicitly enumerated in this property.",
+              "description": "List *exactly* the phases that should be run in the primary execution of this command. Phases in this list may declare dependencies on phases that are not listed. If they do, the excluded phases will affect execution order but will be skipped during execution. This will cause any included phases that depend on them to not write cache entries, since Rush cannot guarantee build correctness.",
               "type": "array",
               "items": {
                 "type": "string"

--- a/common/changes/@microsoft/rush/stages-disable-implicit-expansion_2022-02-16-22-42.json
+++ b/common/changes/@microsoft/rush/stages-disable-implicit-expansion_2022-02-16-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable implicit expansion of phases listed in command-line.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -16,6 +16,18 @@
       "name": "build",
       "phases": ["_phase:build", "_phase:test"]
     },
+    {
+      "commandKind": "phased",
+      "name": "test-only",
+      "summary": "Run only unit tests, skip building",
+      "description": "Runs only the \"test\" phase without ensuring projects have been built first. Failures are expected if projects were not previously built.",
+      "enableParallelism": true,
+      "incremental": true,
+      /**
+       * Even though `_phase:test` depends on `_phase:build`, skip `_phase:build`. This should mean that we run all tests in parallel.
+       */
+      "phases": ["_phase:test"]
+    },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.


### PR DESCRIPTION
## Summary
Modifies evaluation of the `"phases"` field for `"commandKind": "phased"` in `command-line.json` to be an exact list of the phases to execute for the command, instead of quietly injecting any phases that were declared as dependencies of listed phases.

## Details
The main motivation for this is authoring of a watch mode command that performs an asset deployment phase at the end of both the initial execution and subsequent delta executions; however, the build phase used for the initial execution and for the delta executions are different phases (the latter skips cleaning, for example) and so in order to build the dependency graph correctly, the only options are:
1) Disable implicit phase dependency expansion, such that a `_phase:deploy` can be written that depends on both `_phase:build` and `_phase:build-incremental`. In the initial build, `_phase:build` runs, followed by `_phase:deploy`. In the watch rebuild, `_phase:build-incremental` runs, followed by `_phase:deploy`.
2) Write a plugin that taps the (not yet implemented) `prepareOperations` hooks as in #3225
3) Create a separate phase (and thereby a separate npm script) that does exactly the same work but has different declared dependencies.

This PR is option (1).

## How it was tested
Added a sample command `rush test-only` to the Rush Stack repo and validated that running it only invokes the `test` phase.