### PR TITLE
[rush] Split dependency analysis out from RushConfiguration.

### DIFF
--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -12,7 +12,8 @@ import {
   Path,
   FileSystem,
   PackageNameParser,
-  FileSystemStats
+  FileSystemStats,
+  Import
 } from '@rushstack/node-core-library';
 import { trueCasePathSync } from 'true-case-path';
 
@@ -33,8 +34,13 @@ import { ExperimentsConfiguration } from './ExperimentsConfiguration';
 import { PackageNameParsers } from './PackageNameParsers';
 import { RepoStateFile } from '../logic/RepoStateFile';
 import { LookupByPath } from '../logic/LookupByPath';
-import { DependencyType, PackageJsonDependency } from './PackageJsonEditor';
 import { RushPluginsConfiguration } from './RushPluginsConfiguration';
+import type * as DependencyAnalyzerModuleType from '../logic/DependencyAnalyzer';
+
+const DependencyAnalyzerModule: typeof DependencyAnalyzerModuleType = Import.lazy(
+  '../logic/DependencyAnalyzer',
+  require
+);
 
 const MINIMUM_SUPPORTED_RUSH_JSON_VERSION: string = '0.0.0';
 const DEFAULT_BRANCH: string = 'master';
@@ -495,11 +501,7 @@ export class RushConfiguration {
   private _projectsByName: Map<string, RushConfigurationProject> | undefined;
 
   // variant -> common-versions configuration
-  private _commonVersionsConfigurations: Map<string, CommonVersionsConfiguration> | undefined;
-  // variant -> map of package name -> implicitly preferred version
-  private _implicitlyPreferredVersions: Map<string, Map<string, string>> | undefined;
-  // variant -> map of package name to a set of specified dependency versions
-  private _allDependencyVersions: Map<string, Map<string, Set<string>>> | undefined;
+  private _commonVersionsConfigurationsByVariant: Map<string, CommonVersionsConfiguration> | undefined;
 
   private _versionPolicyConfiguration: VersionPolicyConfiguration;
   private _versionPolicyConfigurationFilePath: string;
@@ -1529,19 +1531,19 @@ export class RushConfiguration {
    * @param variant - The name of the current variant in use by the active command.
    */
   public getCommonVersions(variant?: string | undefined): CommonVersionsConfiguration {
-    if (!this._commonVersionsConfigurations) {
-      this._commonVersionsConfigurations = new Map();
+    if (!this._commonVersionsConfigurationsByVariant) {
+      this._commonVersionsConfigurationsByVariant = new Map();
     }
 
     // Use an empty string as the key when no variant provided. Anything else would possibly conflict
-    // with a varient created by the user
+    // with a variant created by the user
     const variantKey: string = variant || '';
     let commonVersionsConfiguration: CommonVersionsConfiguration | undefined =
-      this._commonVersionsConfigurations.get(variantKey);
+      this._commonVersionsConfigurationsByVariant.get(variantKey);
     if (!commonVersionsConfiguration) {
       const commonVersionsFilename: string = this.getCommonVersionsFilePath(variant);
       commonVersionsConfiguration = CommonVersionsConfiguration.loadFromFile(commonVersionsFilename);
-      this._commonVersionsConfigurations.set(variantKey, commonVersionsConfiguration);
+      this._commonVersionsConfigurationsByVariant.set(variantKey, commonVersionsConfiguration);
     }
 
     return commonVersionsConfiguration;
@@ -1554,48 +1556,11 @@ export class RushConfiguration {
    * @returns A map of dependency name --\> version specifier for implicitly preferred versions.
    */
   public getImplicitlyPreferredVersions(variant?: string | undefined): Map<string, string> {
-    if (!this._implicitlyPreferredVersions) {
-      this._implicitlyPreferredVersions = new Map();
-    }
-
-    // Use an empty string as the key when no variant provided. Anything else would possibly conflict
-    // with a variant created by the user
-    const variantKey: string = variant || '';
-    let implicitlyPreferredVersions: Map<string, string> | undefined =
-      this._implicitlyPreferredVersions.get(variantKey);
-    if (!implicitlyPreferredVersions) {
-      // Only generate implicitly preferred versions for variants that request it
-      const commonVersionsConfiguration: CommonVersionsConfiguration = this.getCommonVersions(variant);
-      const useImplicitlyPreferredVersions: boolean =
-        commonVersionsConfiguration.implicitlyPreferredVersions !== undefined
-          ? commonVersionsConfiguration.implicitlyPreferredVersions
-          : true;
-
-      if (useImplicitlyPreferredVersions) {
-        // First, collect all the direct dependencies of all local projects, and their versions:
-        // direct dependency name --> set of version specifiers
-        const versionsForDependencies: Map<string, Set<string>> = this._getAllDependencyVersions(variant);
-
-        // If any dependency has more than one version, then filter it out (since we don't know which version
-        // should be preferred).  What remains will be the list of preferred dependencies.
-        // dependency --> version specifier
-        const implicitlyPreferred: Map<string, string> = new Map<string, string>();
-        for (const [dep, versions] of versionsForDependencies) {
-          if (versions.size === 1) {
-            const version: string = Array.from(versions)[0];
-            implicitlyPreferred.set(dep, version);
-          }
-        }
-
-        implicitlyPreferredVersions = implicitlyPreferred;
-      } else {
-        implicitlyPreferredVersions = new Map();
-      }
-
-      this._implicitlyPreferredVersions.set(variantKey, implicitlyPreferredVersions);
-    }
-
-    return implicitlyPreferredVersions;
+    const dependencyAnalyzer: DependencyAnalyzerModuleType.DependencyAnalyzer =
+      DependencyAnalyzerModule.DependencyAnalyzer.forRushConfiguration(this);
+    const dependencyAnalysis: DependencyAnalyzerModuleType.IDependencyAnalysis =
+      dependencyAnalyzer.getAnalysis(variant);
+    return dependencyAnalysis.implicitlyPreferredVersionByPackageName;
   }
 
   /**
@@ -1765,85 +1730,6 @@ export class RushConfiguration {
       }
     }
     return undefined;
-  }
-
-  /**
-   * @internal
-   */
-  public _getAllDependencyVersions(variant?: string | undefined): Map<string, Set<string>> {
-    if (!this._allDependencyVersions) {
-      this._allDependencyVersions = new Map();
-    }
-
-    const variantKey: string = variant || '';
-    let allDependencyVersions: Map<string, Set<string>> | undefined =
-      this._allDependencyVersions.get(variantKey);
-    if (!allDependencyVersions) {
-      allDependencyVersions = new Map();
-
-      const commonVersions: CommonVersionsConfiguration = this.getCommonVersions(variant);
-      const allowedAlternativeVersions: Map<
-        string,
-        ReadonlyArray<string>
-      > = commonVersions.allowedAlternativeVersions;
-      for (const project of this.projects) {
-        const dependencies: PackageJsonDependency[] = [
-          ...project.packageJsonEditor.dependencyList,
-          ...project.packageJsonEditor.devDependencyList
-        ];
-        for (const { name: dependencyName, version: dependencyVersion, dependencyType } of dependencies) {
-          if (dependencyType === DependencyType.Peer) {
-            // If this is a peer dependency, it isn't a real dependency in this context, so it shouldn't
-            // be included in the list of dependency versions.
-            continue;
-          }
-
-          const alternativesForThisDependency: ReadonlyArray<string> =
-            allowedAlternativeVersions.get(dependencyName) || [];
-
-          // For each dependency, collectImplicitlyPreferredVersions() is collecting the set of all version specifiers
-          // that appear across the repo.  If there is only one version specifier, then that's the "preferred" one.
-          // However, there are a few cases where additional version specifiers can be safely ignored.
-          let ignoreVersion: boolean = false;
-
-          // 1. If the version specifier was listed in "allowedAlternativeVersions", then it's never a candidate.
-          //    (Even if it's the only version specifier anywhere in the repo, we still ignore it, because
-          //    otherwise the rule would be difficult to explain.)
-          if (alternativesForThisDependency.indexOf(dependencyVersion) > 0) {
-            ignoreVersion = true;
-          } else {
-            // Is it a local project?
-            const localProject: RushConfigurationProject | undefined = this.getProjectByName(dependencyName);
-            if (localProject) {
-              // 2. If it's a symlinked local project, then it's not a candidate, because the package manager will
-              //    never even see it.
-              // However there are two ways that a local project can NOT be symlinked:
-              // - if the local project doesn't satisfy the referenced semver specifier; OR
-              // - if the local project was specified in "cyclicDependencyProjects" in rush.json
-              if (
-                !project.cyclicDependencyProjects.has(dependencyName) &&
-                semver.satisfies(localProject.packageJsonEditor.version, dependencyVersion)
-              ) {
-                ignoreVersion = true;
-              }
-            }
-
-            if (!ignoreVersion) {
-              let versionForDependency: Set<string> | undefined = allDependencyVersions.get(dependencyName);
-              if (!versionForDependency) {
-                versionForDependency = new Set<string>();
-                allDependencyVersions.set(dependencyName, versionForDependency);
-              }
-              versionForDependency.add(dependencyVersion);
-            }
-          }
-        }
-      }
-
-      this._allDependencyVersions.set(variantKey, allDependencyVersions);
-    }
-
-    return allDependencyVersions;
   }
 
   private _getVariantConfigFolderPath(variant?: string | undefined): string {

--- a/apps/rush-lib/src/cli/actions/AddAction.ts
+++ b/apps/rush-lib/src/cli/actions/AddAction.ts
@@ -174,7 +174,7 @@ export class AddAction extends BaseRushAction {
       this.rushGlobalFolder
     );
 
-    await updater.doRushAdd({
+    await updater.doRushAddAsync({
       projects: projects,
       packagesToAdd,
       devDependency: this._devDependencyFlag.value,

--- a/apps/rush-lib/src/cli/actions/test/AddAction.test.ts
+++ b/apps/rush-lib/src/cli/actions/test/AddAction.test.ts
@@ -15,7 +15,7 @@ describe(AddAction.name, () => {
 
     beforeEach(() => {
       doRushAddMock = jest
-        .spyOn(PackageJsonUpdater.prototype, 'doRushAdd')
+        .spyOn(PackageJsonUpdater.prototype, 'doRushAddAsync')
         .mockImplementation(() => Promise.resolve());
       jest.spyOn(process, 'exit').mockImplementation();
       oldExitCode = process.exitCode;

--- a/apps/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/apps/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -28,7 +28,7 @@ export interface IDependencyAnalysis {
 
 export class DependencyAnalyzer {
   private static _dependencyAnalyzerByRushConfiguration:
-    | Map<RushConfiguration, DependencyAnalyzer>
+    | WeakMap<RushConfiguration, DependencyAnalyzer>
     | undefined;
 
   private _rushConfiguration: RushConfiguration;
@@ -40,7 +40,7 @@ export class DependencyAnalyzer {
 
   public static forRushConfiguration(rushConfiguration: RushConfiguration): DependencyAnalyzer {
     if (!DependencyAnalyzer._dependencyAnalyzerByRushConfiguration) {
-      DependencyAnalyzer._dependencyAnalyzerByRushConfiguration = new Map();
+      DependencyAnalyzer._dependencyAnalyzerByRushConfiguration = new WeakMap();
     }
 
     let analyzer: DependencyAnalyzer | undefined =
@@ -168,7 +168,7 @@ export class DependencyAnalyzer {
   ): Map<string, string> {
     // Only generate implicitly preferred versions for variants that request it
     const useImplicitlyPreferredVersions: boolean =
-      commonVersionsConfiguration.implicitlyPreferredVersions ?? true
+      commonVersionsConfiguration.implicitlyPreferredVersions ?? true;
 
     if (useImplicitlyPreferredVersions) {
       // If any dependency has more than one version, then filter it out (since we don't know which version

--- a/apps/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/apps/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -168,9 +168,7 @@ export class DependencyAnalyzer {
   ): Map<string, string> {
     // Only generate implicitly preferred versions for variants that request it
     const useImplicitlyPreferredVersions: boolean =
-      commonVersionsConfiguration.implicitlyPreferredVersions !== undefined
-        ? commonVersionsConfiguration.implicitlyPreferredVersions
-        : true;
+      commonVersionsConfiguration.implicitlyPreferredVersions ?? true
 
     if (useImplicitlyPreferredVersions) {
       // If any dependency has more than one version, then filter it out (since we don't know which version

--- a/apps/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/apps/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as semver from 'semver';
+import { CommonVersionsConfiguration } from '../api/CommonVersionsConfiguration';
+import { DependencyType, PackageJsonDependency } from '../api/PackageJsonEditor';
+import { RushConfiguration } from '../api/RushConfiguration';
+import { RushConfigurationProject } from '../api/RushConfigurationProject';
+
+export interface IDependencyAnalysis {
+  /**
+   * The common versions configuration from the repo's rush configuration.
+   */
+  commonVersionsConfiguration: CommonVersionsConfiguration;
+
+  /**
+   * A map of all direct dependencies that only have a single semantic version specifier,
+   * unless the variant has the {@link CommonVersionsConfiguration.implicitlyPreferredVersions} option
+   * set to `false`.
+   */
+  implicitlyPreferredVersionByPackageName: Map<string, string>;
+
+  /**
+   * A map of dependency name to the set of version specifiers used in the repo.
+   */
+  allVersionsByPackageName: Map<string, Set<string>>;
+}
+
+export class DependencyAnalyzer {
+  private static _dependencyAnalyzerByRushConfiguration:
+    | Map<RushConfiguration, DependencyAnalyzer>
+    | undefined;
+
+  private _rushConfiguration: RushConfiguration;
+  private _analysisByVariant: Map<string, IDependencyAnalysis> = new Map();
+
+  private constructor(rushConfiguration: RushConfiguration) {
+    this._rushConfiguration = rushConfiguration;
+  }
+
+  public static forRushConfiguration(rushConfiguration: RushConfiguration): DependencyAnalyzer {
+    if (!DependencyAnalyzer._dependencyAnalyzerByRushConfiguration) {
+      DependencyAnalyzer._dependencyAnalyzerByRushConfiguration = new Map();
+    }
+
+    let analyzer: DependencyAnalyzer | undefined =
+      DependencyAnalyzer._dependencyAnalyzerByRushConfiguration.get(rushConfiguration);
+    if (!analyzer) {
+      analyzer = new DependencyAnalyzer(rushConfiguration);
+      DependencyAnalyzer._dependencyAnalyzerByRushConfiguration.set(rushConfiguration, analyzer);
+    }
+
+    return analyzer;
+  }
+
+  public getAnalysis(variant?: string): IDependencyAnalysis {
+    // Use an empty string as the key when no variant provided. Anything else would possibly conflict
+    // with a variant created by the user
+    const variantKey: string = variant || '';
+    let analysis: IDependencyAnalysis | undefined = this._analysisByVariant.get(variantKey);
+    if (!analysis) {
+      const commonVersionsConfiguration: CommonVersionsConfiguration =
+        this._rushConfiguration.getCommonVersions(variant);
+
+      const allVersionsByPackageName: Map<string, Set<string>> = this._collectAllVersionsByPackageName(
+        commonVersionsConfiguration
+      );
+
+      const implicitlyPreferredVersionByPackageName: Map<string, string> =
+        this._getImplicitlyPreferredVersionByPackageName(
+          commonVersionsConfiguration,
+          allVersionsByPackageName
+        );
+
+      analysis = {
+        commonVersionsConfiguration,
+        implicitlyPreferredVersionByPackageName,
+        allVersionsByPackageName
+      };
+      this._analysisByVariant.set(variantKey, analysis);
+    }
+
+    return analysis;
+  }
+
+  /**
+   * Generates the {@link IDependencyAnalysis.allVersionsByPackageName} map.
+   *
+   * @remarks
+   * The result of this function is not cached.
+   */
+  private _collectAllVersionsByPackageName(
+    commonVersionsConfiguration: CommonVersionsConfiguration
+  ): Map<string, Set<string>> {
+    const allVersionsByPackageName: Map<string, Set<string>> = new Map();
+    const allowedAlternativeVersions: Map<
+      string,
+      ReadonlyArray<string>
+    > = commonVersionsConfiguration.allowedAlternativeVersions;
+    for (const project of this._rushConfiguration.projects) {
+      const dependencies: PackageJsonDependency[] = [
+        ...project.packageJsonEditor.dependencyList,
+        ...project.packageJsonEditor.devDependencyList
+      ];
+      for (const { name: dependencyName, version: dependencyVersion, dependencyType } of dependencies) {
+        if (dependencyType === DependencyType.Peer) {
+          // If this is a peer dependency, it isn't a real dependency in this context, so it shouldn't
+          // be included in the list of dependency versions.
+          continue;
+        }
+
+        const alternativesForThisDependency: ReadonlyArray<string> =
+          allowedAlternativeVersions.get(dependencyName) || [];
+
+        // For each dependency, collectImplicitlyPreferredVersions() is collecting the set of all version specifiers
+        // that appear across the repo.  If there is only one version specifier, then that's the "preferred" one.
+        // However, there are a few cases where additional version specifiers can be safely ignored.
+        let ignoreVersion: boolean = false;
+
+        // 1. If the version specifier was listed in "allowedAlternativeVersions", then it's never a candidate.
+        //    (Even if it's the only version specifier anywhere in the repo, we still ignore it, because
+        //    otherwise the rule would be difficult to explain.)
+        if (alternativesForThisDependency.indexOf(dependencyVersion) > 0) {
+          ignoreVersion = true;
+        } else {
+          // Is it a local project?
+          const localProject: RushConfigurationProject | undefined =
+            this._rushConfiguration.getProjectByName(dependencyName);
+          if (localProject) {
+            // 2. If it's a symlinked local project, then it's not a candidate, because the package manager will
+            //    never even see it.
+            // However there are two ways that a local project can NOT be symlinked:
+            // - if the local project doesn't satisfy the referenced semver specifier; OR
+            // - if the local project was specified in "cyclicDependencyProjects" in rush.json
+            if (
+              !project.cyclicDependencyProjects.has(dependencyName) &&
+              semver.satisfies(localProject.packageJsonEditor.version, dependencyVersion)
+            ) {
+              ignoreVersion = true;
+            }
+          }
+
+          if (!ignoreVersion) {
+            let versionForDependency: Set<string> | undefined = allVersionsByPackageName.get(dependencyName);
+            if (!versionForDependency) {
+              versionForDependency = new Set<string>();
+              allVersionsByPackageName.set(dependencyName, versionForDependency);
+            }
+            versionForDependency.add(dependencyVersion);
+          }
+        }
+      }
+    }
+
+    return allVersionsByPackageName;
+  }
+
+  /**
+   * Generates the {@link IDependencyAnalysis.implicitlyPreferredVersionByPackageName} map,
+   * given the {@link IDependencyAnalysis.allVersionsByPackageName} map.
+   *
+   * @remarks
+   * The result of this function is not cached.
+   */
+  private _getImplicitlyPreferredVersionByPackageName(
+    commonVersionsConfiguration: CommonVersionsConfiguration,
+    allVersionsByPackageName: Map<string, Set<string>>
+  ): Map<string, string> {
+    // Only generate implicitly preferred versions for variants that request it
+    const useImplicitlyPreferredVersions: boolean =
+      commonVersionsConfiguration.implicitlyPreferredVersions !== undefined
+        ? commonVersionsConfiguration.implicitlyPreferredVersions
+        : true;
+
+    if (useImplicitlyPreferredVersions) {
+      // If any dependency has more than one version, then filter it out (since we don't know which version
+      // should be preferred).  What remains will be the list of preferred dependencies.
+      // dependency --> version specifier
+      const implicitlyPreferred: Map<string, string> = new Map<string, string>();
+      for (const [dep, versions] of allVersionsByPackageName) {
+        if (versions.size === 1) {
+          const version: string = Array.from(versions)[0];
+          implicitlyPreferred.set(dep, version);
+        }
+      }
+
+      return implicitlyPreferred;
+    } else {
+      return new Map();
+    }
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzer.test.ts
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzer.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { RushConfiguration } from '../../api/RushConfiguration';
+import { DependencyAnalyzer, IDependencyAnalysis } from '../DependencyAnalyzer';
+
+describe(DependencyAnalyzer.name, () => {
+  function getAnalysisForRepoByName(repoName: string): IDependencyAnalysis {
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(
+      `${__dirname}/DependencyAnalyzerTestRepos/${repoName}/rush.json`
+    );
+    const dependencyAnalyzer: DependencyAnalyzer = DependencyAnalyzer.forRushConfiguration(rushConfiguration);
+    const analysis: IDependencyAnalysis = dependencyAnalyzer.getAnalysis();
+    return analysis;
+  }
+
+  it('correctly gets the list of dependencies in a repo without allowed alternative versions', () => {
+    const analysis: IDependencyAnalysis = getAnalysisForRepoByName('no-allowed-alternatives');
+    expect(analysis.allVersionsByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => Set {
+          "1.0.0",
+        },
+        "dep-2" => Set {
+          "1.0.0",
+        },
+        "dep-3" => Set {
+          "1.0.0",
+        },
+      }
+    `);
+    expect(analysis.implicitlyPreferredVersionByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => "1.0.0",
+        "dep-2" => "1.0.0",
+        "dep-3" => "1.0.0",
+      }
+    `);
+  });
+
+  it('correctly gets the list of dependencies in a repo with allowed alternative versions', () => {
+    const analysis: IDependencyAnalysis = getAnalysisForRepoByName('allowed-alternatives');
+    expect(analysis.allVersionsByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => Set {
+          "1.0.0",
+        },
+        "dep-2" => Set {
+          "1.0.0",
+          "2.0.0",
+        },
+        "dep-3" => Set {
+          "1.0.0",
+        },
+      }
+    `);
+    expect(analysis.implicitlyPreferredVersionByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => "1.0.0",
+        "dep-2" => "1.0.0",
+        "dep-3" => "1.0.0",
+      }
+    `);
+  });
+
+  it('correctly gets the list of dependencies in a repo with non-allowed inconsistent versions', () => {
+    const analysis: IDependencyAnalysis = getAnalysisForRepoByName(
+      'no-allowed-alternatives-with-inconsistent-versions'
+    );
+    expect(analysis.allVersionsByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => Set {
+          "1.0.0",
+        },
+        "dep-2" => Set {
+          "1.0.0",
+          "2.0.0",
+        },
+        "dep-3" => Set {
+          "1.0.0",
+        },
+      }
+    `);
+    expect(analysis.implicitlyPreferredVersionByPackageName).toMatchInlineSnapshot(`
+      Map {
+        "dep-1" => "1.0.0",
+        "dep-3" => "1.0.0",
+      }
+    `);
+  });
+});

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/a/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "Test package a",
+  "dependencies": {
+    "dep-1": "1.0.0",
+    "dep-2": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/b/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "description": "Test package b",
+  "dependencies": {
+    "a": ">=1.0.0 <2.0.0",
+    "dep-2": "2.0.0",
+    "dep-3": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/common/config/rush/common-versions.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/common/config/rush/common-versions.json
@@ -1,0 +1,5 @@
+{
+  "allowedAlternativeVersions": {
+    "dep-2": ["2.0.0"]
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/rush.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/allowed-alternatives/rush.json
@@ -1,0 +1,17 @@
+{
+  "pnpmVersion": "6.7.1",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "a"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "b"
+    }
+  ]
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/a/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "Test package a",
+  "dependencies": {
+    "dep-1": "1.0.0",
+    "dep-2": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/b/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "description": "Test package b",
+  "dependencies": {
+    "a": ">=1.0.0 <2.0.0",
+    "dep-2": "2.0.0",
+    "dep-3": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/rush.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives-with-inconsistent-versions/rush.json
@@ -1,0 +1,17 @@
+{
+  "pnpmVersion": "6.7.1",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "a"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "b"
+    }
+  ]
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/a/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "Test package a",
+  "dependencies": {
+    "dep-1": "1.0.0",
+    "dep-2": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/b/package.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "description": "Test package b",
+  "dependencies": {
+    "a": ">=1.0.0 <2.0.0",
+    "dep-2": "1.0.0",
+    "dep-3": "1.0.0"
+  }
+}

--- a/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/rush.json
+++ b/apps/rush-lib/src/logic/test/DependencyAnalyzerTestRepos/no-allowed-alternatives/rush.json
@@ -1,0 +1,17 @@
+{
+  "pnpmVersion": "6.7.1",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "a"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "b"
+    }
+  ]
+}

--- a/common/changes/@microsoft/rush/clean-up-dependency-analysis_2022-04-06-05-54.json
+++ b/common/changes/@microsoft/rush/clean-up-dependency-analysis_2022-04-06-05-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -656,8 +656,6 @@ export class RushConfiguration {
     get experimentsConfiguration(): ExperimentsConfiguration;
     findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
     findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
-    // @internal (undocumented)
-    _getAllDependencyVersions(variant?: string | undefined): Map<string, Set<string>>;
     getCommittedShrinkwrapFilename(variant?: string | undefined): string;
     getCommonVersions(variant?: string | undefined): CommonVersionsConfiguration;
     getCommonVersionsFilePath(variant?: string | undefined): string;


### PR DESCRIPTION
This a refactor suggested in https://github.com/microsoft/rushstack/pull/3314#discussion_r843197891