### PR TITLE
[rush-lib] Added Parallelism percentage value support

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -342,9 +342,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         environmentVariable: EnvironmentVariableNames.RUSH_PARALLELISM,
         description:
           'Specifies the maximum number of concurrent processes to launch during a build.' +
-          ' The COUNT should be a positive integer or else the word "max" to specify a count that is equal to' +
-          ' the number of CPU cores. If this parameter is omitted, then the default value depends on the' +
-          ' operating system and number of CPU cores.'
+          ' The COUNT should be a positive integer, a percentage value (eg. "50%") or the word "max"' +
+          ' to specify a count that is equal to the number of CPU cores. If this parameter is omitted,' +
+          ' then the default value depends on the operating system and number of CPU cores.'
       });
       this._timelineParameter = this.defineFlagParameter({
         parameterLongName: '--timeline',

--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -342,7 +342,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         environmentVariable: EnvironmentVariableNames.RUSH_PARALLELISM,
         description:
           'Specifies the maximum number of concurrent processes to launch during a build.' +
-          ' The COUNT should be a positive integer, a percentage value (eg. "50%") or the word "max"' +
+          ' The COUNT should be a positive integer, a percentage value (eg. "50%%") or the word "max"' +
           ' to specify a count that is equal to the number of CPU cores. If this parameter is omitted,' +
           ' then the default value depends on the operating system and number of CPU cores.'
       });

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -140,12 +140,13 @@ Optional arguments:
   -p COUNT, --parallelism COUNT
                         Specifies the maximum number of concurrent processes 
                         to launch during a build. The COUNT should be a 
-                        positive integer or else the word \\"max\\" to specify a 
-                        count that is equal to the number of CPU cores. If 
-                        this parameter is omitted, then the default value 
-                        depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively be specified 
-                        via the RUSH_PARALLELISM environment variable.
+                        positive integer, a percentage value (eg. \\"50%\\") or 
+                        the word \\"max\\" to specify a count that is equal to 
+                        the number of CPU cores. If this parameter is omitted,
+                         then the default value depends on the operating 
+                        system and number of CPU cores. This parameter may 
+                        alternatively be specified via the RUSH_PARALLELISM 
+                        environment variable.
   --timeline            After the build is complete, print additional 
                         statistics and CPU usage information, including an 
                         ASCII chart of the start and stop times for each 
@@ -383,12 +384,13 @@ Optional arguments:
   -p COUNT, --parallelism COUNT
                         Specifies the maximum number of concurrent processes 
                         to launch during a build. The COUNT should be a 
-                        positive integer or else the word \\"max\\" to specify a 
-                        count that is equal to the number of CPU cores. If 
-                        this parameter is omitted, then the default value 
-                        depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively be specified 
-                        via the RUSH_PARALLELISM environment variable.
+                        positive integer, a percentage value (eg. \\"50%\\") or 
+                        the word \\"max\\" to specify a count that is equal to 
+                        the number of CPU cores. If this parameter is omitted,
+                         then the default value depends on the operating 
+                        system and number of CPU cores. This parameter may 
+                        alternatively be specified via the RUSH_PARALLELISM 
+                        environment variable.
   --timeline            After the build is complete, print additional 
                         statistics and CPU usage information, including an 
                         ASCII chart of the start and stop times for each 
@@ -933,12 +935,13 @@ Optional arguments:
   -p COUNT, --parallelism COUNT
                         Specifies the maximum number of concurrent processes 
                         to launch during a build. The COUNT should be a 
