### PR TITLE
[api-extractor] Throw an error if API Extractor attempts to process non-.d.ts files

### DIFF
--- a/apps/api-extractor/src/api/ExtractorMessageId.ts
+++ b/apps/api-extractor/src/api/ExtractorMessageId.ts
@@ -95,7 +95,13 @@ export const enum ExtractorMessageId {
   /**
    * "The property ___ has a setter but no getter."
    */
-  MissingGetter = 'ae-missing-getter'
+  MissingGetter = 'ae-missing-getter',
+
+  /**
+   * "Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension.
+   * Troubleshooting tips: `https://api-extractor.com/link/dts-error`"
+   */
+  NotDtsFileExtension = 'ae-wrong-input-file-type'
 }
 
 export const allExtractorMessageIds: Set<string> = new Set<string>([
@@ -114,5 +120,6 @@ export const allExtractorMessageIds: Set<string> = new Set<string>([
   'ae-cyclic-inherit-doc',
   'ae-unresolved-link',
   'ae-setter-with-docs',
-  'ae-missing-getter'
+  'ae-missing-getter',
+  'ae-wrong-input-file-type'
 ]);

--- a/apps/api-extractor/src/api/ExtractorMessageId.ts
+++ b/apps/api-extractor/src/api/ExtractorMessageId.ts
@@ -101,7 +101,7 @@ export const enum ExtractorMessageId {
    * "Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension.
    * Troubleshooting tips: `https://api-extractor.com/link/dts-error`"
    */
-  NotDtsFileExtension = 'ae-wrong-input-file-type'
+  WrongInputFileType = 'ae-wrong-input-file-type'
 }
 
 export const allExtractorMessageIds: Set<string> = new Set<string>([

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -206,14 +206,17 @@ export class Collector {
 
     // We can throw this error earlier in CompilerState.ts, but intentionally wait until after we've logged the
     // associated diagnostic message above to make debugging easier for developers.
-    const badSourceFile: boolean = sourceFiles.some(
+    // Typically there will be many such files -- to avoid too much noise, only report the first one.
+    const badSourceFile: ts.SourceFile | undefined = sourceFiles.find(
       ({ fileName }) => !ExtractorConfig.hasDtsFileExtension(fileName)
     );
     if (badSourceFile) {
-      throw new Error(
-        'API Extractor expects to only process .d.ts files, but encountered non-.d.ts file(s).\n' +
-          'Run with the "--diagnostics" flag and inspect the "Files analyzed by compiler" to find the unexpected ' +
-          'file(s).'
+      this.messageRouter.addAnalyzerIssueForPosition(
+        ExtractorMessageId.NotDtsFileExtension,
+        'Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. ' +
+          'Troubleshooting tips: https://api-extractor.com/link/dts-error',
+        badSourceFile,
+        0
       );
     }
 

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -212,7 +212,7 @@ export class Collector {
     );
     if (badSourceFile) {
       this.messageRouter.addAnalyzerIssueForPosition(
-        ExtractorMessageId.NotDtsFileExtension,
+        ExtractorMessageId.WrongInputFileType,
         'Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. ' +
           'Troubleshooting tips: https://api-extractor.com/link/dts-error',
         badSourceFile,

--- a/apps/api-extractor/src/schemas/api-extractor-defaults.json
+++ b/apps/api-extractor/src/schemas/api-extractor-defaults.json
@@ -71,6 +71,9 @@
       "ae-unresolved-inheritdoc-base": {
         "logLevel": "warning",
         "addToApiReportFile": true
+      },
+      "ae-wrong-input-file-type": {
+        "logLevel": "error"
       }
     },
     "tsdocMessageReporting": {

--- a/common/changes/@microsoft/api-extractor/better-ts-file-error_2022-04-10-00-42.json
+++ b/common/changes/@microsoft/api-extractor/better-ts-file-error_2022-04-10-00-42.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/api-extractor",
       "comment": "Throw an error early if API Extractor will attempt to process non-.d.ts files",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/api-extractor"

--- a/common/changes/@microsoft/api-extractor/better-ts-file-error_2022-04-10-00-42.json
+++ b/common/changes/@microsoft/api-extractor/better-ts-file-error_2022-04-10-00-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Throw an error early if API Extractor will attempt to process non-.d.ts files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -135,13 +135,13 @@ export const enum ExtractorMessageId {
     MisplacedPackageTag = "ae-misplaced-package-tag",
     MissingGetter = "ae-missing-getter",
     MissingReleaseTag = "ae-missing-release-tag",
-    NotDtsFileExtension = "ae-wrong-input-file-type",
     PreapprovedBadReleaseTag = "ae-preapproved-bad-release-tag",
     PreapprovedUnsupportedType = "ae-preapproved-unsupported-type",
     SetterWithDocs = "ae-setter-with-docs",
     UnresolvedInheritDocBase = "ae-unresolved-inheritdoc-base",
     UnresolvedInheritDocReference = "ae-unresolved-inheritdoc-reference",
-    UnresolvedLink = "ae-unresolved-link"
+    UnresolvedLink = "ae-unresolved-link",
+    WrongInputFileType = "ae-wrong-input-file-type",
 }
 
 // @public

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -141,7 +141,7 @@ export const enum ExtractorMessageId {
     UnresolvedInheritDocBase = "ae-unresolved-inheritdoc-base",
     UnresolvedInheritDocReference = "ae-unresolved-inheritdoc-reference",
     UnresolvedLink = "ae-unresolved-link",
-    WrongInputFileType = "ae-wrong-input-file-type",
+    WrongInputFileType = "ae-wrong-input-file-type"
 }
 
 // @public

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -135,6 +135,7 @@ export const enum ExtractorMessageId {
     MisplacedPackageTag = "ae-misplaced-package-tag",
     MissingGetter = "ae-missing-getter",
     MissingReleaseTag = "ae-missing-release-tag",
+    NotDtsFileExtension = "ae-wrong-input-file-type",
     PreapprovedBadReleaseTag = "ae-preapproved-bad-release-tag",
     PreapprovedUnsupportedType = "ae-preapproved-unsupported-type",
     SetterWithDocs = "ae-setter-with-docs",
@@ -264,6 +265,5 @@ export interface IExtractorMessagesConfig {
     extractorMessageReporting?: IConfigMessageReportingTable;
     tsdocMessageReporting?: IConfigMessageReportingTable;
 }
-
 
 ```


### PR DESCRIPTION
## Summary

A first stab at addressing https://github.com/microsoft/rushstack/issues/3328.

## Details

* Note that I decided to throw an error here instead of within `CompilerState.ts` (which is the earliest point we could throw an error) to make debugging easier for developers.
* Happy to bike-shed the error message itself a bit. I want to make sure it's clear for developers.
* We don't need to check if `this.program.getRootFileNames()` has any non-`.d.ts` files because there's earlier logic that filters these files out (see `CompilerState._generateFilePathsForAnalysis`).

## How it was tested

I manually added some non-`.d.ts` files to the files that API Extractor processes and validated that that this error was thrown. Is it easy to add a test that verifies that API Extractor throws an error under certain situations? If not, then maybe my manual verification is enough.
