### PR TITLE
[heft-jest-plugin] Add --disable-code-coverage option

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/enelson-skip-code-coverage_2022-04-23-20-23.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-skip-code-coverage_2022-04-23-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Add command-line option for temporarily disabling code coverage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -66,6 +66,7 @@ export interface IJestPluginOptions {
   configurationPath?: string;
   debugHeftReporter?: boolean;
   detectOpenHandles?: boolean;
+  disableCodeCoverage?: boolean;
   disableConfigurationModuleResolution?: boolean;
   findRelatedTests?: ReadonlyArray<string>;
   maxWorkers?: string;
@@ -217,6 +218,10 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
       // Pass test names as the command line remainder
       jestArgv.findRelatedTests = true;
       jestArgv._ = [...options.findRelatedTests];
+    }
+
+    if (options?.disableCodeCoverage) {
+      jestConfig.collectCoverage = false;
     }
 
     // Stringify the config and pass it into Jest directly
@@ -615,6 +620,14 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         ' This corresponds to the "--detectOpenHandles" parameter in Jest\'s documentation.'
     });
 
+    const disableCodeCoverage: IHeftFlagParameter = heftSession.commandLine.registerFlagParameter({
+      associatedActionNames: ['test'],
+      parameterLongName: '--disable-code-coverage',
+      environmentVariable: 'HEFT_JEST_DISABLE_CODE_COVERAGE',
+      description:
+        'Disable any configured code coverage.' + '  If no code coverage is configured, has no effect.'
+    });
+
     const findRelatedTests: IHeftStringListParameter = heftSession.commandLine.registerStringListParameter({
       associatedActionNames: ['test'],
       parameterLongName: '--find-related-tests',
@@ -704,6 +717,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
         configurationPath: config.value,
         debugHeftReporter: debugHeftReporter.value,
         detectOpenHandles: detectOpenHandles.value,
+        disableCodeCoverage: disableCodeCoverage.value,
         findRelatedTests: findRelatedTests.value,
         maxWorkers: maxWorkers.value,
         // Temporary workaround for https://github.com/microsoft/rushstack/issues/2759


### PR DESCRIPTION
## Summary

Add a command-line option for Heft that temporarily disables code coverage.

Fixes #3307

## Details

In some cases (for example, when using `--watch` on files that end up running tests in multiple files), the output of the code coverage reporter can be long and get in the way of the test failures the developer is focusing on.

A command-line option allows a developer to temporarily opt-out of code coverage while focusing on fixing, and then they can turn it back on (without the hassle of hand-editing a `jest.config.json` and possibly accidentally checking it in).

## How it was tested

 - Tested locally in projects with and without code coverage turned on
 - Confirmed coverage is ON if configured unless `--disable-code-coverage` is specified

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
