### PR TITLE
Fix watching when rush.json is not in the root

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,41 +2,19 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Launch",
-			"type": "node",
-			"request": "launch",
-			"program": "${workspaceRoot}/common/node_modules/gulp/bin/gulp.js",
-			"stopOnEntry": false,
-			"args": [
-			],
-			"cwd": "${workspaceRoot}/gulp-core-build",
-			"runtimeExecutable": null,
-			"runtimeArgs": [
-				"--nolazy"
-			],
-			"env": {
-				"NODE_ENV": "development"
-			},
-			"externalConsole": false,
-			"sourceMaps": false,
-			"outDir": null
-		},
-		{
 			"name": "Rush Debug",
 			"type": "node",
 			"request": "launch",
-			"program": "${workspaceRoot}/apps/rush-lib/lib/start.js",
+			"program": "${workspaceRoot}/apps/rush/lib/start-dev.js",
 			"stopOnEntry": true,
 			"args": [
-				"update",
-				"--variant",
-				"test"
+				"start"
 			],
 			"cwd": "${workspaceRoot}",
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy",
-				"--debug"
+				"--inspect-brk"
 			],
 			"env": {
 				"NODE_ENV": "development"

--- a/common/changes/@microsoft/rush/fix-non-root-watch_2022-04-12-00-00.json
+++ b/common/changes/@microsoft/rush/fix-non-root-watch_2022-04-12-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix watch-mode phased commands when rush.json is not in the repository root. Fix watch-mode change detection on Linux.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes #3333

## Details
Revises the folder watcher logic to not assume that rush.json is in the repository root.
Fixes the manual directiory scan used on Linux to correctly pick up newly added folders.

## How it was tested
Running `rush start` in the repo under debugger and validating watcher state at each step of the way.