### PR TITLE
[api-extractor] Adds support for surfacing whether a class member is protected

### DIFF
--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -334,10 +334,12 @@ export class ApiModelGenerator {
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
       const docComment: tsdoc.DocComment | undefined = apiItemMetadata.tsdocComment;
       const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
+      const isProtected: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Protected) !== 0;
 
       apiConstructor = new ApiConstructor({
         docComment,
         releaseTag,
+        isProtected,
         parameters,
         overloadIndex,
         excerptTokens
@@ -709,11 +711,13 @@ export class ApiModelGenerator {
       }
       const isOptional: boolean =
         (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
+      const isProtected: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Protected) !== 0;
 
       apiMethod = new ApiMethod({
         name,
         docComment,
         releaseTag,
+        isProtected,
         isStatic,
         isOptional,
         typeParameters,
@@ -846,11 +850,13 @@ export class ApiModelGenerator {
       const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
       const isOptional: boolean =
         (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
+      const isProtected: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Protected) !== 0;
 
       apiProperty = new ApiProperty({
         name,
         docComment,
         releaseTag,
+        isProtected,
         isStatic,
         isOptional,
         excerptTokens,

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -255,7 +255,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []
@@ -298,6 +299,7 @@
                   "text": "constructor();"
                 }
               ],
+              "isProtected": false,
               "releaseTag": "Public",
               "overloadIndex": 1,
               "parameters": []
@@ -320,6 +322,7 @@
                   "text": ");"
                 }
               ],
+              "isProtected": false,
               "releaseTag": "Public",
               "overloadIndex": 2,
               "parameters": [
@@ -400,6 +403,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -445,6 +449,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
                 "endIndex": 6
@@ -499,6 +504,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -567,6 +573,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 8,
                 "endIndex": 9
@@ -618,6 +625,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -653,7 +661,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -681,7 +690,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Method",
@@ -711,6 +721,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -754,7 +765,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -782,7 +794,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Method",
@@ -820,6 +833,7 @@
               ],
               "isOptional": false,
               "isStatic": true,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
                 "endIndex": 6
@@ -866,6 +880,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -904,7 +919,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -931,7 +947,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "extendsTokenRange": {
@@ -2449,6 +2466,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ancillaryDeclarations/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ancillaryDeclarations/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -203,6 +203,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -256,6 +257,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -303,6 +305,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 4
@@ -603,6 +606,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -640,6 +644,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -683,7 +688,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -702,7 +708,8 @@
                 "startIndex": 0,
                 "endIndex": 0
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -729,7 +736,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -760,7 +768,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -279,7 +279,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -306,7 +307,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "extendsTokenRange": {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -209,7 +209,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []
@@ -257,7 +258,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -289,7 +291,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -239,7 +239,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []
@@ -287,7 +288,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -319,7 +321,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -278,6 +278,7 @@
                   ],
                   "isOptional": false,
                   "isStatic": false,
+                  "isProtected": false,
                   "returnTypeTokenRange": {
                     "startIndex": 3,
                     "endIndex": 4

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -203,6 +203,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -232,6 +233,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -277,6 +279,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -306,6 +309,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -351,6 +355,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -380,6 +385,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -258,6 +258,7 @@
                   ],
                   "isOptional": false,
                   "isStatic": false,
+                  "isProtected": false,
                   "returnTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -213,7 +213,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -245,7 +246,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -277,7 +279,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -309,7 +312,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -341,7 +345,8 @@
                 "startIndex": 1,
                 "endIndex": 3
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             }
           ],
           "implementsTokenRanges": []

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ecmaScriptPrivateFields/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ecmaScriptPrivateFields/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/excerptTokens/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/excerptTokens/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -240,6 +240,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
                 "endIndex": 6

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -399,6 +399,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
                 "endIndex": 6
@@ -461,6 +462,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 5,
                 "endIndex": 6

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -212,6 +212,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -263,6 +264,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -301,6 +303,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/namedDefaultImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/namedDefaultImport/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -208,7 +208,8 @@
                 "startIndex": 1,
                 "endIndex": 2
               },
-              "isStatic": false
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Method",
@@ -235,6 +236,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3
@@ -288,6 +290,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 3,
                 "endIndex": 4
@@ -342,6 +345,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1005,
+    "schemaVersion": 1006,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -203,6 +203,7 @@
               ],
               "isOptional": false,
               "isStatic": false,
+              "isProtected": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.4.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.4.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.4.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.4.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
@@ -1753,10 +1753,10 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.45.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.2.tgz}
+  file:../temp/tarballs/rushstack-heft-0.45.4.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.4.tgz}
     name: '@rushstack/heft'
