### PR TITLE
[API-Extractor] Potential fix for off-by-one separator index bug.

### DIFF
--- a/apps/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/apps/api-extractor/src/generators/ExcerptBuilder.ts
@@ -54,6 +54,12 @@ interface IBuildSpanState {
    * setting this flag.  After the new token is added, this flag is cleared.
    */
   disableMergingForNextToken: boolean;
+
+  /**
+   * Tracks whether the last appended token was a separator. If so, and we're in the middle of
+   * capturing a token range, then omit the separator from the range.
+   */
+  lastAppendedTokenIsSeparator: boolean;
 }
 
 export class ExcerptBuilder {
@@ -113,7 +119,8 @@ export class ExcerptBuilder {
       startingNode: span.node,
       stopBeforeChildKind,
       tokenRangesByNode,
-      disableMergingForNextToken: false
+      disableMergingForNextToken: false,
+      lastAppendedTokenIsSeparator: false
     });
   }
 
@@ -158,12 +165,13 @@ export class ExcerptBuilder {
       } else {
         ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Content, span.prefix, state);
       }
+      state.lastAppendedTokenIsSeparator = false;
     }
 
     for (const child of span.children) {
       if (span.node === state.startingNode) {
         if (state.stopBeforeChildKind && child.kind === state.stopBeforeChildKind) {
-          // We reached the a child whose kind is stopBeforeChildKind, so stop traversing
+          // We reached a child whose kind is stopBeforeChildKind, so stop traversing
           return false;
         }
       }
@@ -175,17 +183,26 @@ export class ExcerptBuilder {
 
     if (span.suffix) {
       ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Content, span.suffix, state);
+      state.lastAppendedTokenIsSeparator = false;
     }
     if (span.separator) {
       ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Content, span.separator, state);
+      state.lastAppendedTokenIsSeparator = true;
     }
 
     // Are we building a excerpt?  If so, set its range
     if (capturedTokenRange) {
       capturedTokenRange.startIndex = excerptStartIndex;
 
-      // We will assign capturedTokenRange.startIndex to be the index after the last token that was appended so far
-      capturedTokenRange.endIndex = excerptTokens.length;
+      // We will assign capturedTokenRange.startIndex to be the index after the last token
+      // that was appended so far. However, if the last appended token was a separator,
+      // then omit it from the range.
+      let excerptEndIndex: number = excerptTokens.length;
+      if (state.lastAppendedTokenIsSeparator) {
+        excerptEndIndex--;
+      }
+
+      capturedTokenRange.endIndex = excerptEndIndex;
 
       state.disableMergingForNextToken = true;
     }

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -797,7 +797,7 @@
           ],
           "extendsTokenRange": {
             "startIndex": 1,
-            "endIndex": 3
+            "endIndex": 2
           },
           "implementsTokenRanges": [
             {
@@ -806,7 +806,7 @@
             },
             {
               "startIndex": 6,
-              "endIndex": 8
+              "endIndex": 7
             }
           ]
         },
@@ -1378,7 +1378,7 @@
           "extendsTokenRanges": [
             {
               "startIndex": 1,
-              "endIndex": 3
+              "endIndex": 2
             }
           ]
         },

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -310,7 +310,7 @@
           ],
           "extendsTokenRange": {
             "startIndex": 1,
-            "endIndex": 3
+            "endIndex": 2
           },
           "implementsTokenRanges": []
         }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
@@ -193,7 +193,7 @@
           "members": [],
           "extendsTokenRange": {
             "startIndex": 1,
-            "endIndex": 3
+            "endIndex": 2
           },
           "implementsTokenRanges": []
         }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
@@ -194,7 +194,7 @@
           "extendsTokenRanges": [
             {
               "startIndex": 1,
-              "endIndex": 3
+              "endIndex": 2
             }
           ]
         },
@@ -223,7 +223,7 @@
           "extendsTokenRanges": [
             {
               "startIndex": 1,
-              "endIndex": 3
+              "endIndex": 2
             }
           ]
         },
@@ -252,7 +252,7 @@
           "extendsTokenRanges": [
             {
               "startIndex": 1,
-              "endIndex": 3
+              "endIndex": 2
             }
           ]
         }

--- a/common/changes/@microsoft/api-extractor/excerpt-tokens_2022-04-05-16-46.json
+++ b/common/changes/@microsoft/api-extractor/excerpt-tokens_2022-04-05-16-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Addressing excerptToken off by one bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/excerpt-tokens_2022-04-05-16-46.json
+++ b/common/changes/@microsoft/api-extractor/excerpt-tokens_2022-04-05-16-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Addressing excerptToken off by one bug",
+      "comment": "Fix an issue where .api.json excerpt text included extra whitespace (GitHub #3316)",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
## Summary

tokenRanges are capable of being off by one when the last token has a separator and this is shown when multiple interfaces are implemented for example. This happens when an additional excerptToken is created from a separator. Fixes: #3316

## Details
Going off of Pete's comment in Zulipchat we identified an edge case in the recursion for building excerptTokens when there is a separator on the last leaf node of the recursion tree, and keeping track of the last token having a separator will keep track of the state and address this scenario.

## How it was tested
Tests in api-documenter/extractor that have their output changed by this changeset:
api-documenter-test.api.json implementsTokenRanges: Line 809
api-extractor-senarios: bundledPackages api.json: line 313 in the extendsTokenRange
api-extractor-senarios: importType api.json: line 197,226,255 in the extendsTokenRange
