### PR TITLE
[rush] Write telemetry in all phased commands

### DIFF
--- a/common/changes/@microsoft/rush/phased-telemetry_2022-05-12-23-49.json
+++ b/common/changes/@microsoft/rush/phased-telemetry_2022-05-12-23-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Write local telemetry for all phased commands, including partial runs when running in watch mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -473,7 +473,7 @@ export interface ITelemetryData {
     readonly durationInSeconds: number;
     // (undocumented)
     readonly extraData?: {
-        [key: string]: string;
+        [key: string]: string | number | boolean;
     };
     readonly name: string;
     readonly platform?: string;

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -40,7 +40,7 @@ export interface ITelemetryData {
    * @example 5.63.0
    */
   readonly rushVersion?: string;
-  readonly extraData?: { [key: string]: string };
+  readonly extraData?: { [key: string]: string | number | boolean };
 }
 
 const MAX_FILE_COUNT: number = 100;


### PR DESCRIPTION
## Summary
Enables writing telemetry to disk and via the `flushTelemetry` hook for all phased commands, not just the default `build` and `rebuild`.

## Details
Telemetry will be written after the initial run and after all watch-mode reruns, with the following additional metadata:
```ts
interface IPhasedCommandTelemetry {
  isInitial: boolean;
  isWatch: boolean;

  countAll: number;
  countSuccess: number;
  countSuccessWithWarnings: number;
  countFailure: number;
  countBlocked: number;
  countFromCache: number;
  countSkipped: number;
  countNoOp: number;
}
```

## How it was tested
Local runs with telemetry enabled.
