### PR TITLE
[rush-azure-storage-build-cache-plugin] Add plugin for Azure authentication prompt

### DIFF
--- a/apps/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginManager.ts
@@ -53,8 +53,10 @@ export class PluginManager {
     const builtInPluginConfigurations: IBuiltInPluginConfiguration[] = options.builtInPluginConfigurations;
 
     const ownPackageJsonDependencies: Record<string, string> = require('../../package.json').dependencies;
-    function tryAddBuiltInPlugin(builtInPluginName: string): void {
-      const pluginPackageName: string = `@rushstack/${builtInPluginName}`;
+    function tryAddBuiltInPlugin(builtInPluginName: string, pluginPackageName?: string): void {
+      if (!pluginPackageName) {
+        pluginPackageName = `@rushstack/${builtInPluginName}`;
+      }
       if (ownPackageJsonDependencies[pluginPackageName]) {
         builtInPluginConfigurations.push({
           packageName: pluginPackageName,
@@ -69,6 +71,10 @@ export class PluginManager {
 
     tryAddBuiltInPlugin('rush-amazon-s3-build-cache-plugin');
     tryAddBuiltInPlugin('rush-azure-storage-build-cache-plugin');
+    tryAddBuiltInPlugin(
+      'rush-azure-interactive-auth-plugin',
+      '@rushstack/rush-azure-storage-build-cache-plugin'
+    );
 
     this._builtInPluginLoaders = builtInPluginConfigurations.map((pluginConfiguration) => {
       return new BuiltInPluginLoader({

--- a/apps/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/apps/rush-lib/src/pluginFramework/PluginManager.ts
@@ -71,6 +71,9 @@ export class PluginManager {
 
     tryAddBuiltInPlugin('rush-amazon-s3-build-cache-plugin');
     tryAddBuiltInPlugin('rush-azure-storage-build-cache-plugin');
+    // This is a secondary plugin inside the `@rushstack/rush-azure-storage-build-cache-plugin`
+    // package. Because that package comes with Rush (for now), it needs to get registered here.
+    // If the necessary config file doesn't exist, this plugin doesn't do anything.
     tryAddBuiltInPlugin(
       'rush-azure-interactive-auth-plugin',
       '@rushstack/rush-azure-storage-build-cache-plugin'

--- a/apps/rush/src/start-dev.ts
+++ b/apps/rush/src/start-dev.ts
@@ -11,8 +11,10 @@ import { RushCommandSelector } from './RushCommandSelector';
 
 const builtInPluginConfigurations: rushLib._IBuiltInPluginConfiguration[] = [];
 
-function includePlugin(pluginName: string): void {
-  const pluginPackageName: string = `@rushstack/${pluginName}`;
+function includePlugin(pluginName: string, pluginPackageName?: string): void {
+  if (!pluginPackageName) {
+    pluginPackageName = `@rushstack/${pluginName}`;
+  }
   builtInPluginConfigurations.push({
     packageName: pluginPackageName,
     pluginName: pluginName,
@@ -25,6 +27,8 @@ function includePlugin(pluginName: string): void {
 
 includePlugin('rush-amazon-s3-build-cache-plugin');
 includePlugin('rush-azure-storage-build-cache-plugin');
+// Including this here so that developers can reuse it without installing the plugin a second time
+includePlugin('rush-azure-interactive-auth-plugin', '@rushstack/rush-azure-storage-build-cache-plugin');
 
 const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 RushCommandSelector.execute(currentPackageVersion, rushLib, {

--- a/common/changes/@microsoft/rush/rush-azure-interactive-auth-plugin_2022-04-04-21-31.json
+++ b/common/changes/@microsoft/rush/rush-azure-interactive-auth-plugin_2022-04-04-21-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add an additional plugin to rush-azure-storage-build-cache-plugin that can be used to prompt for Azure authentication before a command runs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -43,7 +43,7 @@ export class AzureStorageAuthentication {
     tryGetCachedCredentialAsync(): Promise<string | undefined>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
-    updateCachedCredentialInteractiveAsync(terminal: ITerminal, expiresOn?: Date): Promise<void>;
+    updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresAfter?: Date): Promise<void>;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -43,8 +43,7 @@ export class AzureStorageAuthentication {
     tryGetCachedCredentialAsync(): Promise<string | undefined>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
-    // (undocumented)
-    updateCachedCredentialInteractiveAsync(terminal: ITerminal): Promise<void>;
+    updateCachedCredentialInteractiveAsync(terminal: ITerminal, expiresOn?: Date): Promise<void>;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/rush-plugin-manifest.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/rush-plugin-manifest.json
@@ -6,6 +6,12 @@
       "description": "Rush plugin for Azure storage cloud build cache",
       "entryPoint": "lib/index.js",
       "optionsSchema": "lib/schemas/azure-blob-storage-config.schema.json"
+    },
+    {
+      "pluginName": "rush-azure-interactive-auth-plugin",
+      "description": "Rush plugin for interactive authentication to Azure",
+      "entryPoint": "lib/RushAzureInteractiveAuthPlugin.js",
+      "optionsSchema": "lib/schemas/azure-interactive-auth.schema.json"
     }
   ]
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -100,19 +100,20 @@ export class AzureStorageAuthentication {
    * Launches an interactive flow to renew a cached credential.
    *
    * @param terminal - The terminal to log output to
-   * @param expiresOn - If specified, and a cached credential exists that is still valid after `expiresOn`, no action will be taken.
+   * @param onlyIfExistingCredentialExpiresAfter - If specified, and a cached credential exists that is still valid
+   * after the date specified, no action will be taken.
    */
-  public async updateCachedCredentialInteractiveAsync(terminal: ITerminal, expiresOn?: Date): Promise<void> {
+  public async updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresAfter?: Date): Promise<void> {
     await CredentialCache.usingAsync(
       {
         supportEditing: true
       },
       async (credentialsCache: CredentialCache) => {
-        if (expiresOn) {
-          const expiry: Date | undefined = credentialsCache.tryGetCacheEntry(
+        if (onlyIfExistingCredentialExpiresAfter) {
+          const existingCredentialExpiration: Date | undefined = credentialsCache.tryGetCacheEntry(
             this._credentialCacheId
           )?.expires;
-          if (expiry && expiry > expiresOn) {
+          if (existingCredentialExpiration && existingCredentialExpiration > onlyIfExistingCredentialExpiresAfter) {
             return;
           }
         }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IRushPlugin, RushSession, RushConfiguration, ILogger } from '@rushstack/rush-sdk';
+import type { AzureEnvironmentNames } from './AzureStorageAuthentication';
+
+const PLUGIN_NAME: 'AzureInteractiveAuthPlugin' = 'AzureInteractiveAuthPlugin';
+
+/**
+ * @public
+ */
+export interface IAzureInteractiveAuthOptions {
+  /**
+   * The name of the the Azure storage account to authenticate to.
+   */
+  readonly storageAccountName: string;
+
+  /**
+   * The name of the container in the Azure storage account to authenticate to.
+   */
+  readonly storageContainerName: string;
+
+  /**
+   * The Azure environment the storage account exists in. Defaults to AzureCloud.
+   */
+  readonly azureEnvironment?: AzureEnvironmentNames;
+
+  /**
+   * If specified and a credential exists that will be valid for at least this many minutes from the time
+   * of execution, no action will be taken.
+   */
+  readonly minimumValidityInMinutes?: number;
+
+  /**
+   * The set of Rush global commands before which credentials should be updated.
+   */
+  readonly globalCommands?: string[];
+
+  /**
+   * The set of Rush phased commands before which credentials should be updated.
+   */
+  readonly phasedCommands?: string[];
+}
+
+/**
+ * This plugin is for performing interactive authentication to an arbitrary Azure blob storage account.
+ * It is meant to be used for scenarios where custom commands may interact with Azure blob storage beyond
+ * the scope of the build cache (for build cache, use the RushAzureStorageBuildCachePlugin).
+ *
+ * However, since the authentication has the same dependencies, if the repository already uses the build
+ * cache plugin, the additional functionality for authentication can be provided at minimal cost.
+ *
+ * @public
+ */
+export default class RushAzureInteractieAuthPlugin implements IRushPlugin {
+  private readonly _options: IAzureInteractiveAuthOptions | undefined;
+
+  public readonly pluginName: 'AzureInteractiveAuthPlugin' = PLUGIN_NAME;
+
+  public constructor(options: IAzureInteractiveAuthOptions | undefined) {
+    this._options = options;
+  }
+
+  public apply(rushSession: RushSession, rushConfig: RushConfiguration): void {
+    const options: IAzureInteractiveAuthOptions | undefined = this._options;
+
+    if (!options) {
+      // Plugin is not enabled.
+      return;
+    }
+
+    const { globalCommands, phasedCommands } = options;
+
+    const { hooks } = rushSession;
+
+    const handler: () => Promise<void> = async () => {
+      const { AzureStorageAuthentication } = await import('./AzureStorageAuthentication');
+      const {
+        storageAccountName,
+        storageContainerName,
+        azureEnvironment = 'AzurePublicCloud',
+        minimumValidityInMinutes
+      } = options;
+
+      const logger: ILogger = rushSession.getLogger(PLUGIN_NAME);
+      logger.terminal.writeLine(
+        `Authenticating to Azure container "${storageContainerName}" on account "${storageAccountName}" in environment "${azureEnvironment}".`
+      );
+
+      let minimumExpiry: Date | undefined;
+      if (typeof minimumValidityInMinutes === 'number') {
+        minimumExpiry = new Date(Date.now() + minimumValidityInMinutes * 60 * 1000);
+      }
+
+      await new AzureStorageAuthentication({
+        storageAccountName: storageAccountName,
+        storageContainerName: storageContainerName,
+        azureEnvironment: options.azureEnvironment,
+        isCacheWriteAllowed: true
+      }).updateCachedCredentialInteractiveAsync(logger.terminal, minimumExpiry);
+    };
+
+    if (globalCommands) {
+      for (const commandName of globalCommands) {
+        hooks.runGlobalCustomCommand.for(commandName).tapPromise(PLUGIN_NAME, handler);
+      }
+    }
+
+    if (phasedCommands) {
+      for (const commandName of phasedCommands) {
+        hooks.runPhasedCommand.for(commandName).tapPromise(PLUGIN_NAME, handler);
+      }
+    }
+  }
+}

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Configuration for Azure interactive auth prompt",
+
+  "type": "object",
+
+  "additionalProperties": false,
+
+  "required": ["storageAccountName", "storageContainerName"],
+
+  "properties": {
+    "storageAccountName": {
+      "type": "string",
+      "description": "(Required) The name of the the Azure storage account to authenticate to."
+    },
+
+    "storageContainerName": {
+      "type": "string",
+      "description": "(Required) The name of the container in the Azure storage account to authenticate to."
+    },
+
+    "azureEnvironment": {
+      "type": "string",
+      "description": "The Azure environment the storage account exists in. Defaults to AzurePublicCloud.",
+      "enum": ["AzurePublicCloud", "AzureChina", "AzureGermany", "AzureGovernment"]
+    },
+
+    "minimumValidityInMinutes": {
+      "type": "number",
+      "description": "If specified and a credential exists that will be valid for at least this many minutes from the time of execution, no action will be taken."
+    },
+
+    "globalCommands": {
+      "type": "array",
+      "description": "The set of global rush commands before which this plugin should update credentials.",
+      "items": {
+        "type": "string"
+      }
+    },
+
+    "phasedCommands": {
+      "type": "array",
+      "description": "The set of phased rush commands before which this plugin should update credentials.",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a separately callable plugin to the `@rushstack/rush-azure-storage-build-cache-plugin` that can be used to refresh Azure credentials at the start of a rush command. Expected usage is to prompt a user immediately if authentication is required to a dev-deployment storage account or similar.

## Details
Leverages the existing infrastructure in the plugin to perform an interactive auth prompt, but as a separately named plugin. Configuration for the storage account is read from the plugin configuration.

Until such time as the Azure Storage build cache plugin is removed from the default install (Rush 6 release), this plugin is enabled by default but doesn't take any action unless a config file is provided.

## How it was tested
Configured the plugin in the repo and bound it to the `rush build` action temporarily. Verified the presence of an auth prompt when running `rush build` but not when running `rush start` (since the plugin was not configured to run when `rush start` was invoked).