### PR TITLE
[rush] By default, truncate long lists of package names when running rush check.

### DIFF
--- a/apps/rush-lib/src/cli/actions/CheckAction.ts
+++ b/apps/rush-lib/src/cli/actions/CheckAction.ts
@@ -12,6 +12,7 @@ import { Variants } from '../../api/Variants';
 export class CheckAction extends BaseRushAction {
   private _variant!: CommandLineStringParameter;
   private _jsonFlag!: CommandLineFlagParameter;
+  private _verboseFlag!: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -33,6 +34,12 @@ export class CheckAction extends BaseRushAction {
       parameterLongName: '--json',
       description: 'If this flag is specified, output will be in JSON format.'
     });
+    this._verboseFlag = this.defineFlagParameter({
+      parameterLongName: '--verbose',
+      description:
+        'If this flag is specified, long lists of package names will not be truncated. ' +
+        `This has no effect if the ${this._jsonFlag.longName} flag is also specified.`
+    });
   }
 
   protected async runAsync(): Promise<void> {
@@ -49,7 +56,8 @@ export class CheckAction extends BaseRushAction {
 
     VersionMismatchFinder.rushCheck(this.rushConfiguration, {
       variant: this._variant.value,
-      printAsJson: this._jsonFlag.value
+      printAsJson: this._jsonFlag.value,
+      truncateLongPackageNameLists: !this._verboseFlag.value
     });
   }
 }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -303,7 +303,7 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: check 1`] = `
-"usage: rush check [-h] [--variant VARIANT] [--json]
+"usage: rush check [-h] [--variant VARIANT] [--json] [--verbose]
 
 Checks each project's package.json files and ensures that all dependencies 
 are of the same version throughout the repository.
@@ -314,6 +314,9 @@ Optional arguments:
                      This parameter may alternatively be specified via the 
                      RUSH_VARIANT environment variable.
   --json             If this flag is specified, output will be in JSON format.
