### PR TITLE
[rush-lib] Fix verbose logging for selected operations

### DIFF
--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -185,11 +185,16 @@ export class OperationExecutionManager {
     if (!this._quietMode) {
       const plural: string = totalOperations === 1 ? '' : 's';
       this._terminal.writeStdoutLine(`Selected ${totalOperations} operation${plural}:`);
-      this._terminal.writeStdoutLine(
-        Array.from(this._executionRecords, (x) => `  ${x.name}`)
-          .sort()
-          .join('\n')
-      );
+      const nonSilentOperations: string[] = [];
+      for (const record of this._executionRecords) {
+        if (!record.runner.silent) {
+          nonSilentOperations.push(record.name);
+        }
+      }
+      nonSilentOperations.sort();
+      for (const name of nonSilentOperations) {
+        this._terminal.writeStdoutLine(`  ${name}`);
+      }
       this._terminal.writeStdoutLine('');
     }
 

--- a/common/changes/@microsoft/rush/fix-verbose-log_2022-03-09-23-38.json
+++ b/common/changes/@microsoft/rush/fix-verbose-log_2022-03-09-23-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix the \"selected operations\" logging for commands that skipped projects to only display the operations that will be executed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes a regression in the "Selected ${x} operations:" verbose log for phased commands.

## Details
Ensures that architectural no-ops in the operation graph are not displayed.

## How it was tested
Ran `rush build -v -o rush-lib` and verified that only the operations pertaining to the `@microsoft/rush-lib` project were displayed.