### PR TITLE
[rush] Fix links to API Reference docs

### DIFF
--- a/apps/rush/README.md
+++ b/apps/rush/README.md
@@ -72,6 +72,6 @@ For more details and support resources, please visit: https://rushjs.io
 - [UPGRADING.md](
   https://github.com/microsoft/rushstack/blob/master/apps/rush/UPGRADING.md) - Instructions
   for migrating existing projects to use a newer version of Rush
-- [API Reference](https://rushstack.io/pages/api/rush-lib/)
+- [API Reference](https://api.rushstack.io/pages/rush-lib/)
 
 Rush is part of the [Rush Stack](https://rushstack.io/) family of projects.

--- a/common/changes/@microsoft/rush/enelson-api-links_2022-04-07-12-56.json
+++ b/common/changes/@microsoft/rush/enelson-api-links_2022-04-07-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-sdk/README.md
+++ b/libraries/rush-sdk/README.md
@@ -25,6 +25,6 @@ Verbose logging can be turn on by set environment variable `RUSH_SDK_DEBUG` to `
 - [CHANGELOG.md](
   https://github.com/microsoft/rushstack/blob/master/apps/rush/CHANGELOG.md) - Find
   out what's new in the latest version
-- [API Reference](https://rushstack.io/pages/api/rush-lib/)
+- [API Reference](https://api.rushstack.io/pages/rush-lib/)
 
 Rush is part of the [Rush Stack](https://rushstack.io/) family of projects.


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3310.

## Details

Update links to the API Reference in README files.

