### PR TITLE
[rush-amazon-s3-build-cache-plugin] retry failed S3 requests with the same behavior as the the azure blob storage

### DIFF
--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/.gitignore
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/.gitignore
@@ -1,1 +1,2 @@
 s3data/.minio.sys
+s3data/rush-build-cache/test

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/README.md
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/README.md
@@ -16,3 +16,32 @@ In this folder run `docker-compose down`
 # build the code: rushx build
 rushx read-s3-object
 ```
+
+# Test retries
+
+To test that requests can be retried start the proxy server which will fail every second request:
+
+```bash
+rushx start-proxy-server
+```
+
+Update the build-cache.json file:
+```json
+{
+  "cacheProvider": "amazon-s3",
+  "amazonS3Configuration": {
+    "s3Endpoint": "http://localhost:9002",
+    "s3Region": "us-east-1",
+    "s3Prefix": "rush-build-cache/test",
+    "isCacheWriteAllowed": true
+  }
+}
+```
+
+Run the rush rebuild command
+
+```bash
+cd apps
+cd rush
+RUSH_BUILD_CACHE_CREDENTIAL="minio:minio123" node lib/start-dev.js --debug rebuild --verbose
+```

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/README.md
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/README.md
@@ -17,7 +17,7 @@ In this folder run `docker-compose down`
 rushx read-s3-object
 ```
 
-# Test retries
+# Testing retries
 
 To test that requests can be retried start the proxy server which will fail every second request:
 

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft build --clean",
-    "read-s3-object": "node ./lib/readObject.js"
+    "read-s3-object": "node ./lib/readObject.js",
+    "start-proxy-server": "node ./lib/startProxyServer.js"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
@@ -16,6 +17,8 @@
     "@rushstack/node-core-library": "workspace:*",
     "@types/node": "12.20.24",
     "eslint": "~8.7.0",
-    "typescript": "~4.5.2"
+    "typescript": "~4.5.2",
+    "http-proxy": "~1.18.1",
+    "@types/http-proxy": "~1.17.8"
   }
 }

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/src/startProxyServer.ts
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/src/startProxyServer.ts
@@ -1,0 +1,27 @@
+import * as httpProxy from 'http-proxy';
+import * as http from 'http';
+
+const proxy: httpProxy = httpProxy.createProxyServer({});
+
+const hasFailed: { [k: string]: boolean } = {};
+
+let requestCount: number = 0;
+const server: http.Server = http.createServer((req, res) => {
+  requestCount += 1;
+
+  if (req.url && requestCount % 2 === 0 && !hasFailed[req.url]) {
+    console.log('failing', req.url);
+    hasFailed[req.url] = true;
+    res.statusCode = 500;
+    res.end();
+    return;
+  } else if (req.url) {
+    console.log('proxying', req.url);
+  }
+
+  proxy.web(req, res, {
+    target: 'http://127.0.0.1:9000'
+  });
+});
+
+server.listen(9002);

