### PR TITLE
[api-documenter] Added a CLI flag to choose between UDP and SDP YAML formats

### DIFF
--- a/apps/api-documenter/src/cli/YamlAction.ts
+++ b/apps/api-documenter/src/cli/YamlAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import { CommandLineFlagParameter, CommandLineChoiceParameter } from '@rushstack/ts-command-line';
 
 import { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
@@ -12,6 +12,7 @@ import { OfficeYamlDocumenter } from '../documenters/OfficeYamlDocumenter';
 export class YamlAction extends BaseAction {
   private _officeParameter!: CommandLineFlagParameter;
   private _newDocfxNamespacesParameter!: CommandLineFlagParameter;
+  private _yamlFormatParameter!: CommandLineChoiceParameter;
 
   public constructor(parser: ApiDocumenterCommandLine) {
     super({
@@ -40,6 +41,15 @@ export class YamlAction extends BaseAction {
         ` adds them to the table of contents.  This will also affect file layout as namespaced items will be nested` +
         ` under a directory for the namespace instead of just within the package.`
     });
+    this._yamlFormatParameter = this.defineChoiceParameter({
+      parameterLongName: '--yaml-format',
+      alternatives: ['udp', 'sdp'],
+      defaultValue: 'sdp',
+      description:
+        `Specifies the YAML format - udp or sdp. Universal Document Processor (udp) should be used if you generating` +
+        ` YAML files for DocFX 2.x. Schema Driven Processor (sdp) should be used with DocFX 3.x.` +
+        ` NOTE: This parameter is ignored if you use --office.`
+    });
   }
 
   protected async onExecute(): Promise<void> {
@@ -48,7 +58,11 @@ export class YamlAction extends BaseAction {
 
     const yamlDocumenter: YamlDocumenter = this._officeParameter.value
       ? new OfficeYamlDocumenter(apiModel, inputFolder, this._newDocfxNamespacesParameter.value)
-      : new YamlDocumenter(apiModel, this._newDocfxNamespacesParameter.value);
+      : new YamlDocumenter(
+          apiModel,
+          this._newDocfxNamespacesParameter.value,
+          this._yamlFormatParameter.value
+        );
 
     yamlDocumenter.generateFiles(outputFolder);
   }

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -89,15 +89,17 @@ interface INameOptions {
  */
 export class YamlDocumenter {
   protected readonly newDocfxNamespaces: boolean;
+  private readonly _yamlFormat: string;
   private readonly _apiModel: ApiModel;
   private readonly _markdownEmitter: CustomMarkdownEmitter;
 
   private _apiItemsByCanonicalReference: Map<string, ApiItem>;
   private _yamlReferences: IYamlReferences | undefined;
 
-  public constructor(apiModel: ApiModel, newDocfxNamespaces: boolean = false) {
+  public constructor(apiModel: ApiModel, newDocfxNamespaces: boolean = false, yamlFormat: string = 'sdp') {
     this._apiModel = apiModel;
     this.newDocfxNamespaces = newDocfxNamespaces;
+    this._yamlFormat = yamlFormat;
     this._markdownEmitter = new CustomMarkdownEmitter(this._apiModel);
     this._apiItemsByCanonicalReference = new Map<string, ApiItem>();
 
@@ -114,7 +116,9 @@ export class YamlDocumenter {
       this._visitApiItems(outputFolder, apiPackage, undefined);
     }
 
-    convertUDPYamlToSDP(outputFolder);
+    if (this._yamlFormat === 'sdp') {
+      convertUDPYamlToSDP(outputFolder);
+    }
 
     this._writeTocFile(outputFolder, this._apiModel.packages);
   }

--- a/common/changes/@microsoft/api-documenter/master_2022-03-19-05-04.json
+++ b/common/changes/@microsoft/api-documenter/master_2022-03-19-05-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Add --yaml-format flag for `api-documenter yaml` command, which allows for choosing between UDP (DocFX 2.x) and SDP (DocFX 3.x)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
## Summary

As mentioned by @rbuckton in  #3268, a Pull Request #2382 makes it impossible to use api-documenter along with DocFX 2.x. In other words, no one except of Microsoft can use it anymore. 

The reason is quite trivial - after api-documenter generates valid DocFX 2.x YAML files (UDP format), it converts them to a new SDP format supported only by DocFX 3.x. 

[    convertUDPYamlToSDP(outputFolder);
](https://github.com/microsoft/rushstack/blob/b03815b3a3c273972344ccebe55c36da7e59ac2f/apps/api-documenter/src/documenters/YamlDocumenter.ts#L117)

To solve this problem I have added a new flag for the `api-documenter yaml` command - `--yaml-format`, which allows for choosing whether to produce UDP or SDP YAML files.

Fixes #3268

## Details

I have added a flag `--yaml-format` which can used in this way: 

```
$ api-documenter yaml --yaml-format udp
```

or 

```
$ api-documenter yaml --yaml-format sdp
```

When udp is specified, the udp->sdp convertion is bypassed. If `sdp` is specified (or flag is omitted), it works in the old way. This way it should not break backward compatibility. 

## How it was tested

I am new to the Rush project, so I did not figure out how to create unit tests for that (and whether some test project for api-documenter ever exists). 

So I have just built the api-documenter project, run it with both flag values (and without flag) and made sure that `YamlMime` in the beginning of generated files have correct values (`### YamlMime:UniversalReference` for UDP and `### YamlMime:TS<something>` for SDP). 

Also, I added UDP YAML files to my DocFX 2.55 project and made sure that the documentation is generated properly. It works well except of the typealias entries, but it is a different story.