### PR TITLE
[rush-lib] Add hooks for phased/global commands

### DIFF
--- a/apps/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/api/CommandLineConfiguration.ts
@@ -56,7 +56,8 @@ export interface IPhase extends IPhaseJson {
 export interface ICommandWithParameters {
   associatedParameters: Set<Parameter>;
 }
-export interface IPhasedCommand extends IPhasedCommandWithoutPhasesJson, ICommandWithParameters {
+
+export interface IPhasedCommandConfig extends IPhasedCommandWithoutPhasesJson, ICommandWithParameters {
   /**
    * If set to "true," then this phased command was generated from a bulk command, and
    * was not explicitly defined in the command-line.json file.
@@ -76,9 +77,9 @@ export interface IPhasedCommand extends IPhasedCommandWithoutPhasesJson, IComman
   watchPhases: Set<IPhase>;
 }
 
-export interface IGlobalCommand extends IGlobalCommandJson, ICommandWithParameters {}
+export interface IGlobalCommandConfig extends IGlobalCommandJson, ICommandWithParameters {}
 
-export type Command = IGlobalCommand | IPhasedCommand;
+export type Command = IGlobalCommandConfig | IPhasedCommandConfig;
 
 export type Parameter = IFlagParameterJson | IChoiceParameterJson | IStringParameterJson;
 
@@ -364,7 +365,7 @@ export class CommandLineConfiguration {
           throw new Error(`Phases for the "${RushConstants.buildCommandName}" were not found.`);
         }
 
-        const rebuildCommand: IPhasedCommand = {
+        const rebuildCommand: IPhasedCommandConfig = {
           ...DEFAULT_REBUILD_COMMAND_JSON,
           commandKind: RushConstants.phasedCommandKind,
           isSynthetic: true,
@@ -614,7 +615,7 @@ export class CommandLineConfiguration {
     return name.replace(/:/g, '_'); // Replace colons with underscores to be filesystem-safe
   }
 
-  private _translateBulkCommandToPhasedCommand(command: IBulkCommandJson): IPhasedCommand {
+  private _translateBulkCommandToPhasedCommand(command: IBulkCommandJson): IPhasedCommandConfig {
     const phaseName: string = command.name;
     const phase: IPhase = {
       name: phaseName,
@@ -643,7 +644,7 @@ export class CommandLineConfiguration {
 
     const phases: Set<IPhase> = new Set([phase]);
 
-    const translatedCommand: IPhasedCommand = {
+    const translatedCommand: IPhasedCommandConfig = {
       ...command,
       commandKind: 'phased',
       isSynthetic: true,

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -19,8 +19,8 @@ import { RushConstants } from '../logic/RushConstants';
 import {
   Command,
   CommandLineConfiguration,
-  IGlobalCommand,
-  IPhasedCommand
+  IGlobalCommandConfig,
+  IPhasedCommandConfig
 } from '../api/CommandLineConfiguration';
 import { Utilities } from '../utilities/Utilities';
 
@@ -321,7 +321,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private _addGlobalScriptAction(
     commandLineConfiguration: CommandLineConfiguration,
-    command: IGlobalCommand
+    command: IGlobalCommandConfig
   ): void {
     if (
       command.name === RushConstants.buildCommandName ||
@@ -334,7 +334,7 @@ export class RushCommandLineParser extends CommandLineParser {
       );
     }
 
-    const sharedCommandOptions: IBaseScriptActionOptions<IGlobalCommand> =
+    const sharedCommandOptions: IBaseScriptActionOptions<IGlobalCommandConfig> =
       this._getSharedCommandActionOptions(commandLineConfiguration, command);
 
     this.addAction(
@@ -349,12 +349,10 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private _addPhasedCommandLineConfigAction(
     commandLineConfiguration: CommandLineConfiguration,
-    command: IPhasedCommand
+    command: IPhasedCommandConfig
   ): void {
-    const baseCommandOptions: IBaseScriptActionOptions<IPhasedCommand> = this._getSharedCommandActionOptions(
-      commandLineConfiguration,
-      command
-    );
+    const baseCommandOptions: IBaseScriptActionOptions<IPhasedCommandConfig> =
+      this._getSharedCommandActionOptions(commandLineConfiguration, command);
 
     this.addAction(
       new PhasedScriptAction({

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -129,7 +129,11 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
 
     this._throwPluginErrorIfNeed();
 
-    await this.rushSession.hooks.initialize.promise();
+    const { hooks: sessionHooks } = this.rushSession;
+    if (sessionHooks.initialize.isUsed()) {
+      // Avoid the cost of compiling the hook if it wasn't tapped.
+      await sessionHooks.initialize.promise(this);
+    }
 
     return super.onExecute();
   }

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -14,6 +14,7 @@ import { RushCommandLineParser } from './../RushCommandLineParser';
 import { Utilities } from '../../utilities/Utilities';
 import { RushGlobalFolder } from '../../api/RushGlobalFolder';
 import { RushSession } from '../../pluginFramework/RushSession';
+import type { IRushCommand } from '../../pluginFramework/RushLifeCycle';
 
 export interface IBaseRushActionOptions extends ICommandLineActionOptions {
   /**
@@ -35,7 +36,7 @@ export interface IBaseRushActionOptions extends ICommandLineActionOptions {
  * The base class for a few specialized Rush command-line actions that
  * can be used without a rush.json configuration.
  */
-export abstract class BaseConfiglessRushAction extends CommandLineAction {
+export abstract class BaseConfiglessRushAction extends CommandLineAction implements IRushCommand {
   private _parser: RushCommandLineParser;
   private _safeForSimultaneousRushProcesses: boolean;
 

--- a/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -96,12 +96,12 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
       await sessionHooks.runAnyGlobalCustomCommand.promise(this);
     }
 
-    const specificHook: AsyncSeriesHook<IGlobalCommand> | undefined = sessionHooks.runGlobalCustomCommand.get(
+    const hookForAction: AsyncSeriesHook<IGlobalCommand> | undefined = sessionHooks.runGlobalCustomCommand.get(
       this.actionName
     );
-    if (specificHook) {
+    if (hookForAction) {
       // Run the more specific hook for a command with this name after the general hook
-      await specificHook.promise(this);
+      await hookForAction.promise(this);
     }
 
     const additionalPathFolders: string[] =

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -118,12 +118,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       await sessionHooks.runAnyPhasedCommand.promise(this);
     }
 
-    const specificHook: AsyncSeriesHook<IPhasedCommand> | undefined = sessionHooks.runPhasedCommand.get(
+    const hookForAction: AsyncSeriesHook<IPhasedCommand> | undefined = sessionHooks.runPhasedCommand.get(
       this.actionName
     );
-    if (specificHook) {
+    if (hookForAction) {
       // Run the more specific hook for a command with this name after the general hook
-      await specificHook.promise(this);
+      await hookForAction.promise(this);
     }
 
     const isQuietMode: boolean = !this._verboseParameter.value;

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -78,9 +78,9 @@ export {
 } from './pluginFramework/RushSession';
 
 export {
-  IRushAction,
-  IGlobalScriptAction,
-  IPhasedScriptAction,
+  IRushCommand,
+  IGlobalCommand,
+  IPhasedCommand,
   RushLifecycleHooks
 } from './pluginFramework/RushLifeCycle';
 

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -77,7 +77,12 @@ export {
   CloudBuildCacheProviderFactory
 } from './pluginFramework/RushSession';
 
-export { RushLifecycleHooks } from './pluginFramework/RushLifeCycle';
+export {
+  IRushAction,
+  IGlobalScriptAction,
+  IPhasedScriptAction,
+  RushLifecycleHooks
+} from './pluginFramework/RushLifeCycle';
 
 export { IRushPlugin } from './pluginFramework/IRushPlugin';
 export { IBuiltInPluginConfiguration as _IBuiltInPluginConfiguration } from './pluginFramework/PluginLoader/BuiltInPluginLoader';

--- a/apps/rush-lib/src/logic/operations/test/OperationSelector.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationSelector.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { JsonFile } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../../api/RushConfiguration';
-import { CommandLineConfiguration, IPhasedCommand } from '../../../api/CommandLineConfiguration';
+import { CommandLineConfiguration, IPhasedCommandConfig } from '../../../api/CommandLineConfiguration';
 import { IOperationOptions, IOperationFactory, OperationSelector } from '../OperationSelector';
 import { Operation } from '../Operation';
 import { ICommandLineJson } from '../../../api/CommandLineJson';
@@ -56,7 +56,9 @@ describe(OperationSelector.name, () => {
 
   describe(OperationSelector.prototype.createOperations.name, () => {
     it('handles a full build', () => {
-      const buildCommand: IPhasedCommand = commandLineConfiguration.commands.get('build')! as IPhasedCommand;
+      const buildCommand: IPhasedCommandConfig = commandLineConfiguration.commands.get(
+        'build'
+      )! as IPhasedCommandConfig;
 
       const selector: OperationSelector = new OperationSelector({
         phasesToRun: buildCommand.phases
@@ -75,7 +77,9 @@ describe(OperationSelector.name, () => {
     });
 
     it('handles filtered projects', () => {
-      const buildCommand: IPhasedCommand = commandLineConfiguration.commands.get('build')! as IPhasedCommand;
+      const buildCommand: IPhasedCommandConfig = commandLineConfiguration.commands.get(
+        'build'
+      )! as IPhasedCommandConfig;
 
       const selector: OperationSelector = new OperationSelector({
         phasesToRun: buildCommand.phases

--- a/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -1,14 +1,78 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AsyncSeriesHook } from 'tapable';
+import { AsyncSeriesHook, HookMap } from 'tapable';
 
 /**
+ * Information about the currently executing action provided to plugins.
+ * @beta
+ */
+export interface IRushAction {
+  /**
+   * The name of this action, as seen on the command line
+   */
+  readonly actionName: string;
+}
+
+/**
+ * Information about the currently executing global script action (as defined in command-line.json) provided to plugins.
+ * @beta
+ */
+export interface IGlobalScriptAction extends IRushAction {
+  // Nothing added.
+}
+
+/**
+ * Information about the currently executing phased script action (as defined in command-line.json, or default "build" or "rebuild") provided to plugins.
+ * @beta
+ */
+export interface IPhasedScriptAction extends IRushAction {
+  // Will add hooks once the API surface is finalized
+}
+
+/**
+ * Hooks into the lifecycle of the Rush process invocation that plugins may tap into.
+ *
  * @beta
  */
 export class RushLifecycleHooks {
   /**
-   * The hook to run when all rush plugins is initialized.
+   * The hook to run before executing any Rush CLI Command.
    */
-  public initialize: AsyncSeriesHook<void> = new AsyncSeriesHook<void>();
+  public initialize: AsyncSeriesHook<IRushAction> = new AsyncSeriesHook<IRushAction>(
+    ['action'],
+    'initialize'
+  );
+
+  /**
+   * The hook to run before executing any global Rush CLI Command (as defined in command-line.json).
+   */
+  public runAnyGlobalScriptCommand: AsyncSeriesHook<IGlobalScriptAction> =
+    new AsyncSeriesHook<IGlobalScriptAction>(['action'], 'runAnyGlobalScriptCommand');
+
+  /**
+   * A hook map to allow plugins to hook specific named global script commands before execution.
+   */
+  public runGlobalScriptCommand: HookMap<AsyncSeriesHook<IGlobalScriptAction>> = new HookMap(
+    (key: string) => {
+      return new AsyncSeriesHook<IGlobalScriptAction>(['action'], key);
+    },
+    'runGlobalScriptCommand'
+  );
+
+  /**
+   * The hook to run before executing any phased Rush CLI Command (as defined in command-line.json, or the default "build" or "rebuild").
+   */
+  public runAnyPhasedScriptCommand: AsyncSeriesHook<IPhasedScriptAction> =
+    new AsyncSeriesHook<IPhasedScriptAction>(['action'], 'runAnyPhasedScriptCommand');
+
+  /**
+   * A hook map to allow plugins to hook specific named phased script commands before execution.
+   */
+  public runPhasedScriptCommand: HookMap<AsyncSeriesHook<IPhasedScriptAction>> = new HookMap(
+    (key: string) => {
+      return new AsyncSeriesHook<IPhasedScriptAction>(['action'], key);
+    },
+    'runPhasedScriptCommand'
+  );
 }

--- a/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/apps/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -4,29 +4,29 @@
 import { AsyncSeriesHook, HookMap } from 'tapable';
 
 /**
- * Information about the currently executing action provided to plugins.
+ * Information about the currently executing command provided to plugins.
  * @beta
  */
-export interface IRushAction {
+export interface IRushCommand {
   /**
-   * The name of this action, as seen on the command line
+   * The name of this command, as seen on the command line
    */
   readonly actionName: string;
 }
 
 /**
- * Information about the currently executing global script action (as defined in command-line.json) provided to plugins.
+ * Information about the currently executing global script command (as defined in command-line.json) provided to plugins.
  * @beta
  */
-export interface IGlobalScriptAction extends IRushAction {
+export interface IGlobalCommand extends IRushCommand {
   // Nothing added.
 }
 
 /**
- * Information about the currently executing phased script action (as defined in command-line.json, or default "build" or "rebuild") provided to plugins.
+ * Information about the currently executing phased script command (as defined in command-line.json, or default "build" or "rebuild") provided to plugins.
  * @beta
  */
-export interface IPhasedScriptAction extends IRushAction {
+export interface IPhasedCommand extends IRushCommand {
   // Will add hooks once the API surface is finalized
 }
 
@@ -39,40 +39,38 @@ export class RushLifecycleHooks {
   /**
    * The hook to run before executing any Rush CLI Command.
    */
-  public initialize: AsyncSeriesHook<IRushAction> = new AsyncSeriesHook<IRushAction>(
-    ['action'],
+  public initialize: AsyncSeriesHook<IRushCommand> = new AsyncSeriesHook<IRushCommand>(
+    ['command'],
     'initialize'
   );
 
   /**
-   * The hook to run before executing any global Rush CLI Command (as defined in command-line.json).
+   * The hook to run before executing any global Rush CLI Command (defined in command-line.json).
    */
-  public runAnyGlobalScriptCommand: AsyncSeriesHook<IGlobalScriptAction> =
-    new AsyncSeriesHook<IGlobalScriptAction>(['action'], 'runAnyGlobalScriptCommand');
-
-  /**
-   * A hook map to allow plugins to hook specific named global script commands before execution.
-   */
-  public runGlobalScriptCommand: HookMap<AsyncSeriesHook<IGlobalScriptAction>> = new HookMap(
-    (key: string) => {
-      return new AsyncSeriesHook<IGlobalScriptAction>(['action'], key);
-    },
-    'runGlobalScriptCommand'
+  public runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand> = new AsyncSeriesHook<IGlobalCommand>(
+    ['command'],
+    'runAnyGlobalCustomCommand'
   );
 
   /**
-   * The hook to run before executing any phased Rush CLI Command (as defined in command-line.json, or the default "build" or "rebuild").
+   * A hook map to allow plugins to hook specific named global commands (defined in command-line.json) before execution.
    */
-  public runAnyPhasedScriptCommand: AsyncSeriesHook<IPhasedScriptAction> =
-    new AsyncSeriesHook<IPhasedScriptAction>(['action'], 'runAnyPhasedScriptCommand');
+  public runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>> = new HookMap((key: string) => {
+    return new AsyncSeriesHook<IGlobalCommand>(['command'], key);
+  }, 'runGlobalCustomCommand');
 
   /**
-   * A hook map to allow plugins to hook specific named phased script commands before execution.
+   * The hook to run before executing any phased Rush CLI Command (defined in command-line.json, or the default "build" or "rebuild").
    */
-  public runPhasedScriptCommand: HookMap<AsyncSeriesHook<IPhasedScriptAction>> = new HookMap(
-    (key: string) => {
-      return new AsyncSeriesHook<IPhasedScriptAction>(['action'], key);
-    },
-    'runPhasedScriptCommand'
+  public runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand> = new AsyncSeriesHook<IPhasedCommand>(
+    ['command'],
+    'runAnyPhasedCommand'
   );
+
+  /**
+   * A hook map to allow plugins to hook specific named phased commands (defined in command-line.json) before execution.
+   */
+  public runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>> = new HookMap((key: string) => {
+    return new AsyncSeriesHook<IPhasedCommand>(['command'], key);
+  }, 'runPhasedCommand');
 }

--- a/common/changes/@microsoft/rush/new-rush-hooks_2022-02-25-22-08.json
+++ b/common/changes/@microsoft/rush/new-rush-hooks_2022-02-25-22-08.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add plugin hooks for specific command kinds (phased, global) and allow to tap command execution by command name. Pass executing command to hook so that plugins can access it.",
+      "comment": "Add plugin hooks for global and phased commands and allow plugins to tap into command execution by command name, or into the execution of any command by command kind.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/new-rush-hooks_2022-02-25-22-08.json
+++ b/common/changes/@microsoft/rush/new-rush-hooks_2022-02-25-22-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add plugin hooks for specific command kinds (phased, global) and allow to tap command execution by command name. Pass executing command to hook so that plugins can access it.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -268,7 +268,7 @@ export interface IGetChangedProjectsOptions {
 }
 
 // @beta
-export interface IGlobalScriptAction extends IRushAction {
+export interface IGlobalCommand extends IRushCommand {
 }
 
 // @public
@@ -311,7 +311,7 @@ export interface IPackageManagerOptionsJsonBase {
 }
 
 // @beta
-export interface IPhasedScriptAction extends IRushAction {
+export interface IPhasedCommand extends IRushCommand {
 }
 
 // @internal
@@ -323,7 +323,7 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
 }
 
 // @beta
-export interface IRushAction {
+export interface IRushCommand {
     readonly actionName: string;
 }
 
@@ -694,11 +694,11 @@ export class _RushGlobalFolder {
 
 // @beta
 export class RushLifecycleHooks {
-    initialize: AsyncSeriesHook<IRushAction>;
-    runAnyGlobalScriptCommand: AsyncSeriesHook<IGlobalScriptAction>;
-    runAnyPhasedScriptCommand: AsyncSeriesHook<IPhasedScriptAction>;
-    runGlobalScriptCommand: HookMap<AsyncSeriesHook<IGlobalScriptAction>>;
-    runPhasedScriptCommand: HookMap<AsyncSeriesHook<IPhasedScriptAction>>;
+    initialize: AsyncSeriesHook<IRushCommand>;
+    runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand>;
+    runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand>;
+    runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>>;
+    runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>>;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import { AsyncSeriesHook } from 'tapable';
+import { HookMap } from 'tapable';
 import { IPackageJson } from '@rushstack/node-core-library';
 import { ITerminal } from '@rushstack/node-core-library';
 import { ITerminalProvider } from '@rushstack/node-core-library';
@@ -266,6 +267,10 @@ export interface IGetChangedProjectsOptions {
     terminal: ITerminal;
 }
 
+// @beta
+export interface IGlobalScriptAction extends IRushAction {
+}
+
 // @public
 export interface ILaunchOptions {
     alreadyReportedNodeTooNewError?: boolean;
@@ -305,12 +310,21 @@ export interface IPackageManagerOptionsJsonBase {
     environmentVariables?: IConfigurationEnvironment;
 }
 
+// @beta
+export interface IPhasedScriptAction extends IRushAction {
+}
+
 // @internal
 export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     pnpmStore?: PnpmStoreOptions;
     preventManualShrinkwrapChanges?: boolean;
     strictPeerDependencies?: boolean;
     useWorkspaces?: boolean;
+}
+
+// @beta
+export interface IRushAction {
+    readonly actionName: string;
 }
 
 // @beta (undocumented)
@@ -678,9 +692,13 @@ export class _RushGlobalFolder {
     get path(): string;
 }
 
-// @beta (undocumented)
+// @beta
 export class RushLifecycleHooks {
-    initialize: AsyncSeriesHook<void>;
+    initialize: AsyncSeriesHook<IRushAction>;
+    runAnyGlobalScriptCommand: AsyncSeriesHook<IGlobalScriptAction>;
+    runAnyPhasedScriptCommand: AsyncSeriesHook<IPhasedScriptAction>;
+    runGlobalScriptCommand: HookMap<AsyncSeriesHook<IGlobalScriptAction>>;
+    runPhasedScriptCommand: HookMap<AsyncSeriesHook<IPhasedScriptAction>>;
 }
 
 // @beta (undocumented)


### PR DESCRIPTION
## Summary
Adds Rush lifecycle hooks for global command and phased command execution. Allows to tap for all commands or by name.
Updates the Rush lifecycle hooks to pass the currently executing command object.

Split from #3225 .

## Details
Adds a `runAnyPhasedScriptCommand` hook that runs after `initialize` but before the more specific `runPhasedScriptCommand.for(commandName)` hook.
Adds a `runAnyGlobalScriptCommand` hook that runs after `initialize` but before the more specific `runGlobalScriptCommand.for(commandName)` hook.
Passes the currently executing command to the relevant hook, so that properties (and minimally the name) can be read by the plugin.

Waiting for #3245 before adding hooks to phased commands directly.

## How it was tested
Verified that existing phased and global commands still work. Using the new hooks is for a future PR.