### PR TITLE
[rush-lib] Split out `OperationExecutionRecord` from `Operation`

### DIFF
--- a/apps/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/apps/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -69,7 +69,8 @@ export class AsyncOperationQueue
       } else if (operation.dependencies.size === 0) {
         // This task is ready to process, hand it to the iterator.
         queue.splice(i, 1);
-        waitingIterators.pop()!({
+        // Needs to have queue semantics, otherwise tools that iterate it get confused
+        waitingIterators.shift()!({
           value: operation,
           done: false
         });

--- a/apps/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -5,20 +5,37 @@ import type { StdioSummarizer } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
-import type { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 
+/**
+ * Information passed to the executing `IOperationRunner`
+ *
+ * @beta
+ */
 export interface IOperationRunnerContext {
-  repoCommandLineConfiguration: CommandLineConfiguration;
+  /**
+   * The writer into which this `IOperationRunner` should write its logs.
+   */
   collatedWriter: CollatedWriter;
-  stdioSummarizer: StdioSummarizer;
-  quietMode: boolean;
+  /**
+   * If Rush was invoked with `--debug`
+   */
   debugMode: boolean;
+  /**
+   * Defaults to `true`. Will be `false` if Rush was invoked with `--verbose`.
+   */
+  quietMode: boolean;
+  /**
+   * Object used to report a summary at the end of the Rush invocation.
+   */
+  stdioSummarizer: StdioSummarizer;
 }
 
 /**
  * The `Operation` class is a node in the dependency graph of work that needs to be scheduled by the
  * `OperationExecutionManager`. Each `Operation` has a `runner` member of type `IOperationRunner`, whose
  * implementation manages the actual process for running a single operation.
+ *
+ * @beta
  */
 export interface IOperationRunner {
   /**
@@ -32,10 +49,14 @@ export interface IOperationRunner {
   isSkipAllowed: boolean;
 
   /**
-   * Assigned by execute().  True if the script was an empty string.  Operationally an empty string is
-   * like a shell command that succeeds instantly, but e.g. it would be odd to report time statistics for it.
+   * Indicates that this runner's duration has meaning.
    */
-  hadEmptyScript: boolean;
+  reportTiming: boolean;
+
+  /**
+   * Indicates that this runner is architectural and should not be reported on.
+   */
+  silent: boolean;
 
   /**
    * If set to true, a warning result should not make Rush exit with a nonzero

--- a/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
@@ -5,6 +5,24 @@ import type { OperationStatus } from './OperationStatus';
 import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
 
 /**
+ *
+ */
+export interface INullOperationRunnerParams {
+  /**
+   * The name to report in logs.
+   */
+  name: string;
+  /**
+   * The result to report from the runner.
+   */
+  result: OperationStatus;
+  /**
+   * If true, the operation will not log anything or be tracked in statistics.
+   */
+  silent: boolean;
+}
+
+/**
  * Implementation of `IOperationRunner` for operations that require no work, such as empty scripts,
  * skipped operations, or blocked operations.
  */
@@ -22,7 +40,7 @@ export class NullOperationRunner implements IOperationRunner {
 
   public readonly result: OperationStatus;
 
-  public constructor(name: string, result: OperationStatus, silent: boolean) {
+  public constructor({ name, result, silent }: INullOperationRunnerParams) {
     this.name = name;
     this.result = result;
     this.silent = silent;

--- a/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/NullOperationRunner.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { OperationStatus } from './OperationStatus';
-import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import type { OperationStatus } from './OperationStatus';
+import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
 
 /**
  * Implementation of `IOperationRunner` for operations that require no work, such as empty scripts,
- * or operations that are skipped by filters.
+ * skipped operations, or blocked operations.
  */
 export class NullOperationRunner implements IOperationRunner {
-  private readonly _result: OperationStatus;
   public readonly name: string;
-  public readonly hadEmptyScript: boolean = true;
-  // The operation may never be skipped; it doesn't do anything anyway
-  public isSkipAllowed: boolean = false;
-  // The operation is a no-op, so skip writing an empty cache entry
-  public isCacheWriteAllowed: boolean = false;
+  // This operation does nothing, so timing is meaningless
+  public readonly reportTiming: boolean = false;
+  public readonly silent: boolean;
+  // The operation may be skipped; it doesn't do anything anyway
+  public isSkipAllowed: boolean = true;
+  // The operation is a no-op, so is cacheable.
+  public isCacheWriteAllowed: boolean = true;
   // Nothing will get logged, no point allowing warnings
   public readonly warningsAreAllowed: boolean = false;
 
-  public constructor(name: string, result: OperationStatus) {
+  public readonly result: OperationStatus;
+
+  public constructor(name: string, result: OperationStatus, silent: boolean) {
     this.name = name;
-    this._result = result;
+    this.result = result;
+    this.silent = silent;
   }
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
-    return this._result;
+    return this.result;
   }
 }

--- a/apps/rush-lib/src/logic/operations/Operation.ts
+++ b/apps/rush-lib/src/logic/operations/Operation.ts
@@ -1,20 +1,35 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { StdioSummarizer } from '@rushstack/terminal';
-import { CollatedWriter } from '@rushstack/stream-collator';
-
-import { Stopwatch } from '../../utilities/Stopwatch';
-import { OperationStatus } from './OperationStatus';
-import { OperationError } from './OperationError';
+import { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import { IPhase } from '../../api/CommandLineConfiguration';
 import { IOperationRunner } from './IOperationRunner';
 
 /**
  * The `Operation` class is a node in the dependency graph of work that needs to be scheduled by the
  * `OperationExecutionManager`. Each `Operation` has a `runner` member of type `IOperationRunner`, whose
  * implementation manages the actual process of running a single operation.
+ *
+ * The graph of `Operation` instances will be cloned into a separate execution graph after processing.
+ *
+ * @beta
  */
 export class Operation {
+  /**
+   * The Rush phase associated with this Operation, if any
+   */
+  public readonly associatedPhase: IPhase | undefined;
+
+  /**
+   * The Rush project associated with this Operation, if any
+   */
+  public readonly associatedProject: RushConfigurationProject | undefined;
+
+  /**
+   * A set of all dependencies which must be executed before this operation is complete.
+   */
+  public readonly dependencies: Set<Operation> = new Set<Operation>();
+
   /**
    * When the scheduler is ready to process this `Operation`, the `runner` implements the actual work of
    * running the operation.
@@ -22,76 +37,26 @@ export class Operation {
   public runner: IOperationRunner;
 
   /**
-   * The current execution status of an operation. Operations start in the 'ready' state,
-   * but can be 'blocked' if an upstream operation failed. It is 'executing' when
-   * the operation is executing. Once execution is complete, it is either 'success' or
-   * 'failure'.
+   * The weight for this operation. This scalar is the contribution of this operation to the
+   * `criticalPathLength` calculation above. Modify to indicate the following:
+   * - `weight` === 1: indicates that this operation has an average duration
+   * - `weight` &gt; 1: indicates that this operation takes longer than average and so the scheduler
+   *     should try to favor starting it over other, shorter operations. An example might be an operation that
+   *     bundles an entire application and runs whole-program optimization.
+   * - `weight` &lt; 1: indicates that this operation takes less time than average and so the scheduler
+   *     should favor other, longer operations over it. An example might be an operation to unpack a cached
+   *     output, or an operation using NullOperationRunner, which might use a value of 0.
    */
-  public status: OperationStatus;
+  public weight: number = 1;
 
-  /**
-   * A set of all dependencies which must be executed before this operation is complete.
-   * When dependencies finish execution, they are removed from this list.
-   */
-  public dependencies: Set<Operation> = new Set<Operation>();
-
-  /**
-   * The inverse of dependencies, lists all projects which are directly dependent on this one.
-   */
-  public dependents: Set<Operation> = new Set<Operation>();
-
-  /**
-   * This number represents how far away this Operation is from the furthest "root" project (i.e.
-   * a project with no dependents). This helps us to calculate the critical path (i.e. the
-   * longest chain of projects which must be executed in order, thereby limiting execution speed
-   * of the entire operation tree.
-   *
-   * This number is calculated via a memoized depth-first search, and when choosing the next
-   * operation to execute, the operation with the highest criticalPathLength is chosen.
-   *
-   * Example:
-   *        (0) A
-   *             \
-   *          (1) B     C (0)         (applications)
-   *               \   /|\
-   *                \ / | \
-   *             (2) D  |  X (1)      (utilities)
-   *                    | / \
-   *                    |/   \
-   *                (2) Y     Z (2)   (other utilities)
-   *
-   * All roots (A & C) have a criticalPathLength of 0.
-   * B has a score of 1, since A depends on it.
-   * D has a score of 2, since we look at the longest chain (e.g D->B->A is longer than D->C)
-   * X has a score of 1, since the only package which depends on it is A
-   * Z has a score of 2, since only X depends on it, and X has a score of 1
-   * Y has a score of 2, since the chain Y->X->C is longer than Y->C
-   *
-   * The algorithm is implemented in AsyncOperationQueue.ts as calculateCriticalPathLength()
-   */
-  public criticalPathLength: number | undefined;
-
-  /**
-   * The error which occurred while executing this operation, this is stored in case we need
-   * it later (for example to re-print errors at end of execution).
-   */
-  public error: OperationError | undefined;
-
-  /**
-   * The operation writer which contains information from the output streams of this operation
-   */
-  public collatedWriter!: CollatedWriter;
-
-  public stdioSummarizer!: StdioSummarizer;
-
-  /**
-   * The stopwatch which measures how long it takes the operation to execute
-   */
-  public stopwatch!: Stopwatch;
-
-  public constructor(runner: IOperationRunner, initialStatus: OperationStatus) {
+  public constructor(
+    runner: IOperationRunner,
+    project?: RushConfigurationProject | undefined,
+    phase?: IPhase | undefined
+  ) {
     this.runner = runner;
-    this.status = initialStatus;
+    this.associatedPhase = phase;
+    this.associatedProject = project;
   }
 
   public get name(): string {

--- a/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { StdioSummarizer } from '@rushstack/terminal';
+import { CollatedWriter, StreamCollator } from '@rushstack/stream-collator';
+
+import { OperationStatus } from './OperationStatus';
+import { OperationError } from './OperationError';
+import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import { Operation } from './Operation';
+import { Stopwatch } from '../../utilities/Stopwatch';
+
+export interface IOperationExecutionRecordContext {
+  streamCollator: StreamCollator;
+
+  debugMode: boolean;
+  quietMode: boolean;
+}
+
+/**
+ * Internal class representing everything about executing an operation
+ */
+export class OperationExecutionRecord implements IOperationRunnerContext {
+  /**
+   * The current execution status of an operation. Operations start in the 'ready' state,
+   * but can be 'blocked' if an upstream operation failed. It is 'executing' when
+   * the operation is executing. Once execution is complete, it is either 'success' or
+   * 'failure'.
+   */
+  public status: OperationStatus = OperationStatus.Ready;
+
+  /**
+   * The error which occurred while executing this operation, this is stored in case we need
+   * it later (for example to re-print errors at end of execution).
+   */
+  public error: OperationError | undefined = undefined;
+
+  /**
+   * This number represents how far away this Operation is from the furthest "root" operation (i.e.
+   * an operation with no consumers). This helps us to calculate the critical path (i.e. the
+   * longest chain of projects which must be executed in order, thereby limiting execution speed
+   * of the entire operation tree.
+   *
+   * This number is calculated via a memoized depth-first search, and when choosing the next
+   * operation to execute, the operation with the highest criticalPathLength is chosen.
+   *
+   * Example:
+   *        (0) A
+   *             \
+   *          (1) B     C (0)         (applications)
+   *               \   /|\
+   *                \ / | \
+   *             (2) D  |  X (1)      (utilities)
+   *                    | / \
+   *                    |/   \
+   *                (2) Y     Z (2)   (other utilities)
+   *
+   * All roots (A & C) have a criticalPathLength of 0.
+   * B has a score of 1, since A depends on it.
+   * D has a score of 2, since we look at the longest chain (e.g D->B->A is longer than D->C)
+   * X has a score of 1, since the only package which depends on it is A
+   * Z has a score of 2, since only X depends on it, and X has a score of 1
+   * Y has a score of 2, since the chain Y->X->C is longer than Y->C
+   *
+   * The algorithm is implemented in AsyncOperationQueue.ts as calculateCriticalPathLength()
+   */
+  public criticalPathLength: number | undefined = undefined;
+
+  /**
+   * The set of operations that must complete before this operation executes.
+   */
+  public readonly dependencies: Set<OperationExecutionRecord> = new Set();
+  /**
+   * The set of operations that depend on this operation.
+   */
+  public readonly consumers: Set<OperationExecutionRecord> = new Set();
+
+  public readonly stopwatch: Stopwatch = new Stopwatch();
+  public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer();
+
+  public readonly runner: IOperationRunner;
+  public readonly weight: number;
+
+  private readonly _context: IOperationExecutionRecordContext;
+
+  private _collatedWriter: CollatedWriter | undefined = undefined;
+
+  public constructor(operation: Operation, context: IOperationExecutionRecordContext) {
+    this.runner = operation.runner;
+    this.weight = operation.weight;
+    this._context = context;
+  }
+
+  public get name(): string {
+    return this.runner.name;
+  }
+
+  public get debugMode(): boolean {
+    return this._context.debugMode;
+  }
+
+  public get quietMode(): boolean {
+    return this._context.quietMode;
+  }
+
+  public get collatedWriter(): CollatedWriter {
+    // Lazy instantiate because the registerTask() call affects display ordering
+    if (!this._collatedWriter) {
+      this._collatedWriter = this._context.streamCollator.registerTask(this.name);
+    }
+    return this._collatedWriter;
+  }
+}

--- a/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -110,4 +110,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
     }
     return this._collatedWriter;
   }
+
+  public finish(): void {
+    this._collatedWriter?.close();
+    this.stdioSummarizer.close();
+    this.stopwatch.stop();
+  }
 }

--- a/apps/rush-lib/src/logic/operations/OperationSelector.ts
+++ b/apps/rush-lib/src/logic/operations/OperationSelector.ts
@@ -44,7 +44,7 @@ export function createOperations(
     return `${project.packageName};${phase.name}`;
   }
 
-  function getOperation(phase: IPhase, project: RushConfigurationProject): Operation {
+  function getOrCreateOperation(phase: IPhase, project: RushConfigurationProject): Operation {
     const key: string = getOperationKey(phase, project);
     let operation: Operation | undefined = operations.get(key);
     if (!operation) {
@@ -55,7 +55,7 @@ export function createOperations(
             phase,
             project
           })
-        : new NullOperationRunner(key, OperationStatus.Skipped, true);
+        : new NullOperationRunner({ name: key, result: OperationStatus.Skipped, silent: true });
 
       operation = new Operation(runner, project, phase);
       operations.set(key, operation);
@@ -68,7 +68,7 @@ export function createOperations(
       const { dependencies } = operation;
 
       for (const depPhase of self) {
-        dependencies.add(getOperation(depPhase, project));
+        dependencies.add(getOrCreateOperation(depPhase, project));
       }
 
       if (upstream.size) {
@@ -76,7 +76,7 @@ export function createOperations(
         if (dependencyProjects.size) {
           for (const depPhase of upstream) {
             for (const dependencyProject of dependencyProjects) {
-              dependencies.add(getOperation(depPhase, dependencyProject));
+              dependencies.add(getOrCreateOperation(depPhase, dependencyProject));
             }
           }
         }
@@ -89,7 +89,7 @@ export function createOperations(
   // Create tasks for selected phases and projects
   for (const phase of phaseSelection) {
     for (const project of projectSelection) {
-      getOperation(phase, project);
+      getOrCreateOperation(phase, project);
     }
   }
 

--- a/apps/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/apps/rush-lib/src/logic/operations/OperationStatus.ts
@@ -2,15 +2,40 @@
 // See LICENSE in the project root for license information.
 
 /**
- * Enumeration defining potential states of an operation: not started, executing, or completed
+ * Enumeration defining potential states of an operation
+ * @beta
  */
 export enum OperationStatus {
+  /**
+   * The Operation is on the queue, ready to execute (but may be waiting for dependencies)
+   */
   Ready = 'READY',
+  /**
+   * The Operation is currently executing
+   */
   Executing = 'EXECUTING',
+  /**
+   * The Operation completed successfully and did not write to standard output
+   */
   Success = 'SUCCESS',
+  /**
+   * The Operation completed successfully, but wrote to standard output
+   */
   SuccessWithWarning = 'SUCCESS WITH WARNINGS',
+  /**
+   * The Operation was skipped via the legacy incremental build logic
+   */
   Skipped = 'SKIPPED',
+  /**
+   * The Operation had its outputs restored from the build cache
+   */
   FromCache = 'FROM CACHE',
+  /**
+   * The Operation failed
+   */
   Failure = 'FAILURE',
+  /**
+   * The Operation could not be executed because one or more of its dependencies failed
+   */
   Blocked = 'BLOCKED'
 }

--- a/apps/rush-lib/src/logic/operations/ShellOperationRunnerFactory.ts
+++ b/apps/rush-lib/src/logic/operations/ShellOperationRunnerFactory.ts
@@ -14,7 +14,7 @@ import { NullOperationRunner } from './NullOperationRunner';
 import { convertSlashesForWindows, ShellOperationRunner } from './ShellOperationRunner';
 import { OperationStatus } from './OperationStatus';
 
-export interface IOperationFactoryOptions {
+export interface IShellOperationRunnerFactoryOptions {
   rushConfiguration: RushConfiguration;
   buildCacheConfiguration?: BuildCacheConfiguration | undefined;
   commandLineConfiguration: CommandLineConfiguration;
@@ -23,11 +23,11 @@ export interface IOperationFactoryOptions {
   projectChangeAnalyzer: ProjectChangeAnalyzer;
 }
 
-export class OperationFactory implements IOperationRunnerFactory {
-  private readonly _options: IOperationFactoryOptions;
+export class ShellOperationRunnerFactory implements IOperationRunnerFactory {
+  private readonly _options: IShellOperationRunnerFactoryOptions;
   private readonly _customParametersByPhase: Map<IPhase, string[]>;
 
-  public constructor(options: IOperationFactoryOptions) {
+  public constructor(options: IShellOperationRunnerFactoryOptions) {
     this._options = options;
     this._customParametersByPhase = new Map();
   }
@@ -35,11 +35,11 @@ export class OperationFactory implements IOperationRunnerFactory {
   public createOperationRunner(options: IOperationOptions): IOperationRunner {
     const { phase, project } = options;
 
-    const factoryOptions: IOperationFactoryOptions = this._options;
+    const factoryOptions: IShellOperationRunnerFactoryOptions = this._options;
 
     const customParameterValues: ReadonlyArray<string> = this._getCustomParameterValuesForPhase(phase);
 
-    const commandToRun: string | undefined = OperationFactory._getScriptToRun(
+    const commandToRun: string | undefined = ShellOperationRunnerFactory._getScriptToRun(
       project,
       phase.name,
       customParameterValues
@@ -50,7 +50,7 @@ export class OperationFactory implements IOperationRunnerFactory {
       );
     }
 
-    const displayName: string = OperationFactory._getDisplayName(phase, project);
+    const displayName: string = ShellOperationRunnerFactory._getDisplayName(phase, project);
 
     // Empty build script indicates a no-op, so use a no-op runner
     const runner: IOperationRunner = commandToRun
@@ -65,7 +65,7 @@ export class OperationFactory implements IOperationRunnerFactory {
           projectChangeAnalyzer: factoryOptions.projectChangeAnalyzer,
           phase
         })
-      : new NullOperationRunner(displayName, OperationStatus.FromCache, false);
+      : new NullOperationRunner({ name: displayName, result: OperationStatus.FromCache, silent: false });
 
     return runner;
   }

--- a/apps/rush-lib/src/logic/operations/test/MockOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/test/MockOperationRunner.ts
@@ -9,7 +9,8 @@ import { IOperationRunner, IOperationRunnerContext } from '../IOperationRunner';
 export class MockOperationRunner implements IOperationRunner {
   private readonly _action: ((terminal: CollatedTerminal) => Promise<OperationStatus>) | undefined;
   public readonly name: string;
-  public readonly hadEmptyScript: boolean = false;
+  public readonly reportTiming: boolean = true;
+  public readonly silent: boolean = false;
   public isSkipAllowed: boolean = false;
   public isCacheWriteAllowed: boolean = false;
   public readonly warningsAreAllowed: boolean;

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -32,7 +32,7 @@ function createExecutionManager(
   executionManagerOptions: IOperationExecutionManagerOptions,
   operationRunner: IOperationRunner
 ): OperationExecutionManager {
-  const operation: Operation = new Operation(operationRunner, OperationStatus.Ready);
+  const operation: Operation = new Operation(operationRunner);
 
   return new OperationExecutionManager(new Set([operation]), executionManagerOptions);
 }
@@ -69,8 +69,7 @@ describe(OperationExecutionManager.name, () => {
             debugMode: false,
             parallelism: 'tequila',
             changedProjectsOnly: false,
-            destination: mockWritable,
-            repoCommandLineConfiguration: undefined!
+            destination: mockWritable
           })
       ).toThrowErrorMatchingSnapshot();
     });
@@ -83,8 +82,7 @@ describe(OperationExecutionManager.name, () => {
         debugMode: false,
         parallelism: '1',
         changedProjectsOnly: false,
-        destination: mockWritable,
-        repoCommandLineConfiguration: undefined!
+        destination: mockWritable
       };
     });
 
@@ -140,8 +138,7 @@ describe(OperationExecutionManager.name, () => {
           debugMode: false,
           parallelism: '1',
           changedProjectsOnly: false,
-          destination: mockWritable,
-          repoCommandLineConfiguration: undefined!
+          destination: mockWritable
         };
       });
 
@@ -175,8 +172,7 @@ describe(OperationExecutionManager.name, () => {
           debugMode: false,
           parallelism: '1',
           changedProjectsOnly: false,
-          destination: mockWritable,
-          repoCommandLineConfiguration: undefined!
+          destination: mockWritable
         };
       });
 

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -8,7 +8,7 @@ exports[`OperationExecutionManager Error logging printedStderrAfterError 2`] = `
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -71,7 +71,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 project[default] [gray]]=======================================================[default]
+    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
 ",
   },
   Object {
@@ -97,7 +97,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Projects failed to build.[default]
+    "text": "[red]Operations failed.[default]
 
 ",
   },
@@ -110,7 +110,7 @@ exports[`OperationExecutionManager Error logging printedStdoutAfterErrorWithEmpt
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -173,7 +173,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 project[default] [gray]]=======================================================[default]
+    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
 ",
   },
   Object {
@@ -199,7 +199,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Projects failed to build.[default]
+    "text": "[red]Operations failed.[default]
 
 ",
   },
@@ -212,7 +212,7 @@ exports[`OperationExecutionManager Warning logging Fail on warning Logs warnings
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -275,7 +275,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 project[default] [gray]]=========================================[default]
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
 ",
   },
   Object {
@@ -285,7 +285,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -301,7 +301,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]Projects succeeded with warnings.[default]
+    "text": "[yellow]Operations succeeded with warnings.[default]
 
 ",
   },
@@ -312,7 +312,7 @@ exports[`OperationExecutionManager Warning logging Success on warning Logs warni
 Array [
   Object {
     "kind": "O",
-    "text": "Selected 1 project:
+    "text": "Selected 1 operation:
 ",
   },
   Object {
@@ -375,7 +375,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 project[default] [gray]]=========================================[default]
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
 ",
   },
   Object {
@@ -385,7 +385,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
 
 ",
   },

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationSelector.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationSelector.test.ts.snap
@@ -1,95 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OperationSelector createOperations handles a full build 1`] = `
+exports[`createOperations handles a full build 1`] = `
 Array [
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "b (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "c (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "d (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "e (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "f (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "g (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "h (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "i (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (no-deps)",
       "a (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (no-deps)",
       "b (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "d (no-deps)",
       "b (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "e (no-deps)",
       "c (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -97,445 +97,445 @@ Array [
       "a (upstream-self)",
       "h (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h (no-deps)",
+      "a (upstream-self)",
+    ],
+    "name": "h (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "g (no-deps)",
       "a (upstream-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-self)",
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "isCacheWriteAllowed": true,
-    "name": "h (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "i (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "j (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
       "h (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
       "h (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
       "h (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "d (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "e (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "f (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "g (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "h (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "i (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "j (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "d (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "e (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "f (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "g (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "h (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "i (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "j (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1-self)",
       "h (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "i (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -543,8 +543,8 @@ Array [
       "a (upstream-1-self-upstream)",
       "a (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -552,8 +552,8 @@ Array [
       "b (upstream-1-self-upstream)",
       "b (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -561,8 +561,8 @@ Array [
       "b (upstream-1-self-upstream)",
       "b (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -570,8 +570,8 @@ Array [
       "c (upstream-1-self-upstream)",
       "c (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -581,8 +581,8 @@ Array [
       "a (upstream-2-self)",
       "h (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -590,8 +590,8 @@ Array [
       "a (upstream-1-self-upstream)",
       "a (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
@@ -599,690 +599,1131 @@ Array [
       "a (upstream-1-self-upstream)",
       "a (upstream-2-self)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "h (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "i (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "i (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "j (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "j (complex)",
+    "silent": false,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered phases 1`] = `
+exports[`createOperations handles filtered phases 1`] = `
 Array [
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
     "name": "a (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "b;_phase:no-deps",
       "a (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
     "name": "b (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "c;_phase:no-deps",
       "b (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
     "name": "c (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "c;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "d;_phase:no-deps",
       "b (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
     "name": "d (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "d;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "e;_phase:no-deps",
       "c (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
     "name": "e (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "e;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "f;_phase:no-deps",
       "a (upstream-self)",
       "h (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "f;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
+      "h;_phase:no-deps",
       "a (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "g (upstream-self)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-self)",
-    ],
-    "isCacheWriteAllowed": false,
     "name": "h (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "name": "h;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "g (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "g;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:no-deps",
+    ],
     "name": "i (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "name": "i;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:no-deps",
+    ],
     "name": "j (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:no-deps",
+    "silent": true,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered phases 2`] = `
+exports[`createOperations handles filtered phases 2`] = `
 Array [
   Object {
     "dependencies": Array [
       "a (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "b (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "b (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "a;_phase:upstream-2-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "c (upstream-3)",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
+    ],
+    "name": "c (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "c (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "c (complex)",
+    "name": "b;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "b;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "a;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-2-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "d (upstream-3)",
-      "a (upstream-1)",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "d (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "d (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "e (upstream-3)",
-      "b (upstream-1)",
+      "c;_phase:upstream-1-self-upstream",
+      "c;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "e (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1)",
+      "c;_phase:upstream-2",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "f (complex)",
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-    ],
-    "isCacheWriteAllowed": false,
-    "name": "g (complex)",
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-3)",
-    ],
-    "isCacheWriteAllowed": false,
-    "name": "h (complex)",
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-3)",
-    ],
-    "isCacheWriteAllowed": true,
-    "name": "i (complex)",
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-3)",
-    ],
-    "isCacheWriteAllowed": true,
-    "name": "j (complex)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
-    "name": "b (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "isCacheWriteAllowed": false,
-    "name": "c (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "isCacheWriteAllowed": false,
-    "name": "d (upstream-3)",
+    "name": "e (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (upstream-1)",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "e (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "isCacheWriteAllowed": false,
-    "name": "f (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
-    "name": "g (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
-    "name": "h (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "i (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "j (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-1)",
+    "name": "c;_phase:upstream-2",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "b (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1-self",
+    ],
+    "name": "c;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1)",
+    ],
+    "name": "b;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-2",
+    ],
+    "name": "c;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "h;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+      "h;_phase:upstream-2-self",
+    ],
+    "name": "f (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+      "h;_phase:upstream-2",
+    ],
+    "name": "f (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "h;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "h;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+    ],
+    "name": "g (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "g (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+    ],
+    "name": "h (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "h (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i (upstream-3)",
+    ],
+    "name": "i (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "j (upstream-3)",
+    ],
+    "name": "j (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "b (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "d (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "e (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "c (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
       "h (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "isCacheWriteAllowed": true,
-    "name": "g (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "isCacheWriteAllowed": true,
-    "name": "h (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "i (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "j (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "b (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "c (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "d (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "e (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "f (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "g (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "h (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "g (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "h (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
+    "name": "i (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "d (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "e (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "f (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "g (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
     "name": "i (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "j (no-deps)",
+    "silent": false,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered phases on filtered projects 1`] = `
+exports[`createOperations handles filtered phases on filtered projects 1`] = `
 Array [
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+      "h;_phase:upstream-1",
+    ],
     "name": "f (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
+    "name": "a;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "h;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
     "name": "a (upstream-2)",
+    "silent": false,
   },
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
     "name": "c (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "b;_phase:upstream-1",
+    "silent": true,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered phases on filtered projects 2`] = `
+exports[`createOperations handles filtered phases on filtered projects 2`] = `
 Array [
   Object {
     "dependencies": Array [
       "f (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "h;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+      "h;_phase:upstream-2-self",
+    ],
+    "name": "f (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+      "h;_phase:upstream-2",
+    ],
+    "name": "f (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "f (complex)",
+    "name": "h;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "h;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "a;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "a;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-2-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-3)",
-      "a (upstream-1)",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "c (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
-      "a (upstream-1)",
+      "b;_phase:upstream-2",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "f (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "isCacheWriteAllowed": false,
     "name": "c (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "b;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "b;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-2-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
+      "h;_phase:no-deps",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
-    "name": "c (upstream-1)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "f (no-deps)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
+    "name": "h;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "c (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "f (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
     "name": "c (no-deps)",
+    "silent": false,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered projects 1`] = `
+exports[`createOperations handles filtered projects 1`] = `
 Array [
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "g (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "g (no-deps)",
+      "a;_phase:upstream-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "g (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "a;_phase:upstream-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "name": "a;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
     "name": "g (upstream-1)",
+    "silent": false,
   },
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
     "name": "g (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "name": "a;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
     "name": "g (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-2",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "g (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "g (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "g (upstream-2-self)",
+    "silent": false,
   },
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
     "name": "g (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
+    "name": "a;_phase:upstream-1-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "g (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "g (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "a;_phase:upstream-2-self",
+    "silent": true,
   },
 ]
 `;
 
-exports[`OperationSelector createOperations handles filtered projects 2`] = `
+exports[`createOperations handles filtered projects 2`] = `
 Array [
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "f (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "c (no-deps)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "f (no-deps)",
       "a (upstream-self)",
+      "h;_phase:upstream-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "h;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "h;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "c (no-deps)",
+      "b;_phase:upstream-self",
+    ],
+    "name": "c (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
       "a (upstream-self)",
     ],
-    "isCacheWriteAllowed": false,
-    "name": "c (upstream-self)",
+    "name": "b;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
+      "h;_phase:no-deps",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-1)",
+    "silent": false,
   },
   Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": false,
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
     "name": "c (upstream-1)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
-      "a (no-deps)",
+      "h;_phase:upstream-1",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-2)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-2)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (no-deps)",
     ],
-    "isCacheWriteAllowed": false,
+    "name": "h;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
     "name": "c (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "b;_phase:upstream-1",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
-      "a (upstream-1)",
+      "h;_phase:upstream-2",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-3)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-3)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": false,
+    "name": "h;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
     "name": "c (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "b;_phase:upstream-2",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "f (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-1)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-1-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "f (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "f (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-2)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "c (upstream-2-self)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "a (upstream-1-self)",
-      "a (no-deps)",
+      "h;_phase:upstream-1-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (upstream-1-self-upstream)",
-  },
-  Object {
-    "dependencies": Array [],
-    "isCacheWriteAllowed": true,
-    "name": "a (upstream-1-self-upstream)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
-      "a (no-deps)",
+      "h;_phase:upstream-1",
     ],
-    "isCacheWriteAllowed": false,
+    "name": "h;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1-self",
+    ],
     "name": "c (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "b;_phase:upstream-1-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "f (upstream-3)",
       "a (upstream-1-self-upstream)",
-      "a (upstream-1-self)",
+      "h;_phase:upstream-1-self-upstream",
       "a (upstream-2-self)",
-      "a (upstream-1)",
+      "h;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "f (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "h;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-2-self",
+    "silent": true,
   },
   Object {
     "dependencies": Array [
       "a (upstream-3)",
     ],
-    "isCacheWriteAllowed": true,
     "name": "a (complex)",
+    "silent": false,
   },
   Object {
     "dependencies": Array [
       "c (upstream-3)",
-      "a (upstream-1-self)",
-      "a (upstream-1)",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
     ],
-    "isCacheWriteAllowed": false,
     "name": "c (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "b;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-2-self",
+    "silent": true,
   },
 ]
 `;

--- a/common/changes/@rushstack/heft/operation-execution-record_2022-02-10-02-09.json
+++ b/common/changes/@rushstack/heft/operation-execution-record_2022-02-10-02-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Refactors internals of phased commands to prepare a cleaner public API surface for plugins that impact scheduling or provide custom operation runners.

## Details
Separates the concerns of `Operation`, which is a graph node while declaring what will be run, from `OperationExecutionRecord`, which is the runtime entity at execution time that includes the result state.

## How it was tested
Local phased build executions.