-    version: 0.45.2
+    version: 0.45.4
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:

--- a/common/changes/@microsoft/api-extractor-model/protected-mixin_2022-05-20-22-50.json
+++ b/common/changes/@microsoft/api-extractor-model/protected-mixin_2022-05-20-22-50.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor-model",
-      "comment": "Add parsing logic to parse whether a class constructor, property, or method has the \\\"protected\\\" modifier.",
+      "comment": "Add parsing logic to parse whether a class constructor, property, or method has the 'protected' modifier.",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/api-extractor-model/protected-mixin_2022-05-20-22-50.json
+++ b/common/changes/@microsoft/api-extractor-model/protected-mixin_2022-05-20-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Add parsing logic to parse whether a class constructor, property, or method has the \\\"protected\\\" modifier.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/protected-mixin_2022-05-20-22-50.json
+++ b/common/changes/@microsoft/api-extractor/protected-mixin_2022-05-20-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add an ApiParameterMixin that adds an isProtected parameter to class constructor, property, and method API items.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -508,6 +508,21 @@ export class ApiPropertySignature extends ApiPropertyItem {
 }
 
 // @public
+export function ApiProtectedMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiProtectedMixin);
+
+// @public
+export interface ApiProtectedMixin extends ApiItem {
+    readonly isProtected: boolean;
+    // @override (undocumented)
+    serializeInto(jsonObject: Partial<IApiItemJson>): void;
+}
+
+// @public
+export namespace ApiProtectedMixin {
+    export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiProtectedMixin;
+}
+
+// @public
 export function ApiReleaseTagMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiReleaseTagMixin);
 
 // @public
@@ -659,7 +674,7 @@ export interface IApiClassOptions extends IApiItemContainerMixinOptions, IApiNam
 }
 
 // @public
-export interface IApiConstructorOptions extends IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
+export interface IApiConstructorOptions extends IApiParameterListMixinOptions, IApiProtectedMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
 }
 
 // @public
@@ -721,7 +736,7 @@ export interface IApiItemOptions {
 }
 
 // @public
-export interface IApiMethodOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiStaticMixinOptions, IApiOptionalMixinOptions, IApiDeclaredItemOptions {
+export interface IApiMethodOptions extends IApiNameMixinOptions, IApiTypeParameterListMixinOptions, IApiParameterListMixinOptions, IApiProtectedMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiStaticMixinOptions, IApiOptionalMixinOptions, IApiDeclaredItemOptions {
 }
 
 // @public (undocumented)
@@ -782,11 +797,17 @@ export interface IApiPropertyItemOptions extends IApiNameMixinOptions, IApiRelea
 }
 
 // @public
