### PR TITLE
[rush] Fix `--strict-peer-dependencies` for PNPM >= 7.0.0

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -4,28 +4,28 @@ importers:
 
   typescript-newest-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.4.tgz
-      '@rushstack/heft': file:rushstack-heft-0.44.13.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.4.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.13.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
 
   typescript-v3-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-2.5.4.tgz
-      '@rushstack/heft': file:rushstack-heft-0.44.13.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.5.4.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.44.13.tgz
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
@@ -1673,19 +1673,19 @@ packages:
       commander: 2.20.3
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-2.5.4.tgz_eslint@8.7.0+typescript@4.6.3:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.5.4.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-2.5.4.tgz
+  file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz
     name: '@rushstack/eslint-config'
-    version: 2.5.4
+    version: 2.6.0
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=3.0.0'
     dependencies:
       '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.1.3.tgz
-      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.8.6.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.6.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.6.tgz_eslint@8.7.0+typescript@4.6.3
+      '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.9.0.tgz_eslint@8.7.0+typescript@4.6.3
+      '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.4.0.tgz_eslint@8.7.0+typescript@4.6.3
+      '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.3.0.tgz_eslint@8.7.0+typescript@4.6.3
       '@typescript-eslint/eslint-plugin': 5.20.0_e20e806d7f50be84027c83f3a408385a
       '@typescript-eslint/experimental-utils': 5.20.0_eslint@8.7.0+typescript@4.6.3
       '@typescript-eslint/parser': 5.20.0_eslint@8.7.0+typescript@4.6.3
@@ -1705,11 +1705,11 @@ packages:
     version: 1.1.3
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-0.8.6.tgz_eslint@8.7.0+typescript@4.6.3:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.8.6.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-0.8.6.tgz
+  file:../temp/tarballs/rushstack-eslint-plugin-0.9.0.tgz_eslint@8.7.0+typescript@4.6.3:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-0.9.0.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-plugin-0.9.0.tgz
     name: '@rushstack/eslint-plugin'
-    version: 0.8.6
+    version: 0.9.0
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
@@ -1721,11 +1721,11 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.6.tgz_eslint@8.7.0+typescript@4.6.3:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.6.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.3.6.tgz
+  file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.4.0.tgz_eslint@8.7.0+typescript@4.6.3:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.4.0.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.4.0.tgz
     name: '@rushstack/eslint-plugin-packlets'
-    version: 0.3.6
+    version: 0.4.0
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
@@ -1737,11 +1737,11 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.6.tgz_eslint@8.7.0+typescript@4.6.3:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.6.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.2.6.tgz
+  file:../temp/tarballs/rushstack-eslint-plugin-security-0.3.0.tgz_eslint@8.7.0+typescript@4.6.3:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-plugin-security-0.3.0.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-plugin-security-0.3.0.tgz
     name: '@rushstack/eslint-plugin-security'
-    version: 0.2.6
+    version: 0.3.0
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
@@ -1753,17 +1753,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.44.13.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.44.13.tgz}
+  file:../temp/tarballs/rushstack-heft-0.45.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.0.tgz}
     name: '@rushstack/heft'
-    version: 0.44.13
+    version: 0.45.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.8.2.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.3.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.10.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.10.9.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.8.3.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.4.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.11.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.10.10.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -1776,21 +1776,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.8.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.8.2.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.8.3.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.8.3.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.8.2
+    version: 0.8.3
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.3.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.10.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.4.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.11.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.45.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.45.3.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.45.4.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.45.4.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.45.3
+    version: 3.45.4
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5
@@ -1803,10 +1803,10 @@ packages:
       z-schema: 5.0.2
     dev: true
 
-  file:../temp/tarballs/rushstack-rig-package-0.3.10.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.10.tgz}
+  file:../temp/tarballs/rushstack-rig-package-0.3.11.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.11.tgz}
     name: '@rushstack/rig-package'
-    version: 0.3.10
+    version: 0.3.11
     dependencies:
       resolve: 1.17.0
       strip-json-comments: 3.1.1
