### PR TITLE
[heft-jest-plugin] Enable clearMocks in shared jest config

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/enelson-default-jest_2022-04-21-15-15.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-default-jest_2022-04-21-15-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "Enable clearMocks: true by default",
+      "comment": "(BREAKING CHANGE) Enable clearMocks: true by default",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-jest-plugin/enelson-default-jest_2022-04-21-15-15.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-default-jest_2022-04-21-15-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Enable clearMocks: true by default",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/UPGRADING.md
+++ b/heft-plugins/heft-jest-plugin/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrade notes for @rushstack/heft-jest-plugin
 
-### Heft 0.3.0
+### Version 0.3.0
 
 This release of `heft-jest-plugin` enabled Jest's `clearMocks` option by default.
 If your project didn't already have this option turned on, it is possible that

--- a/heft-plugins/heft-jest-plugin/UPGRADING.md
+++ b/heft-plugins/heft-jest-plugin/UPGRADING.md
@@ -1,0 +1,24 @@
+# Upgrade notes for @rushstack/heft-jest-plugin
+
+### Heft 0.3.0
+
+This release of `heft-jest-plugin` enabled Jest's `clearMocks` option by default.
+If your project didn't already have this option turned on, it is possible that
+previously passing unit tests will fail after the upgrade.
+
+If you do have failing unit tests, then most likely the assertions in the test
+were incorrect, because the number of calls and call parameters were not being
+cleared between tests. The ideal solution is to correct these assertions.
+
+If you can't immediately address the failing unit tests, you can turn `clearMocks`
+back off in your `config/jest.config.json` file:
+
+```json
+{
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
+
+  "clearMocks": false
+}
+```
+
+For more information on the `clearMocks` option, see [Jest's clearMocks documentation](https://jestjs.io/docs/configuration#clearmocks-boolean).

--- a/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
+++ b/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
@@ -9,6 +9,12 @@
   // In order for HeftJestReporter to receive console.log() events, we must set verbose=false
   "verbose": false,
 
+  // If mocks are not cleared between tests, it opens the door to accidental reliance on
+  // ordering of tests or describe blocks, eventually resulting in intermittent failures.
+  //
+  // We suggest this setting for any heft project (in a monorepo or not).
+  "clearMocks": true,
+
   // "Adding '<rootDir>/src' here enables src/__mocks__ to be used for mocking Node.js system modules
   "roots": ["<rootDir>/src"],
 


### PR DESCRIPTION
## Summary

Enable `"clearMocks": true` in the shared jest config for `heft-jest-plugin`.

Fixes #3325.

## Details

I think this is a bare minimum setting and appropriate for the shared config.

If you have a project without this setting, it is _possible_ you could upgrade `heft-jest-plugin` and have to fix some unit tests, so `patch` doesn't seem appropriate (I picked `minor` for this case).

## How it was tested

Full rebuild of Rush passes successfully.
