### PR TITLE
[rush] Fix an issue where "rush list --json" prints non-json output in a repo that uses rush plugins with autoinstallers.

### DIFF
--- a/common/changes/@microsoft/rush/fix-json-flag_2022-05-03-21-15.json
+++ b/common/changes/@microsoft/rush/fix-json-flag_2022-05-03-21-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush list --json\" prints non-json output in a repo that uses rush plugins with autoinstallers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/test/__snapshots__/CommandLineConfiguration.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/CommandLineConfiguration.test.ts.snap
@@ -17,5 +17,3 @@ exports[`CommandLineConfiguration Forbids a misnamed phase 3`] = `"In command-li
 exports[`CommandLineConfiguration Forbids a misnamed phase 4`] = `"In command-line.json, the phase \\"_phase:A\\"'s name is not a valid phase name. Phase names must begin with the required prefix \\"_phase:\\" followed by a name containing lowercase letters, numbers, or hyphens. The name must start with a letter and must not end with a hyphen."`;
 
 exports[`CommandLineConfiguration Forbids a misnamed phase 5`] = `"In command-line.json, the phase \\"_phase:A-\\"'s name is not a valid phase name. Phase names must begin with the required prefix \\"_phase:\\" followed by a name containing lowercase letters, numbers, or hyphens. The name must start with a letter and must not end with a hyphen."`;
-
-exports[`CommandLineConfiguration parameters does not allow a parameter to only be associated with phased commands but not have any associated phases 1`] = `"command-line.json defines a parameter \\"--flag\\" that is only associated with phased commands, but lists no associated phases."`;

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -72,6 +72,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private _debugParameter!: CommandLineFlagParameter;
   private _quietParameter!: CommandLineFlagParameter;
+  private _restrictConsoleOutput: boolean = RushCommandLineParser.shouldRestrictConsoleOutput();
   private readonly _rushOptions: IRushCommandLineParserOptions;
   private readonly _terminalProvider: ConsoleTerminalProvider;
   private readonly _terminal: Terminal;
@@ -98,7 +99,7 @@ export class RushCommandLineParser extends CommandLineParser {
     try {
       const rushJsonFilename: string | undefined = RushConfiguration.tryFindRushJsonLocation({
         startingFolder: this._rushOptions.cwd,
-        showVerbose: !RushCommandLineParser.shouldRestrictConsoleOutput()
+        showVerbose: !this._restrictConsoleOutput
       });
       if (rushJsonFilename) {
         this.rushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFilename);
@@ -121,7 +122,8 @@ export class RushCommandLineParser extends CommandLineParser {
       rushSession: this.rushSession,
       rushConfiguration: this.rushConfiguration,
       terminal: this._terminal,
-      builtInPluginConfigurations: this._rushOptions.builtInPluginConfigurations
+      builtInPluginConfigurations: this._rushOptions.builtInPluginConfigurations,
+      restrictConsoleOutput: this._restrictConsoleOutput
     });
 
     this._populateActions();

--- a/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -38,7 +38,10 @@ export class InitAutoinstallerAction extends BaseRushAction {
   protected async runAsync(): Promise<void> {
     const autoinstallerName: string = this._name.value!;
 
-    const autoinstaller: Autoinstaller = new Autoinstaller(autoinstallerName, this.rushConfiguration);
+    const autoinstaller: Autoinstaller = new Autoinstaller({
+      autoinstallerName,
+      rushConfiguration: this.rushConfiguration
+    });
 
     if (FileSystem.exists(autoinstaller.folderFullPath)) {
       // It's okay if the folder is empty

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -13,7 +13,7 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
   public constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'update-autoinstaller',
-      summary: 'Updates autoinstaller package dependenices',
+      summary: 'Updates autoinstaller package dependencies',
       documentation: 'Use this command to regenerate the shrinkwrap file for an autoinstaller folder.',
       parser
     });
@@ -32,7 +32,10 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
   protected async runAsync(): Promise<void> {
     const autoinstallerName: string = this._name.value!;
 
-    const autoinstaller: Autoinstaller = new Autoinstaller(autoinstallerName, this.rushConfiguration);
+    const autoinstaller: Autoinstaller = new Autoinstaller({
+      autoinstallerName,
+      rushConfiguration: this.rushConfiguration
+    });
     autoinstaller.update();
 
     console.log('\nSuccess.');

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -84,7 +84,10 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
   }
 
   private async _prepareAutoinstallerName(): Promise<void> {
-    const autoInstaller: Autoinstaller = new Autoinstaller(this._autoinstallerName, this.rushConfiguration);
+    const autoInstaller: Autoinstaller = new Autoinstaller({
+      autoinstallerName: this._autoinstallerName,
+      rushConfiguration: this.rushConfiguration
+    });
 
     await autoInstaller.prepareAsync();
   }

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -49,7 +49,7 @@ Positional arguments:
                         repo, and create or update the shrinkwrap file as 
                         needed
     update-autoinstaller
-                        Updates autoinstaller package dependenices
+                        Updates autoinstaller package dependencies
     update-cloud-credentials
                         (EXPERIMENTAL) Update the credentials used by the 
                         build cache provider.

--- a/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
@@ -14,6 +14,10 @@ import {
   PluginLoaderBase
 } from './PluginLoaderBase';
 
+interface IAutoinstallerPluginLoaderOptions extends IPluginLoaderOptions<IRushPluginConfiguration> {
+  restrictConsoleOutput: boolean;
+}
+
 /**
  * @beta
  */
@@ -22,12 +26,13 @@ export class AutoinstallerPluginLoader extends PluginLoaderBase<IRushPluginConfi
 
   public readonly packageFolder: string;
 
-  public constructor(options: IPluginLoaderOptions<IRushPluginConfiguration>) {
+  public constructor(options: IAutoinstallerPluginLoaderOptions) {
     super(options);
-    this._autoinstaller = new Autoinstaller(
-      options.pluginConfiguration.autoinstallerName,
-      this._rushConfiguration
-    );
+    this._autoinstaller = new Autoinstaller({
+      autoinstallerName: options.pluginConfiguration.autoinstallerName,
+      rushConfiguration: this._rushConfiguration,
+      restrictConsoleOutput: options.restrictConsoleOutput
+    });
 
     this.packageFolder = path.join(this._autoinstaller.folderFullPath, 'node_modules', this.packageName);
   }

--- a/libraries/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginManager.ts
@@ -16,6 +16,7 @@ export interface IPluginManagerOptions {
   rushConfiguration: RushConfiguration;
   rushSession: RushSession;
   builtInPluginConfigurations: IBuiltInPluginConfiguration[];
+  restrictConsoleOutput: boolean;
 }
 
 export interface ICustomCommandLineConfigurationInfo {
@@ -27,6 +28,7 @@ export class PluginManager {
   private readonly _terminal: ITerminal;
   private readonly _rushConfiguration: RushConfiguration;
   private readonly _rushSession: RushSession;
+  private readonly _restrictConsoleOutput: boolean;
   private readonly _builtInPluginLoaders: BuiltInPluginLoader[];
   private readonly _autoinstallerPluginLoaders: AutoinstallerPluginLoader[];
   private readonly _installedAutoinstallerNames: Set<string>;
@@ -38,6 +40,7 @@ export class PluginManager {
     this._terminal = options.terminal;
     this._rushConfiguration = options.rushConfiguration;
     this._rushSession = options.rushSession;
+    this._restrictConsoleOutput = options.restrictConsoleOutput;
 
     this._installedAutoinstallerNames = new Set<string>();
 
@@ -93,7 +96,8 @@ export class PluginManager {
       return new AutoinstallerPluginLoader({
         pluginConfiguration,
         rushConfiguration: this._rushConfiguration,
-        terminal: this._terminal
+        terminal: this._terminal,
+        restrictConsoleOutput: this._restrictConsoleOutput
       });
     });
   }


### PR DESCRIPTION
## Summary

The plugin autoinstallation prints to the console by default. This change suppresses that output using the same heuristics that suppresses the banner.

## How it was tested

Tested in the repo where I initially observed this.