### PR TITLE
[rush-lib] Continue on failure in watch mode commands

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -43,6 +43,7 @@ export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPh
 }
 
 interface IExecuteInternalOptions {
+  isWatch: boolean;
   operationSelector: OperationSelector;
   executionManagerOptions: IOperationExecutionManagerOptions;
   projectSelection: Set<RushConfigurationProject>;
@@ -154,6 +155,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
     const isWatch: boolean = this._watchParameter?.value || this._alwaysWatch;
 
     const executeOptions: IExecuteInternalOptions = {
+      isWatch,
       operationSelector,
       executionManagerOptions,
       projectSelection,
@@ -242,6 +244,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
       );
 
       const executeOptions: IExecuteInternalOptions = {
+        isWatch: true,
         operationSelector,
         projectSelection,
         operationFactoryOptions: {
@@ -332,7 +335,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
    * Runs a single invocation of the command
    */
   private async _runOnce(options: IExecuteInternalOptions): Promise<void> {
-    const { operationSelector, projectSelection, operationFactoryOptions } = options;
+    const { isWatch, operationSelector, projectSelection, operationFactoryOptions } = options;
 
     const operationFactory: OperationFactory = new OperationFactory(operationFactoryOptions);
 
@@ -375,7 +378,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommand> {
       if (!ignoreHooks) {
         this._doAfterTask(stopwatch, false);
       }
-      throw new AlreadyReportedError();
+      if (!isWatch) {
+        throw new AlreadyReportedError();
+      }
     }
   }
 

--- a/common/changes/@microsoft/rush/fix-watch-errors_2022-02-17-01-57.json
+++ b/common/changes/@microsoft/rush/fix-watch-errors_2022-02-17-01-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "For watch mode commands, allow the command to continue even if the initial build fails.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -16,6 +16,25 @@
       "name": "build",
       "phases": ["_phase:build", "_phase:test"]
     },
+
+    {
+      "commandKind": "phased",
+      "name": "start",
+      "summary": "Build all projects, then watch for changes, build and test.",
+      "description": "Build all projects, then watches for changes and builds and runs tests for affected projects.",
+      "safeForSimultaneousRushProcesses": false,
+
+      "enableParallelism": true,
+      "incremental": true,
+      // Initial execution only uses the build phase so that all dependencies of watch phases have been built
+      "phases": ["_phase:build"],
+      "watchOptions": {
+        // Act as though `--watch` is always passed. If false, adds support for passing `--watch`.
+        "alwaysWatch": true,
+        // During watch recompilation run both build and test for affected projects
+        "watchPhases": ["_phase:build", "_phase:test"]
+      }
+    },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.


### PR DESCRIPTION
## Summary
Fixes watch-mode commands behavior if the initial build encounters errors to still start watching for changes, since the typical use case is to run a build in watch mode and requiring the command to be initiated from a good state is counterproductive.

## Details
If a command is configured to watch, warnings or failures in the initial execution no longer terminate the action.

## How it was tested
Defined a command `rush start` in the Rush Stack repo. The command performs an initial build using `_phase:build` and then enters watch mode, running both `_phase:build` and `_phase:test` on affected projects.