### PR TITLE
[rush] Fix an edge case where `rush update` fails in a repo with no dependencies.

### DIFF
--- a/apps/rush-lib/src/logic/base/BaseProjectShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseProjectShrinkwrapFile.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { FileSystem } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile } from '@rushstack/node-core-library';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushConstants } from '../RushConstants';
@@ -24,6 +24,14 @@ export abstract class BaseProjectShrinkwrapFile {
     this.projectShrinkwrapFilePath = BaseProjectShrinkwrapFile.getFilePathForProject(this.project);
 
     this._shrinkwrapFile = shrinkwrapFile;
+  }
+
+  /**
+   * Save an empty project shrinkwrap file. This is used in repos with no dependencies.
+   */
+  public static async saveEmptyProjectShrinkwrapFileAsync(project: RushConfigurationProject): Promise<void> {
+    const projectShrinkwrapFilePath: string = BaseProjectShrinkwrapFile.getFilePathForProject(project);
+    await JsonFile.saveAsync({}, projectShrinkwrapFilePath, { ensureFolderExists: true });
   }
 
   /**

--- a/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/apps/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -389,7 +389,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         async (project) => {
           await tempShrinkwrapFile.getProjectShrinkwrap(project)?.updateProjectShrinkwrapAsync();
         },
-        { concurrency: 30 }
+        { concurrency: 10 }
       );
     } else if (
       this.rushConfiguration.packageManager === 'pnpm' &&
@@ -402,7 +402,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         async (project) => {
           await BaseProjectShrinkwrapFile.saveEmptyProjectShrinkwrapFileAsync(project);
         },
-        { concurrency: 30 }
+        { concurrency: 10 }
       );
     } else {
       // This is an unexpected case

--- a/common/changes/@microsoft/rush/fix-no-deps-edge-case_2022-04-06-08-41.json
+++ b/common/changes/@microsoft/rush/fix-no-deps-edge-case_2022-04-06-08-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an edge case where `rush update` fails in a PNPM workspaces repo with no dependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

If you run `rush init` in an empty folder, create a project without any dependencies, and run `rush update`, Rush crashes with a nasty:

```
ERROR: Cannot read property 'getProjectShrinkwrap' of undefined
```

## Details

If no projects in a workspace have dependencies, PNPM doesn't generate a lockfile. This PR handles that by generating empty (i.e. - `{}`) `project/.rush/temp/shrinkwrap-deps.json` files. This allows the repo to be usable.

## How it was tested

Tested in a new repo with a single project with no dependencies.