### PR TITLE
[rush] Fix install-run-rush --help.

### DIFF
--- a/common/changes/@microsoft/rush/fix-install-run-rush-help_2022-04-12-02-24.json
+++ b/common/changes/@microsoft/rush/fix-install-run-rush-help_2022-04-12-02-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where running the \"install-run-rush\" script with the \"--help\" parameter won't install Rush.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -84,7 +84,7 @@ function _run(): void {
       };
     } else if (!arg.startsWith('-') || arg === '-h' || arg === '--help') {
       // We either found something that looks like a command (i.e. - doesn't start with a "-"),
-      // or we found the -h/--help flag flag, which can be run without a command
+      // or we found the -h/--help flag, which can be run without a command
       commandFound = true;
     }
   }

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -82,10 +82,10 @@ function _run(): void {
         info: () => {},
         error: console.error
       };
-    }
-    if (!arg.startsWith('-')) {
+    } else if (!arg.startsWith('-') || arg === '-h' || arg === '--help') {
+      // We either found something that looks like a command (i.e. - doesn't start with a "-"),
+      // or we found the -h/--help flag flag, which can be run without a command
       commandFound = true;
-      break;
     }
   }
 


### PR DESCRIPTION
## Summary

`install-run-rush --help` currently throws an exception and does not install Rush. This broke one of rush-sdk's scenarios.

## Details

This fix adds a special case for the `-h` and `--help` flags.

## How it was tested

Ran `install-run-rush --help` and confirmed that it installs rush-lib.