--- a/common/changes/@microsoft/rush/retry-cloud-cache-requests_2022-03-10-22-16.json
+++ b/common/changes/@microsoft/rush/retry-cloud-cache-requests_2022-03-10-22-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix transient errors in the aws s3 cloud cache plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/retry-cloud-cache-requests_2022-03-10-22-16.json
+++ b/common/changes/@microsoft/rush/retry-cloud-cache-requests_2022-03-10-22-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix transient errors in the aws s3 cloud cache plugin",
+      "comment": "Improve retry logic in the Amazon S3 cloud cache plugin and improve reporting when the user is not authenticated.",
       "type": "none"
     }
   ],

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -415,6 +415,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "http-proxy",
+      "allowedCategories": [ "tests" ]
+    },
+    {
       "name": "https-proxy-agent",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1194,16 +1194,20 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@rushstack/rush-amazon-s3-build-cache-plugin': workspace:*
+      '@types/http-proxy': ~1.17.8
       '@types/node': 12.20.24
       eslint: ~8.7.0
+      http-proxy: ~1.18.1
       typescript: ~4.5.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@rushstack/rush-amazon-s3-build-cache-plugin': link:../../rush-plugins/rush-amazon-s3-build-cache-plugin
+      '@types/http-proxy': 1.17.8
       '@types/node': 12.20.24
       eslint: 8.7.0
+      http-proxy: 1.18.1
       typescript: 4.5.5
 
   ../../build-tests/rush-project-change-analyzer-test:

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/package.json
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "heft build --clean",
     "start": "heft test --clean --watch",
+    "test": "heft test",
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build"
   },

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
@@ -152,6 +152,12 @@ export class AmazonS3Client {
       ) {
         // unauthorized due to not providing credentials,
         // silence error for better DX when e.g. running locally without credentials
+        this._writeWarningLine(
+          `No credentials found and received a ${response.status}`,
+          ' response code from the cloud storage.',
+          ' Maybe run rush update-cloud-credentials',
+          ' or set the RUSH_BUILD_CACHE_CREDENTIAL env'
+        );
         return {
           hasNetworkError: false,
           response: undefined
@@ -193,7 +199,16 @@ export class AmazonS3Client {
     try {
       this._terminal.writeDebugLine(...messageParts);
     } catch (err) {
-      //
+      // ignore error
+    }
+  }
+
+  private _writeWarningLine(...messageParts: (string | IColorableSequence)[]): void {
+    // if the terminal has been closed then don't bother sending a warning message
+    try {
+      this._terminal.writeWarningLine(...messageParts);
+    } catch (err) {
+      // ignore error
     }
   }
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
@@ -147,7 +147,12 @@ export class AmazonS3Client {
           hasNetworkError: false,
           response: undefined
         };
-      } else if (response.status === 403 && !this._credentials) {
+      } else if (
+        (response.status === 400 || response.status === 401 || response.status === 403) &&
+        !this._credentials
+      ) {
+        // unauthorized due to not providing credentials,
+        // silence error for better DX when e.g. running locally without credentials
         return {
           hasNetworkError: false,
           response: undefined

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
@@ -362,6 +362,44 @@ describe(AmazonS3Client.name, () => {
           spy.mockReset();
           spy.mockRestore();
         });
+
+        it('Retries on 400 error', async () => {
+          const spy = jest.spyOn(global, 'setTimeout');
+          await runAndExpectErrorAsync(
+            async () =>
+              await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+                responseInit: {
+                  status: 400,
+                  statusText: 'Bad Request'
+                }
+              })
+          );
+          expect(setTimeout).toHaveBeenCalledTimes(3);
+          expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 4000);
+          expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 8000);
+          expect(setTimeout).toHaveBeenNthCalledWith(3, expect.any(Function), 16000);
+          spy.mockReset();
+          spy.mockRestore();
+        });
+
+        it('Retries on 401 error', async () => {
+          const spy = jest.spyOn(global, 'setTimeout');
+          await runAndExpectErrorAsync(
+            async () =>
+              await makeGetRequestAsync(credentials, DUMMY_OPTIONS, 'abc123', {
+                responseInit: {
+                  status: 401,
+                  statusText: 'Unauthorized'
+                }
+              })
+          );
+          expect(setTimeout).toHaveBeenCalledTimes(3);
+          expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 4000);
+          expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 8000);
+          expect(setTimeout).toHaveBeenNthCalledWith(3, expect.any(Function), 16000);
+          spy.mockReset();
+          spy.mockRestore();
+        });
       }
 
       describe('Without credentials', () => {

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
@@ -452,12 +452,14 @@ describe(AmazonS3Client.name, () => {
 
         for (const code of [400, 401, 403]) {
           it(`Handles missing credentials object when ${code}`, async () => {
-            let warningSpy: jest.SpyInstance<any, unknown[]> | undefined;
+            let warningSpy: jest.SpyInstance<unknown, unknown[]> | undefined;
             const result: Buffer | undefined = await makeS3ClientRequestAsync(
               undefined,
               DUMMY_OPTIONS,
               async (s3Client) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (s3Client as any)._writeWarningLine = () => {};
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 warningSpy = jest.spyOn(s3Client as any, '_writeWarningLine');
                 return await s3Client.getObjectAsync('abc123');
               },

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
@@ -116,6 +116,54 @@ Array [
 
 exports[`AmazonS3Client Making requests Getting an object With credentials Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
 
+exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 400 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 401 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
+
 exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Can get an object 1`] = `
 Array [
   "http://localhost:9000/abc123",
@@ -245,6 +293,60 @@ Array [
 
 exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
 
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 400 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token,Signature=2a4b8f28b1bdd37af6bb0fd79212c223e2c28e4f94bfb5d1c94a16bb056d5624",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 401 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token,Signature=2a4b8f28b1bdd37af6bb0fd79212c223e2c28e4f94bfb5d1c94a16bb056d5624",
+        ],
+        "X-Amz-Security-Token": Array [
+          "sessionToken",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
+
 exports[`AmazonS3Client Making requests Getting an object Without credentials Can get an object 1`] = `
 Array [
   "http://localhost:9000/abc123",
@@ -341,6 +443,48 @@ Array [
   },
 ]
 `;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 400 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 401 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
 
 exports[`AmazonS3Client Making requests Uploading an object Throws an error if credentials are not provided 1`] = `[TypeError: Cannot read properties of undefined (reading 'body')]`;
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
@@ -425,7 +425,7 @@ Array [
 
 exports[`AmazonS3Client Making requests Getting an object Without credentials Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials Handles missing credentials object 1`] = `
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles missing credentials object when 400 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -444,7 +444,7 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 400 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles missing credentials object when 401 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -463,9 +463,7 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
-
-exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 401 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object Without credentials Handles missing credentials object when 403 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -483,8 +481,6 @@ Array [
   },
 ]
 `;
-
-exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
 
 exports[`AmazonS3Client Making requests Uploading an object Throws an error if credentials are not provided 1`] = `[TypeError: Cannot read properties of undefined (reading 'body')]`;
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/__snapshots__/AmazonS3Client.test.ts.snap
@@ -116,54 +116,6 @@ Array [
 
 exports[`AmazonS3Client Making requests Getting an object With credentials Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
 
-exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 400 error 1`] = `
-Array [
-  "http://localhost:9000/abc123",
-  Object {
-    "headers": Headers {
-      Symbol(map): Object {
-        "Authorization": Array [
-          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
-        ],
-        "x-amz-content-sha256": Array [
-          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        ],
-        "x-amz-date": Array [
-          "20200418T123242Z",
-        ],
-      },
-    },
-    "verb": "GET",
-  },
-]
-`;
-
-exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
-
-exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 401 error 1`] = `
-Array [
-  "http://localhost:9000/abc123",
-  Object {
-    "headers": Headers {
-      Symbol(map): Object {
-        "Authorization": Array [
-          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
-        ],
-        "x-amz-content-sha256": Array [
-          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        ],
-        "x-amz-date": Array [
-          "20200418T123242Z",
-        ],
-      },
-    },
-    "verb": "GET",
-  },
-]
-`;
-
-exports[`AmazonS3Client Making requests Getting an object With credentials Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
-
 exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Can get an object 1`] = `
 Array [
   "http://localhost:9000/abc123",
@@ -293,7 +245,7 @@ Array [
 
 exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Handles an unexpected error 2`] = `[Error: Amazon S3 responded with status code 500 (Server Error)]`;
 
-exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 400 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token should not retry on 400 error 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -318,9 +270,9 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token should not retry on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
 
-exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 401 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token should not retry on 401 error 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -345,7 +297,55 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object With credentials including a session token Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
+exports[`AmazonS3Client Making requests Getting an object With credentials including a session token should not retry on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials should not retry on 400 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials should not retry on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials should not retry on 401 error 1`] = `
+Array [
+  "http://localhost:9000/abc123",
+  Object {
+    "headers": Headers {
+      Symbol(map): Object {
+        "Authorization": Array [
+          "AWS4-HMAC-SHA256 Credential=accessKeyId/20200418/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=194608e9e7ba6d8aa4a019b3b6fd237e6b09ef1f45ff7fa60cbb81c1875538be",
+        ],
+        "x-amz-content-sha256": Array [
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ],
+        "x-amz-date": Array [
+          "20200418T123242Z",
+        ],
+      },
+    },
+    "verb": "GET",
+  },
+]
+`;
+
+exports[`AmazonS3Client Making requests Getting an object With credentials should not retry on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
 
 exports[`AmazonS3Client Making requests Getting an object Without credentials Can get an object 1`] = `
 Array [
@@ -444,7 +444,7 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 400 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 400 error 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -463,9 +463,9 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
+exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 400 error 2`] = `[Error: Amazon S3 responded with status code 400 (Bad Request)]`;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 401 error 1`] = `
+exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 401 error 1`] = `
 Array [
   "http://localhost:9000/abc123",
   Object {
@@ -484,7 +484,7 @@ Array [
 ]
 `;
 
-exports[`AmazonS3Client Making requests Getting an object Without credentials Retries on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
+exports[`AmazonS3Client Making requests Getting an object Without credentials should not retry on 401 error 2`] = `[Error: Amazon S3 responded with status code 401 (Unauthorized)]`;
 
 exports[`AmazonS3Client Making requests Uploading an object Throws an error if credentials are not provided 1`] = `[TypeError: Cannot read properties of undefined (reading 'body')]`;
 


### PR DESCRIPTION


## Summary

Fixes #3198, transient S3 errors updating build cache causes CI to fail

## Details

## How it was tested

Added one unit test with mocks to test that the retries are called.

Added support for starting a proxy server which will return 500 on every second request to test that the build-cache works when running rush build. This is documented in `build-tests/rush-amazon-s3-build-cache-plugin-integration-test/README.md`

## Todo

- [x] Rush change
- [ ] Rush version --bump
