### PR TITLE
[heft-jest-plugin] Add --run-in-band flag

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/junker-add-run-in-band_2022-03-30-16-10.json
+++ b/common/changes/@rushstack/heft-jest-plugin/junker-add-run-in-band_2022-03-30-16-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Add \"--run-in-band\" flag to trigger Jest's \"--runInBand\" option",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -70,6 +70,7 @@ export interface IJestPluginOptions {
   findRelatedTests?: ReadonlyArray<string>;
   maxWorkers?: string;
   passWithNoTests?: boolean;
+  runInBand?: boolean;
   silent?: boolean;
   testNamePattern?: string;
   testPathPattern?: ReadonlyArray<string>;
@@ -176,7 +177,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       watch: testStageProperties.watchMode,
 
       // In debug mode, avoid forking separate processes that are difficult to debug
-      runInBand: debugMode,
+      runInBand: debugMode || options?.runInBand,
       debug: debugMode,
       detectOpenHandles: options?.detectOpenHandles || false,
 
@@ -648,6 +649,15 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
     });
     */
 
+    const runInBandFlag: IHeftFlagParameter = heftSession.commandLine.registerFlagParameter({
+      associatedActionNames: ['test'],
+      parameterLongName: '--run-in-band',
+      environmentVariable: 'HEFT_JEST_RUN_IN_BAND',
+      description:
+        'Run tests in serial using a single process.' +
+        ' This corresponds to the "--runInBand" parameter in Jest\'s documentation.'
+    });
+
     const silent: IHeftFlagParameter = heftSession.commandLine.registerFlagParameter({
       associatedActionNames: ['test'],
       parameterLongName: '--silent',
@@ -708,6 +718,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         maxWorkers: maxWorkers.value,
         // Temporary workaround for https://github.com/microsoft/rushstack/issues/2759
         passWithNoTests: true, // this._passWithNoTests.value,
+        runInBand: runInBandFlag.value,
         silent: silent.value,
         testNamePattern: testNamePattern.value,
         testPathPattern: testPathPattern.value,


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->
The `--runInBand` flag in Jest can provide a significant speedup when running tests in some circumstances. This PR adds a flag to `heft test` to enable it. It also adds an environment variable, `HEFT_JEST_RUN_IN_BAND` to enable the flag in CI.


## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I added this flag to the `JestPlugin` class inside `heft-jest-plugin` because that's where other Jest flags are. I saw that some flags are specified in `apps/heft/src/cli/actions/TestAction.ts`, but that most of them have recently moved into `JestPlugin`.

This change does not break backwards compatibility.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I ran tests on a single project in a private Rush monorepo, using the `--no-build` flag. Without `--run-in-band` tests take 13-14 seconds. With `--run-in-band` tests take just over 3 seconds. I confirmed that this works when using the `HEFT_JEST_RUN_IN_BAND=1` environment variable as well. I also verified that using the `--debug` flag still causes the tests to run in-band.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