-                        positive integer or else the word \\"max\\" to specify a 
-                        count that is equal to the number of CPU cores. If 
-                        this parameter is omitted, then the default value 
-                        depends on the operating system and number of CPU 
-                        cores. This parameter may alternatively be specified 
-                        via the RUSH_PARALLELISM environment variable.
+                        positive integer, a percentage value (eg. \\"50%\\") or 
+                        the word \\"max\\" to specify a count that is equal to 
+                        the number of CPU cores. If this parameter is omitted,
+                         then the default value depends on the operating 
+                        system and number of CPU cores. This parameter may 
+                        alternatively be specified via the RUSH_PARALLELISM 
+                        environment variable.
   --timeline            After the build is complete, print additional 
                         statistics and CPU usage information, including an 
                         ASCII chart of the start and stop times for each 

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -159,22 +159,21 @@ export class OperationExecutionManager {
       } else {
         const parsed: number = parseInt(parallelism, 10);
 
-        if (isNaN(parsed)) {
+        let parallelismInt: number = parsed > 0 ? parsed : 1;
+
+        if (typeof parallelism === 'string' && parallelism.trim().endsWith('%')) {
+          if (parsed <= 0 || parsed > 100) {
+            throw new Error(
+              `Invalid percentage value of '${parallelism}', value cannot be less than '0%' or more than '100%'`
+            );
+          }
+
+          const workers: number = Math.floor((parsed / 100) * numberOfCores);
+          parallelismInt = Math.max(workers, 1);
+        } else if (isNaN(parsed)) {
           throw new Error(
             `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
           );
-        }
-
-        let parallelismInt: number = parsed > 0 ? parsed : 1;
-
-        if (
-          typeof parallelism === 'string' &&
-          parallelism.trim().endsWith('%') &&
-          parsed > 0 &&
-          parsed <= 100
-        ) {
-          const workers: number = Math.floor((parsed / 100) * numberOfCores);
-          parallelismInt = Math.max(workers, 1);
         }
 
         this._parallelism = parallelismInt;

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -159,10 +159,8 @@ export class OperationExecutionManager {
       } else {
         const parallelismAsNumber: number = Number(parallelism);
 
-        const getParallelismValueHighThanZero = (value: number) => (value > 0 ? value : 1);
-
         if (typeof parallelism === 'string' && parallelism.trim().endsWith('%')) {
-          const parsedPercentage = Number(parallelism.trim().replace(/\%$/, ''));
+          const parsedPercentage: number = Number(parallelism.trim().replace(/\%$/, ''));
 
           if (parsedPercentage <= 0 || parsedPercentage > 100) {
             throw new Error(
@@ -171,9 +169,9 @@ export class OperationExecutionManager {
           }
 
           const workers: number = Math.floor((parallelismAsNumber / 100) * numberOfCores);
-          this._parallelism = getParallelismValueHighThanZero(workers);
+          this._parallelism = Math.max(workers, 1);
         } else if (!isNaN(parallelismAsNumber)) {
-          this._parallelism = getParallelismValueHighThanZero(parallelismAsNumber);
+          this._parallelism = Math.max(parallelismAsNumber, 1);
         }
 
         throw new Error(

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -172,11 +172,11 @@ export class OperationExecutionManager {
           this._parallelism = Math.max(workers, 1);
         } else if (!isNaN(parallelismAsNumber)) {
           this._parallelism = Math.max(parallelismAsNumber, 1);
+        } else {
+          throw new Error(
+            `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
+          );
         }
-
-        throw new Error(
-          `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
-        );
       }
     } else {
       // If an explicit parallelism number wasn't provided, then choose a sensible

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -157,10 +157,24 @@ export class OperationExecutionManager {
       if (parallelism === 'max') {
         this._parallelism = numberOfCores;
       } else {
-        const parallelismInt: number = parseInt(parallelism, 10);
+        const parsed: number = parseInt(parallelism, 10);
 
-        if (isNaN(parallelismInt)) {
-          throw new Error(`Invalid parallelism value of '${parallelism}', expected a number or 'max'`);
+        if (isNaN(parsed)) {
+          throw new Error(
+            `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
+          );
+        }
+
+        let parallelismInt: number = parsed > 0 ? parsed : 1;
+
+        if (
+          typeof parallelism === 'string' &&
+          parallelism.trim().endsWith('%') &&
+          parsed > 0 &&
+          parsed <= 100
+        ) {
+          const workers: number = Math.floor((parsed / 100) * numberOfCores);
+          parallelismInt = Math.max(workers, 1);
         }
 
         this._parallelism = parallelismInt;

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -157,26 +157,28 @@ export class OperationExecutionManager {
       if (parallelism === 'max') {
         this._parallelism = numberOfCores;
       } else {
-        const parsed: number = parseInt(parallelism, 10);
+        const parallelismAsNumber: number = Number(parallelism);
 
-        let parallelismInt: number = parsed > 0 ? parsed : 1;
+        const getParallelismValueHighThanZero = (value: number) => (value > 0 ? value : 1);
 
         if (typeof parallelism === 'string' && parallelism.trim().endsWith('%')) {
-          if (parsed <= 0 || parsed > 100) {
+          const parsedPercentage = Number(parallelism.trim().replace(/\%$/, ''));
+
+          if (parsedPercentage <= 0 || parsedPercentage > 100) {
             throw new Error(
               `Invalid percentage value of '${parallelism}', value cannot be less than '0%' or more than '100%'`
             );
           }
 
-          const workers: number = Math.floor((parsed / 100) * numberOfCores);
-          parallelismInt = Math.max(workers, 1);
-        } else if (isNaN(parsed)) {
-          throw new Error(
-            `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
-          );
+          const workers: number = Math.floor((parallelismAsNumber / 100) * numberOfCores);
+          this._parallelism = getParallelismValueHighThanZero(workers);
+        } else if (!isNaN(parallelismAsNumber)) {
+          this._parallelism = getParallelismValueHighThanZero(parallelismAsNumber);
         }
 
-        this._parallelism = parallelismInt;
+        throw new Error(
+          `Invalid parallelism value of '${parallelism}', expected a number, a percentage, or 'max'`
+        );
       }
     } else {
       // If an explicit parallelism number wasn't provided, then choose a sensible

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -78,6 +78,22 @@ describe(OperationExecutionManager.name, () => {
     });
   });
 
+  describe('Constructor', () => {
+    it('createsWithPercentageBasedParallelism', () => {
+      expect(
+        () =>
+          new OperationExecutionManager(new Set(), {
+            quietMode: false,
+            debugMode: false,
+            parallelism: '50%',
+            changedProjectsOnly: false,
+            destination: mockWritable,
+            repoCommandLineConfiguration: undefined!
+          })
+      ).toBeInstanceOf(Function);
+    });
+  });
+
   describe('Error logging', () => {
     beforeEach(() => {
       executionManagerOptions = {

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -76,9 +76,7 @@ describe(OperationExecutionManager.name, () => {
           })
       ).toThrowErrorMatchingSnapshot();
     });
-  });
 
-  describe('Constructor', () => {
     it('createsWithPercentageBasedParallelism', () => {
       expect(
         () =>
@@ -86,11 +84,25 @@ describe(OperationExecutionManager.name, () => {
             quietMode: false,
             debugMode: false,
             parallelism: '50%',
+            showTimeline: false,
             changedProjectsOnly: false,
-            destination: mockWritable,
-            repoCommandLineConfiguration: undefined!
+            destination: mockWritable
           })
       ).toBeInstanceOf(Function);
+    });
+
+    it('throwsErrorOnInvalidParallelismPercentage', () => {
+      expect(
+        () =>
+          new OperationExecutionManager(new Set(), {
+            quietMode: false,
+            debugMode: false,
+            parallelism: '200%',
+            showTimeline: false,
+            changedProjectsOnly: false,
+            destination: mockWritable
+          })
+      ).toThrowErrorMatchingSnapshot();
     });
   });
 

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number, a percentage, or 'max'"`;
 
+exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelismPercentage 1`] = `"Invalid percentage value of '200%', value cannot be less than '0%' or more than '100%'"`;
+
 exports[`OperationExecutionManager Error logging printedStderrAfterError 1`] = `"An error occurred."`;
 
 exports[`OperationExecutionManager Error logging printedStderrAfterError 2`] = `

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number or 'max'"`;
+exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number, a percentage, or 'max'"`;
 
 exports[`OperationExecutionManager Error logging printedStderrAfterError 1`] = `"An error occurred."`;
 

--- a/common/changes/@microsoft/rush/parallelism-flexibility_2022-03-06-20-41.json
+++ b/common/changes/@microsoft/rush/parallelism-flexibility_2022-03-06-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for percentage values for --parallelism flag, eg. \"50%\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Adds support for percentage values, see https://github.com/microsoft/rushstack/issues/3257

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

This is the first pull request I'm introducing in an effort to avoid draining resources of local developer machines.

Since developers still have to specify the --parallelism flag, my next idea would be to add some functionality that let's us use all cores minus 1. There's no specific issue for this yet.

Jest has support for percentage-values, so I figured this should be a welcome change for flexibility regardless. This code was also heavily inspired by jest's implementation, found here: https://github.com/facebook/jest/blob/e0b33b74b5afd738edc183858b5c34053cfc26dd/packages/jest-config/src/getMaxWorkers.ts#L29

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I added a test that simply ensures that the generation won't fail. I found that creating a snapshot should be unnecessary in this case.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I actually did not run this against any repo.. Maybe I need to do that. 🙃 

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
