### PR TITLE
[rush] Generate timeline chart on optional --timeline flag

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -94,6 +94,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   private _parallelismParameter: CommandLineStringParameter | undefined;
   private _ignoreHooksParameter!: CommandLineFlagParameter;
   private _watchParameter: CommandLineFlagParameter | undefined;
+  private _timelineParameter: CommandLineFlagParameter | undefined;
 
   public constructor(options: IPhasedScriptActionOptions) {
     super(options);
@@ -143,6 +144,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     // if parallelism is not enabled, then restrict to 1 core
     const parallelism: string | undefined = this._enableParallelism ? this._parallelismParameter!.value : '1';
 
+    const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
+
     const changedProjectsOnly: boolean = this._isIncrementalBuildAllowed && this._changedProjectsOnly.value;
 
     const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
@@ -175,7 +178,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     const executionManagerOptions: IOperationExecutionManagerOptions = {
       quietMode: isQuietMode,
       debugMode: this.parser.isDebug,
-      parallelism: parallelism,
+      parallelism,
+      showTimeline,
       changedProjectsOnly
     };
 
@@ -345,6 +349,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           ' The COUNT should be a positive integer or else the word "max" to specify a count that is equal to' +
           ' the number of CPU cores. If this parameter is omitted, then the default value depends on the' +
           ' operating system and number of CPU cores.'
+      });
+      this._timelineParameter = this.defineFlagParameter({
+        parameterLongName: '--timeline',
+        description:
+          'After the build is complete, print additional statistics and CPU usage information,' +
+          ' including an ASCII chart of the start and stop times for each operation.'
       });
     }
 

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -115,8 +115,8 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: build 1`] = `
-"usage: rush build [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
-                  [-o PROJECT] [-i PROJECT] [-I PROJECT]
+"usage: rush build [-h] [-p COUNT] [--timeline] [-t PROJECT] [-T PROJECT]
+                  [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
                   [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
                   [--ignore-hooks] [-s] [-m]
@@ -145,6 +145,10 @@ Optional arguments:
                         depends on the operating system and number of CPU 
                         cores. This parameter may alternatively be specified 
                         via the RUSH_PARALLELISM environment variable.
+  --timeline            After the build is complete, print additional 
+                        statistics and CPU usage information, including an 
+                        ASCII chart of the start and stop times for each 
+                        operation.
   -t PROJECT, --to PROJECT
                         Normally all projects in the monorepo will be 
                         processed; adding this parameter will instead select 
@@ -358,8 +362,9 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
-"usage: rush import-strings [-h] [-p COUNT] [-t PROJECT] [-T PROJECT]
-                           [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
+"usage: rush import-strings [-h] [-p COUNT] [--timeline] [-t PROJECT]
+                           [-T PROJECT] [-f PROJECT] [-o PROJECT] [-i PROJECT]
+                           [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
                            [--from-version-policy VERSION_POLICY_NAME] [-v]
                            [--ignore-hooks]
@@ -380,6 +385,10 @@ Optional arguments:
                         depends on the operating system and number of CPU 
                         cores. This parameter may alternatively be specified 
                         via the RUSH_PARALLELISM environment variable.
+  --timeline            After the build is complete, print additional 
+                        statistics and CPU usage information, including an 
+                        ASCII chart of the start and stop times for each 
+                        operation.
   -t PROJECT, --to PROJECT
                         Normally all projects in the monorepo will be 
                         processed; adding this parameter will instead select 
@@ -899,8 +908,8 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
-"usage: rush rebuild [-h] [-p COUNT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
-                    [-o PROJECT] [-i PROJECT] [-I PROJECT]
+"usage: rush rebuild [-h] [-p COUNT] [--timeline] [-t PROJECT] [-T PROJECT]
+                    [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
                     [--from-version-policy VERSION_POLICY_NAME] [-v]
                     [--ignore-hooks] [-s] [-m]
@@ -926,6 +935,10 @@ Optional arguments:
                         depends on the operating system and number of CPU 
                         cores. This parameter may alternatively be specified 
                         via the RUSH_PARALLELISM environment variable.
+  --timeline            After the build is complete, print additional 
+                        statistics and CPU usage information, including an 
+                        ASCII chart of the start and stop times for each 
+                        operation.
   -t PROJECT, --to PROJECT
                         Normally all projects in the monorepo will be 
                         processed; adding this parameter will instead select 

--- a/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/apps/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -21,6 +21,7 @@ export interface IOperationExecutionManagerOptions {
   quietMode: boolean;
   debugMode: boolean;
   parallelism: string | undefined;
+  showTimeline: boolean;
   changedProjectsOnly: boolean;
   destination?: TerminalWritable;
 }
@@ -29,6 +30,39 @@ export interface IOperationExecutionManagerOptions {
  * Format "======" lines for a shell window with classic 80 columns
  */
 const ASCII_HEADER_WIDTH: number = 79;
+
+/**
+ * Timeline - a wider column width for printing the timeline summary
+ */
+const TIMELINE_WIDTH: number = 109;
+
+/**
+ * Timeline - symbols representing each operation status
+ */
+const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
+  [OperationStatus.Ready]: '?',
+  [OperationStatus.Executing]: '?',
+  [OperationStatus.Success]: '#',
+  [OperationStatus.SuccessWithWarning]: '!',
+  [OperationStatus.Failure]: '!',
+  [OperationStatus.Blocked]: '.',
+  [OperationStatus.Skipped]: '%',
+  [OperationStatus.FromCache]: '%'
+};
+
+/**
+ * Timeline - colorizer for each operation status
+ */
+const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => string> = {
+  [OperationStatus.Ready]: colors.yellow,
+  [OperationStatus.Executing]: colors.yellow,
+  [OperationStatus.Success]: colors.green,
+  [OperationStatus.SuccessWithWarning]: colors.yellow,
+  [OperationStatus.Failure]: colors.red,
+  [OperationStatus.Blocked]: colors.red,
+  [OperationStatus.Skipped]: colors.green,
+  [OperationStatus.FromCache]: colors.green
+};
 
 /**
  * A class which manages the execution of a set of tasks with interdependencies.
@@ -41,6 +75,7 @@ export class OperationExecutionManager {
   private readonly _executionRecords: Set<OperationExecutionRecord>;
   private readonly _quietMode: boolean;
   private readonly _parallelism: number;
+  private readonly _showTimeline: boolean;
   private readonly _totalOperations: number;
 
   private readonly _outputWritable: TerminalWritable;
@@ -55,9 +90,10 @@ export class OperationExecutionManager {
   private _completedOperations: number;
 
   public constructor(operations: Set<Operation>, options: IOperationExecutionManagerOptions) {
-    const { quietMode, debugMode, parallelism, changedProjectsOnly } = options;
+    const { quietMode, debugMode, parallelism, showTimeline, changedProjectsOnly } = options;
     this._completedOperations = 0;
     this._quietMode = quietMode;
+    this._showTimeline = showTimeline;
     this._hasAnyFailures = false;
     this._hasAnyNonAllowedWarnings = false;
     this._changedProjectsOnly = changedProjectsOnly;
@@ -228,6 +264,10 @@ export class OperationExecutionManager {
     );
 
     this._printOperationStatus();
+
+    if (this._showTimeline) {
+      this._printTimeline();
+    }
 
     if (this._hasAnyFailures) {
       this._terminal.writeStderrLine(colors.red('Operations failed.') + '\n');
@@ -547,5 +587,132 @@ export class OperationExecutionManager {
 
     this._terminal.writeStdoutLine(leftPart + rightPart);
     this._terminal.writeStdoutLine('');
+  }
+
+  /**
+   * Print a more detailed timeline and analysis of CPU usage for the build.
+   */
+  private _printTimeline(): void {
+    //
+    // Gather the operation records we'll be displaying
+    //
+
+    const operations: OperationExecutionRecord[] = [];
+
+    for (const operation of this._executionRecords) {
+      if (operation.stopwatch.startTime && operation.stopwatch.endTime) {
+        operations.push(operation);
+      }
+    }
+
+    operations.sort((a, b) => a.stopwatch.startTime! - b.stopwatch.startTime!);
+
+    //
+    // Determine timing for all tasks (wall clock and execution times)
+    //
+
+    const allStart: number = operations[0].stopwatch.startTime!;
+    const allEnd: number = Math.max(...operations.map((operation) => operation.stopwatch.endTime!));
+    const allDuration: number = allEnd - allStart;
+    const workDuration: number = operations
+      .map((operation) => operation.stopwatch.duration)
+      .reduce((sum, value) => sum + value);
+
+    //
+    // Do some calculations to determine what size timeline chart we need.
+    //
+
+    const maxNameLength: number = Math.max(...operations.map((operation) => operation.name.length));
+    const maxDurationLength: number = Math.max(
+      ...operations.map((operation) => operation.stopwatch.duration.toFixed(1).length + 1)
+    );
+    const chartWidth: number = TIMELINE_WIDTH - maxNameLength - maxDurationLength - 3;
+    //
+    // Loop through all operations, assembling some statistics about operations and
+    // phases, if applicable.
+    //
+
+    const output: string[] = [];
+
+    const durationByPhase: Map<string, number> = new Map();
+
+    const busyCpus: number[] = Array(this._parallelism).fill(-1);
+
+    output.push('='.repeat(TIMELINE_WIDTH));
+
+    for (const operation of operations) {
+      // Track time by phase
+      const phaseMatch: RegExpMatchArray | null = operation.name.match(/\((.+)\)$/);
+      if (phaseMatch) {
+        durationByPhase.set(
+          phaseMatch[1],
+          (durationByPhase.get(phaseMatch[1]) || 0) + operation.stopwatch.duration
+        );
+      }
+
+      // Track busy CPUs
+      const openCpu: number = busyCpus.findIndex((end) => end === -1 || end < operation.stopwatch.startTime!);
+      busyCpus[openCpu] = operation.stopwatch.endTime!;
+
+      // Build timeline chart
+
+      const startIdx: number = Math.floor(
+        ((operation.stopwatch.startTime! - allStart) * chartWidth) / allDuration
+      );
+      const endIdx: number = Math.floor(
+        ((operation.stopwatch.endTime! - allStart) * chartWidth) / allDuration
+      );
+      const length: number = endIdx - startIdx + 1;
+
+      const chart: string =
+        colors.gray('-'.repeat(startIdx)) +
+        TIMELINE_CHART_COLORIZER[operation.status](TIMELINE_CHART_SYMBOLS[operation.status].repeat(length)) +
+        colors.gray('-'.repeat(chartWidth - endIdx));
+      output.push(
+        colors.cyan(operation.name.padEnd(maxNameLength)) +
+          ' ' +
+          chart +
+          ' ' +
+          colors.white((operation.stopwatch.duration.toFixed(1) + 's').padStart(maxDurationLength))
+      );
+    }
+
+    output.push('='.repeat(TIMELINE_WIDTH));
+
+    //
+    // Format legend and summary areas
+    //
+
+    const usedCpus: number = busyCpus.filter((cpu) => cpu !== -1).length;
+
+    const legend: string[] = ['LEGEND:', '  [#] Success  [!] Failed/warnings  [%] Skipped/cached'];
+
+    const summary: string[] = [
+      'Total Work: ' + workDuration.toFixed(1) + 's',
+      'Wall Clock: ' + (allDuration / 1000).toFixed(1) + 's',
+      `Parallelism Used: ${usedCpus}/${this._parallelism}`
+    ];
+
+    output.push(legend[0] + summary[0].padStart(TIMELINE_WIDTH - legend[0].length));
+    output.push(legend[1] + summary[1].padStart(TIMELINE_WIDTH - legend[1].length));
+    output.push(summary[2].padStart(TIMELINE_WIDTH));
+
+    //
+    // Include time-by-phase, if phases are enabled
+    //
+
+    if (durationByPhase.size > 0) {
+      output.push('BY PHASE:');
+
+      const maxPhaseName: number = Math.max(16, ...[...durationByPhase.keys()].map((name) => name.length));
+
+      for (const [phase, duration] of durationByPhase.entries()) {
+        output.push('  ' + colors.cyan(phase.padEnd(maxPhaseName)) + duration.toFixed(1).padStart(8) + 's');
+      }
+    }
+
+    output.push('');
+
+    this._terminal.writeStdoutLine(output.join('\n'));
   }
 }

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -68,6 +68,7 @@ describe(OperationExecutionManager.name, () => {
             quietMode: false,
             debugMode: false,
             parallelism: 'tequila',
+            showTimeline: false,
             changedProjectsOnly: false,
             destination: mockWritable
           })
@@ -81,6 +82,7 @@ describe(OperationExecutionManager.name, () => {
         quietMode: false,
         debugMode: false,
         parallelism: '1',
+        showTimeline: false,
         changedProjectsOnly: false,
         destination: mockWritable
       };
@@ -137,6 +139,7 @@ describe(OperationExecutionManager.name, () => {
           quietMode: false,
           debugMode: false,
           parallelism: '1',
+          showTimeline: false,
           changedProjectsOnly: false,
           destination: mockWritable
         };
@@ -171,6 +174,7 @@ describe(OperationExecutionManager.name, () => {
           quietMode: false,
           debugMode: false,
           parallelism: '1',
+          showTimeline: false,
           changedProjectsOnly: false,
           destination: mockWritable
         };

--- a/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/apps/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -200,6 +200,29 @@ describe(OperationExecutionManager.name, () => {
         expect(allMessages).toContain('Warning: step 1 succeeded with warnings');
         expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
       });
+
+      it('logs warnings correctly with --timeline option', async () => {
+        executionManagerOptions.showTimeline = true;
+
+        executionManager = createExecutionManager(
+          executionManagerOptions,
+          new MockOperationRunner(
+            'success with warnings (success)',
+            async (terminal: CollatedTerminal) => {
+              terminal.writeStdoutLine('Build step 1' + EOL);
+              terminal.writeStdoutLine('Warning: step 1 succeeded with warnings' + EOL);
+              return OperationStatus.SuccessWithWarning;
+            },
+            /* warningsAreAllowed */ true
+          )
+        );
+
+        await executionManager.executeAsync();
+        const allMessages: string = mockWritable.getAllOutput();
+        expect(allMessages).toContain('Build step 1');
+        expect(allMessages).toContain('Warning: step 1 succeeded with warnings');
+        expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
+      });
     });
   });
 });

--- a/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/apps/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -401,3 +401,142 @@ Array [
   },
 ]
 `;
+
+exports[`OperationExecutionManager Warning logging Success on warning logs warnings correctly with --timeline option 1`] = `
+Array [
+  Object {
+    "kind": "O",
+    "text": "Selected 1 operation:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  success with warnings (success)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Executing a maximum of 1 simultaneous processes...
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]success with warnings (success)[default] [gray]]==============================[[default] [white]1 of 1[default] [gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Build step 1
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Warning: step 1 succeeded with warnings
+
+",
+  },
+  Object {
+    "kind": "E",
+    "text": "[yellow]\\"success with warnings (success)\\" completed with warnings in 0.10 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "=============================================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[cyan]success with warnings (success)[default] [yellow]!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!![default] [white]0.2s[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "=============================================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "LEGEND:                                                                                      Total Work: 0.2s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                       Wall Clock: 0.2s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "                                                                                        Parallelism Used: 1/1
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "BY PHASE:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [cyan]success         [default]     0.2s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+]
+`;

--- a/apps/rush-lib/src/utilities/Stopwatch.ts
+++ b/apps/rush-lib/src/utilities/Stopwatch.ts
@@ -102,4 +102,18 @@ export class Stopwatch {
 
     return (curTime - this._startTime) / 1000.0;
   }
+
+  /**
+   * Return the start time of the most recent stopwatch run.
+   */
+  public get startTime(): number | undefined {
+    return this._startTime;
+  }
+
+  /**
+   * Return the end time of the most recent stopwatch run.
+   */
+  public get endTime(): number | undefined {
+    return this._endTime;
+  }
 }

--- a/common/changes/@microsoft/rush/enelson-timeline-chart_2022-03-30-16-14.json
+++ b/common/changes/@microsoft/rush/enelson-timeline-chart_2022-03-30-16-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add --timeline option for more detail generated at end of rush build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

For rush bulk actions that support parallelism (like `build`), support an additional `--timeline` flag parameter that generates additional detail about the build timeline.

Although interesting locally, the primary goal is to add a single flag that can be used in CI environments so that monorepo administrators can easily compare the behavior of `rush build` on different machines, operating systems, with different project selector flags, etc.

## Details

Original output proposed in https://github.com/microsoft/rushstack/pull/3139, this one cleans it up and adjusts the naming post-phased-builds.

> In our monorepo, having a flag like this would be _very_ useful -- we're currently experimenting with different hardware for our builds and more details about how many CPUs we can effectively make use of, etc., across different pipelines and PR builds, would be great to have on-hand for every build.

Open to any additional feedback on the naming or logic!

## How it was tested

- Tested a variety of scenarios in Rushstack (with phased build support) and in our local monorepo (not yet upgraded to phased builds).

Example output (mixed from-cache / build):

```console
=============================================================================================================
@rushstack/tree-pattern (build)           %------------------------------------------------------------  0.3s
@rushstack/eslint-patch (build)           %------------------------------------------------------------  0.1s
@rushstack/eslint-plugin-security (build) %------------------------------------------------------------  0.1s
@rushstack/eslint-plugin-packlets (build) %------------------------------------------------------------  0.1s
@rushstack/eslint-plugin (build)          %------------------------------------------------------------  0.1s
@rushstack/tree-pattern (test)            %------------------------------------------------------------  0.1s
@rushstack/eslint-patch (test)            %------------------------------------------------------------  0.0s
@rushstack/eslint-plugin-security (test)  %------------------------------------------------------------  0.0s
@rushstack/eslint-plugin (test)           %------------------------------------------------------------  0.0s
@rushstack/eslint-config (build)          %------------------------------------------------------------  0.0s
@rushstack/eslint-plugin-packlets (test)  %------------------------------------------------------------  0.0s
@rushstack/ts-command-line (build)        ##############-----------------------------------------------  9.8s
@rushstack/rig-package (build)            %------------------------------------------------------------  0.1s
@rushstack/node-core-library (build)      %------------------------------------------------------------  0.2s
@rushstack/eslint-config (test)           %------------------------------------------------------------  0.0s
@rushstack/rig-package (test)             %------------------------------------------------------------  0.0s
@microsoft/api-extractor-model (build)    %%-----------------------------------------------------------  0.8s
@rushstack/heft-config-file (build)       %%-----------------------------------------------------------  0.7s
@rushstack/node-core-library (test)       %%-----------------------------------------------------------  0.6s
@rushstack/heft-config-file (test)        -%-----------------------------------------------------------  0.0s
@microsoft/api-extractor-model (test)     -%-----------------------------------------------------------  0.0s
@microsoft/api-extractor (build)          -------------#####################--------------------------- 14.9s
@rushstack/ts-command-line (test)         -------------#########---------------------------------------  6.3s
@microsoft/api-extractor (test)           ---------------------------------#############---------------  9.1s
@rushstack/heft (build)                   ---------------------------------#####################------- 15.3s
@rushstack/heft (test)                    -----------------------------------------------------########  5.3s
=============================================================================================================
LEGEND:                                                                                     Total Work: 64.0s
  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                      Wall Clock: 45.7s
                                                                                       Parallelism Used: 6/16
BY PHASE:
  build               42.6s
  test                21.5s

rush build (45.74 seconds)
```

Example output (a blocking failure):

```console
=============================================================================================================
@hbo/hbo-node-rig            %-------------------------------------------------------------------------- 0.0s
@hbo/hbo-web-barebones-rig   %-------------------------------------------------------------------------- 0.0s
@hbo/eslint-abcdef-abcdefghi !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 1.9s
=============================================================================================================
LEGEND:                                                                                      Total Work: 1.9s
  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                       Wall Clock: 1.9s
                                                                                       Parallelism Used: 1/16
```

Example output (rebuild):

```console
=============================================================================================================
@rushstack/tree-pattern (build)           ###----------------------------------------------------------  4.8s
@rushstack/eslint-patch (build)           ##-----------------------------------------------------------  2.7s
@rushstack/eslint-patch (test)            -%-----------------------------------------------------------  0.0s
@rushstack/eslint-plugin-security (build) --####-------------------------------------------------------  4.6s
@rushstack/eslint-plugin-packlets (build) --#####------------------------------------------------------  5.4s
@rushstack/eslint-plugin (build)          --#####------------------------------------------------------  6.6s
@rushstack/tree-pattern (test)            --###--------------------------------------------------------  3.0s
@rushstack/eslint-plugin-security (test)  -----##########---------------------------------------------- 14.0s
@rushstack/eslint-plugin-packlets (test)  ------####---------------------------------------------------  5.1s
@rushstack/eslint-config (build)          ------%------------------------------------------------------  0.0s
@rushstack/eslint-plugin (test)           ------##############----------------------------------------- 20.0s
@rushstack/ts-command-line (build)        -------#############----------------------------------------- 21.1s
@rushstack/rig-package (build)            -------#############----------------------------------------- 20.9s
@rushstack/node-core-library (build)      -------################-------------------------------------- 25.0s
@rushstack/eslint-config (test)           -------%-----------------------------------------------------  0.0s
@rushstack/rig-package (test)             -------------------######------------------------------------  8.0s
@rushstack/ts-command-line (test)         -------------------#########--------------------------------- 12.0s
@microsoft/api-extractor-model (build)    ----------------------#################---------------------- 27.0s
@rushstack/heft-config-file (build)       ----------------------################----------------------- 24.4s
@rushstack/node-core-library (test)       ----------------------############--------------------------- 19.0s
@rushstack/heft-config-file (test)        -------------------------------------###---------------------  4.7s
@microsoft/api-extractor (build)          --------------------------------------###########------------ 15.6s
@microsoft/api-extractor-model (test)     --------------------------------------####-------------------  4.1s
@microsoft/api-extractor (test)           ------------------------------------------------######-------  8.7s
@rushstack/heft (build)                   ------------------------------------------------##########--- 14.6s
@rushstack/heft (test)                    ---------------------------------------------------------####  4.7s
=============================================================================================================
LEGEND:                                                                                    Total Work: 276.2s
  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                      Wall Clock: 98.5s
                                                                                       Parallelism Used: 7/16
BY PHASE:
  build              172.8s
  test               103.3s

rush rebuild (1 minute 38.5 seconds)
```
