### PR TITLE
[rush-lib] Disable legacy skip if build cache enabled

### DIFF
--- a/common/changes/@microsoft/rush/disable-skip-if-cache_2022-04-27-19-57.json
+++ b/common/changes/@microsoft/rush/disable-skip-if-cache_2022-04-27-19-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable legacy skip logic when build cache is enabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -409,6 +409,9 @@ export class ShellOperationRunner implements IOperationRunner {
       this._projectBuildCache = undefined;
 
       if (this._buildCacheConfiguration && this._buildCacheConfiguration.buildCacheEnabled) {
+        // Disable legacy skip logic if the build cache is in play
+        this.isSkipAllowed = false;
+
         const projectConfiguration: RushProjectConfiguration | undefined =
           await RushProjectConfiguration.tryLoadForProjectAsync(this._rushProject, terminal);
         if (projectConfiguration) {


### PR DESCRIPTION
## Summary
Fixes #3311 

## Details
Disables the legacy skip behavior if the build cache is enabled.

## How it was tested
Local builds.