### PR TITLE
[rush] Split 'NO OP' into its own status, distinct from 'FROM CACHE'

### DIFF
--- a/common/changes/@microsoft/rush/empty-script_2022-04-24-22-20.json
+++ b/common/changes/@microsoft/rush/empty-script_2022-04-24-22-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Report status of projects with an empty script as \"empty script,\" instead of as \"from cache.\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/empty-script_2022-04-24-22-20.json
+++ b/common/changes/@microsoft/rush/empty-script_2022-04-24-22-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Report status of projects with an empty script as \"empty script,\" instead of as \"from cache.\"",
+      "comment": "Report status of projects with an empty script as \"did not define any work,\" instead of as \"from cache.\"",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -530,10 +530,10 @@ export class Operation {
 // @beta
 export enum OperationStatus {
     Blocked = "BLOCKED",
-    EmptyScript = "EMPTY SCRIPT",
     Executing = "EXECUTING",
     Failure = "FAILURE",
     FromCache = "FROM CACHE",
+    NoOp = "NOOP",
     Ready = "READY",
     Skipped = "SKIPPED",
     Success = "SUCCESS",

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -533,7 +533,7 @@ export enum OperationStatus {
     Executing = "EXECUTING",
     Failure = "FAILURE",
     FromCache = "FROM CACHE",
-    NoOp = "NOOP",
+    NoOp = "NO OP",
     Ready = "READY",
     Skipped = "SKIPPED",
     Success = "SUCCESS",

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -530,6 +530,7 @@ export class Operation {
 // @beta
 export enum OperationStatus {
     Blocked = "BLOCKED",
+    EmptyScript = "EMPTY SCRIPT",
     Executing = "EXECUTING",
     Failure = "FAILURE",
     FromCache = "FROM CACHE",

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -48,7 +48,7 @@ const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
   [OperationStatus.Blocked]: '.',
   [OperationStatus.Skipped]: '%',
   [OperationStatus.FromCache]: '%',
-  [OperationStatus.EmptyScript]: '%'
+  [OperationStatus.NoOp]: '%'
 };
 
 /**
@@ -63,7 +63,7 @@ const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => stri
   [OperationStatus.Blocked]: colors.red,
   [OperationStatus.Skipped]: colors.green,
   [OperationStatus.FromCache]: colors.green,
-  [OperationStatus.EmptyScript]: colors.blue
+  [OperationStatus.NoOp]: colors.gray
 };
 
 /**
@@ -370,11 +370,11 @@ export class OperationExecutionManager {
       }
 
       /**
-       * This operation was skipped via legacy change detection.
+       * This operation intentionally didn't do anything.
        */
-      case OperationStatus.EmptyScript: {
+      case OperationStatus.NoOp: {
         if (!silent) {
-          record.collatedWriter.terminal.writeStdoutLine(colors.gray(`"${name}" had an empty script.`));
+          record.collatedWriter.terminal.writeStdoutLine(colors.gray(`"${name}" did not define any work.`));
         }
         break;
       }
@@ -433,7 +433,7 @@ export class OperationExecutionManager {
         case OperationStatus.SuccessWithWarning:
         case OperationStatus.Blocked:
         case OperationStatus.Failure:
-        case OperationStatus.EmptyScript:
+        case OperationStatus.NoOp:
           break;
         default:
           // This should never happen
@@ -467,10 +467,10 @@ export class OperationExecutionManager {
     );
 
     this._writeCondensedSummary(
-      OperationStatus.EmptyScript,
+      OperationStatus.NoOp,
       operationsByStatus,
       colors.gray,
-      'These operations had an empty script:'
+      'These operations did not define any work:'
     );
 
     this._writeCondensedSummary(

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -41,5 +41,5 @@ export enum OperationStatus {
   /**
    * The Operation was a no-op (for example, it had an empty script)
    */
-  NoOp = 'NOOP'
+  NoOp = 'NO OP'
 }

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -37,5 +37,9 @@ export enum OperationStatus {
   /**
    * The Operation could not be executed because one or more of its dependencies failed
    */
-  Blocked = 'BLOCKED'
+  Blocked = 'BLOCKED',
+  /**
+   * The Operation had an empty script
+   */
+  EmptyScript = 'EMPTY SCRIPT'
 }

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -39,7 +39,7 @@ export enum OperationStatus {
    */
   Blocked = 'BLOCKED',
   /**
-   * The Operation had an empty script
+   * The Operation was a no-op (for example, it had an empty script)
    */
-  EmptyScript = 'EMPTY SCRIPT'
+  NoOp = 'NOOP'
 }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -87,7 +87,7 @@ function createShellOperations(
         // Empty build script indicates a no-op, so use a no-op runner
         operation.runner = new NullOperationRunner({
           name: displayName,
-          result: OperationStatus.EmptyScript,
+          result: OperationStatus.NoOp,
           silent: false
         });
       }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -87,7 +87,7 @@ function createShellOperations(
         // Empty build script indicates a no-op, so use a no-op runner
         operation.runner = new NullOperationRunner({
           name: displayName,
-          result: OperationStatus.FromCache,
+          result: OperationStatus.EmptyScript,
           silent: false
         });
       }


### PR DESCRIPTION
## Summary

Right now, projects with an empty script are reported as "from cache" after their operations 'complete.' This is misleading. This PR adds a separate status to specifically report that no work was performed for these projects.

## How it was tested

Ran `rush build` in a repo that has projects with empty scripts.