### PR TITLE
[localization-plugin] Fix a small tsdoc error

### DIFF
--- a/common/changes/@rushstack/localization-plugin/enelson-resx-data_2022-04-04-12-52.json
+++ b/common/changes/@rushstack/localization-plugin/enelson-resx-data_2022-04-04-12-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/localization-plugin"
+}

--- a/webpack/localization-plugin/src/interfaces.ts
+++ b/webpack/localization-plugin/src/interfaces.ts
@@ -122,7 +122,7 @@ export interface ILocalizedData {
   normalizeResxNewlines?: 'lf' | 'crlf';
 
   /**
-   * If set to true, do not warn on missing RESX <data> element comments.
+   * If set to true, do not warn on missing RESX `<data>` element comments.
    */
   ignoreMissingResxComments?: boolean;
 }


### PR DESCRIPTION
## Summary

Wrap invalid HTML tag in backticks, so that it renders as a code snippet.

## Details

Writing unescaped (un-backticked) "tags" in TSdoc comments causes downstream processes (such as the docusaurus API build) to fail.

Detecting this at build time is still on the todo list (https://github.com/microsoft/rushstack/issues/2973), this PR just fixes the one-off issue.

## How it was tested

 - Confirmed that the `rushstack-websites` repo can build again.