@@ -1818,10 +1818,10 @@ packages:
     version: 0.2.3
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.10.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.10.9.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.10.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.10.10.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.10.9
+    version: 4.10.10
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/common/changes/@microsoft/rush/fix-pnpmNoStrictPeerDependenciesOption_2022-05-07-09-46.json
+++ b/common/changes/@microsoft/rush/fix-pnpmNoStrictPeerDependenciesOption_2022-05-07-09-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Incorporate the fact that --strict-peer-dependencies is now true by default in PNPM >= 7.0.0.",
+      "comment": "Fix handing of the `strictPeerDependencies` option when using PNPM >= 7.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-pnpmNoStrictPeerDependenciesOption_2022-05-07-09-46.json
+++ b/common/changes/@microsoft/rush/fix-pnpmNoStrictPeerDependenciesOption_2022-05-07-09-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Incorporate the fact that --strict-peer-dependencies is now true by default in PNPM >= 7.0.0.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -484,7 +484,6 @@ export class RushConfiguration {
   private _repositoryDefaultRemote: string;
 
   private _npmOptions: NpmOptionsConfiguration;
-  private _pnpmVersion: string;
   private _pnpmOptions: PnpmOptionsConfiguration;
   private _yarnOptions: YarnOptionsConfiguration;
   private _packageManagerConfigurationOptions!: PackageManagerOptionsConfigurationBase;
@@ -582,7 +581,6 @@ export class RushConfiguration {
     this.__rushPluginsConfiguration = new RushPluginsConfiguration(rushPluginsConfigFilename);
 
     this._npmOptions = new NpmOptionsConfiguration(rushConfigurationJson.npmOptions || {});
-    this._pnpmVersion = rushConfigurationJson.pnpmVersion || '';
     this._pnpmOptions = new PnpmOptionsConfiguration(
       rushConfigurationJson.pnpmOptions || {},
       this._commonTempFolder
@@ -1471,13 +1469,6 @@ export class RushConfiguration {
    */
   public get npmOptions(): NpmOptionsConfiguration {
     return this._npmOptions;
-  }
-
-  /**
-   * TODO
-   */
-  public get pnpmVersion(): string {
-    return this._pnpmVersion;
   }
 
   /**

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -484,6 +484,7 @@ export class RushConfiguration {
   private _repositoryDefaultRemote: string;
 
   private _npmOptions: NpmOptionsConfiguration;
+  private _pnpmVersion: string;
   private _pnpmOptions: PnpmOptionsConfiguration;
   private _yarnOptions: YarnOptionsConfiguration;
   private _packageManagerConfigurationOptions!: PackageManagerOptionsConfigurationBase;
@@ -581,6 +582,7 @@ export class RushConfiguration {
     this.__rushPluginsConfiguration = new RushPluginsConfiguration(rushPluginsConfigFilename);
 
     this._npmOptions = new NpmOptionsConfiguration(rushConfigurationJson.npmOptions || {});
+    this._pnpmVersion = rushConfigurationJson.pnpmVersion || '';
     this._pnpmOptions = new PnpmOptionsConfiguration(
       rushConfigurationJson.pnpmOptions || {},
       this._commonTempFolder
@@ -1469,6 +1471,13 @@ export class RushConfiguration {
    */
   public get npmOptions(): NpmOptionsConfiguration {
     return this._npmOptions;
+  }
+
+  /**
+   * TODO
+   */
+  public get pnpmVersion(): string {
+    return this._pnpmVersion;
   }
 
   /**

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -574,7 +574,7 @@ export abstract class BaseInstallManager {
         args.push('--network-concurrency', options.networkConcurrency.toString());
       }
 
-      if (semver.gte(this._rushConfiguration.pnpmVersion, '7.0.0')) {
+      if (semver.gte(this._rushConfiguration.packageManagerToolVersion, '7.0.0')) {
         // pnpm >= 7.0.0 handles peer dependencies strict by default
         if (this._rushConfiguration.pnpmOptions.strictPeerDependencies === false) {
           args.push('--no-strict-peer-dependencies');

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -574,8 +574,16 @@ export abstract class BaseInstallManager {
         args.push('--network-concurrency', options.networkConcurrency.toString());
       }
 
-      if (this._rushConfiguration.pnpmOptions.strictPeerDependencies) {
-        args.push('--strict-peer-dependencies');
+      if (true) {
+        // pnpm >= 7.0.0 handles peer dependencies strict by default
+        if (this._rushConfiguration.pnpmOptions.noStrictPeerDependencies) {
+          args.push('--no-strict-peer-dependencies');
+        }
+      } else {
+        // pnpm < 7.0.0 handles does not handle peer dependencies strict by default
+        if (this._rushConfiguration.pnpmOptions.strictPeerDependencies) {
+          args.push('--strict-peer-dependencies');
+        }
       }
     } else if (this._rushConfiguration.packageManager === 'yarn') {
       args.push('--link-folder', 'yarn-link');

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -574,9 +574,9 @@ export abstract class BaseInstallManager {
         args.push('--network-concurrency', options.networkConcurrency.toString());
       }
 
-      if (true) {
+      if (semver.gte(this._rushConfiguration.pnpmVersion, '7.0.0')) {
         // pnpm >= 7.0.0 handles peer dependencies strict by default
-        if (this._rushConfiguration.pnpmOptions.noStrictPeerDependencies) {
+        if (this._rushConfiguration.pnpmOptions.strictPeerDependencies === false) {
           args.push('--no-strict-peer-dependencies');
         }
       } else {

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -580,7 +580,7 @@ export abstract class BaseInstallManager {
           args.push('--no-strict-peer-dependencies');
         }
       } else {
-        // pnpm < 7.0.0 handles does not handle peer dependencies strict by default
+        // pnpm < 7.0.0 does not handle peer dependencies strict by default
         if (this._rushConfiguration.pnpmOptions.strictPeerDependencies) {
           args.push('--strict-peer-dependencies');
         }

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -92,7 +92,7 @@
           "enum": ["local", "global"]
         },
         "strictPeerDependencies": {
-          "description": "If true, then Rush will add the \"--strict-peer-dependencies\" option when invoking PNPM. This causes \"rush install\" to fail if there are unsatisfied peer dependencies, which is an invalid state that can cause build failures or incompatible dependency versions. (For historical reasons, JavaScript package managers generally do not treat this invalid state as an error.) The default value is false.",
+          "description": "If true, then the installation will fail if there is a missing or invalid peer dependency in the tree. The default is the default of PNPM. Note that the default of PNPM changed in version 7 of PNPM. For PNPM version < 7.0.0, the default was false and for PNPM >= 7.0.0 the default is true. If strictPeerDependency is set to true, then Rush will add the \"--strict-peer-dependencies\" option when invoking PNPM version < 7.0.0. If strictPeerDependency is set to false, then Rush will add the \"--no-strict-peer-dependencies\" option when invoking PNPM version < 7.0.0.",
           "type": "boolean"
         },
         "resolutionStrategy": {

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -92,7 +92,7 @@
           "enum": ["local", "global"]
         },
         "strictPeerDependencies": {
-          "description": "If true, then the installation will fail if there is a missing or invalid peer dependency in the tree. The default is the default of PNPM. Note that the default of PNPM changed in version 7 of PNPM. For PNPM version < 7.0.0, the default was false and for PNPM >= 7.0.0 the default is true. If strictPeerDependency is set to true, then Rush will add the \"--strict-peer-dependencies\" option when invoking PNPM version < 7.0.0. If strictPeerDependency is set to false, then Rush will add the \"--no-strict-peer-dependencies\" option when invoking PNPM version < 7.0.0.",
+          "description": "If true, then the installation will fail if there is a missing or invalid peer dependency in the tree, which is an invalid state that can cause build failures or incompatible dependency versions. (For historical reasons, JavaScript package managers generally do not treat this invalid state as an error.) This is done via the \"--strict-peer-dependencies\" flag in PNPM version < 7.0.0 and via the \"--no-strict-peer-dependencies\" flag in PNPM >= 7.0.0. The default value is false.",
           "type": "boolean"
         },
         "resolutionStrategy": {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

In version 7.0.0, PNPM changed default value for parameter `--strict-peer-dependencies` from `false` to `true`.

Problem: Rush does not behave correctly with `pnpmOptions.strictPeerDependencies` set to false in `rush.json` as then argument `--no-strict-peer-dependencies` is not passed to the call of PNPM if PNPM is used in version >= 7.0.0. As a result, our monorepo could not been built anymore even though we have set `pnpmOptions.strictPeerDependencies` to `false`.

Solution: Ensure that Rush adds argument `--no-strict-peer-dependencies` to the call of PNPM if `pnpmOptions.strictPeerDependencies` is set to false and PNPM >= 7.0.0 is used. Argument `--strict-peer-dependencies` is added if `pnpmOptions.strictPeerDependencies` is set to true and PNPM < 7.0.0 is used.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I tested it with the same repo in which we have `pnpmOptions.strictPeerDependencies` set to `false`. It was tested once with pnpm version 6.32.10 and once with pnpm version 7.0.0. The command line argument `--strict-peer-dependencies` and `--no-strict-peer-dependencies` are set correctly.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
