### PR TITLE
[rush-serve-plugin] Fix missing runtime dependency

### DIFF
--- a/common/changes/@rushstack/rush-serve-plugin/serve-missing-dependency_2022-04-26-00-35.json
+++ b/common/changes/@rushstack/rush-serve-plugin/serve-missing-dependency_2022-04-26-00-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "Fix missing runtime dependency on @rushstack/heft-config-file.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2111,6 +2111,7 @@ importers:
       express: 4.17.1
     dependencies:
       '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
+      '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@rushstack/rig-package': link:../../libraries/rig-package
       '@rushstack/rush-sdk': link:../../libraries/rush-sdk
@@ -2119,7 +2120,6 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
-      '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/express': 4.17.13
       '@types/heft-jest': 1.0.1

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@rushstack/debug-certificate-manager": "workspace:*",
+    "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rig-package": "workspace:*",
     "@rushstack/rush-sdk": "workspace:*",
@@ -26,7 +27,6 @@
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/express": "4.17.13",
     "@types/heft-jest": "1.0.1",


### PR DESCRIPTION
## Summary
Fixes a missing runtime dependency in @rushstack/rush-serve-plugin on @rushstack/heft-config-file

## Details
The dependency is needed to read rush-project-serve.json from projects.

## How it was tested
Had been using a runtime workaround in consuming packages.