### PR TITLE
[rush-lib] Allow phased commands to install prior to execution if requested

### DIFF
--- a/common/changes/@microsoft/rush/install-option_2022-05-02-21-50.json
+++ b/common/changes/@microsoft/rush/install-option_2022-05-02-21-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Provide ability for phased script commands to internally invoke \"rush install\" prior to execution.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/libraries/rush-lib/src/api/CommandLineConfiguration.ts
@@ -92,7 +92,8 @@ export interface IPhasedCommandConfig extends IPhasedCommandWithoutPhasesJson, I
   watchPhases: Set<IPhase>;
   /**
    * If set to `true`, then this phased command will always perform an install before executing, regardless of CLI flags.
-   * If set to `false`, then this phased command will support the "--install" CLI flag.
+   * If set to `false`, then Rush will define a built-in "--install" CLI flag for this command.
+   * If undefined, then Rush does not define a built-in "--install" CLI flag for this command and no installation is performed.
    */
   alwaysInstall: boolean | undefined;
 }

--- a/libraries/rush-lib/src/api/CommandLineJson.ts
+++ b/libraries/rush-lib/src/api/CommandLineJson.ts
@@ -49,6 +49,9 @@ export interface IPhasedCommandJson extends IPhasedCommandWithoutPhasesJson {
     alwaysWatch: boolean;
     watchPhases: string[];
   };
+  installOptions?: {
+    alwaysInstall: boolean;
+  };
 }
 
 /**

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -396,7 +396,8 @@ export class RushCommandLineParser extends CommandLineParser {
         watchPhases: command.watchPhases,
         phases: commandLineConfiguration.phases,
 
-        alwaysWatch: command.alwaysWatch
+        alwaysWatch: command.alwaysWatch,
+        alwaysInstall: command.alwaysInstall
       })
     );
   }

--- a/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
+++ b/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushGlobalFolder } from '../../api/RushGlobalFolder';
+import type { BaseInstallManager } from '../base/BaseInstallManager';
+import { InstallManagerFactory } from '../InstallManagerFactory';
+import { SetupChecks } from '../SetupChecks';
+import { PurgeManager } from '../PurgeManager';
+import { VersionMismatchFinder } from '../versionMismatch/VersionMismatchFinder';
+
+export interface IRunInstallOptions {
+  rushConfiguration: RushConfiguration;
+  rushGlobalFolder: RushGlobalFolder;
+  isDebug: boolean;
+}
+
+export async function doBasicInstallAsync(options: IRunInstallOptions): Promise<void> {
+  const { rushConfiguration, rushGlobalFolder, isDebug } = options;
+
+  VersionMismatchFinder.ensureConsistentVersions(rushConfiguration);
+  SetupChecks.validate(rushConfiguration);
+
+  const purgeManager: typeof PurgeManager.prototype = new PurgeManager(rushConfiguration, rushGlobalFolder);
+
+  const installManager: BaseInstallManager = InstallManagerFactory.getInstallManager(
+    rushConfiguration,
+    rushGlobalFolder,
+    purgeManager,
+    {
+      debug: isDebug,
+      allowShrinkwrapUpdates: false,
+      checkOnly: false,
+      bypassPolicy: false,
+      noLink: false,
+      fullUpgrade: false,
+      recheckShrinkwrap: false,
+      collectLogFile: false,
+      pnpmFilterArguments: [],
+      maxInstallAttempts: 1,
+      networkConcurrency: undefined
+    }
+  );
+
+  try {
+    await installManager.doInstallAsync();
+  } finally {
+    purgeManager.deleteAll();
+  }
+}

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -209,6 +209,20 @@
                   }
                 }
               }
+            },
+            "installOptions": {
+              "title": "Install Options",
+              "description": "Controls behavior related to performing installation as part of executing this command.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["alwaysInstall"],
+              "properties": {
+                "alwaysInstall": {
+                  "title": "Always Install",
+                  "description": "Indicates that this command will always perform a standard \"rush install\" before executing, as if the \"--install\" CLI flag was passed.",
+                  "type": "boolean"
+                }
+              }
             }
           }
         },
@@ -225,7 +239,8 @@
             "enableParallelism": { "$ref": "#/definitions/anything" },
             "incremental": { "$ref": "#/definitions/anything" },
             "phases": { "$ref": "#/definitions/anything" },
-            "watchOptions": { "$ref": "#/definitions/anything" }
+            "watchOptions": { "$ref": "#/definitions/anything" },
+            "installOptions": { "$ref": "#/definitions/anything" }
           }
         }
       ]


### PR DESCRIPTION
## Summary
Allows phased commands to opt into performing a `rush install` prior to execution.

## Details
Adds a new section `installOptions` to phased command definitions. The section contains one option `alwaysInstall: boolean`. If set to `true`, the command will always invoke a full `rush install` (which may detect that nothing needs to be done) prior to execution. If set to `false`, then the command provides an `--install` CLI parameter to perform the installation but does not do so by default.

## How it was tested
Locally added the option to `rush start`, tested with `alwaysInstall: false` and verified that `--install` was available and worked as intended. Tested with `alwaysInstall: true` and verified that `--install` was not available and the installation occurred automatically.