### PR TITLE
Temporarily disable publishing of "@rushstack/module-minifier-plugin"

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -1060,13 +1060,13 @@
       "packageName": "@rushstack/module-minifier-plugin",
       "projectFolder": "webpack/module-minifier-plugin",
       "reviewCategory": "libraries",
-      "shouldPublish": true
+      "shouldPublish": false
     },
     {
       "packageName": "@rushstack/webpack5-module-minifier-plugin",
       "projectFolder": "webpack/module-minifier-plugin-5",
       "reviewCategory": "libraries",
-      "shouldPublish": true
+      "shouldPublish": false
     },
     {
       "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin",


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

It appears that PR https://github.com/microsoft/rushstack/pull/3428 was meant to publish a different major version of `@rushstack/module-minifier-plugin`.

However it has inadvertently created a new public NPM package:  https://www.npmjs.com/package/@rushstack/webpack5-module-minifier-plugin

And it also somehow broke the regular Rush publishing job:

[buildId=935](https://dev.azure.com/RushStack/GitHubProjects/_build/results?buildId=9352&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=36cda829-0688-5024-61b7-a8d0dbb1db49)
````
Invoking "rush publish --apply --publish --include-all --target-branch main --add-commit-details --set-access-level public"
---------------------------------------------------------------------------------------------------------------------------

Rush Multi-Project Build Tool 5.68.1 - https://rushjs.io/
Node.js version is 12.22.12 (LTS)

Starting "rush publish"

Checking Git policy for this repository.

Validating package manager shrinkwrap file.

ERROR: The package name "@rushstack/webpack5-module-minifier-plugin" specified
in rush.json does not match the name "@rushstack/module-minifier-plugin" from
package.json
##[error]Bash exited with code '1'.
Finishing: Rush Publish (Policy: noRush)
````


<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Let's temporarily disable publishing until @dmichon-msft and @iclanton can investigate.