### PR TITLE
[rush] always run `postRushInstall`, and run after writing telemetry

### DIFF
--- a/common/changes/@microsoft/rush/fix-post-install-hook_2022-05-06-14-56.json
+++ b/common/changes/@microsoft/rush/fix-post-install-hook_2022-05-06-14-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "[rush] always run `postRushInstall`, and run _after_ writing telemetry",
+      "comment": "Update the `postRushInstall` hook to always run, and move its execution to after telemetry is written.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-post-install-hook_2022-05-06-14-56.json
+++ b/common/changes/@microsoft/rush/fix-post-install-hook_2022-05-06-14-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush] always run `postRushInstall`, and run _after_ writing telemetry",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -151,12 +151,6 @@ export abstract class BaseInstallAction extends BaseRushAction {
     try {
       await installManager.doInstallAsync();
 
-      this.eventHooksManager.handle(
-        Event.postRushInstall,
-        this.parser.isDebug,
-        this._ignoreHooksParameter.value
-      );
-
       if (warnAboutScriptUpdate) {
         console.log(
           os.EOL +
@@ -178,6 +172,12 @@ export abstract class BaseInstallAction extends BaseRushAction {
       stopwatch.stop();
 
       this._collectTelemetry(stopwatch, installManagerOptions, installSuccessful);
+      this.parser.flushTelemetry();
+      this.eventHooksManager.handle(
+        Event.postRushInstall,
+        this.parser.isDebug,
+        this._ignoreHooksParameter.value
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

This moves executing the `postRushInstall` hook to after telemetry is written and flushed.

It also changes the logic to run the hook even on a failure. If this would be a breaking change maybe we should add a new hook that is specifically used for reading telemetry files?

fixes #3400

## How it was tested

Tested locally in another project using `node <snip>/rushstack/libraries/rush-lib/lib/start.js --debug update`, and it worked.