-export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiStaticMixinOptions {
+export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiProtectedMixinOptions, IApiStaticMixinOptions {
 }
 
 // @public
 export interface IApiPropertySignatureOptions extends IApiPropertyItemOptions {
+}
+
+// @public
+export interface IApiProtectedMixinOptions extends IApiItemOptions {
+    // (undocumented)
+    isProtected: boolean;
 }
 
 // @public

--- a/libraries/api-extractor-model/src/index.ts
+++ b/libraries/api-extractor-model/src/index.ts
@@ -31,6 +31,7 @@ export {
   ApiTypeParameterListMixin
 } from './mixins/ApiTypeParameterListMixin';
 export { IApiItemContainerMixinOptions, ApiItemContainerMixin } from './mixins/ApiItemContainerMixin';
+export { IApiProtectedMixinOptions, ApiProtectedMixin } from './mixins/ApiProtectedMixin';
 export { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from './mixins/ApiReleaseTagMixin';
 export { IApiReturnTypeMixinOptions, ApiReturnTypeMixin } from './mixins/ApiReturnTypeMixin';
 export { IApiStaticMixinOptions, ApiStaticMixin } from './mixins/ApiStaticMixin';

--- a/libraries/api-extractor-model/src/mixins/ApiProtectedMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiProtectedMixin.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.s
+
+import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
+import { DeserializerContext } from '../model/DeserializerContext';
+
+/**
+ * Constructor options for {@link (IApiProtectedMixinOptions:interface)}.
+ * @public
+ */
+export interface IApiProtectedMixinOptions extends IApiItemOptions {
+  isProtected: boolean;
+}
+
+export interface IApiProtectedMixinJson extends IApiItemJson {
+  isProtected: boolean;
+}
+
+const _isProtected: unique symbol = Symbol('ApiProtectedMixin._isProtected');
+
+/**
+ * The mixin base class for API items that can have the TypeScript `protected` keyword applied to them.
+ *
+ * @remarks
+ *
+ * This is part of the {@link ApiModel} hierarchy of classes, which are serializable representations of
+ * API declarations.  The non-abstract classes (e.g. `ApiClass`, `ApiEnum`, `ApiInterface`, etc.) use
+ * TypeScript "mixin" functions (e.g. `ApiDeclaredItem`, `ApiItemContainerMixin`, etc.) to add various
+ * features that cannot be represented as a normal inheritance chain (since TypeScript does not allow a child class
+ * to extend more than one base class).  The "mixin" is a TypeScript merged declaration with three components:
+ * the function that generates a subclass, an interface that describes the members of the subclass, and
+ * a namespace containing static members of the class.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ApiProtectedMixin extends ApiItem {
+  /**
+   * Whether the declaration has the TypeScript `protected` keyword.
+   */
+  readonly isProtected: boolean;
+
+  /** @override */
+  serializeInto(jsonObject: Partial<IApiItemJson>): void;
+}
+
+/**
+ * Mixin function for {@link (ApiProtectedMixin:interface)}.
+ *
+ * @param baseClass - The base class to be extended
+ * @returns A child class that extends baseClass, adding the {@link (ApiProtectedMixin:interface)} functionality.
+ *
+ * @public
+ */
+export function ApiProtectedMixin<TBaseClass extends IApiItemConstructor>(
+  baseClass: TBaseClass
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): TBaseClass & (new (...args: any[]) => ApiProtectedMixin) {
+  class MixedClass extends baseClass implements ApiProtectedMixin {
+    public [_isProtected]: boolean;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public constructor(...args: any[]) {
+      super(...args);
+
+      const options: IApiProtectedMixinOptions = args[0];
+      this[_isProtected] = options.isProtected;
+    }
+
+    /** @override */
+    public static onDeserializeInto(
+      options: Partial<IApiProtectedMixinOptions>,
+      context: DeserializerContext,
+      jsonObject: IApiProtectedMixinJson
+    ): void {
+      baseClass.onDeserializeInto(options, context, jsonObject);
+
+      options.isProtected = jsonObject.isProtected;
+    }
+
+    public get isProtected(): boolean {
+      return this[_isProtected];
+    }
+
+    /** @override */
+    public serializeInto(jsonObject: Partial<IApiProtectedMixinJson>): void {
+      super.serializeInto(jsonObject);
+
+      jsonObject.isProtected = this.isProtected;
+    }
+  }
+
+  return MixedClass;
+}
+
+/**
+ * Static members for {@link (ApiProtectedMixin:interface)}.
+ * @public
+ */
+export namespace ApiProtectedMixin {
+  /**
+   * A type guard that tests whether the specified `ApiItem` subclass extends the `ApiProtectedMixin` mixin.
+   *
+   * @remarks
+   *
+   * The JavaScript `instanceof` operator cannot be used to test for mixin inheritance, because each invocation of
+   * the mixin function produces a different subclass.  (This could be mitigated by `Symbol.hasInstance`, however
+   * the TypeScript type system cannot invoke a runtime test.)
+   */
+  export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiProtectedMixin {
+    return apiItem.hasOwnProperty(_isProtected);
+  }
+}

--- a/libraries/api-extractor-model/src/model/ApiConstructor.ts
+++ b/libraries/api-extractor-model/src/model/ApiConstructor.ts
@@ -9,6 +9,7 @@ import {
 import { ApiItemKind } from '../items/ApiItem';
 import { IApiDeclaredItemOptions, ApiDeclaredItem } from '../items/ApiDeclaredItem';
 import { IApiParameterListMixinOptions, ApiParameterListMixin } from '../mixins/ApiParameterListMixin';
+import { ApiProtectedMixin, IApiProtectedMixinOptions } from '../mixins/ApiProtectedMixin';
 import { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from '../mixins/ApiReleaseTagMixin';
 
 /**
@@ -17,6 +18,7 @@ import { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from '../mixins/ApiRel
  */
 export interface IApiConstructorOptions
   extends IApiParameterListMixinOptions,
+    IApiProtectedMixinOptions,
     IApiReleaseTagMixinOptions,
     IApiDeclaredItemOptions {}
 
@@ -47,7 +49,9 @@ export interface IApiConstructorOptions
  *
  * @public
  */
-export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(ApiDeclaredItem)) {
+export class ApiConstructor extends ApiParameterListMixin(
+  ApiReleaseTagMixin(ApiProtectedMixin(ApiDeclaredItem))
+) {
   public constructor(options: IApiConstructorOptions) {
     super(options);
   }

--- a/libraries/api-extractor-model/src/model/ApiMethod.ts
+++ b/libraries/api-extractor-model/src/model/ApiMethod.ts
@@ -8,6 +8,7 @@ import {
   Component
 } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
 import { ApiItemKind } from '../items/ApiItem';
+import { ApiProtectedMixin, IApiProtectedMixinOptions } from '../mixins/ApiProtectedMixin';
 import { ApiStaticMixin, IApiStaticMixinOptions } from '../mixins/ApiStaticMixin';
 import { IApiDeclaredItemOptions, ApiDeclaredItem } from '../items/ApiDeclaredItem';
 import { IApiParameterListMixinOptions, ApiParameterListMixin } from '../mixins/ApiParameterListMixin';
@@ -28,6 +29,7 @@ export interface IApiMethodOptions
   extends IApiNameMixinOptions,
     IApiTypeParameterListMixinOptions,
     IApiParameterListMixinOptions,
+    IApiProtectedMixinOptions,
     IApiReleaseTagMixinOptions,
     IApiReturnTypeMixinOptions,
     IApiStaticMixinOptions,
@@ -58,7 +60,9 @@ export interface IApiMethodOptions
 export class ApiMethod extends ApiNameMixin(
   ApiTypeParameterListMixin(
     ApiParameterListMixin(
-      ApiReleaseTagMixin(ApiReturnTypeMixin(ApiStaticMixin(ApiOptionalMixin(ApiDeclaredItem))))
+      ApiReleaseTagMixin(
+        ApiReturnTypeMixin(ApiProtectedMixin(ApiStaticMixin(ApiOptionalMixin(ApiDeclaredItem))))
+      )
     )
   )
 ) {

--- a/libraries/api-extractor-model/src/model/ApiProperty.ts
+++ b/libraries/api-extractor-model/src/model/ApiProperty.ts
@@ -8,6 +8,7 @@ import {
   Component
 } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
 import { ApiItemKind } from '../items/ApiItem';
+import { ApiProtectedMixin, IApiProtectedMixinOptions } from '../mixins/ApiProtectedMixin';
 import { ApiStaticMixin, IApiStaticMixinOptions } from '../mixins/ApiStaticMixin';
 import { ApiPropertyItem, IApiPropertyItemOptions } from '../items/ApiPropertyItem';
 
@@ -15,7 +16,10 @@ import { ApiPropertyItem, IApiPropertyItemOptions } from '../items/ApiPropertyIt
  * Constructor options for {@link ApiProperty}.
  * @public
  */
-export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiStaticMixinOptions {}
+export interface IApiPropertyOptions
+  extends IApiPropertyItemOptions,
+    IApiProtectedMixinOptions,
+    IApiStaticMixinOptions {}
 
 /**
  * Represents a TypeScript property declaration that belongs to an `ApiClass`.
@@ -51,7 +55,7 @@ export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiStatic
  *
  * @public
  */
-export class ApiProperty extends ApiStaticMixin(ApiPropertyItem) {
+export class ApiProperty extends ApiProtectedMixin(ApiStaticMixin(ApiPropertyItem)) {
   public constructor(options: IApiPropertyOptions) {
     super(options);
   }

--- a/libraries/api-extractor-model/src/model/DeserializerContext.ts
+++ b/libraries/api-extractor-model/src/model/DeserializerContext.ts
@@ -43,12 +43,20 @@ export enum ApiJsonSchemaVersion {
   V_1005 = 1005,
 
   /**
+   * Add an `isProtected` field to `IApiConstructorOptions`, `IApiPropertyOptions`, and `IApiMethodOptions` to
+   * track whether a class member has the `protected` modifier.
+   *
+   * When loading older JSON files, the value defaults to `false`.
+   */
+  V_1006 = 1006,
+
+  /**
    * The current latest .api.json schema version.
    *
    * IMPORTANT: When incrementing this number, consider whether `OLDEST_SUPPORTED` or `OLDEST_FORWARDS_COMPATIBLE`
    * should be updated.
    */
-  LATEST = V_1005,
+  LATEST = V_1006,
 
   /**
    * The oldest .api.json schema version that is still supported for backwards compatibility.


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3386.

## Details

* Adds a new `ApiProtectedMixin` mixin similar to the existing `ApiStaticMixin` mixin. Applies this mixin to the class constructor, property, and method API items.
* Updated api-extractor-model to parse whether a class member has the `protected` modifier.
* Did not update api-documenter. That is coming in a subsequent PR.

## How it was tested

Added some additional test cases to the build tests, ran `rush rebuild`, manually verified that the `.api.json` files looked correct.
