### PR TITLE
fixed usage of deprecated webpack-dev-server api

### DIFF
--- a/common/changes/@rushstack/heft-dev-cert-plugin/thelarkinn-issue-3421_2022-05-17-01-29.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/thelarkinn-issue-3421_2022-05-17-01-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "fix issue where webpack-dev-server v4 users recieved deprecation warnings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/thelarkinn-issue-3421_2022-05-17-00-30.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/thelarkinn-issue-3421_2022-05-17-00-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "fix: removed deprecation warning for webpack-dev-server",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
+++ b/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
@@ -82,7 +82,7 @@ export class DevCertPlugin implements IHeftPlugin {
 
   private _determineMajorVersion(version?: string): number | undefined {
     if (version) {
-      return Number(version.split('.')[0]);
+      return parseInt(version);
     } else {
       return;
     }

--- a/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
+++ b/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
@@ -101,7 +101,6 @@ export class DevCertPlugin implements IHeftPlugin {
       if (webpackDevServerMajorVersion && webpackDevServerMajorVersion === 4) {
         webpackConfiguration.devServer = {
           ...webpackConfiguration.devServer,
-          // This API throws depreaction warnings for webpack
           server: {
             type: 'https',
             options: {
@@ -113,7 +112,6 @@ export class DevCertPlugin implements IHeftPlugin {
       } else {
         webpackConfiguration.devServer = {
           ...webpackConfiguration.devServer,
-          // This API throws depreaction warnings for webpack
           https: {
             key: certificate.pemKey,
             cert: certificate.pemCertificate

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -196,9 +196,8 @@ export class WebpackPlugin implements IHeftPlugin {
       // Register a plugin to callback after webpack is done with the first compilation
       // so we can move on to post-build
       let firstCompilationDoneCallback: (() => void) | undefined;
-      const originalBeforeCallback: typeof options.onBeforeSetupMiddleware | undefined =
-        options.onBeforeSetupMiddleware;
-      options.onBeforeSetupMiddleware = (devServer) => {
+      const originalBeforeCallback: typeof options.setupMiddlewares | undefined = options.setupMiddlewares;
+      options.setupMiddlewares = (middlewares, devServer) => {
         compiler.hooks.done.tap('heft-webpack-plugin', () => {
           if (firstCompilationDoneCallback) {
             firstCompilationDoneCallback();
@@ -207,8 +206,9 @@ export class WebpackPlugin implements IHeftPlugin {
         });
 
         if (originalBeforeCallback) {
-          return originalBeforeCallback(devServer);
+          return originalBeforeCallback(middlewares, devServer);
         }
+        return middlewares;
       };
 
       // The webpack-dev-server package has a design flaw, where merely loading its package will set the


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Fixes #3421 
(one part of it)
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
This PR removes deprecation warnings thrown by webpack-dev-server when using the webpack-5-rig. This PR provides support for the DevCertPlugin to allow it to use both webpack-dev-server v3 and v4 API's.  
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
I ran both the heft-webpack5-everything-test and heft-webpack4-everything-test and ensured that both dev servers launched successfully without any errors or deprecation warnings. (They both leverage the DevCertPlugin)
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
