### PR TITLE
[rush-lib] Support tags in rush.json and selectors

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -450,19 +450,28 @@
        * in "version-policies.json" file.  See the "rush publish" documentation for more info.
        * NOTE: "versionPolicyName" and "shouldPublish" are alternatives; you cannot specify them both.
        */
-      /*[LINE "HYPOTHETICAL"]*/ "versionPolicyName": ""
+      /*[LINE "HYPOTHETICAL"]*/ "versionPolicyName": "",
+
+      /**
+        * An optional set of custom tags that can be used to select this project. For example,
+        * adding "my-custom-tag" will allow this project to be selected by the
+        * command "rush list --only tag:my-custom-tag"
+        */
+      /*[LINE "HYPOTHETICAL"]*/ "tags": ["apps", "web"]
     },
 
     {
       "packageName": "my-controls",
       "projectFolder": "libraries/my-controls",
-      "reviewCategory": "production"
+      "reviewCategory": "production",
+      "tags": ["libraries", "web"]
     },
 
     {
       "packageName": "my-toolchain",
       "projectFolder": "tools/my-toolchain",
-      "reviewCategory": "tools"
+      "reviewCategory": "tools",
+      "tags": ["tools"]
     }
     /*[END "DEMO"]*/
   ]

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -387,6 +387,13 @@
   /*[LINE "HYPOTHETICAL"]*/ "hotfixChangeEnabled": false,
 
   /**
+    * This is an optional, but recommended, list of available tags that can be applied
+    * to projects. If this property is not specified, any tag is allowed. This
+    * list is useful in preventing typos when specifying tags for projects.
+    */
+  /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "apps", "Web", "tools" ],
+
+  /**
    * (Required) This is the inventory of projects to be managed by Rush.
    *
    * Rush does not automatically scan for projects using wildcards, for a few reasons:

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -246,6 +246,7 @@ export interface IRushConfigurationJson {
   approvedPackagesPolicy?: IApprovedPackagesPolicyJson;
   gitPolicy?: IRushGitPolicyJson;
   telemetryEnabled?: boolean;
+  allowedProjectTags?: string[];
   projects: IRushConfigurationProjectJson[];
   eventHooks?: IEventHooksJson;
   hotfixChangeEnabled?: boolean;
@@ -771,6 +772,9 @@ export class RushConfiguration {
       a.packageName.localeCompare(b.packageName)
     );
 
+    const allowedProjectTags: Set<string> | undefined = this._rushConfigurationJson.allowedProjectTags
+      ? new Set(this._rushConfigurationJson.allowedProjectTags)
+      : undefined;
     const usedTempNames: Set<string> = new Set();
     for (let i: number = 0, len: number = sortedProjectJsons.length; i < len; i++) {
       const projectJson: IRushConfigurationProjectJson = sortedProjectJsons[i];
@@ -781,7 +785,8 @@ export class RushConfiguration {
       const project: RushConfigurationProject = new RushConfigurationProject({
         projectJson,
         rushConfiguration: this,
-        tempProjectName
+        tempProjectName,
+        allowedProjectTags
       });
 
       this._projects.push(project);

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -494,6 +494,9 @@ export class RushConfiguration {
   // Lazily loaded when the projectsByName() getter is called.
   private _projectsByName: Map<string, RushConfigurationProject> | undefined;
 
+  // Lazily loaded when the projectsByTag() getter is called.
+  private _projectsByTag: ReadonlyMap<string, ReadonlySet<RushConfigurationProject>> | undefined;
+
   // variant -> common-versions configuration
   private _commonVersionsConfigurations: Map<string, CommonVersionsConfiguration> | undefined;
   // variant -> map of package name -> implicitly preferred version
@@ -1429,6 +1432,27 @@ export class RushConfiguration {
     }
 
     return this._projectsByName!;
+  }
+
+  /**
+   * Obtains the mapping from custom tags to projects.
+   * @beta
+   */
+  public get projectsByTag(): ReadonlyMap<string, ReadonlySet<RushConfigurationProject>> {
+    if (!this._projectsByTag) {
+      const projectsByTag: Map<string, Set<RushConfigurationProject>> = new Map();
+      for (const project of this.projects) {
+        for (const tag of project.tags) {
+          let collection: Set<RushConfigurationProject> | undefined = projectsByTag.get(tag);
+          if (!collection) {
+            projectsByTag.set(tag, (collection = new Set()));
+          }
+          collection.add(project);
+        }
+      }
+      this._projectsByTag = projectsByTag;
+    }
+    return this._projectsByTag;
   }
 
   /**

--- a/apps/rush-lib/src/api/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/api/RushConfigurationProject.ts
@@ -24,6 +24,7 @@ export interface IRushConfigurationProjectJson {
   shouldPublish?: boolean;
   skipRushCheck?: boolean;
   publishFolder?: string;
+  tags?: string[];
 }
 
 /**
@@ -66,6 +67,7 @@ export class RushConfigurationProject {
   private readonly _skipRushCheck: boolean;
   private readonly _publishFolder: string;
   private readonly _rushConfiguration: RushConfiguration;
+  private readonly _tags: Set<string>;
 
   private _versionPolicy: VersionPolicy | undefined = undefined;
   private _dependencyProjects: Set<RushConfigurationProject> | undefined = undefined;
@@ -165,6 +167,8 @@ export class RushConfigurationProject {
     if (projectJson.publishFolder) {
       this._publishFolder = path.join(this._publishFolder, projectJson.publishFolder);
     }
+
+    this._tags = new Set(projectJson.tags);
   }
 
   /**
@@ -441,5 +445,13 @@ export class RushConfigurationProject {
       }
     }
     return isMain;
+  }
+
+  /**
+   * The set of tags applied to this project.
+   * @beta
+   */
+  public get tags(): ReadonlySet<string> {
+    return this._tags;
   }
 }

