### PR TITLE
[rush-lib] Support workspace:alias@version

### DIFF
--- a/common/changes/@microsoft/rush/workspace-aliases_2022-05-11-19-38.json
+++ b/common/changes/@microsoft/rush/workspace-aliases_2022-05-11-19-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support `workspace:alias@version` dependency specifiers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/DependencySpecifier.ts
+++ b/libraries/rush-lib/src/logic/DependencySpecifier.ts
@@ -77,8 +77,8 @@ export class DependencySpecifier {
   public readonly specifierType: DependencySpecifierType;
 
   /**
-   * If `specifierType` is `alias`, then this is the parsed target dependency.
-   * For example, if version specifier i `"npm:other-package@^1.2.3"` then this is the parsed object for
+   * If `specifierType` is `alias` or `workspace`, then this is the parsed target dependency.
+   * For example, if version specifier is `"npm:other-package@^1.2.3"` then this is the parsed object for
    * `other-package@^1.2.3`.
    */
   public readonly aliasTarget: DependencySpecifier | undefined;
@@ -91,8 +91,18 @@ export class DependencySpecifier {
     // to the trimmed version range.
     if (versionSpecifier.startsWith('workspace:')) {
       this.specifierType = DependencySpecifierType.Workspace;
-      this.versionSpecifier = versionSpecifier.slice(this.specifierType.length + 1).trim();
-      this.aliasTarget = undefined;
+      versionSpecifier = versionSpecifier.slice(this.specifierType.length + 1).trim();
+      const index: number = versionSpecifier.indexOf('@', 1);
+      this.aliasTarget =
+        index > 0
+          ? new DependencySpecifier(
+              versionSpecifier.slice(0, index),
+              `workspace:${versionSpecifier.slice(index + 1)}`
+            )
+          : undefined;
+      if (index < 0) {
+        this.versionSpecifier = versionSpecifier;
+      }
       return;
     }
 

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { DependencySpecifier } from '../DependencySpecifier';
+
+describe(DependencySpecifier.name, () => {
+  it('parses correctly', () => {
+    for (const specifier of [
+      'workspace:@rushstack/heft@3.2.4',
+      'workspace:foo@^3.2.1',
+      'workspace:*',
+      'npm:@rushstack/heft@3.2.4',
+      'npm:foo@^3.2.1',
+      'npm:bar@',
+      '^1.2.3',
+      '~24.42.1',
+      '^0',
+      '3',
+      '*',
+      ''
+    ]) {
+      expect(new DependencySpecifier('foo', specifier)).toMatchSnapshot(specifier);
+    }
+  });
+});

--- a/libraries/rush-lib/src/logic/test/__snapshots__/DependencySpecifier.test.ts.snap
+++ b/libraries/rush-lib/src/logic/test/__snapshots__/DependencySpecifier.test.ts.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DependencySpecifier parses correctly 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Tag",
+  "versionSpecifier": "",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: * 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Range",
+  "versionSpecifier": "*",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: ^0 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Range",
+  "versionSpecifier": "^0",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: ^1.2.3 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Range",
+  "versionSpecifier": "^1.2.3",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: ~24.42.1 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Range",
+  "versionSpecifier": "~24.42.1",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: 3 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Range",
+  "versionSpecifier": "3",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: npm:@rushstack/heft@3.2.4 1`] = `
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "@rushstack/heft",
+    "specifierType": "Version",
+    "versionSpecifier": "3.2.4",
+  },
+  "packageName": "foo",
+  "specifierType": "Alias",
+  "versionSpecifier": "npm:@rushstack/heft@3.2.4",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: npm:bar@ 1`] = `
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "bar",
+    "specifierType": "Tag",
+    "versionSpecifier": "",
+  },
+  "packageName": "foo",
+  "specifierType": "Alias",
+  "versionSpecifier": "npm:bar@",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: npm:foo@^3.2.1 1`] = `
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "foo",
+    "specifierType": "Range",
+    "versionSpecifier": "^3.2.1",
+  },
+  "packageName": "foo",
+  "specifierType": "Alias",
+  "versionSpecifier": "npm:foo@^3.2.1",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: workspace:* 1`] = `
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "foo",
+  "specifierType": "Workspace",
+  "versionSpecifier": "*",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: workspace:@rushstack/heft@3.2.4 1`] = `
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "@rushstack/heft",
+    "specifierType": "Workspace",
+    "versionSpecifier": "3.2.4",
+  },
+  "packageName": "foo",
+  "specifierType": "Workspace",
+  "versionSpecifier": "workspace:@rushstack/heft@3.2.4",
+}
+`;
+
+exports[`DependencySpecifier parses correctly: workspace:foo@^3.2.1 1`] = `
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "foo",
+    "specifierType": "Workspace",
+    "versionSpecifier": "^3.2.1",
+  },
+  "packageName": "foo",
+  "specifierType": "Workspace",
+  "versionSpecifier": "workspace:foo@^3.2.1",
+}
+`;


### PR DESCRIPTION
## Summary
The `workspace:` protocol can be used with package aliases. This PR gives Rush the ability to parse such expressions as `workspace:alias@version`.

## Details
Adds support for `npm:` and `workspace:` aliasing to the Rush dependency tree.

## How it was tested
Added unit tests for dependency parsing.
Validated existing tree still works.