### PR TITLE
[api-extractor]: update getGlobalVariableAnalyzer to support changes to typescript internals in v4.7

### DIFF
--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -108,10 +108,13 @@ export class TypeScriptInternals {
 
   public static getGlobalVariableAnalyzer(program: ts.Program): IGlobalVariableAnalyzer {
     const anyProgram: any = program;
-    if (!anyProgram.getDiagnosticsProducingTypeChecker) {
-      throw new InternalError('Missing Program.getDiagnosticsProducingTypeChecker');
+    const typeCheckerInstance: any =
+      anyProgram.getDiagnosticsProducingTypeChecker ?? anyProgram.getTypeChecker;
+
+    if (!typeCheckerInstance) {
+      throw new InternalError('Missing Program.getDiagnosticsProducingTypeChecker or Program.getTypeChecker');
     }
-    const typeChecker: any = anyProgram.getDiagnosticsProducingTypeChecker();
+    const typeChecker: any = typeCheckerInstance();
     if (!typeChecker.getEmitResolver) {
       throw new InternalError('Missing TypeChecker.getEmitResolver');
     }

--- a/common/changes/@microsoft/api-extractor/users-chhol-update-api-for-getDiagnosticsProducingTypeChecker_2022-05-04-21-31.json
+++ b/common/changes/@microsoft/api-extractor/users-chhol-update-api-for-getDiagnosticsProducingTypeChecker_2022-05-04-21-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "update getGlobalVariableAnalyzer to support changes to typescript internals in v4.7",
+      "comment": "Update the global variable analyzer to add support for changes to the TypeScript internals coming in v4.7",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/api-extractor/users-chhol-update-api-for-getDiagnosticsProducingTypeChecker_2022-05-04-21-31.json
+++ b/common/changes/@microsoft/api-extractor/users-chhol-update-api-for-getDiagnosticsProducingTypeChecker_2022-05-04-21-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "update getGlobalVariableAnalyzer to support changes to typescript internals in v4.7",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This PR is intended to (hopefully) provide a backwards compatible solution for incoming breaking changes in typescript's internals as of v4.7.0 (currently in beta). This PR closes https://github.com/microsoft/rushstack/issues/3349. 

API-Extractor relies on Typescript internals to function, and those internals have been changed with this PR for the upcoming minor version of Typescript: https://github.com/microsoft/TypeScript/pull/36747/files.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
This change checks the validity of either API and should execute based on one being available. I tended towards keeping things less verbose to keep from requiring multiple nested if statements, etc. One place this is apparent is the error thrown. Rather than trying to track down which instance is missing, it seemed that providing a note that either is missing keeps parity for the error intent. I'm certainly open to a more verbosity in the checks, it simply seemed unnecessary as we really care that one of these API's exists (depending on version).

This change should not break compatibility from what I can tell, though I'm not super familiar with the use of internals here. 

I don't believe this should result in a significant performance degradation - though more verbose alternatives possibly could.

*NOTE: I chose to submit this as a patch because it doesn't seem fundamentally additive to the API Extractor in any meaningful way. While it does affect the package, it's both backwards compatible and relatively specific to the internals from what I can tell. Happy to update to minor if folks feel that's needed, but patch seemed most reasonable in my own assessment.*
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
~I'm pushing this up for PR first as I assume there may be conversation required about this change - I plan on manually testing this primarily against the v4.7.0-beta branch in one of our local repositories to ensure that things run correctly.~

Updated a local version of the project to 4.7.0-beta and it appears as though this ran successfully. No project changes meant no changes to our docs, but the error no longer throws and we get green. Edit (again): Ran with changes and api-extractor completed successfully in that scenario as well.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/13071055/166832791-091f3f66-139a-4870-b63b-f9070c28f612.png">


<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
