### PR TITLE
[rush] After execute operations hook

### DIFF
--- a/common/changes/@microsoft/rush/after-execute-operations-hook_2022-05-09-21-26.json
+++ b/common/changes/@microsoft/rush/after-execute-operations-hook_2022-05-09-21-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a new `afterExecuteOperations` hook to phased command execution. This hook is used for the console timeline view and the standard result summary.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -287,6 +287,12 @@ export interface IEnvironmentConfigurationInitializeOptions {
     doNotNormalizePaths?: boolean;
 }
 
+// @alpha
+export interface IExecutionResult {
+    readonly operationResults: ReadonlyMap<Operation, IOperationExecutionResult>;
+    readonly status: OperationStatus;
+}
+
 // @beta
 export interface IExperimentsJson {
     buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
@@ -358,6 +364,14 @@ export class IndividualVersionPolicy extends VersionPolicy {
 
 // @internal
 export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
+}
+
+// @alpha
+export interface IOperationExecutionResult {
+    readonly error: Error | undefined;
+    readonly status: OperationStatus;
+    readonly stdioSummarizer: StdioSummarizer;
+    readonly stopwatch: IStopwatchResult;
 }
 
 // @alpha
@@ -444,6 +458,14 @@ export interface IRushSessionOptions {
     getIsDebugMode: () => boolean;
     // (undocumented)
     terminalProvider: ITerminalProvider;
+}
+
+// @alpha
+export interface IStopwatchResult {
+    get duration(): number;
+    get endTime(): number | undefined;
+    get startTime(): number | undefined;
+    toString(): string;
 }
 
 // @beta (undocumented)
@@ -605,6 +627,7 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
 
 // @alpha
 export class PhasedCommandHooks {
+    readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
     readonly waitingForChanges: SyncHook<void>;
 }

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -33,6 +33,9 @@ import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlu
 import { ShellOperationRunnerPlugin } from '../../logic/operations/ShellOperationRunnerPlugin';
 import { Event } from '../../api/EventHooks';
 import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
+import { OperationStatus } from '../../logic/operations/OperationStatus';
+import { IExecutionResult } from '../../logic/operations/IOperationExecutionResult';
+import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
 
 /**
  * Constructor parameters for BulkScriptAction.
@@ -58,11 +61,11 @@ interface IRunPhasesOptions {
 }
 
 interface IExecutionOperationsOptions {
+  createOperationsContext: ICreateOperationsContext;
   executionManagerOptions: IOperationExecutionManagerOptions;
   ignoreHooks: boolean;
   operations: Set<Operation>;
   stopwatch: Stopwatch;
-  isWatch: boolean;
   terminal: Terminal;
 }
 
@@ -142,6 +145,16 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const stopwatch: Stopwatch = Stopwatch.start();
 
+    const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
+
+    const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
+    if (showTimeline) {
+      const { ConsoleTimelinePlugin } = await import('../../logic/operations/ConsoleTimelinePlugin');
+      new ConsoleTimelinePlugin(terminal).apply(this.hooks);
+    }
+    // Enable the standard summary
+    new OperationResultSummarizerPlugin(terminal).apply(this.hooks);
+
     const { hooks: sessionHooks } = this.rushSession;
     if (sessionHooks.runAnyPhasedCommand.isUsed()) {
       // Avoid the cost of compiling the hook if it wasn't tapped.
@@ -151,6 +164,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     const hookForAction: AsyncSeriesHook<IPhasedCommand> | undefined = sessionHooks.runPhasedCommand.get(
       this.actionName
     );
+
     if (hookForAction) {
       // Run the more specific hook for a command with this name after the general hook
       await hookForAction.promise(this);
@@ -162,11 +176,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     // if parallelism is not enabled, then restrict to 1 core
     const parallelism: string | undefined = this._enableParallelism ? this._parallelismParameter!.value : '1';
 
-    const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
-
     const changedProjectsOnly: boolean = this._isIncrementalBuildAllowed && this._changedProjectsOnly.value;
 
-    const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
     if (!this._disableBuildCache) {
       buildCacheConfiguration = await BuildCacheConfiguration.tryLoadAsync(
@@ -208,7 +219,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       quietMode: isQuietMode,
       debugMode: this.parser.isDebug,
       parallelism,
-      showTimeline,
       changedProjectsOnly
     };
 
@@ -239,13 +249,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       initialCreateOperationsContext
     );
 
-    const { isWatch } = initialCreateOperationsContext;
-
     const initialOptions: IExecutionOperationsOptions = {
+      createOperationsContext: initialCreateOperationsContext,
       ignoreHooks: false,
       operations,
       stopwatch,
-      isWatch,
       executionManagerOptions,
       terminal
     };
@@ -311,20 +319,26 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         terminal.writeLine(`    ${colors.cyan(name)}`);
       }
 
-      const operations: Set<Operation> = await this.hooks.createOperations.promise(new Set(), {
+      // Account for consumer relationships
+      const createOperationsContext: ICreateOperationsContext = {
         ...initialCreateOperationsContext,
         isInitial: false,
         projectChangeAnalyzer: state,
         projectsInUnknownState: changedProjects,
         phaseSelection
-      });
+      };
+
+      const operations: Set<Operation> = await this.hooks.createOperations.promise(
+        new Set(),
+        createOperationsContext
+      );
 
       const executeOptions: IExecutionOperationsOptions = {
+        createOperationsContext,
         // For now, don't run pre-build or post-build in watch mode
         ignoreHooks: true,
         operations,
         stopwatch,
-        isWatch: true,
         executionManagerOptions,
         terminal
       };
@@ -435,23 +449,33 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
    * Runs a set of operations and reports the results.
    */
   private async _executeOperations(options: IExecutionOperationsOptions): Promise<void> {
-    const { executionManagerOptions, ignoreHooks, operations, stopwatch, isWatch, terminal } = options;
+    const { executionManagerOptions, ignoreHooks, operations, stopwatch, terminal } = options;
 
     const executionManager: OperationExecutionManager = new OperationExecutionManager(
       operations,
       executionManagerOptions
     );
 
+    const { isWatch } = options.createOperationsContext;
+
+    let success: boolean = false;
+
     try {
-      await executionManager.executeAsync();
+      const result: IExecutionResult = await executionManager.executeAsync();
+      success = result.status === OperationStatus.Success;
+
+      await this.hooks.afterExecuteOperations.promise(result, options.createOperationsContext);
 
       stopwatch.stop();
-      terminal.writeLine(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
 
-      if (!ignoreHooks) {
-        this._doAfterTask(stopwatch, true);
+      const message: string = `rush ${this.actionName} (${stopwatch.toString()})`;
+      if (result.status === OperationStatus.Success) {
+        terminal.writeLine(colors.green(message));
+      } else {
+        terminal.writeLine(message);
       }
     } catch (error) {
+      success = false;
       stopwatch.stop();
 
       if (error instanceof AlreadyReportedError) {
@@ -467,14 +491,14 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
         terminal.writeErrorLine(colors.red(`rush ${this.actionName} - Errors! (${stopwatch.toString()})`));
       }
+    }
 
-      if (!ignoreHooks) {
-        this._doAfterTask(stopwatch, false);
-      }
+    if (!ignoreHooks) {
+      this._doAfterTask(stopwatch, success);
+    }
 
-      if (!isWatch) {
-        throw new AlreadyReportedError();
-      }
+    if (!success && !isWatch) {
+      throw new AlreadyReportedError();
     }
   }
 

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -81,6 +81,7 @@ export { ExperimentsConfiguration, IExperimentsJson } from './api/ExperimentsCon
 export { ProjectChangeAnalyzer, IGetChangedProjectsOptions } from './logic/ProjectChangeAnalyzer';
 
 export { IOperationRunner, IOperationRunnerContext } from './logic/operations/IOperationRunner';
+export { IExecutionResult, IOperationExecutionResult } from './logic/operations/IOperationExecutionResult';
 export { IOperationOptions, Operation } from './logic/operations/Operation';
 export { OperationStatus } from './logic/operations/OperationStatus';
 
@@ -109,3 +110,5 @@ export { ICloudBuildCacheProvider } from './logic/buildCache/ICloudBuildCachePro
 export { ICredentialCacheOptions, ICredentialCacheEntry, CredentialCache } from './logic/CredentialCache';
 
 export { ITelemetryData } from './logic/Telemetry';
+
+export { IStopwatchResult } from './utilities/Stopwatch';

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ITerminal } from '@rushstack/node-core-library';
+import colors from 'colors/safe';
+import { IPhase } from '../../api/CommandLineConfiguration';
+import {
+  ICreateOperationsContext,
+  IPhasedCommandPlugin,
+  PhasedCommandHooks
+} from '../../pluginFramework/PhasedCommandHooks';
+import { IExecutionResult } from './IOperationExecutionResult';
+import { OperationStatus } from './OperationStatus';
+
+const PLUGIN_NAME: 'ConsoleTimelinePlugin' = 'ConsoleTimelinePlugin';
+
+/* Sample output:
+==============================================================================================================================
+          @rushstack/tree-pattern (build) ###########-------------------------------------------------------------------- 3.3s
+          @rushstack/eslint-patch (build) ########----------------------------------------------------------------------- 2.2s
+           @rushstack/eslint-patch (test) -------%----------------------------------------------------------------------- 0.0s
+@rushstack/eslint-plugin-security (build) ----------########################--------------------------------------------- 6.8s
+@rushstack/eslint-plugin-packlets (build) ----------############################----------------------------------------- 8.1s
+         @rushstack/eslint-plugin (build) ----------##############################--------------------------------------- 8.7s
+           @rushstack/tree-pattern (test) ----------#####---------------------------------------------------------------- 1.2s
+ @rushstack/eslint-plugin-security (test) ---------------------------------############---------------------------------- 3.3s
+ @rushstack/eslint-plugin-packlets (test) -------------------------------------#####------------------------------------- 1.1s
+         @rushstack/eslint-config (build) ---------------------------------------%--------------------------------------- 0.0s
+          @rushstack/eslint-plugin (test) ---------------------------------------#############--------------------------- 3.8s
+          @rushstack/eslint-config (test) ---------------------------------------%--------------------------------------- 0.0s
+     @rushstack/node-core-library (build) ---------------------------------------################################-------- 9.5s
+      @rushstack/node-core-library (test) ----------------------------------------------------------------------######### 2.2s
+==============================================================================================================================
+LEGEND:                                                                                                      Total Work: 50.3s
+  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op                                                 Wall Clock: 23.7s
+                                                                                                       Max Parallelism Used: 5
+                                                                                                     Avg Parallelism Used: 2.1
+BY PHASE:
+      _phase:build 38.6s
+       _phase:test 11.7s
+*/
+
+/**
+ * Phased command plugin that emits a timeline to the console.
+ */
+export class ConsoleTimelinePlugin implements IPhasedCommandPlugin {
+  private readonly _terminal: ITerminal;
+
+  public constructor(terminal: ITerminal) {
+    this._terminal = terminal;
+  }
+
+  public apply(hooks: PhasedCommandHooks): void {
+    hooks.afterExecuteOperations.tap(
+      PLUGIN_NAME,
+      (result: IExecutionResult, context: ICreateOperationsContext): void => {
+        _printTimeline(this._terminal, result);
+      }
+    );
+  }
+}
+
+/**
+ * Timeline - a wider column width for printing the timeline summary
+ */
+const TIMELINE_WIDTH: number = 109;
+
+/**
+ * Timeline - symbols representing each operation status
+ */
+const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
+  [OperationStatus.Ready]: '?',
+  [OperationStatus.Executing]: '?',
+  [OperationStatus.Success]: '#',
+  [OperationStatus.SuccessWithWarning]: '!',
+  [OperationStatus.Failure]: '!',
+  [OperationStatus.Blocked]: '.',
+  [OperationStatus.Skipped]: '%',
+  [OperationStatus.FromCache]: '%',
+  [OperationStatus.NoOp]: '%'
+};
+
+/**
+ * Timeline - colorizer for each operation status
+ */
+const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => string> = {
+  [OperationStatus.Ready]: colors.yellow,
+  [OperationStatus.Executing]: colors.yellow,
+  [OperationStatus.Success]: colors.green,
+  [OperationStatus.SuccessWithWarning]: colors.yellow,
+  [OperationStatus.Failure]: colors.red,
+  [OperationStatus.Blocked]: colors.red,
+  [OperationStatus.Skipped]: colors.green,
+  [OperationStatus.FromCache]: colors.green,
+  [OperationStatus.NoOp]: colors.gray
+};
+
+interface ITimelineRecord {
+  startTime: number;
+  endTime: number;
+  durationString: string;
+  name: string;
+  status: OperationStatus;
+}
+/**
+ * Print a more detailed timeline and analysis of CPU usage for the build.
+ * @internal
+ */
+export function _printTimeline(terminal: ITerminal, result: IExecutionResult): void {
+  //
+  // Gather the operation records we'll be displaying. Do some inline max()
+  // finding to reduce the number of times we need to loop through operations.
+  //
+
+  const durationByPhase: Map<IPhase, number> = new Map();
+
+  const data: ITimelineRecord[] = [];
+  let longestNameLength: number = 0;
+  let longestDurationLength: number = 0;
+  let allStart: number = Infinity;
+  let allEnd: number = -Infinity;
+  let workDuration: number = 0;
+
+  for (const [operation, operationResult] of result.operationResults) {
+    if (operation.runner?.silent) {
+      continue;
+    }
+
+    const { stopwatch } = operationResult;
+
+    const { startTime, endTime } = stopwatch;
+
+    if (startTime && endTime) {
+      const nameLength: number = operation.name?.length || 0;
+      if (nameLength > longestNameLength) {
+        longestNameLength = nameLength;
+      }
+
+      const { duration } = stopwatch;
+      const durationString: string = duration.toFixed(1);
+      const durationLength: number = durationString.length;
+      if (durationLength > longestDurationLength) {
+        longestDurationLength = durationLength;
+      }
+
+      if (endTime > allEnd) {
+        allEnd = endTime;
+      }
+      if (startTime < allStart) {
+        allStart = startTime;
+      }
+      workDuration += duration;
+
+      const { associatedPhase } = operation;
+
+      if (associatedPhase) {
+        durationByPhase.set(associatedPhase, (durationByPhase.get(associatedPhase) || 0) + duration);
+      }
+
+      data.push({
+        startTime,
+        endTime,
+        durationString,
+        name: operation.name!,
+        status: operationResult.status
+      });
+    }
+  }
+
+  data.sort((a, b) => a.startTime - b.startTime);
+
+  //
+  // Determine timing for all tasks (wall clock and execution times)
+  //
+
+  const allDuration: number = allEnd - allStart;
+  const allDurationSeconds: number = allDuration / 1000;
+
+  //
+  // Do some calculations to determine what size timeline chart we need.
+  //
+
+  const maxWidth: number = process.stdout.columns || TIMELINE_WIDTH;
+  const chartWidth: number = maxWidth - longestNameLength - longestDurationLength - 4;
+  //
+  // Loop through all operations, assembling some statistics about operations and
+  // phases, if applicable.
+  //
+
+  const busyCpus: number[] = [];
+  function getOpenCPU(time: number): number {
+    const len: number = busyCpus.length;
+    for (let i: number = 0; i < len; i++) {
+      if (busyCpus[i] <= time) {
+        return i;
+      }
+    }
+    return len;
+  }
+
+  // Start with a newline
+  terminal.writeLine('');
+  terminal.writeLine('='.repeat(maxWidth));
+
+  for (const { startTime, endTime, durationString, name, status } of data) {
+    // Track busy CPUs
+    const openCpu: number = getOpenCPU(startTime);
+    busyCpus[openCpu] = endTime;
+
+    // Build timeline chart
+    const startIdx: number = Math.floor(((startTime - allStart) * chartWidth) / allDuration);
+    const endIdx: number = Math.floor(((endTime - allStart) * chartWidth) / allDuration);
+    const length: number = endIdx - startIdx + 1;
+
+    const chart: string =
+      colors.gray('-'.repeat(startIdx)) +
+      TIMELINE_CHART_COLORIZER[status](TIMELINE_CHART_SYMBOLS[status].repeat(length)) +
+      colors.gray('-'.repeat(chartWidth - endIdx));
+    terminal.writeLine(
+      `${colors.cyan(name.padStart(longestNameLength))} ${chart} ${colors.white(
+        durationString.padStart(longestDurationLength) + 's'
+      )}`
+    );
+  }
+
+  terminal.writeLine('='.repeat(maxWidth));
+
+  //
+  // Format legend and summary areas
+  //
+
+  const usedCpus: number = busyCpus.length;
+
+  const legend: string[] = ['LEGEND:', '  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op'];
+
+  const summary: string[] = [
+    `Total Work: ${workDuration.toFixed(1)}s`,
+    `Wall Clock: ${allDurationSeconds.toFixed(1)}s`
+  ];
+
+  terminal.writeLine(legend[0] + summary[0].padStart(maxWidth - legend[0].length));
+  terminal.writeLine(legend[1] + summary[1].padStart(maxWidth - legend[1].length));
+  terminal.writeLine(`Max Parallelism Used: ${usedCpus}`.padStart(maxWidth));
+  terminal.writeLine(
+    `Avg Parallelism Used: ${(workDuration / allDurationSeconds).toFixed(1)}`.padStart(maxWidth)
+  );
+
+  //
+  // Include time-by-phase, if phases are enabled
+  //
+
+  if (durationByPhase.size > 0) {
+    terminal.writeLine('BY PHASE:');
+
+    let maxPhaseName: number = 16;
+    for (const phase of durationByPhase.keys()) {
+      const len: number = phase.name.length;
+      if (len > maxPhaseName) {
+        maxPhaseName = len;
+      }
+    }
+
+    for (const [phase, duration] of durationByPhase.entries()) {
+      terminal.writeLine(`  ${colors.cyan(phase.name.padStart(maxPhaseName))} ${duration.toFixed(1)}s`);
+    }
+  }
+
+  terminal.writeLine('');
+}

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { StdioSummarizer } from '@rushstack/terminal';
+import type { OperationStatus } from './OperationStatus';
+import type { IStopwatchResult } from '../../utilities/Stopwatch';
+import type { Operation } from './Operation';
+
+/**
+ * The `IOperationExecutionResult` interface represents the results of executing an {@link Operation}.
+ * @alpha
+ */
+export interface IOperationExecutionResult {
+  /**
+   * The current execution status of an operation. Operations start in the 'ready' state,
+   * but can be 'blocked' if an upstream operation failed. It is 'executing' when
+   * the operation is executing. Once execution is complete, it is either 'success' or
+   * 'failure'.
+   */
+  readonly status: OperationStatus;
+  /**
+   * The error which occurred while executing this operation, this is stored in case we need
+   * it later (for example to re-print errors at end of execution).
+   */
+  readonly error: Error | undefined;
+  /**
+   * Object tracking execution timing.
+   */
+  readonly stopwatch: IStopwatchResult;
+  /**
+   * Object used to report a summary at the end of the Rush invocation.
+   */
+  readonly stdioSummarizer: StdioSummarizer;
+}
+
+/**
+ * The `IExecutionResult` interface represents the results of executing a set of {@link Operation}s.
+ * @alpha
+ */
+export interface IExecutionResult {
+  /**
+   * The results for each scheduled operation.
+   */
+  readonly operationResults: ReadonlyMap<Operation, IOperationExecutionResult>;
+  /**
+   * The overall result.
+   */
+  readonly status: OperationStatus;
+}

--- a/libraries/rush-lib/src/logic/operations/OperationError.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationError.ts
@@ -3,6 +3,7 @@
 
 /**
  * Encapsulates information about an error
+ * @alpha
  */
 export class OperationError extends Error {
   protected _type: string;

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -3,25 +3,20 @@
 
 import * as os from 'os';
 import colors from 'colors/safe';
-import {
-  TerminalWritable,
-  StdioWritable,
-  TerminalChunkKind,
-  TextRewriterTransform
-} from '@rushstack/terminal';
+import { TerminalWritable, StdioWritable, TextRewriterTransform } from '@rushstack/terminal';
 import { StreamCollator, CollatedTerminal, CollatedWriter } from '@rushstack/stream-collator';
-import { AlreadyReportedError, NewlineKind, InternalError, Sort, Async } from '@rushstack/node-core-library';
+import { NewlineKind, Async } from '@rushstack/node-core-library';
 
 import { AsyncOperationQueue, IOperationSortFunction } from './AsyncOperationQueue';
 import { Operation } from './Operation';
 import { OperationStatus } from './OperationStatus';
 import { IOperationExecutionRecordContext, OperationExecutionRecord } from './OperationExecutionRecord';
+import { IExecutionResult } from './IOperationExecutionResult';
 
 export interface IOperationExecutionManagerOptions {
   quietMode: boolean;
   debugMode: boolean;
   parallelism: string | undefined;
-  showTimeline: boolean;
   changedProjectsOnly: boolean;
   destination?: TerminalWritable;
 }
@@ -32,41 +27,6 @@ export interface IOperationExecutionManagerOptions {
 const ASCII_HEADER_WIDTH: number = 79;
 
 /**
- * Timeline - a wider column width for printing the timeline summary
- */
-const TIMELINE_WIDTH: number = 109;
-
-/**
- * Timeline - symbols representing each operation status
- */
-const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
-  [OperationStatus.Ready]: '?',
-  [OperationStatus.Executing]: '?',
-  [OperationStatus.Success]: '#',
-  [OperationStatus.SuccessWithWarning]: '!',
-  [OperationStatus.Failure]: '!',
-  [OperationStatus.Blocked]: '.',
-  [OperationStatus.Skipped]: '%',
-  [OperationStatus.FromCache]: '%',
-  [OperationStatus.NoOp]: '%'
-};
-
-/**
- * Timeline - colorizer for each operation status
- */
-const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => string> = {
-  [OperationStatus.Ready]: colors.yellow,
-  [OperationStatus.Executing]: colors.yellow,
-  [OperationStatus.Success]: colors.green,
-  [OperationStatus.SuccessWithWarning]: colors.yellow,
-  [OperationStatus.Failure]: colors.red,
-  [OperationStatus.Blocked]: colors.red,
-  [OperationStatus.Skipped]: colors.green,
-  [OperationStatus.FromCache]: colors.green,
-  [OperationStatus.NoOp]: colors.gray
-};
-
-/**
  * A class which manages the execution of a set of tasks with interdependencies.
  * Initially, and at the end of each task execution, all unblocked tasks
  * are added to a ready queue which is then executed. This is done continually until all
@@ -74,10 +34,9 @@ const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => stri
  */
 export class OperationExecutionManager {
   private readonly _changedProjectsOnly: boolean;
-  private readonly _executionRecords: Set<OperationExecutionRecord>;
+  private readonly _executionRecords: Map<Operation, OperationExecutionRecord>;
   private readonly _quietMode: boolean;
   private readonly _parallelism: number;
-  private readonly _showTimeline: boolean;
   private readonly _totalOperations: number;
 
   private readonly _outputWritable: TerminalWritable;
@@ -92,10 +51,9 @@ export class OperationExecutionManager {
   private _completedOperations: number;
 
   public constructor(operations: Set<Operation>, options: IOperationExecutionManagerOptions) {
-    const { quietMode, debugMode, parallelism, showTimeline, changedProjectsOnly } = options;
+    const { quietMode, debugMode, parallelism, changedProjectsOnly } = options;
     this._completedOperations = 0;
     this._quietMode = quietMode;
-    this._showTimeline = showTimeline;
     this._hasAnyFailures = false;
     this._hasAnyNonAllowedWarnings = false;
     this._changedProjectsOnly = changedProjectsOnly;
@@ -124,7 +82,7 @@ export class OperationExecutionManager {
     };
 
     let totalOperations: number = 0;
-    const executionRecords: Map<Operation, OperationExecutionRecord> = new Map();
+    const executionRecords: Map<Operation, OperationExecutionRecord> = (this._executionRecords = new Map());
     for (const operation of operations) {
       const executionRecord: OperationExecutionRecord = new OperationExecutionRecord(
         operation,
@@ -151,7 +109,6 @@ export class OperationExecutionManager {
         dependencyRecord.consumers.add(consumer);
       }
     }
-    this._executionRecords = new Set(executionRecords.values());
 
     const numberOfCores: number = os.cpus().length;
 
@@ -234,7 +191,7 @@ export class OperationExecutionManager {
    * Executes all operations which have been registered, returning a promise which is resolved when all the
    * operations are completed successfully, or rejects when any operation fails.
    */
-  public async executeAsync(): Promise<void> {
+  public async executeAsync(): Promise<IExecutionResult> {
     this._completedOperations = 0;
     const totalOperations: number = this._totalOperations;
 
@@ -242,7 +199,7 @@ export class OperationExecutionManager {
       const plural: string = totalOperations === 1 ? '' : 's';
       this._terminal.writeStdoutLine(`Selected ${totalOperations} operation${plural}:`);
       const nonSilentOperations: string[] = [];
-      for (const record of this._executionRecords) {
+      for (const record of this._executionRecords.values()) {
         if (!record.runner.silent) {
           nonSilentOperations.push(record.name);
         }
@@ -263,7 +220,10 @@ export class OperationExecutionManager {
     ): number => {
       return a.criticalPathLength! - b.criticalPathLength!;
     };
-    const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(this._executionRecords, prioritySort);
+    const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(
+      this._executionRecords.values(),
+      prioritySort
+    );
 
     // This function is a callback because it may write to the collatedWriter before
     // operation.executeAsync returns (and cleans up the writer)
@@ -283,19 +243,16 @@ export class OperationExecutionManager {
       }
     );
 
-    this._printOperationStatus();
+    const status: OperationStatus = this._hasAnyFailures
+      ? OperationStatus.Failure
+      : this._hasAnyNonAllowedWarnings
+      ? OperationStatus.SuccessWithWarning
+      : OperationStatus.Success;
 
-    if (this._showTimeline) {
-      this._printTimeline();
-    }
-
-    if (this._hasAnyFailures) {
-      this._terminal.writeStderrLine(colors.red('Operations failed.') + '\n');
-      throw new AlreadyReportedError();
-    } else if (this._hasAnyNonAllowedWarnings) {
-      this._terminal.writeStderrLine(colors.yellow('Operations succeeded with warnings.') + '\n');
-      throw new AlreadyReportedError();
-    }
+    return {
+      operationResults: this._executionRecords,
+      status
+    };
   }
 
   /**
@@ -416,361 +373,5 @@ export class OperationExecutionManager {
       // Remove this operation from the dependencies, to unblock the scheduler
       item.dependencies.delete(record);
     }
-  }
-
-  /**
-   * Prints out a report of the status of each project
-   */
-  private _printOperationStatus(): void {
-    const operationsByStatus: Map<OperationStatus, OperationExecutionRecord[]> = new Map();
-    for (const operation of this._executionRecords) {
-      const { status } = operation;
-      switch (status) {
-        // These are the sections that we will report below
-        case OperationStatus.Skipped:
-        case OperationStatus.FromCache:
-        case OperationStatus.Success:
-        case OperationStatus.SuccessWithWarning:
-        case OperationStatus.Blocked:
-        case OperationStatus.Failure:
-        case OperationStatus.NoOp:
-          break;
-        default:
-          // This should never happen
-          throw new InternalError(`Unexpected operation status: ${status}`);
-      }
-
-      if (operation.runner.silent) {
-        // Don't report silenced operations
-        continue;
-      }
-
-      const collection: OperationExecutionRecord[] | undefined = operationsByStatus.get(status);
-      if (collection) {
-        collection.push(operation);
-      } else {
-        operationsByStatus.set(status, [operation]);
-      }
-    }
-
-    // Skip a few lines before we start the summary
-    this._terminal.writeStdoutLine('');
-    this._terminal.writeStdoutLine('');
-    this._terminal.writeStdoutLine('');
-
-    // These are ordered so that the most interesting statuses appear last:
-    this._writeCondensedSummary(
-      OperationStatus.Skipped,
-      operationsByStatus,
-      colors.green,
-      'These operations were already up to date:'
-    );
-
-    this._writeCondensedSummary(
-      OperationStatus.NoOp,
-      operationsByStatus,
-      colors.gray,
-      'These operations did not define any work:'
-    );
-
-    this._writeCondensedSummary(
-      OperationStatus.FromCache,
-      operationsByStatus,
-      colors.green,
-      'These operations were restored from the build cache:'
-    );
-
-    this._writeCondensedSummary(
-      OperationStatus.Success,
-      operationsByStatus,
-      colors.green,
-      'These operations completed successfully:'
-    );
-
-    this._writeDetailedSummary(
-      OperationStatus.SuccessWithWarning,
-      operationsByStatus,
-      colors.yellow,
-      'WARNING'
-    );
-
-    this._writeCondensedSummary(
-      OperationStatus.Blocked,
-      operationsByStatus,
-      colors.white,
-      'These operations were blocked by dependencies that failed:'
-    );
-
-    this._writeDetailedSummary(OperationStatus.Failure, operationsByStatus, colors.red);
-
-    this._terminal.writeStdoutLine('');
-  }
-
-  private _writeCondensedSummary(
-    status: OperationStatus,
-    recordsByStatus: Map<OperationStatus, OperationExecutionRecord[]>,
-    headingColor: (text: string) => string,
-    preamble: string
-  ): void {
-    // Example:
-    //
-    // ==[ BLOCKED: 4 projects ]==============================================================
-    //
-    // These projects were blocked by dependencies that failed:
-    //   @scope/name
-    //   e
-    //   k
-
-    const operations: OperationExecutionRecord[] | undefined = recordsByStatus.get(status);
-    if (!operations || operations.length === 0) {
-      return;
-    }
-    Sort.sortBy(operations, (x) => x.name);
-
-    this._writeSummaryHeader(status, operations, headingColor);
-    this._terminal.writeStdoutLine(preamble);
-
-    const longestTaskName: number = Math.max(...operations.map((x) => x.name.length));
-
-    for (const operation of operations) {
-      if (
-        operation.stopwatch.duration !== 0 &&
-        operation.runner.reportTiming &&
-        operation.status !== OperationStatus.Skipped
-      ) {
-        const time: string = operation.stopwatch.toString();
-        const padding: string = ' '.repeat(longestTaskName - operation.name.length);
-        this._terminal.writeStdoutLine(`  ${operation.name}${padding}    ${time}`);
-      } else {
-        this._terminal.writeStdoutLine(`  ${operation.name}`);
-      }
-    }
-    this._terminal.writeStdoutLine('');
-  }
-
-  private _writeDetailedSummary(
-    status: OperationStatus,
-    recordsByStatus: Map<OperationStatus, OperationExecutionRecord[]>,
-    headingColor: (text: string) => string,
-    shortStatusName?: string
-  ): void {
-    // Example:
-    //
-    // ==[ SUCCESS WITH WARNINGS: 2 projects ]================================
-    //
-    // --[ WARNINGS: f ]------------------------------------[ 5.07 seconds ]--
-    //
-    // [eslint] Warning: src/logic/operations/OperationsExecutionManager.ts:393:3 ...
-
-    const operations: OperationExecutionRecord[] | undefined = recordsByStatus.get(status);
-    if (!operations || operations.length === 0) {
-      return;
-    }
-
-    this._writeSummaryHeader(status, operations, headingColor);
-
-    if (shortStatusName === undefined) {
-      shortStatusName = status;
-    }
-
-    for (const operation of operations) {
-      // Format a header like this
-      //
-      // --[ WARNINGS: f ]------------------------------------[ 5.07 seconds ]--
-
-      // leftPart: "--[ WARNINGS: f "
-      const subheadingText: string = `${shortStatusName}: ${operation.name}`;
-
-      const leftPart: string = colors.gray('--[') + ' ' + headingColor(subheadingText) + ' ';
-      const leftPartLength: number = 4 + subheadingText.length + 1;
-
-      // rightPart: " 5.07 seconds ]--"
-      const time: string = operation.stopwatch.toString();
-      const rightPart: string = ' ' + colors.white(time) + ' ' + colors.gray(']--');
-      const rightPartLength: number = 1 + time.length + 1 + 3;
-
-      // middlePart: "]----------------------["
-      const twoBracketsLength: number = 2;
-      const middlePartLengthMinusTwoBrackets: number = Math.max(
-        ASCII_HEADER_WIDTH - (leftPartLength + rightPartLength + twoBracketsLength),
-        0
-      );
-
-      const middlePart: string = colors.gray(']' + '-'.repeat(middlePartLengthMinusTwoBrackets) + '[');
-
-      this._terminal.writeStdoutLine(leftPart + middlePart + rightPart + '\n');
-
-      const details: string = operation.stdioSummarizer.getReport();
-      if (details) {
-        // Don't write a newline, because the report will always end with a newline
-        this._terminal.writeChunk({ text: details, kind: TerminalChunkKind.Stdout });
-      }
-
-      this._terminal.writeStdoutLine('');
-    }
-  }
-
-  private _writeSummaryHeader(
-    status: OperationStatus,
-    records: OperationExecutionRecord[],
-    headingColor: (text: string) => string
-  ): void {
-    // Format a header like this
-    //
-    // ==[ FAILED: 2 operations ]================================================
-
-    // "2 operations"
-    const projectsText: string = `${records.length}${records.length === 1 ? ' operation' : ' operations'}`;
-    const headingText: string = `${status}: ${projectsText}`;
-
-    // leftPart: "==[ FAILED: 2 operations "
-    const leftPart: string = `${colors.gray('==[')} ${headingColor(headingText)} `;
-    const leftPartLength: number = 3 + 1 + headingText.length + 1;
-
-    const rightPartLengthMinusBracket: number = Math.max(ASCII_HEADER_WIDTH - (leftPartLength + 1), 0);
-
-    // rightPart: "]======================"
-    const rightPart: string = colors.gray(`]${'='.repeat(rightPartLengthMinusBracket)}`);
-
-    this._terminal.writeStdoutLine(leftPart + rightPart);
-    this._terminal.writeStdoutLine('');
-  }
-
-  /**
-   * Print a more detailed timeline and analysis of CPU usage for the build.
-   */
-  private _printTimeline(): void {
-    //
-    // Gather the operation records we'll be displaying. Do some inline max()
-    // finding to reduce the number of times we need to loop through operations.
-    //
-
-    const operations: OperationExecutionRecord[] = [];
-    let longestNameLength: number = 0;
-    let longestDurationLength: number = 0;
-    let allEnd: number = 0;
-
-    for (const operation of this._executionRecords) {
-      if (operation.stopwatch.startTime && operation.stopwatch.endTime) {
-        operations.push(operation);
-
-        const nameLength: number = operation.name.length;
-        if (nameLength > longestNameLength) {
-          longestNameLength = nameLength;
-        }
-
-        const durationLength: number = operation.stopwatch.duration.toFixed(1).length + 1;
-        if (durationLength > longestDurationLength) {
-          longestDurationLength = durationLength;
-        }
-
-        if (operation.stopwatch.endTime! > allEnd) {
-          allEnd = operation.stopwatch.endTime!;
-        }
-      }
-    }
-
-    operations.sort((a, b) => a.stopwatch.startTime! - b.stopwatch.startTime!);
-
-    //
-    // Determine timing for all tasks (wall clock and execution times)
-    //
-
-    const allStart: number = operations[0].stopwatch.startTime!;
-    const allDuration: number = allEnd - allStart;
-    const workDuration: number = operations
-      .map((operation) => operation.stopwatch.duration)
-      .reduce((sum, value) => sum + value);
-
-    //
-    // Do some calculations to determine what size timeline chart we need.
-    //
-
-    const chartWidth: number = TIMELINE_WIDTH - longestNameLength - longestDurationLength - 3;
-    //
-    // Loop through all operations, assembling some statistics about operations and
-    // phases, if applicable.
-    //
-
-    const durationByPhase: Map<string, number> = new Map();
-
-    const busyCpus: number[] = Array(this._parallelism).fill(-1);
-
-    this._terminal.writeStdoutLine('='.repeat(TIMELINE_WIDTH));
-
-    for (const operation of operations) {
-      // Track time by phase
-      const phaseMatch: RegExpMatchArray | null = operation.name.match(/\((.+)\)$/);
-      if (phaseMatch) {
-        durationByPhase.set(
-          phaseMatch[1],
-          (durationByPhase.get(phaseMatch[1]) || 0) + operation.stopwatch.duration
-        );
-      }
-
-      // Track busy CPUs
-      const openCpu: number = busyCpus.findIndex((end) => end === -1 || end < operation.stopwatch.startTime!);
-      busyCpus[openCpu] = operation.stopwatch.endTime!;
-
-      // Build timeline chart
-
-      const startIdx: number = Math.floor(
-        ((operation.stopwatch.startTime! - allStart) * chartWidth) / allDuration
-      );
-      const endIdx: number = Math.floor(
-        ((operation.stopwatch.endTime! - allStart) * chartWidth) / allDuration
-      );
-      const length: number = endIdx - startIdx + 1;
-
-      const chart: string =
-        colors.gray('-'.repeat(startIdx)) +
-        TIMELINE_CHART_COLORIZER[operation.status](TIMELINE_CHART_SYMBOLS[operation.status].repeat(length)) +
-        colors.gray('-'.repeat(chartWidth - endIdx));
-      this._terminal.writeStdoutLine(
-        colors.cyan(operation.name.padEnd(longestNameLength)) +
-          ' ' +
-          chart +
-          ' ' +
-          colors.white((operation.stopwatch.duration.toFixed(1) + 's').padStart(longestDurationLength))
-      );
-    }
-
-    this._terminal.writeStdoutLine('='.repeat(TIMELINE_WIDTH));
-
-    //
-    // Format legend and summary areas
-    //
-
-    const usedCpus: number = busyCpus.filter((cpu) => cpu !== -1).length;
-
-    const legend: string[] = ['LEGEND:', '  [#] Success  [!] Failed/warnings  [%] Skipped/cached'];
-
-    const summary: string[] = [
-      'Total Work: ' + workDuration.toFixed(1) + 's',
-      'Wall Clock: ' + (allDuration / 1000).toFixed(1) + 's',
-      `Parallelism Used: ${usedCpus}/${this._parallelism}`
-    ];
-
-    this._terminal.writeStdoutLine(legend[0] + summary[0].padStart(TIMELINE_WIDTH - legend[0].length));
-    this._terminal.writeStdoutLine(legend[1] + summary[1].padStart(TIMELINE_WIDTH - legend[1].length));
-    this._terminal.writeStdoutLine(summary[2].padStart(TIMELINE_WIDTH));
-
-    //
-    // Include time-by-phase, if phases are enabled
-    //
-
-    if (durationByPhase.size > 0) {
-      this._terminal.writeStdoutLine('BY PHASE:');
-
-      const maxPhaseName: number = Math.max(16, ...[...durationByPhase.keys()].map((name) => name.length));
-
-      for (const [phase, duration] of durationByPhase.entries()) {
-        this._terminal.writeStdoutLine(
-          '  ' + colors.cyan(phase.padEnd(maxPhaseName)) + duration.toFixed(1).padStart(8) + 's'
-        );
-      }
-    }
-
-    this._terminal.writeStdoutLine('');
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -6,7 +6,6 @@ import { InternalError } from '@rushstack/node-core-library';
 import { CollatedWriter, StreamCollator } from '@rushstack/stream-collator';
 
 import { OperationStatus } from './OperationStatus';
-import { OperationError } from './OperationError';
 import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
 import { Operation } from './Operation';
 import { Stopwatch } from '../../utilities/Stopwatch';
@@ -34,7 +33,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
    * The error which occurred while executing this operation, this is stored in case we need
    * it later (for example to re-print errors at end of execution).
    */
-  public error: OperationError | undefined = undefined;
+  public error: Error | undefined = undefined;
 
   /**
    * This number represents how far away this Operation is from the furthest "root" operation (i.e.
@@ -130,7 +129,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
       onResult(this);
     } catch (error) {
       this.status = OperationStatus.Failure;
-      this.error = error as OperationError;
+      this.error = error;
       // Delegate global state reporting
       onResult(this);
     } finally {

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import colors from 'colors/safe';
+import { InternalError, ITerminal } from '@rushstack/node-core-library';
+import {
+  ICreateOperationsContext,
+  IPhasedCommandPlugin,
+  PhasedCommandHooks
+} from '../../pluginFramework/PhasedCommandHooks';
+import { IExecutionResult, IOperationExecutionResult } from './IOperationExecutionResult';
+import { Operation } from './Operation';
+import { OperationStatus } from './OperationStatus';
+
+const PLUGIN_NAME: 'OperationResultSummarizerPlugin' = 'OperationResultSummarizerPlugin';
+
+/**
+ * Format "======" lines for a shell window with classic 80 columns
+ */
+const ASCII_HEADER_WIDTH: number = 79;
+
+type IOperationAndResult = [Operation, IOperationExecutionResult];
+type IOperationsByStatus = Map<OperationStatus, IOperationAndResult[]>;
+
+/**
+ * Phased command plugin that emits a summary of build results to the console.
+ */
+export class OperationResultSummarizerPlugin implements IPhasedCommandPlugin {
+  private readonly _terminal: ITerminal;
+
+  public constructor(terminal: ITerminal) {
+    this._terminal = terminal;
+  }
+
+  public apply(hooks: PhasedCommandHooks): void {
+    hooks.afterExecuteOperations.tap(
+      PLUGIN_NAME,
+      (result: IExecutionResult, context: ICreateOperationsContext): void => {
+        _printOperationStatus(this._terminal, result);
+      }
+    );
+  }
+}
+
+/**
+ * Prints out a report of the status of each project
+ * @internal
+ */
+export function _printOperationStatus(terminal: ITerminal, result: IExecutionResult): void {
+  const { operationResults } = result;
+
+  const operationsByStatus: IOperationsByStatus = new Map();
+  for (const record of operationResults) {
+    if (record[0].runner?.silent) {
+      // Don't report silenced operations
+      continue;
+    }
+
+    const { status } = record[1];
+    switch (status) {
+      // These are the sections that we will report below
+      case OperationStatus.Skipped:
+      case OperationStatus.FromCache:
+      case OperationStatus.Success:
+      case OperationStatus.SuccessWithWarning:
+      case OperationStatus.Blocked:
+      case OperationStatus.Failure:
+      case OperationStatus.NoOp:
+        break;
+      default:
+        // This should never happen
+        throw new InternalError(`Unexpected operation status: ${status}`);
+    }
+
+    const collection: IOperationAndResult[] | undefined = operationsByStatus.get(status);
+    if (collection) {
+      collection.push(record);
+    } else {
+      operationsByStatus.set(status, [record]);
+    }
+  }
+
+  // Skip a few lines before we start the summary
+  terminal.writeLine('\n\n');
+
+  // These are ordered so that the most interesting statuses appear last:
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.Skipped,
+    operationsByStatus,
+    colors.green,
+    'These operations were already up to date:'
+  );
+
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.NoOp,
+    operationsByStatus,
+    colors.gray,
+    'These operations did not define any work:'
+  );
+
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.FromCache,
+    operationsByStatus,
+    colors.green,
+    'These operations were restored from the build cache:'
+  );
+
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.Success,
+    operationsByStatus,
+    colors.green,
+    'These operations completed successfully:'
+  );
+
+  writeDetailedSummary(
+    terminal,
+    OperationStatus.SuccessWithWarning,
+    operationsByStatus,
+    colors.yellow,
+    'WARNING'
+  );
+
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.Blocked,
+    operationsByStatus,
+    colors.white,
+    'These operations were blocked by dependencies that failed:'
+  );
+
+  writeDetailedSummary(terminal, OperationStatus.Failure, operationsByStatus, colors.red);
+
+  terminal.writeLine('');
+
+  switch (result.status) {
+    case OperationStatus.Failure:
+      terminal.writeErrorLine('Operations failed.\n');
+      break;
+    case OperationStatus.SuccessWithWarning:
+      terminal.writeWarningLine('Operations succeeded with warnings.\n');
+      break;
+  }
+}
+
+function writeCondensedSummary(
+  terminal: ITerminal,
+  status: OperationStatus,
+  operationsByStatus: IOperationsByStatus,
+  headingColor: (text: string) => string,
+  preamble: string
+): void {
+  // Example:
+  //
+  // ==[ BLOCKED: 4 projects ]==============================================================
+  //
+  // These projects were blocked by dependencies that failed:
+  //   @scope/name
+  //   e
+  //   k
+  const operations: IOperationAndResult[] | undefined = operationsByStatus.get(status);
+  if (!operations || operations.length === 0) {
+    return;
+  }
+
+  writeSummaryHeader(terminal, status, operations, headingColor);
+  terminal.writeLine(preamble);
+
+  let longestTaskName: number = 0;
+  for (const [operation] of operations) {
+    const nameLength: number = (operation.name || '').length;
+    if (nameLength > longestTaskName) {
+      longestTaskName = nameLength;
+    }
+  }
+
+  for (const [operation, operationResult] of operations) {
+    if (
+      operationResult.stopwatch.duration !== 0 &&
+      operation.runner!.reportTiming &&
+      operationResult.status !== OperationStatus.Skipped
+    ) {
+      const time: string = operationResult.stopwatch.toString();
+      const padding: string = ' '.repeat(longestTaskName - (operation.name || '').length);
+      terminal.writeLine(`  ${operation.name}${padding}    ${time}`);
+    } else {
+      terminal.writeLine(`  ${operation.name}`);
+    }
+  }
+  terminal.writeLine('');
+}
+
+function writeDetailedSummary(
+  terminal: ITerminal,
+  status: OperationStatus,
+  operationsByStatus: IOperationsByStatus,
+  headingColor: (text: string) => string,
+  shortStatusName?: string
+): void {
+  // Example:
+  //
+  // ==[ SUCCESS WITH WARNINGS: 2 projects ]================================
+  //
+  // --[ WARNINGS: f ]------------------------------------[ 5.07 seconds ]--
+  //
+  // [eslint] Warning: src/logic/operations/OperationsExecutionManager.ts:393:3 ...
+
+  const operations: IOperationAndResult[] | undefined = operationsByStatus.get(status);
+  if (!operations || operations.length === 0) {
+    return;
+  }
+
+  writeSummaryHeader(terminal, status, operations, headingColor);
+
+  if (shortStatusName === undefined) {
+    shortStatusName = status;
+  }
+
+  for (const [operation, operationResult] of operations) {
+    // Format a header like this
+    //
+    // --[ WARNINGS: f ]------------------------------------[ 5.07 seconds ]--
+
+    // leftPart: "--[ WARNINGS: f "
+    const subheadingText: string = `${shortStatusName}: ${operation.name}`;
+
+    const leftPartLength: number = 4 + subheadingText.length + 1;
+
+    // rightPart: " 5.07 seconds ]--"
+    const time: string = operationResult.stopwatch.toString();
+    const rightPartLength: number = 1 + time.length + 1 + 3;
+
+    // middlePart: "]----------------------["
+    const twoBracketsLength: 2 = 2;
+    const middlePartLengthMinusTwoBrackets: number = Math.max(
+      ASCII_HEADER_WIDTH - (leftPartLength + rightPartLength + twoBracketsLength),
+      0
+    );
+
+    terminal.writeLine(
+      `${colors.gray('--[')} ${headingColor(subheadingText)} ${colors.gray(
+        `]${'-'.repeat(middlePartLengthMinusTwoBrackets)}[`
+      )} ${colors.white(time)} ${colors.gray(']--')}\n`
+    );
+
+    const details: string = operationResult.stdioSummarizer.getReport();
+    if (details) {
+      // Don't write a newline, because the report will always end with a newline
+      terminal.write(details);
+    }
+
+    terminal.writeLine('');
+  }
+}
+
+function writeSummaryHeader(
+  terminal: ITerminal,
+  status: OperationStatus,
+  operations: ReadonlyArray<unknown>,
+  headingColor: (text: string) => string
+): void {
+  // Format a header like this
+  //
+  // ==[ FAILED: 2 operations ]================================================
+
+  // "2 operations"
+  const projectsText: string = `${operations.length}${
+    operations.length === 1 ? ' operation' : ' operations'
+  }`;
+  const headingText: string = `${status}: ${projectsText}`;
+
+  // leftPart: "==[ FAILED: 2 operations "
+  const leftPartLength: number = 3 + 1 + headingText.length + 1;
+
+  const rightPartLengthMinusBracket: number = Math.max(ASCII_HEADER_WIDTH - (leftPartLength + 1), 0);
+
+  // rightPart: "]======================"
+
+  terminal.writeLine(
+    `${colors.gray('==[')} ${headingColor(headingText)} ${colors.gray(
+      `]${'='.repeat(rightPartLengthMinusBracket)}`
+    )}\n`
+  );
+}

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -4,9 +4,7 @@ exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelism 1
 
 exports[`OperationExecutionManager Constructor throwsErrorOnInvalidParallelismPercentage 1`] = `"Invalid percentage value of '200%', value cannot be less than '0%' or more than '100%'"`;
 
-exports[`OperationExecutionManager Error logging printedStderrAfterError 1`] = `"An error occurred."`;
-
-exports[`OperationExecutionManager Error logging printedStderrAfterError 2`] = `
+exports[`OperationExecutionManager Error logging printedStderrAfterError 1`] = `
 Array [
   Object {
     "kind": "O",
@@ -59,26 +57,14 @@ Array [
   Object {
     "kind": "O",
     "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
+
 ",
   },
   Object {
     "kind": "O",
     "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
 ",
   },
   Object {
@@ -99,16 +85,14 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Operations failed.[default]
-
+    "text": "[red]Operations failed.
+[default]
 ",
   },
 ]
 `;
 
-exports[`OperationExecutionManager Error logging printedStdoutAfterErrorWithEmptyStderr 1`] = `"An error occurred."`;
-
-exports[`OperationExecutionManager Error logging printedStdoutAfterErrorWithEmptyStderr 2`] = `
+exports[`OperationExecutionManager Error logging printedStdoutAfterErrorWithEmptyStderr 1`] = `
 Array [
   Object {
     "kind": "O",
@@ -161,26 +145,14 @@ Array [
   Object {
     "kind": "O",
     "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
+
 ",
   },
   Object {
     "kind": "O",
     "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
 ",
   },
   Object {
@@ -201,16 +173,14 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]Operations failed.[default]
-
+    "text": "[red]Operations failed.
+[default]
 ",
   },
 ]
 `;
 
-exports[`OperationExecutionManager Warning logging Fail on warning Logs warnings correctly 1`] = `"An error occurred."`;
-
-exports[`OperationExecutionManager Warning logging Fail on warning Logs warnings correctly 2`] = `
+exports[`OperationExecutionManager Warning logging Fail on warning Logs warnings correctly 1`] = `
 Array [
   Object {
     "kind": "O",
@@ -263,26 +233,14 @@ Array [
   Object {
     "kind": "O",
     "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
+
 ",
   },
   Object {
     "kind": "O",
     "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
 ",
   },
   Object {
@@ -303,8 +261,8 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]Operations succeeded with warnings.[default]
-
+    "text": "[yellow]Operations succeeded with warnings.
+[default]
 ",
   },
 ]
@@ -363,26 +321,14 @@ Array [
   Object {
     "kind": "O",
     "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
+
 ",
   },
   Object {
     "kind": "O",
     "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
+
 ",
   },
   Object {
@@ -461,42 +407,6 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
-
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-",
-  },
-  Object {
-    "kind": "O",
     "text": "=============================================================================================================
 ",
   },
@@ -517,22 +427,46 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached                                       Wall Clock: 0.2s
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op                                 Wall Clock: 0.2s
 ",
   },
   Object {
     "kind": "O",
-    "text": "                                                                                        Parallelism Used: 1/1
+    "text": "                                                                                      Max Parallelism Used: 1
 ",
   },
   Object {
     "kind": "O",
-    "text": "BY PHASE:
+    "text": "                                                                                    Avg Parallelism Used: 1.0
 ",
   },
   Object {
     "kind": "O",
-    "text": "  [cyan]success         [default]     0.2s
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
 ",
   },
   Object {

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AsyncSeriesWaterfallHook, SyncHook } from 'tapable';
+import { AsyncSeriesHook, AsyncSeriesWaterfallHook, SyncHook } from 'tapable';
 
 import type { CommandLineParameter } from '@rushstack/ts-command-line';
 import type { BuildCacheConfiguration } from '../api/BuildCacheConfiguration';
@@ -11,6 +11,7 @@ import type { RushConfigurationProject } from '../api/RushConfigurationProject';
 
 import type { Operation } from '../logic/operations/Operation';
 import type { ProjectChangeAnalyzer } from '../logic/ProjectChangeAnalyzer';
+import { IExecutionResult } from '../logic/operations/IOperationExecutionResult';
 
 /**
  * A plugin that interacts with a phased commands.
@@ -85,6 +86,14 @@ export class PhasedCommandHooks {
    */
   public readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]> =
     new AsyncSeriesWaterfallHook(['operations', 'context'], 'createOperations');
+
+  /**
+   * Hook invoked after executing a set of operations.
+   * Use the context to distinguish between the initial run and phased runs.
+   * Hook is series for stable output.
+   */
+  public readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]> =
+    new AsyncSeriesHook(['results', 'context']);
 
   /**
    * Hook invoked after a run has finished and the command is watching for changes.

--- a/libraries/rush-lib/src/utilities/CollatedTerminalProvider.ts
+++ b/libraries/rush-lib/src/utilities/CollatedTerminalProvider.ts
@@ -3,6 +3,7 @@
 
 import { ITerminalProvider, TerminalProviderSeverity } from '@rushstack/node-core-library';
 import { CollatedTerminal } from '@rushstack/stream-collator';
+import { TerminalChunkKind } from '@rushstack/terminal';
 
 export interface ICollatedTerminalProviderOptions {
   debugEnabled: boolean;
@@ -40,7 +41,7 @@ export class CollatedTerminalProvider implements ITerminalProvider {
         // Unlike the basic ConsoleTerminalProvider, verbose messages are always passed
         // to stdout -- by convention the user-controlled build script output is sent
         // to verbose, and will be routed to a variety of other providers in the ProjectBuilder.
-        this._collatedTerminal.writeStdoutLine(data);
+        this._collatedTerminal.writeChunk({ text: data, kind: TerminalChunkKind.Stdout });
         break;
       }
 
@@ -48,19 +49,19 @@ export class CollatedTerminalProvider implements ITerminalProvider {
         // Similar to the basic ConsoleTerminalProvider, debug messages are discarded
         // unless they are explicitly enabled.
         if (this._debugEnabled) {
-          this._collatedTerminal.writeStdoutLine(data);
+          this._collatedTerminal.writeChunk({ text: data, kind: TerminalChunkKind.Stdout });
         }
         break;
       }
 
       case TerminalProviderSeverity.error: {
-        this._collatedTerminal.writeStderrLine(data);
+        this._collatedTerminal.writeChunk({ text: data, kind: TerminalChunkKind.Stderr });
         this._hasErrors = true;
         break;
       }
 
       case TerminalProviderSeverity.warning: {
-        this._collatedTerminal.writeStderrLine(data);
+        this._collatedTerminal.writeChunk({ text: data, kind: TerminalChunkKind.Stderr });
         this._hasWarnings = true;
         break;
       }

--- a/libraries/rush-lib/src/utilities/Stopwatch.ts
+++ b/libraries/rush-lib/src/utilities/Stopwatch.ts
@@ -12,10 +12,33 @@ export enum StopwatchState {
 }
 
 /**
+ * Represents a readonly view of a `Stopwatch`.
+ * @alpha
+ */
+export interface IStopwatchResult {
+  /**
+   * Displays how long the stopwatch has been executing in a human readable format.
+   */
+  toString(): string;
+  /**
+   * Get the duration in seconds.
+   */
+  get duration(): number;
+  /**
+   * Return the start time of the most recent stopwatch run.
+   */
+  get startTime(): number | undefined;
+  /**
+   * Return the end time of the most recent stopwatch run.
+   */
+  get endTime(): number | undefined;
+}
+
+/**
  * Represents a typical timer/stopwatch which keeps track
  * of elapsed time in between two events.
  */
-export class Stopwatch {
+export class Stopwatch implements IStopwatchResult {
   private _startTime: number | undefined;
   private _endTime: number | undefined;
   private _state: StopwatchState;


### PR DESCRIPTION
## Summary
Adds a new `afterExecuteOperations` hook to phased command execution. Uses the new hook to power the `--timeline` flag and to print the default result summary.

## Details
Adds a new `afterExecuteOperations` hook that provides the results of all executed commands and the overall execution result.
Refactors support for `--timeline` into a `ConsoleTimelinePlugin` that uses the new hook.
Refactors the default results summary into an `OperationResultSummaryPlugin` that uses the new hook.

Note that the timeline rendering has been migrated to be between the individual operation logs and the overall summary, so that failures are still the most immediate visible result at the end of command execution.

Fixes a bug in `Async` that allowed unbounded parallelism in async iterables.
Modifies `MockWritable` in `@rushstack/terminal` to implement the `ITerminalProvider` interface for ease of unit testing.

## How it was tested
Extensive use of local Rush commands.
Snapshot tests.