### PR TITLE
[rush] Make --quiet flags more consistent

### DIFF
--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -7,7 +7,6 @@ import { RushCommandLineParser } from '../cli/RushCommandLineParser';
 import { RushStartupBanner } from '../cli/RushStartupBanner';
 import { RushXCommandLine } from '../cli/RushXCommandLine';
 import { CommandLineMigrationAdvisor } from '../cli/CommandLineMigrationAdvisor';
-import { Utilities } from '../utilities/Utilities';
 import { EnvironmentVariableNames } from './EnvironmentConfiguration';
 import { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 
@@ -62,7 +61,7 @@ export class Rush {
   public static launch(launcherVersion: string, arg: ILaunchOptions): void {
     const options: ILaunchOptions = Rush._normalizeLaunchOptions(arg);
 
-    if (!Utilities.shouldRestrictConsoleOutput()) {
+    if (!RushCommandLineParser.shouldRestrictConsoleOutput()) {
       RushStartupBanner.logBanner(Rush.version, options.isManaged);
     }
 

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -155,8 +155,11 @@ export class RushCommandLineParser extends CommandLineParser {
    * Used during Rush startup.
    */
   public static peekIsQuiet(): boolean {
-    const flags: string[] = process.argv.slice(2);
-    return flags.includes('-q') || flags.includes('--quiet');
+    for (let i = 2; i < process.argv.length; i++) {
+      const arg = process.argv[i];
+      if (arg === '-q' || arg === '--quiet') return true;
+    }
+    return false;
   }
 
   /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -5,7 +5,7 @@ import colors from 'colors/safe';
 import * as os from 'os';
 import * as path from 'path';
 
-import { CommandLineParser, CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import { CommandLineParser, CommandLineFlagParameter, CommandLineHelper } from '@rushstack/ts-command-line';
 import {
   InternalError,
   AlreadyReportedError,
@@ -22,7 +22,6 @@ import {
   IGlobalCommandConfig,
   IPhasedCommandConfig
 } from '../api/CommandLineConfiguration';
-import { Utilities } from '../utilities/Utilities';
 
 import { AddAction } from './actions/AddAction';
 import { ChangeAction } from './actions/ChangeAction';
@@ -72,6 +71,7 @@ export class RushCommandLineParser extends CommandLineParser {
   public readonly pluginManager: PluginManager;
 
   private _debugParameter!: CommandLineFlagParameter;
+  private _quietParameter!: CommandLineFlagParameter;
   private readonly _rushOptions: IRushCommandLineParserOptions;
   private readonly _terminalProvider: ConsoleTerminalProvider;
   private readonly _terminal: Terminal;
@@ -98,7 +98,7 @@ export class RushCommandLineParser extends CommandLineParser {
     try {
       const rushJsonFilename: string | undefined = RushConfiguration.tryFindRushJsonLocation({
         startingFolder: this._rushOptions.cwd,
-        showVerbose: !Utilities.shouldRestrictConsoleOutput()
+        showVerbose: !RushCommandLineParser.shouldRestrictConsoleOutput()
       });
       if (rushJsonFilename) {
         this.rushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFilename);
@@ -145,6 +145,31 @@ export class RushCommandLineParser extends CommandLineParser {
     return this._debugParameter.value;
   }
 
+  public get isQuiet(): boolean {
+    return this._quietParameter.value;
+  }
+
+  /**
+   * Peek at the -q/--quiet mode flag, before the command line parser is executed.
+   *
+   * Used during Rush startup.
+   */
+  public static peekIsQuiet(): boolean {
+    const flags: string[] = process.argv.slice(2);
+    return flags.includes('-q') || flags.includes('--quiet');
+  }
+
+  /**
+   * Utility to determine if the app should restrict writing to the console.
+   */
+  public static shouldRestrictConsoleOutput(): boolean {
+    return (
+      CommandLineHelper.isTabCompletionActionRequest(process.argv) ||
+      RushCommandLineParser.peekIsQuiet() ||
+      process.argv.indexOf('--json') !== -1
+    );
+  }
+
   public flushTelemetry(): void {
     if (this.telemetry) {
       this.telemetry.flush();
@@ -164,6 +189,12 @@ export class RushCommandLineParser extends CommandLineParser {
       parameterLongName: '--debug',
       parameterShortName: '-d',
       description: 'Show the full call stack if an error occurs while executing the tool'
+    });
+
+    this._quietParameter = this.defineFlagParameter({
+      parameterLongName: '--quiet',
+      parameterShortName: '-q',
+      description: 'Hide rush startup information'
     });
   }
 

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -155,8 +155,8 @@ export class RushCommandLineParser extends CommandLineParser {
    * Used during Rush startup.
    */
   public static peekIsQuiet(): boolean {
-    for (let i = 2; i < process.argv.length; i++) {
-      const arg = process.argv[i];
+    for (let i: number = 2; i < process.argv.length; i++) {
+      const arg: string = process.argv[i];
       if (arg === '-q' || arg === '--quiet') return true;
     }
     return false;

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -150,27 +150,21 @@ export class RushCommandLineParser extends CommandLineParser {
   }
 
   /**
-   * Peek at the -q/--quiet mode flag, before the command line parser is executed.
-   *
-   * Used during Rush startup.
-   */
-  public static peekIsQuiet(): boolean {
-    for (let i: number = 2; i < process.argv.length; i++) {
-      const arg: string = process.argv[i];
-      if (arg === '-q' || arg === '--quiet') return true;
-    }
-    return false;
-  }
-
-  /**
    * Utility to determine if the app should restrict writing to the console.
    */
   public static shouldRestrictConsoleOutput(): boolean {
-    return (
-      CommandLineHelper.isTabCompletionActionRequest(process.argv) ||
-      RushCommandLineParser.peekIsQuiet() ||
-      process.argv.indexOf('--json') !== -1
-    );
+    if (CommandLineHelper.isTabCompletionActionRequest(process.argv)) {
+      return true;
+    }
+
+    for (let i: number = 2; i < process.argv.length; i++) {
+      const arg: string = process.argv[i];
+      if (arg === '-q' || arg === '--quiet' || arg === '--json') {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public flushTelemetry(): void {

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -75,7 +75,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
       }
     }
 
-    if (!Utilities.shouldRestrictConsoleOutput()) {
+    if (!RushCommandLineParser.shouldRestrictConsoleOutput()) {
       console.log(`Starting "rush ${this.actionName}"${os.EOL}`);
     }
     return this.runAsync();

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandLineHelp prints the global help 1`] = `
-"usage: rush [-h] [-d] <command> ...
+"usage: rush [-h] [-d] [-q] <command> ...
 
 Rush makes life easier for JavaScript developers who develop, build, and 
 publish many packages from a central Git repo. It is designed to handle very 
@@ -65,6 +65,7 @@ Optional arguments:
   -h, --help            Show this help message and exit.
   -d, --debug           Show the full call stack if an error occurs while 
                         executing the tool
+  -q, --quiet           Hide rush startup information
 
 [bold]For detailed help about a specific command, use: rush <command> -h[normal]
 "

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -12,7 +12,6 @@ import {
   FileSystemStats
 } from '@rushstack/node-core-library';
 import type * as stream from 'stream';
-import { CommandLineHelper } from '@rushstack/ts-command-line';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 
@@ -424,15 +423,6 @@ export class Utilities {
     options: ILifecycleCommandOptions
   ): child_process.ChildProcess {
     return Utilities._executeLifecycleCommandInternal(command, child_process.spawn, options);
-  }
-
-  /**
-   * Utility to determine if the app should restrict writing to the console.
-   */
-  public static shouldRestrictConsoleOutput(): boolean {
-    return (
-      CommandLineHelper.isTabCompletionActionRequest(process.argv) || process.argv.indexOf('--json') !== -1
-    );
   }
 
   /**

--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { JsonFile } from '@rushstack/node-core-library';
 import { RushConfiguration } from '@microsoft/rush-lib';
 import { RushConstants } from '@microsoft/rush-lib/lib/logic/RushConstants';
-import { Utilities } from '@microsoft/rush-lib/lib/utilities/Utilities';
+import { RushCommandLineParser } from '@microsoft/rush-lib/lib/cli/RushCommandLineParser';
 
 interface IMinimalRushConfigurationJson {
   rushMinimumVersion: string;
@@ -34,7 +34,7 @@ export class MinimalRushConfiguration {
 
   public static loadFromDefaultLocation(): MinimalRushConfiguration | undefined {
     const rushJsonLocation: string | undefined = RushConfiguration.tryFindRushJsonLocation({
-      showVerbose: !Utilities.shouldRestrictConsoleOutput()
+      showVerbose: !RushCommandLineParser.shouldRestrictConsoleOutput()
     });
     if (rushJsonLocation) {
       return MinimalRushConfiguration._loadFromConfigurationFile(rushJsonLocation);

--- a/common/changes/@microsoft/rush/enelson-quiet_2022-03-21-16-19.json
+++ b/common/changes/@microsoft/rush/enelson-quiet_2022-03-21-16-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for -q/--quiet to install-run-rush scripts",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/enelson-quiet_2022-03-21-16-19.json
+++ b/common/changes/@microsoft/rush/enelson-quiet_2022-03-21-16-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add support for -q/--quiet to install-run-rush scripts",
+      "comment": "Add support for suppressing startup information to invocations of `rush`, `rushx`, and the `install-run-rush` scripts.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
## Summary

Make support for `-q/--quiet` consistent for both direction execution and for `install-run-rush` scripts.

The goal is that whether you're running `rush`, `rushx`, or one of their `install-run` variants, you can specify `-q / --quiet` to suppress any startup output.

## Details

For `rushx`, the `install-run-rushx` script now honors the `-q/--quiet` flag in the same way as direct execution:

(In this example, script `"hello"` is defined as `"echo hello"`.)

```console
> rushx --quiet hello
hello

> node ../../common/scripts/install-run-rushx.js --quiet hello
hello

```

For `rush`, the `-q/--quiet` flag has been _added_ as a pre-command flag, similar to `-d/--debug`. It operates in the same way it does with rushx, which is to suppress all informational and diagnostic information printed at startup.

```
> rush --quiet list
a
b
c

> node common/scripts/install-run-rush.js --quiet list
a
b
c

```

As part of this change, the `shouldRestrictConsoleOutput` utility was moved into `RushCommandLineParser`, so that its implementation is closer to the other code processing args for Rush.

For suppressing output in `install-run`, which has quite a few places it can log output, we now pass around a very small logger object (rather than inserting new if statements in every function).  It's possible you could use some of `ITerminal` for this instead, although it seems pretty heavy-duty here.

## How it was tested

Tested all 4 commands (rush, rushx, install-run-rush, install-run-rushx), with and without -q/--quiet flags.
