### PR TITLE
[rush] Fix a few issues with the way "rush add" selects versions.

### DIFF
--- a/apps/rush-lib/src/cli/actions/AddAction.ts
+++ b/apps/rush-lib/src/cli/actions/AddAction.ts
@@ -3,7 +3,6 @@
 
 import * as os from 'os';
 import * as semver from 'semver';
-import { Import } from '@rushstack/node-core-library';
 import { CommandLineFlagParameter, CommandLineStringListParameter } from '@rushstack/ts-command-line';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
@@ -11,11 +10,7 @@ import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { DependencySpecifier } from '../../logic/DependencySpecifier';
 
-import type * as PackageJsonUpdaterTypes from '../../logic/PackageJsonUpdater';
-const packageJsonUpdaterModule: typeof PackageJsonUpdaterTypes = Import.lazy(
-  '../../logic/PackageJsonUpdater',
-  require
-);
+import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
 
 export class AddAction extends BaseRushAction {
   private _allFlag!: CommandLineFlagParameter;
@@ -117,10 +112,10 @@ export class AddAction extends BaseRushAction {
       );
     }
 
+    const packageJsonUpdater: typeof PackageJsonUpdaterType = await import('../../logic/PackageJsonUpdater');
+
     const specifiedPackageNameList: ReadonlyArray<string> = this._packageNameList.values!;
-    const packageNames: string[] = [];
-    const initialVersions: Map<string, string | undefined> = new Map();
-    const rangeStyles: Map<string, PackageJsonUpdaterTypes.SemVerStyle> = new Map();
+    const packagesToAdd: PackageJsonUpdaterType.IRushAddPackage[] = [];
 
     for (const specifiedPackageName of specifiedPackageNameList) {
       /**
@@ -149,13 +144,11 @@ export class AddAction extends BaseRushAction {
           throw new Error(`The SemVer specifier "${version}" is not valid.`);
         }
       }
-      packageNames.push(packageName);
-      initialVersions.set(packageName, version);
 
       /**
        * RangeStyle
        */
-      let rangeStyle: PackageJsonUpdaterTypes.SemVerStyle;
+      let rangeStyle: PackageJsonUpdaterType.SemVerStyle;
       if (version && version !== 'latest') {
         if (this._exactFlag.value || this._caretFlag.value) {
           throw new Error(
@@ -164,29 +157,30 @@ export class AddAction extends BaseRushAction {
           );
         }
 
-        rangeStyle = packageJsonUpdaterModule.SemVerStyle.Passthrough;
+        rangeStyle = packageJsonUpdater.SemVerStyle.Passthrough;
       } else {
         rangeStyle = this._caretFlag.value
-          ? packageJsonUpdaterModule.SemVerStyle.Caret
+          ? packageJsonUpdater.SemVerStyle.Caret
           : this._exactFlag.value
-          ? packageJsonUpdaterModule.SemVerStyle.Exact
-          : packageJsonUpdaterModule.SemVerStyle.Tilde;
+          ? packageJsonUpdater.SemVerStyle.Exact
+          : packageJsonUpdater.SemVerStyle.Tilde;
       }
-      rangeStyles.set(packageName, rangeStyle);
+
+      packagesToAdd.push({ packageName, version, rangeStyle });
     }
 
-    const updater: PackageJsonUpdaterTypes.PackageJsonUpdater =
-      new packageJsonUpdaterModule.PackageJsonUpdater(this.rushConfiguration, this.rushGlobalFolder);
+    const updater: PackageJsonUpdaterType.PackageJsonUpdater = new packageJsonUpdater.PackageJsonUpdater(
+      this.rushConfiguration,
+      this.rushGlobalFolder
+    );
 
     await updater.doRushAdd({
       projects: projects,
-      packageNames,
-      initialVersions,
+      packagesToAdd,
       devDependency: this._devDependencyFlag.value,
       updateOtherPackages: this._makeConsistentFlag.value,
       skipUpdate: this._skipUpdateFlag.value,
-      debugInstall: this.parser.isDebug,
-      rangeStyles
+      debugInstall: this.parser.isDebug
     });
   }
 }

