### PR TITLE
[rush] Force reinstalls if the monorepo absolute path changes

### DIFF
--- a/apps/rush-lib/src/api/LastInstallFlag.ts
+++ b/apps/rush-lib/src/api/LastInstallFlag.ts
@@ -137,7 +137,8 @@ export class LastInstallFlagFactory {
     const currentState: JsonObject = {
       node: process.versions.node,
       packageManager: rushConfiguration.packageManager,
-      packageManagerVersion: rushConfiguration.packageManagerToolVersion
+      packageManagerVersion: rushConfiguration.packageManagerToolVersion,
+      rushJsonFolder: rushConfiguration.rushJsonFolder
     };
 
     if (currentState.packageManager === 'pnpm' && rushConfiguration.pnpmOptions) {

--- a/apps/rush-lib/src/logic/Autoinstaller.ts
+++ b/apps/rush-lib/src/logic/Autoinstaller.ts
@@ -95,7 +95,8 @@ export class Autoinstaller {
       node: process.versions.node,
       packageManager: this._rushConfiguration.packageManager,
       packageManagerVersion: this._rushConfiguration.packageManagerToolVersion,
-      packageJson: packageJson
+      packageJson: packageJson,
+      rushJsonFolder: this._rushConfiguration.rushJsonFolder
     });
 
     if (!lastInstallFlag.isValid() || lock.dirtyWhenAcquired) {

--- a/common/changes/@microsoft/rush/enelson-lastinstall_2022-03-02-14-13.json
+++ b/common/changes/@microsoft/rush/enelson-lastinstall_2022-03-02-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Reinstall automatically if monorepo folder is moved",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

If the entire monorepo has been moved (that is, the root folder of the monorepo was renamed on disk), then on _Windows_, various links no longer work correctly.

As an example:

```console
# Run a "rush-prettier" autoinstaller, all good
cd Acme
rush prettify

# Move the root folder and run the autoinstaller, fails
cd ..
move Acme Acme2
cd Acme2
rush prettify
```

By tracking the absolute path of the `rush.json` folder in the last install state, this issue will automatically be detected.

## Details

Took the simplest route and updated both autoinstallers and common/temp flags.  In my testing so far, Linux and MacOS actually worked fine _without_ this flag, so technically we could wrap it in a platform check if we want.

(On the one hand, moving an entire monorepo around seems like a rare occurrence.  On the other hand, forcing rush install can be a 5+ minute ordeal in some monorepos, so I don't want to do it lightly.)

## How it was tested

Tested locally on MacOS and Windows that autoinstaller is automatically reinstalled and works correctly.
