### PR TITLE
[rush] Export list of workspace packages to pnpmfile

### DIFF
--- a/common/changes/@microsoft/rush/workspace-versions-pnpmfile_2022-05-12-19-50.json
+++ b/common/changes/@microsoft/rush/workspace-versions-pnpmfile_2022-05-12-19-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Export the list of workspace packages to the pnpmfile shim.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -13,6 +13,10 @@ export interface IPnpmfileShimSettings {
   semverPath: string;
   allPreferredVersions: { [dependencyName: string]: string };
   allowedAlternativeVersions: { [dependencyName: string]: ReadonlyArray<string> };
+  /**
+   * The versions of all packages that are part of the workspace.
+   */
+  workspaceVersions: Record<string, string>;
   userPnpmfilePath?: string;
 }
 

--- a/libraries/rush-lib/src/logic/pnpm/PnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmfileConfiguration.ts
@@ -84,6 +84,7 @@ export class PnpmfileConfiguration {
   ): IPnpmfileShimSettings {
     let allPreferredVersions: { [dependencyName: string]: string } = {};
     let allowedAlternativeVersions: { [dependencyName: string]: readonly string[] } = {};
+    const workspaceVersions: Record<string, string> = {};
 
     // Only workspaces shims in the common versions using pnpmfile
     if ((rushConfiguration.packageManagerOptions as PnpmOptionsConfiguration).useWorkspaces) {
@@ -95,11 +96,16 @@ export class PnpmfileConfiguration {
       allowedAlternativeVersions = MapExtensions.toObject(
         commonVersionsConfiguration.allowedAlternativeVersions
       );
+
+      for (const project of rushConfiguration.projects) {
+        workspaceVersions[project.packageName] = project.packageJson.version;
+      }
     }
 
     const settings: IPnpmfileShimSettings = {
       allPreferredVersions,
       allowedAlternativeVersions,
+      workspaceVersions,
       semverPath: require.resolve('semver')
     };
 


### PR DESCRIPTION
## Summary
Exports a mapping of all workspace packages to their current versions to the pnpmfile shim.

## Details
Having the list of all packages that are part of the workspace and their latest versions can be useful for detecting external packages that refer back to workspace packages, and/or identifying if the package currently being examined is a workspace package (since local `package.json`s might not require changes).

## How it was tested
Ran an install and verified the contents of the `common/temp/pnpmfileSettings.json`.