--- a/apps/rush-lib/src/cli/actions/AddAction.ts
+++ b/apps/rush-lib/src/cli/actions/AddAction.ts
@@ -115,7 +115,7 @@ export class AddAction extends BaseRushAction {
     const packageJsonUpdater: typeof PackageJsonUpdaterType = await import('../../logic/PackageJsonUpdater');
 
     const specifiedPackageNameList: ReadonlyArray<string> = this._packageNameList.values!;
-    const packagesToAdd: PackageJsonUpdaterType.IRushAddPackage[] = [];
+    const packagesToAdd: PackageJsonUpdaterType.IPackageForRushAdd[] = [];
 
     for (const specifiedPackageName of specifiedPackageNameList) {
       /**

--- a/apps/rush-lib/src/cli/actions/test/AddAction.test.ts
+++ b/apps/rush-lib/src/cli/actions/test/AddAction.test.ts
@@ -3,7 +3,7 @@
 
 import '../../test/mockRushCommandLineParser';
 
-import { PackageJsonUpdater } from '../../../logic/PackageJsonUpdater';
+import { IPackageJsonUpdaterRushAddOptions, PackageJsonUpdater } from '../../../logic/PackageJsonUpdater';
 import { RushCommandLineParser } from '../../RushCommandLineParser';
 import { AddAction } from '../AddAction';
 
@@ -47,9 +47,18 @@ describe(AddAction.name, () => {
 
         await expect(parser.execute()).resolves.toEqual(true);
         expect(doRushAddMock).toHaveBeenCalledTimes(1);
-        expect(doRushAddMock.mock.calls[0][0].projects).toHaveLength(1);
-        expect(doRushAddMock.mock.calls[0][0].projects[0].packageName).toEqual('a');
-        expect(doRushAddMock.mock.calls[0][0].packageNames).toContain('assert');
+        const doRushAddOptions: IPackageJsonUpdaterRushAddOptions = doRushAddMock.mock.calls[0][0];
+        expect(doRushAddOptions.projects).toHaveLength(1);
+        expect(doRushAddOptions.projects[0].packageName).toEqual('a');
+        expect(doRushAddOptions.packagesToAdd).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "packageName": "assert",
+              "rangeStyle": "tilde",
+              "version": undefined,
+            },
+          ]
+        `);
       });
     });
 
@@ -72,10 +81,19 @@ describe(AddAction.name, () => {
 
         await expect(parser.execute()).resolves.toEqual(true);
         expect(doRushAddMock).toHaveBeenCalledTimes(1);
-        expect(doRushAddMock.mock.calls[0][0].projects).toHaveLength(2);
-        expect(doRushAddMock.mock.calls[0][0].projects[0].packageName).toEqual('a');
-        expect(doRushAddMock.mock.calls[0][0].projects[1].packageName).toEqual('b');
-        expect(doRushAddMock.mock.calls[0][0].packageNames).toContain('assert');
+        const doRushAddOptions: IPackageJsonUpdaterRushAddOptions = doRushAddMock.mock.calls[0][0];
+        expect(doRushAddOptions.projects).toHaveLength(2);
+        expect(doRushAddOptions.projects[0].packageName).toEqual('a');
+        expect(doRushAddOptions.projects[1].packageName).toEqual('b');
+        expect(doRushAddOptions.packagesToAdd).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "packageName": "assert",
+              "rangeStyle": "tilde",
+              "version": undefined,
+            },
+          ]
+        `);
       });
     });
   });

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -29,7 +29,7 @@ export const enum SemVerStyle {
   Passthrough = 'passthrough'
 }
 
-export interface IRushAddPackage {
+export interface IPackageForRushAdd {
   packageName: string;
 
   /**
@@ -55,7 +55,7 @@ export interface IPackageJsonUpdaterRushAddOptions {
   /**
    * The dependencies to be added.
    */
-  packagesToAdd: IRushAddPackage[];
+  packagesToAdd: IPackageForRushAdd[];
   /**
    * Whether or not this dependency should be added as a devDependency or a regular dependency.
    */
@@ -130,7 +130,7 @@ export class PackageJsonUpdater {
       const existingSpecifiedVersions: Set<string> | undefined = allDependencyVersions.get(packageName);
       let implicitlyPreferredVersion: string | undefined;
       if (existingSpecifiedVersions?.size === 1) {
-        implicitlyPreferredVersion = existingSpecifiedVersions.values().next().value;
+        implicitlyPreferredVersion = Array.from(existingSpecifiedVersions)[0];
       }
 
       const explicitlyPreferredVersion: string | undefined =

--- a/common/changes/@microsoft/rush/fix-rush-add_2022-04-05-03-20.json
+++ b/common/changes/@microsoft/rush/fix-rush-add_2022-04-05-03-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix some issues with \"rush add\"'s ability to determine which version to use when adding a dependency that is already present in the repo.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -656,6 +656,8 @@ export class RushConfiguration {
     get experimentsConfiguration(): ExperimentsConfiguration;
     findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
     findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
+    // @internal (undocumented)
+    _getAllDependencyVersions(variant?: string | undefined): Map<string, Set<string>>;
     getCommittedShrinkwrapFilename(variant?: string | undefined): string;
     getCommonVersions(variant?: string | undefined): CommonVersionsConfiguration;
     getCommonVersionsFilePath(variant?: string | undefined): string;


### PR DESCRIPTION
## Summary

I noticed a few issues with the way `rush add` selects the version to use, so this PR tweaks the behavior a bit.

1. When determining the versions of a dependency that are present in a repo, Rush counted `peerDependencies` as regular dependencies. This doesn't make sense.
2. If there is a pinned version specified in `common-versions.json`, `rush add` didn't just use that. After this change, it will.
3. If a mismatch is detected, it doesn't list out which versions are already present. Now it does.

## How it was tested

Tested by rerunning `rush add` in the repo and with the arguments I used when I initially noticed these quirks.