### PR TITLE
[eslint-patch] fix: add empty export for module type detection

### DIFF
--- a/common/changes/@rushstack/eslint-patch/main_2022-04-11-10-57.json
+++ b/common/changes/@rushstack/eslint-patch/main_2022-04-11-10-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix an issue where tools could not determine the module type as CommonJS",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/usage.ts
+++ b/eslint/eslint-patch/src/usage.ts
@@ -5,3 +5,5 @@ throw new Error(
   'The @rushstack/eslint-patch package does not have a default entry point.' +
     ' See README.md for usage instructions.'
 );
+
+export = {};

--- a/eslint/eslint-patch/src/usage.ts
+++ b/eslint/eslint-patch/src/usage.ts
@@ -6,4 +6,4 @@ throw new Error(
     ' See README.md for usage instructions.'
 );
 
-export = {};
+export {};


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Adds a blank `export = {}` to the `eslint-patch` entry point to allow other tools (specifically Vite) to automatically determine this is Common JS.

Fixes #3343

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Adding a blank export provides enough information for Vite to determine this is indeed CommonJS.

This entry point is only used to throw an error to warn the user not to directly import the package. No breaking change. No performance impacts.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Re-built my project with Vite, the warning mentioned in #3343 was no longer output.

Imported the package directly, and validated the usage error was still thrown as expected.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
