### PR TITLE
[rush-serve-plugin] Include missing manifest in publish

### DIFF
--- a/common/changes/@rushstack/rush-serve-plugin/fix-serve-publish_2022-04-12-20-15.json
+++ b/common/changes/@rushstack/rush-serve-plugin/fix-serve-publish_2022-04-12-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "Include rush-plugin-manifest.json in published files.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/rush-plugins/rush-serve-plugin/.npmignore
+++ b/rush-plugins/rush-serve-plugin/.npmignore
@@ -28,3 +28,5 @@
 #--------------------------------------------
 
 # (Add your project-specific overrides here)
+!/includes/**
+!rush-plugin-manifest.json


### PR DESCRIPTION
## Summary
Updates the tarball contents to include the `rush-plugin-manifest.json` file.

## Details
See above

## How it was tested
Verified content of running `pnpm pack` locally.