### PR TITLE
Fix release of set-webpack-public-path-plugin.

### DIFF
--- a/common/changes/@rushstack/set-webpack-public-path-plugin/user-ianc-fix-set-public-path_2022-05-04-02-21.json
+++ b/common/changes/@rushstack/set-webpack-public-path-plugin/user-ianc-fix-set-public-path_2022-05-04-02-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/set-webpack-public-path-plugin",
+      "comment": "Make @rushstack/webpack-plugin-utilities a normal dependency.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/set-webpack-public-path-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2270,12 +2270,13 @@ importers:
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.24
+    dependencies:
+      '@rushstack/webpack-plugin-utilities': link:../webpack-plugin-utilities
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
-      '@rushstack/webpack-plugin-utilities': link:../webpack-plugin-utilities
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6

--- a/webpack/set-webpack-public-path-plugin/package.json
+++ b/webpack/set-webpack-public-path-plugin/package.json
@@ -26,12 +26,14 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "@rushstack/webpack-plugin-utilities": "workspace:*"
+  },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
     "@rushstack/heft-webpack5-plugin": "workspace:*",
-    "@rushstack/webpack-plugin-utilities": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
     "@types/tapable": "1.0.6",


### PR DESCRIPTION
The current release of `@rushstack/set-webpack-public-path-plugin` is broken because `@rushstack/webpack-plugin-utilities` is declared as a devDependency instead of a normal dependency. This PR moves it.