### PR TITLE
[rush-lib] Build Cache: Sanitize projectName in scoped packages

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.5.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.0.tgz_eslint@8.7.0+typescript@4.6.3
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.5.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.3
       typescript: 4.6.3
@@ -831,7 +831,7 @@ packages:
     dev: true
 
   /glob-escape/0.0.2:
-    resolution: {integrity: sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0=}
+    resolution: {integrity: sha512-L/cXYz8x7qer1HAyUQ+mbjcUsJVdpRxpAf7CwqHoNBs9vTpABlGfNN4tzkDxt+u3Z7ZncVyKlCNPtzb0R/7WbA==}
     engines: {node: '>= 0.10'}
     dev: true
 
@@ -850,7 +850,7 @@ packages:
     dev: true
 
   /glob/7.0.6:
-    resolution: {integrity: sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=}
+    resolution: {integrity: sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -1073,7 +1073,7 @@ packages:
     dev: true
 
   /jju/1.4.0:
-    resolution: {integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=}
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
   /js-tokens/4.0.0:
@@ -1104,7 +1104,7 @@ packages:
     dev: true
 
   /jsonfile/4.0.0:
-    resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.6
     dev: true
@@ -1131,11 +1131,11 @@ packages:
     dev: true
 
   /lodash.get/4.4.2:
-    resolution: {integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=}
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
 
   /lodash.isequal/4.5.0:
-    resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     dev: true
 
   /lodash.merge/4.6.2:
@@ -1200,7 +1200,7 @@ packages:
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -1753,10 +1753,10 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.45.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.2.tgz}
+  file:../temp/tarballs/rushstack-heft-0.45.5.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.5.tgz}
     name: '@rushstack/heft'
-    version: 0.45.2
+    version: 0.45.5
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:

--- a/libraries/rush-lib/src/logic/buildCache/CacheEntryId.ts
+++ b/libraries/rush-lib/src/logic/buildCache/CacheEntryId.ts
@@ -90,11 +90,11 @@ export class CacheEntryId {
           case PROJECT_NAME_TOKEN_NAME: {
             switch (tokenAttribute) {
               case undefined: {
-                return `\${${OPTIONS_ARGUMENT_NAME}.projectName}`;
+                return `\${${OPTIONS_ARGUMENT_NAME}.projectName.replace('@','')}`;
               }
 
               case 'normalize': {
-                return `\${${OPTIONS_ARGUMENT_NAME}.projectName.replace(/\\+/g, '++').replace(/\\/\/g, '+')}`;
+                return `\${${OPTIONS_ARGUMENT_NAME}.projectName.replace('@','').replace(/\\+/g, '++').replace(/\\/\/g, '+')}`;
               }
 
               default: {

--- a/libraries/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
+++ b/libraries/rush-lib/src/logic/buildCache/test/__snapshots__/CacheEntryId.test.ts.snap
@@ -36,27 +36,27 @@ exports[`CacheEntryId Valid pattern names Handles a cache entry name for a proje
 
 exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [phaseName:trimPrefix]_[hash] 1`] = `"compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[hash] 1`] = `"@scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[hash] 1`] = `"scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[phaseName:normalize]_[hash] 1`] = `"@scope+project++name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[phaseName:normalize]_[hash] 1`] = `"scope+project++name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[phaseName:trimPrefix]_[hash] 1`] = `"@scope+project++name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName:normalize]_[phaseName:trimPrefix]_[hash] 1`] = `"scope+project++name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName]_[hash] 1`] = `"@scope/project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: [projectName]_[hash] 1`] = `"scope/project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
 exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: no pattern 1`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[hash] 1`] = `"prefix/@scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[hash] 1`] = `"prefix/scope+project++name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[phaseName:normalize]_[hash] 1`] = `"prefix/@scope+project++name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[phaseName:normalize]_[hash] 1`] = `"prefix/scope+project++name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[phaseName:trimPrefix]_[hash] 1`] = `"prefix/@scope+project++name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName:normalize]_[phaseName:trimPrefix]_[hash] 1`] = `"prefix/scope+project++name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[hash] 1`] = `"prefix/@scope/project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[hash] 1`] = `"prefix/scope/project+name_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[phaseName:normalize]_[hash] 1`] = `"prefix/@scope/project+name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[phaseName:normalize]_[hash] 1`] = `"prefix/scope/project+name__phase_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
-exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[phaseName:trimPrefix]_[hash] 1`] = `"prefix/@scope/project+name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
+exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name with a scope: prefix/[projectName]_[phaseName:trimPrefix]_[hash] 1`] = `"prefix/scope/project+name_compile_09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 
 exports[`CacheEntryId Valid pattern names Handles a cache entry name for a project name without a scope: [hash] 1`] = `"09d1ecee6d5f888fa6c35ca804b5dac7c3735ce3"`;
 


### PR DESCRIPTION
This allows the build cache to upload artifacts to S3.

## Summary

Fixes #3452

## Details

This fix removes the @ sign from scoped packages so the resulting artifact name/path can be used on S3.

## How it was tested

The existing tests were enough to visually verify the string replacement worked.

Snapshot tests for `[projectName]` and `[projectName:normalize]` were updated after visual verification.

I believe this completely solves the problem, is backwards compatible, and does not impact performance.
