### PR TITLE
[localization-utilities] Expose parsers directly

### DIFF
--- a/common/changes/@rushstack/localization-utilities/localization-plugin-5_2022-06-07-01-12.json
+++ b/common/changes/@rushstack/localization-utilities/localization-plugin-5_2022-06-07-01-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Expose each parser directly so that they can be used with arbitrary file extensions.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1612,21 +1612,21 @@ importers:
       '@rushstack/heft-node-rig': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@rushstack/typings-generator': workspace:*
+      '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/xmldoc': 1.1.4
-      decache: ~4.5.1
       pseudolocale: ~1.1.0
       xmldoc: ~1.1.2
     dependencies:
       '@rushstack/node-core-library': link:../node-core-library
       '@rushstack/typings-generator': link:../typings-generator
-      decache: 4.5.1
       pseudolocale: 1.1.0
       xmldoc: 1.1.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/xmldoc': 1.1.4
 
@@ -9744,10 +9744,6 @@ packages:
     resolution: {integrity: sha1-JtII6onje1y95gJQoV8DHBak1ms=}
     dev: true
 
-  /callsite/1.0.0:
-    resolution: {integrity: sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==}
-    dev: false
-
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -10924,12 +10920,6 @@ packages:
 
   /debuglog/1.0.1:
     resolution: {integrity: sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=}
-
-  /decache/4.5.1:
-    resolution: {integrity: sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==}
-    dependencies:
-      callsite: 1.0.0
-    dev: false
 
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "964142cc110c45eed3898aebab1f9361ebe58b3c",
+  "pnpmShrinkwrapHash": "065e82bf4b7942542ba0062d3f18fb4059dd59e6",
   "preferredVersionsHash": "d2a5d015a5e5f4861bc36581c3c08cb789ed7fab"
 }

--- a/common/reviews/api/localization-utilities.api.md
+++ b/common/reviews/api/localization-utilities.api.md
@@ -26,6 +26,14 @@ export interface ILocalizedString {
 }
 
 // @public (undocumented)
