### PR TITLE
[heft] Move heft-jest-data file to an easily cacheable location

### DIFF
--- a/apps/heft/src/configuration/HeftConfiguration.ts
+++ b/apps/heft/src/configuration/HeftConfiguration.ts
@@ -73,7 +73,10 @@ export class HeftConfiguration {
    */
   public get projectHeftDataFolder(): string {
     if (!this._projectHeftDataFolder) {
-      this._projectHeftDataFolder = path.join(this.buildFolder, Constants.projectHeftFolderName);
+      this._projectHeftDataFolder = path.join(
+        this.buildFolder,
+        ...Constants.projectHeftFolderName.split('/')
+      );
     }
 
     return this._projectHeftDataFolder;

--- a/apps/heft/src/utilities/Constants.ts
+++ b/apps/heft/src/utilities/Constants.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 export class Constants {
-  public static projectHeftFolderName: string = '.heft';
+  public static projectHeftFolderName: string = 'temp/heft';
 
   public static projectConfigFolderName: string = 'config';
 

--- a/common/changes/@rushstack/heft-jest-plugin/enelson-cache-jest-data_2022-05-29-12-48.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-cache-jest-data_2022-05-29-12-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Change build cache output folder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft/enelson-cache-jest-data_2022-05-29-12-48.json
+++ b/common/changes/@rushstack/heft/enelson-cache-jest-data_2022-05-29-12-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Change build cache output folder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/heft-plugins/heft-jest-plugin/src/HeftJestDataFile.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestDataFile.ts
@@ -88,10 +88,12 @@ export class HeftJestDataFile {
   }
 
   /**
-   * Get the absolute path to the heft-jest-data.json file
+   * Get the absolute path to the heft-jest-data.json file.
+   *
+   * See also: HeftConfiguration.buildCacheFolder.
    */
   public static getConfigFilePath(projectFolder: string): string {
-    return path.join(projectFolder, '.heft', 'build-cache', 'heft-jest-data.json');
+    return path.join(projectFolder, 'temp', 'heft', 'build-cache', 'heft-jest-data.json');
   }
 
   private static async _validateHeftJestDataFileAsync(


### PR DESCRIPTION
## Summary

 - Change the heft data folder location from `.heft/` to `temp/heft`.
 - Modify the `HeftJestDataFile` location to `temp/heft/build-cache/heft-jest-data.json`.

Fix for #3436.

## Details

If you are configuring a monorepo to support build caching and phased builds, and you use Jest, then the generated `HeftJestDataFile` must be included in your build phase's `outputFolderNames` configuration.

However, the current location (the `.heft/` folder) is a bit of an older naming scheme. My proposal is to move the folder to `temp/heft`.

 - In the Rushstack monorepo, which caches the entirety of `temp/` in the build phase, this corrects the problem automatically.
 - In other monorepos, I would suggest caching specific `temp/` subfolders.  For example, you might cache `temp/heft` in the build phase, and `temp/code-coverage` in the test phase.

> There might be a better way to do this. In particular it's a bit messy that `HeftJestDataFile` doesn't follow the configuration of Heft, but I don't see an easy way to change that (wiring heft configuration through the BuildTransformer looked messy for example). So I didn't tackle that problem.

## How it was tested

 - Confirmed locally that with this change, you can cache `temp/heft` and successfully run "test" phase after pulling "build" phase from cache.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
