### PR TITLE
[API Extractor] Add missing required parameter for getResolvedModule to ensure that modules can resolve accurately with Node16/nodenext support

### DIFF
--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -259,9 +259,18 @@ export class ExportAnalyzer {
     importOrExportDeclaration: ts.ImportDeclaration | ts.ExportDeclaration | ts.ImportTypeNode,
     moduleSpecifier: string
   ): boolean {
+    const specifier: ts.TypeNode | ts.Expression | undefined = ts.isImportTypeNode(importOrExportDeclaration)
+      ? importOrExportDeclaration.argument
+      : importOrExportDeclaration.moduleSpecifier;
+    const mode: ts.StringLiteralLike =
+      specifier && ts.isStringLiteralLike(specifier)
+        ? TypeScriptInternals.getModeForUsageLocation(importOrExportDeclaration.getSourceFile(), specifier)
+        : undefined;
+
     const resolvedModule: ts.ResolvedModuleFull | undefined = TypeScriptInternals.getResolvedModule(
       importOrExportDeclaration.getSourceFile(),
-      moduleSpecifier
+      moduleSpecifier,
+      mode
     );
 
     if (resolvedModule === undefined) {
@@ -863,9 +872,18 @@ export class ExportAnalyzer {
     exportSymbol: ts.Symbol
   ): AstModule {
     const moduleSpecifier: string = this._getModuleSpecifier(importOrExportDeclaration);
+    const mode: ts.StringLiteralLike | undefined =
+      importOrExportDeclaration.moduleSpecifier &&
+      ts.isStringLiteralLike(importOrExportDeclaration.moduleSpecifier)
+        ? TypeScriptInternals.getModeForUsageLocation(
+            importOrExportDeclaration.getSourceFile(),
+            importOrExportDeclaration.moduleSpecifier
+          )
+        : undefined;
     const resolvedModule: ts.ResolvedModuleFull | undefined = TypeScriptInternals.getResolvedModule(
       importOrExportDeclaration.getSourceFile(),
-      moduleSpecifier
+      moduleSpecifier,
+      mode
     );
 
     if (resolvedModule === undefined) {

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -262,7 +262,7 @@ export class ExportAnalyzer {
     const specifier: ts.TypeNode | ts.Expression | undefined = ts.isImportTypeNode(importOrExportDeclaration)
       ? importOrExportDeclaration.argument
       : importOrExportDeclaration.moduleSpecifier;
-    const mode: ts.StringLiteralLike =
+    const mode: ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined =
       specifier && ts.isStringLiteralLike(specifier)
         ? TypeScriptInternals.getModeForUsageLocation(importOrExportDeclaration.getSourceFile(), specifier)
         : undefined;
@@ -872,7 +872,7 @@ export class ExportAnalyzer {
     exportSymbol: ts.Symbol
   ): AstModule {
     const moduleSpecifier: string = this._getModuleSpecifier(importOrExportDeclaration);
-    const mode: ts.StringLiteralLike | undefined =
+    const mode: ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined =
       importOrExportDeclaration.moduleSpecifier &&
       ts.isStringLiteralLike(importOrExportDeclaration.moduleSpecifier)
         ? TypeScriptInternals.getModeForUsageLocation(

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -83,12 +83,26 @@ export class TypeScriptInternals {
    */
   public static getResolvedModule(
     sourceFile: ts.SourceFile,
-    moduleNameText: string
+    moduleNameText: string,
+    mode: ts.StringLiteralLike | undefined
   ): ts.ResolvedModuleFull | undefined {
     // Compiler internal:
     // https://github.com/microsoft/TypeScript/blob/v3.2.2/src/compiler/utilities.ts#L218
 
-    return (ts as any).getResolvedModule(sourceFile, moduleNameText);
+    return (ts as any).getResolvedModule(sourceFile, moduleNameText, mode);
+  }
+
+  /**
+   * Gets the mode required for module resolution required with the addition of Node16/nodenext
+   */
+  public static getModeForUsageLocation(
+    file: { impliedNodeFormat?: ts.SourceFile['impliedNodeFormat'] },
+    usage: ts.StringLiteralLike
+  ) {
+    // Compiler internal:
+    // https://github.com/microsoft/TypeScript/blob/v4.7.2/src/compiler/program.ts#L568
+
+    return (ts as any).getModeForUsageLocation(file, usage);
   }
 
   /**

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -84,10 +84,10 @@ export class TypeScriptInternals {
   public static getResolvedModule(
     sourceFile: ts.SourceFile,
     moduleNameText: string,
-    mode: ts.StringLiteralLike | undefined
+    mode: ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined
   ): ts.ResolvedModuleFull | undefined {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v3.2.2/src/compiler/utilities.ts#L218
+    // https://github.com/microsoft/TypeScript/blob/v4.7.2/src/compiler/utilities.ts#L161
 
     return (ts as any).getResolvedModule(sourceFile, moduleNameText, mode);
   }
@@ -97,12 +97,12 @@ export class TypeScriptInternals {
    */
   public static getModeForUsageLocation(
     file: { impliedNodeFormat?: ts.SourceFile['impliedNodeFormat'] },
-    usage: ts.StringLiteralLike
-  ) {
+    usage: ts.StringLiteralLike | undefined
+  ): ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined {
     // Compiler internal:
     // https://github.com/microsoft/TypeScript/blob/v4.7.2/src/compiler/program.ts#L568
 
-    return (ts as any).getModeForUsageLocation(file, usage);
+    return (ts as any).getModeForUsageLocation?.(file, usage);
   }
 
   /**

--- a/common/changes/@microsoft/api-extractor/users-chhol-fix-getResolvedModule-params_2022-05-25-17-20.json
+++ b/common/changes/@microsoft/api-extractor/users-chhol-fix-getResolvedModule-params_2022-05-25-17-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "add missing required parameter for getResolvedModule to ensure typescript can accurately resolve module kind",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/users-chhol-fix-getResolvedModule-params_2022-05-25-17-20.json
+++ b/common/changes/@microsoft/api-extractor/users-chhol-fix-getResolvedModule-params_2022-05-25-17-20.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "add missing required parameter for getResolvedModule to ensure typescript can accurately resolve module kind",
-      "type": "minor"
+      "comment": "Fix an issue where API Extractor would fail to run on a project where `\"moduleResolution\"` is set to `\"Node16\"` in `tsconfig.json`",
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/api-extractor"


### PR DESCRIPTION
…ypescript can resolve accurately

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
With the addition of `Node16` and `nodenext`, Typescript now requires the mode to be passed in order to accurately resolve modules. This PR adds support for `mode` thanks to the help of @DanielRosenwasser and does so in a way that returns undefined gracefully in case the fn isn't supported in older versions.

This resolves #3433.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
1. Add a third param to getResolvedModule for `mode`
2. Create a new function `getModeForUsageLocation` which maps to the TS equivalent
3. Update all callers to gracefully look for the right mode and return undefined if necessary

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Tested locally with Typescript 4.7.2 and the error is gone, API Extractor succeeds.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
