### PR TITLE
Bump versions before running publish.

### DIFF
--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -7,13 +7,18 @@ steps:
   - checkout: self
     persistCredentials: true
   - template: templates/build.yaml
+  - template: templates/bump-versions.yaml
+    parameters:
+      VersionPolicyName: noRush
+  - template: templates/bump-versions.yaml
+    parameters:
+      VersionPolicyName: rush
   - template: templates/publish.yaml
     parameters:
       VersionPolicyName: noRush
+  - script: 'node apps/rush-lib/scripts/plugins-prepublish.js'
+    displayName: 'Prepublish workaround'
   - template: templates/publish.yaml
     parameters:
       VersionPolicyName: rush
-      PrePublishSteps:
-        - script: 'node apps/rush-lib/scripts/plugins-prepublish.js'
-          displayName: 'Prepublish workaround'
   - template: templates/record-published-versions.yaml

--- a/common/config/azure-pipelines/npm-publish.yaml
+++ b/common/config/azure-pipelines/npm-publish.yaml
@@ -7,6 +7,9 @@ steps:
   - checkout: self
     persistCredentials: true
   - template: templates/build.yaml
+  - template: templates/bump-versions.yaml
+    parameters:
+      VersionPolicyName: noRush
   - template: templates/publish.yaml
     parameters:
       VersionPolicyName: noRush

--- a/common/config/azure-pipelines/templates/bump-versions.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions.yaml
@@ -1,0 +1,7 @@
+parameters:
+  - name: VersionPolicyName
+    type: string
+
+steps:
+  - script: 'node common/scripts/install-run-rush.js version --bump --version-policy ${{ parameters.VersionPolicyName }} --target-branch $(Build.SourceBranchName)'
+    displayName: 'Rush Version (Policy: ${{ parameters.VersionPolicyName }})'

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -1,14 +1,8 @@
 parameters:
   - name: VersionPolicyName
     type: string
-  - name: PrePublishSteps
-    type: stepList
-    default: []
 
 steps:
-  - script: 'node common/scripts/install-run-rush.js version --bump --version-policy ${{ parameters.VersionPolicyName }} --target-branch $(Build.SourceBranchName)'
-    displayName: 'Rush Version (Policy: ${{ parameters.VersionPolicyName }})'
-  - ${{ parameters.PrePublishSteps }}
   - script: 'node common/scripts/install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --add-commit-details --set-access-level public'
     displayName: 'Rush Publish (Policy: ${{ parameters.VersionPolicyName }})'
     env:


### PR DESCRIPTION
Because the repo now contains a Rush plugin that isn't part of the Rush lockstepped version policy, publishing of Rush needs to bump all versions (both Rush packages and non-Rush packages) before publishing anything to ensure the plugin gets the right version of rush-sdk when published.