### PR TITLE
[rush-lib] Only schedule operations impacted by detected changes

### DIFF
--- a/common/changes/@microsoft/rush/finer-watch-tasks_2022-05-04-00-03.json
+++ b/common/changes/@microsoft/rush/finer-watch-tasks_2022-05-04-00-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update watcher to only schedule operations impacted by the detected change. A behavior difference will only be observed for repositories that define a phase with no dependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -257,6 +257,7 @@ export interface IConfigurationEnvironmentVariable {
 // @alpha
 export interface ICreateOperationsContext {
     readonly buildCacheConfiguration: BuildCacheConfiguration | undefined;
+    readonly changedProjects: ReadonlySet<RushConfigurationProject>;
     readonly customParameters: ReadonlyMap<string, CommandLineParameter>;
     readonly isIncrementalBuildAllowed: boolean;
     readonly isInitial: boolean;
@@ -519,8 +520,11 @@ export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationB
 // @alpha
 export class Operation {
     constructor(options?: IOperationOptions);
+    addDependency(dependency: Operation): void;
     readonly associatedPhase: IPhase | undefined;
     readonly associatedProject: RushConfigurationProject | undefined;
+    readonly consumers: Set<Operation>;
+    deleteDependency(dependency: Operation): void;
     readonly dependencies: Set<Operation>;
     get name(): string | undefined;
     runner: IOperationRunner | undefined;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -257,7 +257,6 @@ export interface IConfigurationEnvironmentVariable {
 // @alpha
 export interface ICreateOperationsContext {
     readonly buildCacheConfiguration: BuildCacheConfiguration | undefined;
-    readonly changedProjects: ReadonlySet<RushConfigurationProject>;
     readonly customParameters: ReadonlyMap<string, CommandLineParameter>;
     readonly isIncrementalBuildAllowed: boolean;
     readonly isInitial: boolean;
@@ -265,6 +264,7 @@ export interface ICreateOperationsContext {
     readonly phaseSelection: ReadonlySet<IPhase>;
     readonly projectChangeAnalyzer: ProjectChangeAnalyzer;
     readonly projectSelection: ReadonlySet<RushConfigurationProject>;
+    readonly projectsInUnknownState: ReadonlySet<RushConfigurationProject>;
     readonly rushConfiguration: RushConfiguration;
 }
 
@@ -523,9 +523,9 @@ export class Operation {
     addDependency(dependency: Operation): void;
     readonly associatedPhase: IPhase | undefined;
     readonly associatedProject: RushConfigurationProject | undefined;
-    readonly consumers: Set<Operation>;
+    readonly consumers: ReadonlySet<Operation>;
     deleteDependency(dependency: Operation): void;
-    readonly dependencies: Set<Operation>;
+    readonly dependencies: ReadonlySet<Operation>;
     get name(): string | undefined;
     runner: IOperationRunner | undefined;
     weight: number;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -31,7 +31,6 @@ import type { IPhase, IPhasedCommandConfig } from '../../api/CommandLineConfigur
 import { Operation } from '../../logic/operations/Operation';
 import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlugin';
 import { ShellOperationRunnerPlugin } from '../../logic/operations/ShellOperationRunnerPlugin';
-import { Selection } from '../../logic/Selection';
 import { Event } from '../../api/EventHooks';
 import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
 
@@ -201,7 +200,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       rushConfiguration: this.rushConfiguration,
       phaseSelection: new Set(this._initialPhases),
       projectChangeAnalyzer: new ProjectChangeAnalyzer(this.rushConfiguration),
-      projectSelection
+      projectSelection,
+      changedProjects: projectSelection
     };
 
     const executionManagerOptions: IOperationExecutionManagerOptions = {
@@ -311,17 +311,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         terminal.writeLine(`    ${colors.cyan(name)}`);
       }
 
-      // Account for consumer relationships
-      const projectSelection: Set<RushConfigurationProject> = Selection.intersection(
-        Selection.expandAllConsumers(changedProjects),
-        projectsToWatch
-      );
-
       const operations: Set<Operation> = await this.hooks.createOperations.promise(new Set(), {
         ...initialCreateOperationsContext,
         isInitial: false,
         projectChangeAnalyzer: state,
-        projectSelection,
+        changedProjects,
         phaseSelection
       });
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -201,7 +201,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       phaseSelection: new Set(this._initialPhases),
       projectChangeAnalyzer: new ProjectChangeAnalyzer(this.rushConfiguration),
       projectSelection,
-      changedProjects: projectSelection
+      projectsInUnknownState: projectSelection
     };
 
     const executionManagerOptions: IOperationExecutionManagerOptions = {
@@ -315,7 +315,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         ...initialCreateOperationsContext,
         isInitial: false,
         projectChangeAnalyzer: state,
-        changedProjects,
+        projectsInUnknownState: changedProjects,
         phaseSelection
       });
 

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -152,7 +152,6 @@ export class ProjectWatcher {
         };
 
         for (const pathToWatch of pathsToWatch) {
-          console.log(pathToWatch);
           addWatcher(pathToWatch);
         }
 

--- a/libraries/rush-lib/src/logic/operations/Operation.ts
+++ b/libraries/rush-lib/src/logic/operations/Operation.ts
@@ -48,12 +48,12 @@ export class Operation {
   /**
    * A set of all operations which depend on this operation.
    */
-  public readonly consumers: Set<Operation> = new Set<Operation>();
+  public readonly consumers: ReadonlySet<Operation> = new Set<Operation>();
 
   /**
    * A set of all dependencies which must be executed before this operation is complete.
    */
-  public readonly dependencies: Set<Operation> = new Set<Operation>();
+  public readonly dependencies: ReadonlySet<Operation> = new Set<Operation>();
 
   /**
    * When the scheduler is ready to process this `Operation`, the `runner` implements the actual work of
@@ -91,15 +91,17 @@ export class Operation {
    * Adds the specified operation as a dependency and updates the consumer list.
    */
   public addDependency(dependency: Operation): void {
-    this.dependencies.add(dependency);
-    dependency.consumers.add(this);
+    // Cast internally to avoid adding the overhead of getters
+    (this.dependencies as Set<Operation>).add(dependency);
+    (dependency.consumers as Set<Operation>).add(this);
   }
 
   /**
    * Deletes the specified operation as a dependency and updates the consumer list.
    */
   public deleteDependency(dependency: Operation): void {
-    this.dependencies.delete(dependency);
-    dependency.consumers.delete(this);
+    // Cast internally to avoid adding the overhead of getters
+    (this.dependencies as Set<Operation>).delete(dependency);
+    (dependency.consumers as Set<Operation>).delete(this);
   }
 }

--- a/libraries/rush-lib/src/logic/operations/Operation.ts
+++ b/libraries/rush-lib/src/logic/operations/Operation.ts
@@ -46,6 +46,11 @@ export class Operation {
   public readonly associatedProject: RushConfigurationProject | undefined;
 
   /**
+   * A set of all operations which depend on this operation.
+   */
+  public readonly consumers: Set<Operation> = new Set<Operation>();
+
+  /**
    * A set of all dependencies which must be executed before this operation is complete.
    */
   public readonly dependencies: Set<Operation> = new Set<Operation>();
@@ -80,5 +85,21 @@ export class Operation {
    */
   public get name(): string | undefined {
     return this.runner?.name;
+  }
+
+  /**
+   * Adds the specified operation as a dependency and updates the consumer list.
+   */
+  public addDependency(dependency: Operation): void {
+    this.dependencies.add(dependency);
+    dependency.consumers.add(this);
+  }
+
+  /**
+   * Deletes the specified operation as a dependency and updates the consumer list.
+   */
+  public deleteDependency(dependency: Operation): void {
+    this.dependencies.delete(dependency);
+    dependency.consumers.delete(this);
   }
 }

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -66,12 +66,14 @@ describe(PhasedOperationPlugin.name, () => {
     // Add mock runners for included operations.
     hooks.createOperations.tap('MockOperationRunnerPlugin', createMockRunner);
 
-    const context: Pick<ICreateOperationsContext, 'phaseSelection' | 'projectSelection' | 'changedProjects'> =
-      {
-        phaseSelection,
-        projectSelection,
-        changedProjects
-      };
+    const context: Pick<
+      ICreateOperationsContext,
+      'phaseSelection' | 'projectSelection' | 'projectsInUnknownState'
+    > = {
+      phaseSelection,
+      projectSelection,
+      projectsInUnknownState: changedProjects
+    };
     const operations: Set<Operation> = await hooks.createOperations.promise(
       new Set(),
       context as ICreateOperationsContext

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -57,7 +57,8 @@ describe(PhasedOperationPlugin.name, () => {
 
   async function testCreateOperationsAsync(
     phaseSelection: Set<IPhase>,
-    projectSelection: Set<RushConfigurationProject>
+    projectSelection: Set<RushConfigurationProject>,
+    changedProjects: Set<RushConfigurationProject>
   ): Promise<Set<Operation>> {
     const hooks: PhasedCommandHooks = new PhasedCommandHooks();
     // Apply the plugin being tested
@@ -65,10 +66,12 @@ describe(PhasedOperationPlugin.name, () => {
     // Add mock runners for included operations.
     hooks.createOperations.tap('MockOperationRunnerPlugin', createMockRunner);
 
-    const context: Pick<ICreateOperationsContext, 'phaseSelection' | 'projectSelection'> = {
-      phaseSelection,
-      projectSelection
-    };
+    const context: Pick<ICreateOperationsContext, 'phaseSelection' | 'projectSelection' | 'changedProjects'> =
+      {
+        phaseSelection,
+        projectSelection,
+        changedProjects
+      };
     const operations: Set<Operation> = await hooks.createOperations.promise(
       new Set(),
       context as ICreateOperationsContext
@@ -94,6 +97,7 @@ describe(PhasedOperationPlugin.name, () => {
 
     const operations: Set<Operation> = await testCreateOperationsAsync(
       buildCommand.phases,
+      new Set(rushConfiguration.projects),
       new Set(rushConfiguration.projects)
     );
 
@@ -108,6 +112,7 @@ describe(PhasedOperationPlugin.name, () => {
 
     let operations: Set<Operation> = await testCreateOperationsAsync(
       buildCommand.phases,
+      new Set([rushConfiguration.getProjectByName('g')!]),
       new Set([rushConfiguration.getProjectByName('g')!])
     );
 
@@ -120,6 +125,11 @@ describe(PhasedOperationPlugin.name, () => {
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
+      ]),
+      new Set([
+        rushConfiguration.getProjectByName('f')!,
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
       ])
     );
 
@@ -127,10 +137,58 @@ describe(PhasedOperationPlugin.name, () => {
     expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
   });
 
+  it('handles some changed projects', async () => {
+    const buildCommand: IPhasedCommandConfig = commandLineConfiguration.commands.get(
+      'build'
+    )! as IPhasedCommandConfig;
+
+    let operations: Set<Operation> = await testCreateOperationsAsync(
+      buildCommand.phases,
+      new Set(rushConfiguration.projects),
+      new Set([rushConfiguration.getProjectByName('g')!])
+    );
+
+    // Single project
+    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+
+    operations = await testCreateOperationsAsync(
+      buildCommand.phases,
+      new Set(rushConfiguration.projects),
+      new Set([
+        rushConfiguration.getProjectByName('f')!,
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
+      ])
+    );
+
+    // Filtered projects
+    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+  });
+
+  it('handles some changed projects within filtered projects', async () => {
+    const buildCommand: IPhasedCommandConfig = commandLineConfiguration.commands.get(
+      'build'
+    )! as IPhasedCommandConfig;
+
+    const operations: Set<Operation> = await testCreateOperationsAsync(
+      buildCommand.phases,
+      new Set([
+        rushConfiguration.getProjectByName('f')!,
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
+      ]),
+      new Set([rushConfiguration.getProjectByName('a')!, rushConfiguration.getProjectByName('c')!])
+    );
+
+    // Single project
+    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+  });
+
   it('handles filtered phases', async () => {
     // Single phase with a missing dependency
     let operations: Set<Operation> = await testCreateOperationsAsync(
       new Set([commandLineConfiguration.phases.get('_phase:upstream-self')!]),
+      new Set(rushConfiguration.projects),
       new Set(rushConfiguration.projects)
     );
     expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
@@ -143,6 +201,7 @@ describe(PhasedOperationPlugin.name, () => {
         commandLineConfiguration.phases.get('_phase:upstream-1')!,
         commandLineConfiguration.phases.get('_phase:no-deps')!
       ]),
+      new Set(rushConfiguration.projects),
       new Set(rushConfiguration.projects)
     );
     expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
@@ -152,6 +211,11 @@ describe(PhasedOperationPlugin.name, () => {
     // Single phase with a missing dependency
     let operations: Set<Operation> = await testCreateOperationsAsync(
       new Set([commandLineConfiguration.phases.get('_phase:upstream-2')!]),
+      new Set([
+        rushConfiguration.getProjectByName('f')!,
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
+      ]),
       new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
@@ -167,6 +231,11 @@ describe(PhasedOperationPlugin.name, () => {
         commandLineConfiguration.phases.get('_phase:upstream-3')!,
         commandLineConfiguration.phases.get('_phase:upstream-1')!,
         commandLineConfiguration.phases.get('_phase:no-deps')!
+      ]),
+      new Set([
+        rushConfiguration.getProjectByName('f')!,
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
       ]),
       new Set([
         rushConfiguration.getProjectByName('f')!,

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/PhasedOperationPlugin.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/PhasedOperationPlugin.test.ts.snap
@@ -1727,3 +1727,1530 @@ Array [
   },
 ]
 `;
+
+exports[`PhasedOperationPlugin handles some changed projects 1`] = `
+Array [
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "c;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "d;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "e;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "f;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "g (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "h;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "a;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+      "a;_phase:upstream-self",
+    ],
+    "name": "b;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:no-deps",
+      "b;_phase:upstream-self",
+    ],
+    "name": "c;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:no-deps",
+      "b;_phase:upstream-self",
+    ],
+    "name": "d;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "e;_phase:no-deps",
+      "c;_phase:upstream-self",
+    ],
+    "name": "e;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f;_phase:no-deps",
+      "a;_phase:upstream-self",
+      "h;_phase:upstream-self",
+    ],
+    "name": "f;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:no-deps",
+      "a;_phase:upstream-self",
+    ],
+    "name": "h;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g (no-deps)",
+      "a;_phase:upstream-self",
+    ],
+    "name": "g (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:no-deps",
+    ],
+    "name": "i;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:no-deps",
+    ],
+    "name": "j;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "b;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "c;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "d;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:no-deps",
+    ],
+    "name": "e;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+      "h;_phase:no-deps",
+    ],
+    "name": "f;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "g (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:no-deps",
+    ],
+    "name": "h;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
+    "name": "b;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "c;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "d;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-1",
+    ],
+    "name": "e;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+      "h;_phase:upstream-1",
+    ],
+    "name": "f;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
+    "name": "g (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
+    "name": "h;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "c;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "d;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-2",
+    ],
+    "name": "e;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+      "h;_phase:upstream-2",
+    ],
+    "name": "f;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "g (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1",
+    ],
+    "name": "a;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "b;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-1",
+    ],
+    "name": "c;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:upstream-1",
+    ],
+    "name": "d;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "e;_phase:upstream-1",
+    ],
+    "name": "e;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f;_phase:upstream-1",
+    ],
+    "name": "f;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-1)",
+    ],
+    "name": "g (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-1",
+    ],
+    "name": "h;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-1",
+    ],
+    "name": "i;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-1",
+    ],
+    "name": "j;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-2",
+    ],
+    "name": "a;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-2",
+    ],
+    "name": "c;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:upstream-2",
+    ],
+    "name": "d;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "e;_phase:upstream-2",
+    ],
+    "name": "e;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f;_phase:upstream-2",
+    ],
+    "name": "f;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-2)",
+    ],
+    "name": "g (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-2",
+    ],
+    "name": "i;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-2",
+    ],
+    "name": "j;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "b;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1-self",
+    ],
+    "name": "c;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1-self",
+    ],
+    "name": "d;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-1-self",
+    ],
+    "name": "e;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+      "h;_phase:upstream-1-self",
+    ],
+    "name": "f;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "g (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-1-self",
+    ],
+    "name": "h;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a;_phase:upstream-3",
+    ],
+    "name": "a;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-3",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+    ],
+    "name": "b;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c;_phase:upstream-3",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
+    ],
+    "name": "c;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:upstream-3",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
+    ],
+    "name": "d;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "e;_phase:upstream-3",
+      "c;_phase:upstream-1-self-upstream",
+      "c;_phase:upstream-2-self",
+    ],
+    "name": "e;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f;_phase:upstream-3",
+      "a;_phase:upstream-1-self-upstream",
+      "h;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+      "h;_phase:upstream-2-self",
+    ],
+    "name": "f;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-3)",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+    ],
+    "name": "g (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-3",
+      "a;_phase:upstream-1-self-upstream",
+      "a;_phase:upstream-2-self",
+    ],
+    "name": "h;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-3",
+    ],
+    "name": "i;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-3",
+    ],
+    "name": "j;_phase:complex",
+    "silent": true,
+  },
+]
+`;
+
+exports[`PhasedOperationPlugin handles some changed projects 2`] = `
+Array [
+  Object {
+    "dependencies": Array [],
+    "name": "a (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "c (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "d;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "e;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "f (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "g;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "h;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "a (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "b (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (no-deps)",
+      "b (upstream-self)",
+    ],
+    "name": "c (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:no-deps",
+      "b (upstream-self)",
+    ],
+    "name": "d (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "e;_phase:no-deps",
+      "c (upstream-self)",
+    ],
+    "name": "e (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f (no-deps)",
+      "a (upstream-self)",
+      "h (upstream-self)",
+    ],
+    "name": "f (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "h (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "g;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "g (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:no-deps",
+    ],
+    "name": "i;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:no-deps",
+    ],
+    "name": "j;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "b (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "c (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "d;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c (no-deps)",
+    ],
+    "name": "e (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+      "h;_phase:no-deps",
+    ],
+    "name": "f (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "g (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "h (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "b (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1)",
+    ],
+    "name": "c (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1)",
+    ],
+    "name": "d (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-1)",
+    ],
+    "name": "e (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+      "h (upstream-1)",
+    ],
+    "name": "f (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "g (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "h (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+    ],
+    "name": "b (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-2)",
+    ],
+    "name": "c (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-2)",
+    ],
+    "name": "d (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-2)",
+    ],
+    "name": "e (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+      "h (upstream-2)",
+    ],
+    "name": "f (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+    ],
+    "name": "g (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+    ],
+    "name": "h (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-3",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "a (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1)",
+    ],
+    "name": "b (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-1)",
+    ],
+    "name": "c (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "d;_phase:upstream-1",
+    ],
+    "name": "d;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "e (upstream-1)",
+    ],
+    "name": "e (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-1)",
+    ],
+    "name": "f (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-1)",
+    ],
+    "name": "g (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h (upstream-1)",
+    ],
+    "name": "h (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-1",
+    ],
+    "name": "i;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-1",
+    ],
+    "name": "j;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+    ],
+    "name": "a (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-2)",
+    ],
+    "name": "b (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-2)",
+    ],
+    "name": "c (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "d (upstream-2)",
+    ],
+    "name": "d (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "e (upstream-2)",
+    ],
+    "name": "e (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-2)",
+    ],
+    "name": "f (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-2)",
+    ],
+    "name": "g (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h (upstream-2)",
+    ],
+    "name": "h (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-2",
+    ],
+    "name": "i;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-2",
+    ],
+    "name": "j;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "b (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1-self)",
+    ],
+    "name": "c (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-1-self)",
+    ],
+    "name": "d (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-1-self)",
+    ],
+    "name": "e (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+      "h (upstream-1-self)",
+    ],
+    "name": "f (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "g (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "h (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "i;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "j;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-3)",
+    ],
+    "name": "a (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b (upstream-3)",
+      "a (upstream-1-self-upstream)",
+      "a (upstream-2-self)",
+    ],
+    "name": "b (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-3)",
+      "b (upstream-1-self-upstream)",
+      "b (upstream-2-self)",
+    ],
+    "name": "c (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "d (upstream-3)",
+      "b (upstream-1-self-upstream)",
+      "b (upstream-2-self)",
+    ],
+    "name": "d (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "e (upstream-3)",
+      "c (upstream-1-self-upstream)",
+      "c (upstream-2-self)",
+    ],
+    "name": "e (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-3)",
+      "a (upstream-1-self-upstream)",
+      "h (upstream-1-self-upstream)",
+      "a (upstream-2-self)",
+      "h (upstream-2-self)",
+    ],
+    "name": "f (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "g (upstream-3)",
+      "a (upstream-1-self-upstream)",
+      "a (upstream-2-self)",
+    ],
+    "name": "g (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h (upstream-3)",
+      "a (upstream-1-self-upstream)",
+      "a (upstream-2-self)",
+    ],
+    "name": "h (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "i;_phase:upstream-3",
+    ],
+    "name": "i;_phase:complex",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "j;_phase:upstream-3",
+    ],
+    "name": "j;_phase:complex",
+    "silent": true,
+  },
+]
+`;
+
+exports[`PhasedOperationPlugin handles some changed projects within filtered projects 1`] = `
+Array [
+  Object {
+    "dependencies": Array [],
+    "name": "f;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "c (no-deps)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f;_phase:no-deps",
+      "a (upstream-self)",
+      "h;_phase:upstream-self",
+    ],
+    "name": "f (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "a (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "h;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "h;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "c (no-deps)",
+      "b;_phase:upstream-self",
+    ],
+    "name": "c (upstream-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+      "a (upstream-self)",
+    ],
+    "name": "b;_phase:upstream-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "b;_phase:no-deps",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+      "h;_phase:no-deps",
+    ],
+    "name": "f (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:no-deps",
+    ],
+    "name": "c (upstream-1)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+      "h;_phase:upstream-1",
+    ],
+    "name": "f (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "h;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "c (upstream-2)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (no-deps)",
+    ],
+    "name": "b;_phase:upstream-1",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+      "h;_phase:upstream-2",
+    ],
+    "name": "f (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "h;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "c (upstream-3)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "b;_phase:upstream-2",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-1)",
+    ],
+    "name": "f (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1)",
+    ],
+    "name": "a (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-1)",
+    ],
+    "name": "c (upstream-1-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-2)",
+    ],
+    "name": "f (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-2)",
+    ],
+    "name": "a (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-2)",
+    ],
+    "name": "c (upstream-2-self)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+      "h;_phase:upstream-1-self",
+    ],
+    "name": "f (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-1",
+    ],
+    "name": "h;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [],
+    "name": "a (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1-self",
+    ],
+    "name": "c (upstream-1-self-upstream)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-1",
+    ],
+    "name": "b;_phase:upstream-1-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "f (upstream-3)",
+      "a (upstream-1-self-upstream)",
+      "h;_phase:upstream-1-self-upstream",
+      "a (upstream-2-self)",
+      "h;_phase:upstream-2-self",
+    ],
+    "name": "f (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "h;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "h;_phase:upstream-2",
+    ],
+    "name": "h;_phase:upstream-2-self",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-3)",
+    ],
+    "name": "a (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "c (upstream-3)",
+      "b;_phase:upstream-1-self-upstream",
+      "b;_phase:upstream-2-self",
+    ],
+    "name": "c (complex)",
+    "silent": false,
+  },
+  Object {
+    "dependencies": Array [
+      "a (upstream-1-self)",
+    ],
+    "name": "b;_phase:upstream-1-self-upstream",
+    "silent": true,
+  },
+  Object {
+    "dependencies": Array [
+      "b;_phase:upstream-2",
+    ],
+    "name": "b;_phase:upstream-2-self",
+    "silent": true,
+  },
+]
+`;

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -64,9 +64,10 @@ export interface ICreateOperationsContext {
    */
   readonly projectSelection: ReadonlySet<RushConfigurationProject>;
   /**
-   * The set of Rush projects known to contain local changes.
+   * The set of Rush projects that have not been built in the current process since they were last modified.
+   * When `isInitial` is true, this will be an exact match of `projectSelection`.
    */
-  readonly changedProjects: ReadonlySet<RushConfigurationProject>;
+  readonly projectsInUnknownState: ReadonlySet<RushConfigurationProject>;
   /**
    * The Rush configuration
    */

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -64,6 +64,10 @@ export interface ICreateOperationsContext {
    */
   readonly projectSelection: ReadonlySet<RushConfigurationProject>;
   /**
+   * The set of Rush projects known to contain local changes.
+   */
+  readonly changedProjects: ReadonlySet<RushConfigurationProject>;
+  /**
    * The Rush configuration
    */
   readonly rushConfiguration: RushConfiguration;


### PR DESCRIPTION
## Summary
Refines the project watcher and scheduling engine for phased commands to schedule only the operations that would be impacted by the detected change.

## Details
If `command-line.json` defines at least on phase with no dependencies for a watch mode phased command, that phase will now only be run for projects that directly contain changes.
Previously the projects with changes and all of their consumers would run all defined watch phases in response to a change.

## How it was tested
Added unit test.
Verified behavior of `rush start` in various scenarios.
Temporarily defined an extra phase in `rush start` with no dependencies and verified behavior of the phase in response to changes.