+  --verbose          If this flag is specified, long lists of package names 
+                     will not be truncated. This has no effect if the --json 
+                     flag is also specified.
 "
 `;
 

--- a/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -130,6 +130,13 @@ export class VersionMismatchFinder {
 
         if (mismatchFinder.numberOfMismatches > 0) {
           console.log(colors.red(`Found ${mismatchFinder.numberOfMismatches} mis-matching dependencies!`));
+          if (!options.isRushCheckCommand && options.truncateLongPackageNameLists) {
+            // There isn't a --verbose flag in `rush install`/`rush update`, so a long list will always be truncated.
+            console.log(
+              'For more detailed reporting about these version mismatches, use the "rush check --verbose" command.'
+            );
+          }
+
           throw new AlreadyReportedError();
         } else {
           if (options.isRushCheckCommand) {

--- a/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -11,18 +11,21 @@ import { VersionMismatchFinderEntity } from './VersionMismatchFinderEntity';
 import { VersionMismatchFinderProject } from './VersionMismatchFinderProject';
 import { VersionMismatchFinderCommonVersions } from './VersionMismatchFinderCommonVersions';
 
-export interface IVersionMismatchFinderRushCheckOptions {
+const TRUNCATE_AFTER_PACKAGE_NAME_COUNT: number = 5;
+
+export interface IVersionMismatchFinderOptions {
   variant?: string | undefined;
+}
+
+export interface IVersionMismatchFinderRushCheckOptions extends IVersionMismatchFinderOptions {
   printAsJson?: boolean | undefined;
+  truncateLongPackageNameLists?: boolean | undefined;
 }
 
-export interface IVersionMismatchFinderEnsureConsistentVersionsOptions {
-  variant?: string | undefined;
-}
+export interface IVersionMismatchFinderEnsureConsistentVersionsOptions
+  extends IVersionMismatchFinderOptions {}
 
-export interface IVersionMismatchFinderGetMismatchesOptions {
-  variant?: string | undefined;
-}
+export interface IVersionMismatchFinderGetMismatchesOptions extends IVersionMismatchFinderOptions {}
 
 export interface IMismatchDependency {
   dependencyName: string;
@@ -76,7 +79,8 @@ export class VersionMismatchFinder {
   ): void {
     VersionMismatchFinder._checkForInconsistentVersions(rushConfiguration, {
       ...options,
-      isRushCheckCommand: false
+      isRushCheckCommand: false,
+      truncateLongPackageNameLists: true
     });
   }
 
@@ -86,7 +90,7 @@ export class VersionMismatchFinder {
    */
   public static getMismatches(
     rushConfiguration: RushConfiguration,
-    options: IVersionMismatchFinderRushCheckOptions = {}
+    options: IVersionMismatchFinderOptions = {}
   ): VersionMismatchFinder {
     const commonVersions: CommonVersionsConfiguration = rushConfiguration.getCommonVersions(options.variant);
 
@@ -107,6 +111,7 @@ export class VersionMismatchFinder {
       isRushCheckCommand: boolean;
       variant?: string | undefined;
       printAsJson?: boolean | undefined;
+      truncateLongPackageNameLists?: boolean | undefined;
     }
   ): void {
     if (rushConfiguration.ensureConsistentVersions || options.isRushCheckCommand) {
@@ -118,7 +123,7 @@ export class VersionMismatchFinder {
       if (options.printAsJson) {
         mismatchFinder.printAsJson();
       } else {
-        mismatchFinder.print();
+        mismatchFinder.print(options.truncateLongPackageNameLists);
 
         if (mismatchFinder.numberOfMismatches > 0) {
           console.log(colors.red(`Found ${mismatchFinder.numberOfMismatches} mis-matching dependencies!`));
@@ -188,15 +193,34 @@ export class VersionMismatchFinder {
     console.log(JSON.stringify(output, undefined, 2));
   }
 
-  public print(): void {
+  public print(truncateLongPackageNameLists: boolean = false): void {
     // Iterate over the list. For any dependency with mismatching versions, print the projects
     this.getMismatches().forEach((dependency: string) => {
       console.log(colors.yellow(dependency));
       this.getVersionsOfMismatch(dependency)!.forEach((version: string) => {
         console.log(`  ${version}`);
-        this.getConsumersOfMismatch(dependency, version)!.forEach((project: VersionMismatchFinderEntity) => {
-          console.log(`   - ${project.friendlyName}`);
-        });
+        const consumersOfMismatch: VersionMismatchFinderEntity[] = this.getConsumersOfMismatch(
+          dependency,
+          version
+        )!;
+
+        let numberToPrint: number = truncateLongPackageNameLists
+          ? TRUNCATE_AFTER_PACKAGE_NAME_COUNT
+          : consumersOfMismatch.length;
+        let numberRemaining: number = consumersOfMismatch.length;
+        for (const { friendlyName } of consumersOfMismatch) {
+          if (numberToPrint-- === 0) {
+            break;
+          }
+
+          numberRemaining--;
+
+          console.log(`   - ${friendlyName}`);
+        }
+
+        if (numberRemaining > 0) {
+          console.log(`   (and ${numberRemaining} others)`);
+        }
       });
       console.log();
     });

--- a/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -94,13 +94,16 @@ export class VersionMismatchFinder {
   ): VersionMismatchFinder {
     const commonVersions: CommonVersionsConfiguration = rushConfiguration.getCommonVersions(options.variant);
 
-    const projects: VersionMismatchFinderEntity[] = rushConfiguration.projects.map((project) => {
-      return new VersionMismatchFinderProject(project);
-    });
+    const projects: VersionMismatchFinderEntity[] = [];
 
     // Create an object for the purposes of reporting conflicts with preferredVersions
     // or xstitchPreferredVersions from common-versions.json
+    // Make sure this one is first so it doesn't get truncated when a long list is printed
     projects.push(new VersionMismatchFinderCommonVersions(commonVersions));
+
+    for (const project of rushConfiguration.projects) {
+      projects.push(new VersionMismatchFinderProject(project));
+    }
 
     return new VersionMismatchFinder(projects, commonVersions.allowedAlternativeVersions);
   }

--- a/common/changes/@microsoft/rush/rush-check-summary_2022-04-05-04-33.json
+++ b/common/changes/@microsoft/rush/rush-check-summary_2022-04-05-04-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Change the way \"rush change\" prints long lists of package names to include an \"(and <count> more)\" line after the first five listed by name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Right now, in large repos, `rush check` may print a very long list of package names if a mismatching dependency version exists for a dependency listed by many projects.

This change updates that to something that looks like:

```
Starting "rush check"

@rushstack/heft
  0.44.4
   - preferred versions from common-versions.json
   - projectA
   - projectB
   - projectC
   - projectD
   (and 623 others)
  0.44.3
   - @msstream/components-web-video
```

This behavior can be suppressed with a new `--verbose` flag passed to `rush check`. It cannot be suppressed when running `rush install` or `rush update`.

## How it was tested

Tested by changing the version of `@rushstack/heft` for one project in a large repo.