### PR TITLE
[rush] Un-deprecate RushConfigurationProject.packageJson.

### DIFF
--- a/common/changes/@microsoft/rush/un-deprecate-packageJson_2022-04-25-01-53.json
+++ b/common/changes/@microsoft/rush/un-deprecate-packageJson_2022-04-25-01-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove the @deprecated label from `RushConfigurationProject.packageJson`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -756,7 +756,6 @@ export class RushConfigurationProject {
     get isMainProject(): boolean;
     // @deprecated
     get localDependencyProjects(): ReadonlyArray<RushConfigurationProject>;
-    // @deprecated
     get packageJson(): IPackageJson;
     // @beta
     get packageJsonEditor(): PackageJsonEditor;

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -355,7 +355,6 @@ export class RushConfigurationProject {
 
   /**
    * The parsed NPM "package.json" file from projectFolder.
-   * @deprecated Use packageJsonEditor instead
    */
   public get packageJson(): IPackageJson {
     return this._packageJson;


### PR DESCRIPTION
This removes the `@deprecated` label from `RushConfigurationProject`'s `packageJson` property. This is a useful property for tools integrating with `rush-lib`.