+export interface IParseFileOptions {
+    // (undocumented)
+    content: string;
+    // (undocumented)
+    filePath: string;
+}
+
+// @public (undocumented)
 export interface IParseLocFileOptions {
     // (undocumented)
     content: string;
@@ -33,6 +41,8 @@ export interface IParseLocFileOptions {
     filePath: string;
     // (undocumented)
     ignoreMissingResxComments: boolean | undefined;
+    // (undocumented)
+    parser?: ParserKind;
     // (undocumented)
     resxNewlineNormalization: NewlineKind | undefined;
     // (undocumented)
@@ -89,6 +99,15 @@ export interface ITypingsGeneratorOptions {
 
 // @public (undocumented)
 export function parseLocFile(options: IParseLocFileOptions): ILocalizationFile;
+
+// @public (undocumented)
+export function parseLocJson(options: IParseFileOptions): ILocalizationFile;
+
+// @public (undocumented)
+export function parseResJson(options: IParseFileOptions): ILocalizationFile;
+
+// @public (undocumented)
+export type ParserKind = 'resx' | 'loc.json' | 'resjson';
 
 // @public (undocumented)
 export function readResxAsLocFile(resxContents: string, options: IResxReaderOptions): ILocalizationFile;

--- a/libraries/localization-utilities/package.json
+++ b/libraries/localization-utilities/package.json
@@ -12,12 +12,12 @@
   },
   "scripts": {
     "build": "heft build --clean",
-    "_phase:build": "heft build --clean"
+    "_phase:build": "heft build --clean",
+    "_phase:test": "heft test --no-build"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/typings-generator": "workspace:*",
-    "decache": "~4.5.1",
     "pseudolocale": "~1.1.0",
     "xmldoc": "~1.1.2"
   },
@@ -25,6 +25,7 @@
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
+    "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
     "@types/xmldoc": "1.1.4"
   }

--- a/libraries/localization-utilities/src/Pseudolocalization.ts
+++ b/libraries/localization-utilities/src/Pseudolocalization.ts
@@ -1,9 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import decache from 'decache';
+import vm from 'vm';
+import { FileSystem } from '@rushstack/node-core-library';
 
 import { IPseudolocaleOptions } from './interfaces';
+
+const pseudolocalePath: string = require.resolve('pseudolocale/pseudolocale.min.js');
+
+interface IPseudolocale {
+  option: IPseudolocaleOptions;
+  str(str: string): string;
+}
 
 /**
  * Get a function that pseudolocalizes a string.
@@ -11,13 +19,20 @@ import { IPseudolocaleOptions } from './interfaces';
  * @public
  */
 export function getPseudolocalizer(options: IPseudolocaleOptions): (str: string) => string {
-  // pseudolocale maintains static state, so we need to load it as isolated modules
-  decache('pseudolocale');
-  const pseudolocale = require('pseudolocale'); // eslint-disable-line
-
-  pseudolocale.option = {
-    ...pseudolocale.option,
-    ...options
+  // eslint-disable-next-line @typescript-eslint/typedef
+  const pseudolocaleCode: string = FileSystem.readFile(pseudolocalePath);
+  const context: {
+    pseudolocale: IPseudolocale | undefined;
+  } = {
+    pseudolocale: undefined
   };
+
+  vm.runInNewContext(pseudolocaleCode, context);
+  const { pseudolocale } = context;
+  if (!pseudolocale) {
+    throw new Error(`Failed to load pseudolocale module`);
+  }
+
+  Object.assign(pseudolocale.option, options);
   return pseudolocale.str;
 }

--- a/libraries/localization-utilities/src/Pseudolocalization.ts
+++ b/libraries/localization-utilities/src/Pseudolocalization.ts
@@ -19,7 +19,6 @@ interface IPseudolocale {
  * @public
  */
 export function getPseudolocalizer(options: IPseudolocaleOptions): (str: string) => string {
-  // eslint-disable-next-line @typescript-eslint/typedef
   const pseudolocaleCode: string = FileSystem.readFile(pseudolocalePath);
   const context: {
     pseudolocale: IPseudolocale | undefined;
@@ -27,6 +26,7 @@ export function getPseudolocalizer(options: IPseudolocaleOptions): (str: string)
     pseudolocale: undefined
   };
 
+  // Load pseudolocale in an isolated context because the configuration for is stored on a singleton
   vm.runInNewContext(pseudolocaleCode, context);
   const { pseudolocale } = context;
   if (!pseudolocale) {
@@ -34,5 +34,6 @@ export function getPseudolocalizer(options: IPseudolocaleOptions): (str: string)
   }
 
   Object.assign(pseudolocale.option, options);
+  // `pseudolocale.str` captures `pseudolocale` in its closure and refers to `pseudolocale.option`.
   return pseudolocale.str;
 }

--- a/libraries/localization-utilities/src/index.ts
+++ b/libraries/localization-utilities/src/index.ts
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { ILocalizationFile, ILocalizedString, IPseudolocaleOptions } from './interfaces';
-export { parseLocFile, IParseLocFileOptions } from './LocFileParser';
+export type {
+  ILocalizationFile,
+  ILocalizedString,
+  IPseudolocaleOptions,
+  IParseFileOptions
+} from './interfaces';
+export { parseLocJson } from './parsers/parseLocJson';
+export { parseResJson } from './parsers/parseResJson';
+export { parseLocFile, IParseLocFileOptions, ParserKind } from './LocFileParser';
 export {
   ITypingsGeneratorOptions,
   LocFileTypingsGenerator as TypingsGenerator

--- a/libraries/localization-utilities/src/interfaces.ts
+++ b/libraries/localization-utilities/src/interfaces.ts
@@ -33,3 +33,11 @@ export interface ILocalizedString {
   value: string;
   comment?: string;
 }
+
+/**
+ * @public
+ */
+export interface IParseFileOptions {
+  content: string;
+  filePath: string;
+}

--- a/libraries/localization-utilities/src/parsers/parseLocJson.ts
+++ b/libraries/localization-utilities/src/parsers/parseLocJson.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { resolve } from 'path';
+
+import { JsonFile, JsonSchema } from '@rushstack/node-core-library';
+
+import { ILocalizationFile, IParseFileOptions } from '../interfaces';
+
+const LOC_JSON_SCHEMA_PATH: string = resolve(__dirname, '../schemas/locJson.schema.json');
+const LOC_JSON_SCHEMA: JsonSchema = JsonSchema.fromFile(LOC_JSON_SCHEMA_PATH);
+
+/**
+ * @public
+ */
+export function parseLocJson(options: IParseFileOptions): ILocalizationFile {
+  const parsedFile: ILocalizationFile = JsonFile.parseString(options.content);
+  try {
+    LOC_JSON_SCHEMA.validateObject(parsedFile, options.filePath);
+  } catch (e) {
+    throw new Error(`The loc file is invalid. Error: ${e}`);
+  }
+  return parsedFile;
+}

--- a/libraries/localization-utilities/src/parsers/parseResJson.ts
+++ b/libraries/localization-utilities/src/parsers/parseResJson.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { JsonFile } from '@rushstack/node-core-library';
+
+import { ILocalizationFile, IParseFileOptions } from '../interfaces';
+
+/**
+ * @public
+ */
+export function parseResJson(options: IParseFileOptions): ILocalizationFile {
+  const resjsonFile: Record<string, string> = JsonFile.parseString(options.content);
+  const parsedFile: ILocalizationFile = {};
+
+  const usedComments: Map<string, boolean> = new Map();
+  for (const [key, value] of Object.entries(resjsonFile)) {
+    if (key.startsWith('_') && key.endsWith('.comment')) {
+      if (!usedComments.has(key)) {
+        usedComments.set(key, false);
+      }
+    } else {
+      const commentKey: string = `_${key}.comment`;
+      const comment: string | undefined = resjsonFile[commentKey];
+      usedComments.set(commentKey, true);
+      parsedFile[key] = { value, comment };
+    }
+  }
+
+  const orphanComments: string[] = [];
+  for (const [key, used] of usedComments) {
+    if (!used) {
+      orphanComments.push(key.slice(1, -'.comment'.length));
+    }
+  }
+
+  if (orphanComments.length > 0) {
+    throw new Error(
+      'The resjson file is invalid. Comments exist for the following string keys ' +
+        `that don't have values: ${orphanComments.join(', ')}.`
+    );
+  }
+
+  return parsedFile;
+}

--- a/libraries/localization-utilities/src/parsers/test/__snapshots__/parseLocJson.test.ts.snap
+++ b/libraries/localization-utilities/src/parsers/test/__snapshots__/parseLocJson.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseLocJson parses a valid file 1`] = `
+Object {
+  "foo": Object {
+    "comment": "A string",
+    "value": "Foo",
+  },
+}
+`;
+
+exports[`parseLocJson throws on invalid file 1`] = `
+"The loc file is invalid. Error: Error: JSON validation failed:
+test.loc.json
+
+Error: #/foo
+       Additional properties not allowed: baz"
+`;

--- a/libraries/localization-utilities/src/parsers/test/__snapshots__/parseResJson.test.ts.snap
+++ b/libraries/localization-utilities/src/parsers/test/__snapshots__/parseResJson.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseResJson parses a valid file 1`] = `
+Object {
+  "foo": Object {
+    "comment": "A string",
+    "value": "Foo",
+  },
+}
+`;
+
+exports[`parseResJson throws on excess comments 1`] = `"The resjson file is invalid. Comments exist for the following string keys that don't have values: bar."`;

--- a/libraries/localization-utilities/src/parsers/test/parseLocJson.test.ts
+++ b/libraries/localization-utilities/src/parsers/test/parseLocJson.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { parseLocJson } from '../parseLocJson';
+
+describe(parseLocJson.name, () => {
+  it('parses a valid file', () => {
+    const content: string = JSON.stringify({
+      foo: {
+        value: 'Foo',
+        comment: 'A string'
+      }
+    });
+
+    expect(
+      parseLocJson({
+        content,
+        filePath: 'test.loc.json'
+      })
+    ).toMatchSnapshot();
+  });
+
+  it('throws on invalid file', () => {
+    const content: string = JSON.stringify({
+      foo: {
+        value: 'Foo',
+        baz: 'A string'
+      }
+    });
+
+    expect(() =>
+      parseLocJson({
+        content,
+        filePath: 'test.loc.json'
+      })
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/libraries/localization-utilities/src/parsers/test/parseResJson.test.ts
+++ b/libraries/localization-utilities/src/parsers/test/parseResJson.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { parseResJson } from '../parseResJson';
+
+describe(parseResJson.name, () => {
+  it('parses a valid file', () => {
+    const content: string = JSON.stringify({
+      foo: 'Foo',
+      '_foo.comment': 'A string'
+    });
+
+    expect(
+      parseResJson({
+        content,
+        filePath: 'test.resjson'
+      })
+    ).toMatchSnapshot();
+  });
+
+  it('throws on excess comments', () => {
+    const content: string = JSON.stringify({
+      foo: 'Foo',
+      '_bar.comment': 'A string'
+    });
+
+    expect(() =>
+      parseResJson({
+        content,
+        filePath: 'test.resjson'
+      })
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/libraries/localization-utilities/src/test/Pseudolocalization.test.ts
+++ b/libraries/localization-utilities/src/test/Pseudolocalization.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { getPseudolocalizer } from '../Pseudolocalization';
+import type { IPseudolocaleOptions } from '../interfaces';
+
+describe(getPseudolocalizer.name, () => {
+  it('gets distinct pseudolocalizers', () => {
+    const input: 'text' = 'text';
+
+    const fooOptions: IPseudolocaleOptions = {
+      prepend: '-Foo-',
+      append: '-Foo-'
+    };
+    const fooLocale: (str: string) => string = getPseudolocalizer(fooOptions);
+    const foo1: string = fooLocale(input);
+
+    const barOptions: IPseudolocaleOptions = {
+      prepend: '-Bar-',
+      append: '-Bar-'
+    };
+
+    const barLocale: (str: string) => string = getPseudolocalizer(barOptions);
+
+    const bar1: string = barLocale(input);
+    const foo2: string = fooLocale(input);
+    const bar2: string = barLocale(input);
+
+    expect(foo1).toEqual(foo2);
+    expect(bar1).toEqual(bar2);
+
+    expect(foo1).toMatchSnapshot('foo');
+    expect(bar1).toMatchSnapshot('bar');
+  });
+});

--- a/libraries/localization-utilities/src/test/__snapshots__/Pseudolocalization.test.ts.snap
+++ b/libraries/localization-utilities/src/test/__snapshots__/Pseudolocalization.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPseudolocalizer gets distinct pseudolocalizers: bar 1`] = `"-Bar-ţēxţ-Bar-"`;
+
+exports[`getPseudolocalizer gets distinct pseudolocalizers: foo 1`] = `"-Foo-ţēxţ-Foo-"`;

--- a/libraries/localization-utilities/tsconfig.json
+++ b/libraries/localization-utilities/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "target": "ES2019",
+    "types": ["heft-jest", "node"]
+  }
 }


### PR DESCRIPTION
## Summary
Removes the dependency on `decache` in favor of leveraging `vm.runInNewContext` to run each pseudolocalizer in its own context.
Exposes the resjson and loc.json parsers directly, in addition to the current code path through a highly opinionated dispatcher. The motivation being to allow webpack loaders to use the parsers on arbitrary content or on output of other custom loaders.

## How it was tested
New unit tests
Usage in upcoming webpack 5 localization plugin