### PR TITLE
[rush-lib] Fix resolution of change file paths when rush.json is not at the Git root

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -370,7 +370,7 @@ export class ChangeAction extends BaseRushAction {
     return this._git
       .getChangedFiles(this._targetBranch, this._terminal, true, relativeChangesFolder)
       .map((relativePath) => {
-        return path.join(this.rushConfiguration.rushJsonFolder, relativePath);
+        return path.join(repoRoot, relativePath);
       });
   }
 

--- a/common/changes/@microsoft/rush/fix-change-root_2022-02-22-21-43.json
+++ b/common/changes/@microsoft/rush/fix-change-root_2022-02-22-21-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix resolution of change file paths when rush.json is not in the root of the Git repository.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes #3247 

## Details
Fixes conversion of change file paths from relative to absolute.

## How it was tested
Local runs of `rush change` to verify lack of regression.