### PR TITLE
[rush-lib] Fix cache write behavior

### DIFF
--- a/apps/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/apps/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -79,7 +79,8 @@ function _areShallowEqual(object1: JsonObject, object2: JsonObject): boolean {
 export class ShellOperationRunner implements IOperationRunner {
   public readonly name: string;
 
-  public isCacheWriteAllowed: boolean = false;
+  // This runner supports cache writes by default.
+  public isCacheWriteAllowed: boolean = true;
   public isSkipAllowed: boolean;
   public readonly reportTiming: boolean = true;
   public readonly silent: boolean = false;

--- a/common/changes/@microsoft/rush/fix-cache-write_2022-03-25-22-29.json
+++ b/common/changes/@microsoft/rush/fix-cache-write_2022-03-25-22-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix build cache write eligibility.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-cache-write_2022-03-25-22-29.json
+++ b/common/changes/@microsoft/rush/fix-cache-write_2022-03-25-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix build cache write eligibility.",
+      "comment": "Fix an issue where the build cache is never written to.",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
## Summary
Fixes cache writes during build.
Fixes #3287 

## Details
The `ShellOperationRunner` (which is currently the only runner that supports the build cache) now defaults cache write eligibility to `true` instead of `false`. Disabling is handled via propagation from upstream operations.

## How it was tested
Ran `rush build`.
Deleted the build cache.
Ran `node ./apps/rush-lib/lib/start.js build`
Ran `node ./apps/rush-lib/lib/start.js build` again and verified that the result came from the build cache