--- a/apps/rush-lib/src/cli/SelectionParameterSet.ts
+++ b/apps/rush-lib/src/cli/SelectionParameterSet.ts
@@ -18,6 +18,7 @@ import {
   IGitSelectorParserOptions
 } from '../logic/selectors/GitChangedProjectSelectorParser';
 import { NamedProjectSelectorParser } from '../logic/selectors/NamedProjectSelectorParser';
+import { TagProjectSelectorParser } from '../logic/selectors/TagProjectSelectorParser';
 import { VersionPolicyProjectSelectorParser } from '../logic/selectors/VersionPolicyProjectSelectorParser';
 
 /**
@@ -53,9 +54,12 @@ export class SelectionParameterSet {
       ISelectorParser<RushConfigurationProject>
     >();
 
-    selectorParsers.set('name', new NamedProjectSelectorParser(rushConfiguration));
+    const nameSelectorParser: NamedProjectSelectorParser = new NamedProjectSelectorParser(rushConfiguration);
+    selectorParsers.set('name', nameSelectorParser);
     selectorParsers.set('git', new GitChangedProjectSelectorParser(rushConfiguration, gitOptions));
+    selectorParsers.set('tag', new TagProjectSelectorParser(rushConfiguration));
     selectorParsers.set('version-policy', new VersionPolicyProjectSelectorParser(rushConfiguration));
+
     this._selectorParserByScope = selectorParsers;
 
     const getSpecifierCompletions: () => Promise<string[]> = async (): Promise<string[]> => {
@@ -64,6 +68,11 @@ export class SelectionParameterSet {
         for (const completion of selector.getCompletions()) {
           completions.push(`${prefix}:${completion}`);
         }
+      }
+
+      // Include completions from the name parser without a scope
+      for (const completion of nameSelectorParser.getCompletions()) {
+        completions.push(completion);
       }
 
       return completions;

--- a/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/GitChangedProjectSelectorParser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';

--- a/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/ISelectorParser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { ITerminal } from '@rushstack/node-core-library';
 
 export interface IEvaluateSelectorOptions {

--- a/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/NamedProjectSelectorParser.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import { AlreadyReportedError, PackageName } from '@rushstack/node-core-library';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';

--- a/apps/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
@@ -7,7 +7,7 @@ import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
 
-export class VersionPolicyProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
+export class TagProjectSelectorParser implements ISelectorParser<RushConfigurationProject> {
   private readonly _rushConfiguration: RushConfiguration;
 
   public constructor(rushConfiguration: RushConfiguration) {
@@ -19,25 +19,18 @@ export class VersionPolicyProjectSelectorParser implements ISelectorParser<RushC
     terminal,
     parameterName
   }: IEvaluateSelectorOptions): Promise<Iterable<RushConfigurationProject>> {
-    const selection: Set<RushConfigurationProject> = new Set();
-
-    if (!this._rushConfiguration.versionPolicyConfiguration.versionPolicies.has(unscopedSelector)) {
+    const selection: ReadonlySet<RushConfigurationProject> | undefined =
+      this._rushConfiguration.projectsByTag.get(unscopedSelector);
+    if (!selection) {
       terminal.writeErrorLine(
-        `The version policy "${unscopedSelector}" passed to "${parameterName}" does not exist in version-policies.json.`
+        `The tag "${unscopedSelector}" passed to "${parameterName}" does not exist in rush.json.`
       );
       throw new AlreadyReportedError();
     }
-
-    for (const project of this._rushConfiguration.projects) {
-      if (project.versionPolicyName === unscopedSelector) {
-        selection.add(project);
-      }
-    }
-
     return selection;
   }
 
   public getCompletions(): Iterable<string> {
-    return this._rushConfiguration.versionPolicyConfiguration.versionPolicies.keys();
+    return this._rushConfiguration.projectsByTag.keys();
   }
 }

--- a/apps/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
+++ b/apps/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
@@ -23,7 +23,7 @@ export class TagProjectSelectorParser implements ISelectorParser<RushConfigurati
       this._rushConfiguration.projectsByTag.get(unscopedSelector);
     if (!selection) {
       terminal.writeErrorLine(
-        `The tag "${unscopedSelector}" passed to "${parameterName}" does not exist in rush.json.`
+        `The tag "${unscopedSelector}" passed to "${parameterName}" is not specified for any projects in rush.json.`
       );
       throw new AlreadyReportedError();
     }

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -276,6 +276,14 @@
           "publishFolder": {
             "description": "Facilitates postprocessing of a project's files prior to publishing. If specified, the \"publishFolder\" is the relative path to a subfolder of the project folder. The \"rush publish\" command will publish the subfolder instead of the project folder. The subfolder must contain its own package.json file, which is typically a build output.",
             "type": "string"
+          },
+          "tags": {
+            "description": "An optional set of custom tags that can be used to select this project. For example, adding \"my-custom-tag\" will allow this project to be selected by the command \"rush list --only tag:my-custom-tag\".",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_@/.$-]+$"
+            }
           }
         },
         "additionalProperties": false,

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -236,6 +236,14 @@
       "description": "Indicates whether telemetry data should be collected and stored in the Rush temp folder during Rush runs.",
       "type": "boolean"
     },
+    "allowedProjectTags": {
+      "description": "This is an optional, but recommended, list of available tags that can be applied to projects. If this property is not specified, any tag is allowed. This list is useful in preventing typos when specifying tags for projects.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_@/.$-]+$"
+      }
+    },
     "projects": {
       "description": "A list of projects managed by this tool.",
       "type": "array",

--- a/common/changes/@microsoft/rush/rush-tags_2022-03-28-20-28.json
+++ b/common/changes/@microsoft/rush/rush-tags_2022-03-28-20-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Support \"tags\" field in project definitions in rush.json. These may be used to select projects with, for example, \"rush list --only tag:my-custom-tag\".",
+      "comment": "Add a \"tags\" field to project definitions in rush.json. These may be used to select projects, for example, \"rush list --only tag:my-custom-tag\".",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/rush-tags_2022-03-28-20-28.json
+++ b/common/changes/@microsoft/rush/rush-tags_2022-03-28-20-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support \"tags\" field in project definitions in rush.json. These may be used to select projects with, for example, \"rush list --only tag:my-custom-tag\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -567,6 +567,8 @@ export class RushConfiguration {
     get projects(): RushConfigurationProject[];
     // (undocumented)
     get projectsByName(): Map<string, RushConfigurationProject>;
+    // @beta
+    get projectsByTag(): ReadonlyMap<string, ReadonlySet<RushConfigurationProject>>;
     get repositoryDefaultBranch(): string;
     get repositoryDefaultFullyQualifiedRemoteBranch(): string;
     get repositoryDefaultRemote(): string;
@@ -628,6 +630,8 @@ export class RushConfigurationProject {
     get rushConfiguration(): RushConfiguration;
     get shouldPublish(): boolean;
     get skipRushCheck(): boolean;
+    // @beta
+    get tags(): ReadonlySet<string>;
     get tempProjectName(): string;
     get unscopedTempProjectName(): string;
     // @beta


### PR DESCRIPTION
## Summary
Fixes #1241

## Details
Adds a new array field `tags` to the JSON for a `project` in `rush.json`. This field is a set of identifiers that can be used with the standard set of selection parameters to select projects.

### Example:
```json
"projects": [
    {
      "packageName": "a",
      "projectFolder": "a",
      "tags": ["foo", "bar"]
    },
    {
      "packageName": "b",
      "projectFolder": "b",
      "tags": ["bar", "baz"]
    },
]
```

`rush list --only tag:foo` selects `a`
`rush list --only tag:bar` selects `a` and `b`
`rush list --only tag:baz` selects `b`

This plugs into the existing extensible parser for scoped selector arguments, adding to the existing supported protocols:
- `name:PACKAGE_NAME` - select a project whose name matches `PACKAGE_NAME`. Implied for backwards compatibility if no protocol is specified
- `git:REVISION` - selects all projects that contain code changes since `REVISION`, according to Git. Will include dependency changes in the lockfile.
- `version-policy:POLICY_NAME` - selects all projects that have version policy with name `POLICY_NAME`.
Added missing license headers to parser files.
Fixed a gap in the auto-complete logic for the default `name:` parser.

## How it was tested
Added custom tags "webpack", "rig" and "rush-plugin" into `rush.json` in the @rushstack repository and used them with `rush list --only tag:webpack` (and similar) to select the affected projects.