### PR TITLE
Temporarily disable publishing of "module-minifier-plugin" (CI part)

### DIFF
--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -15,8 +15,9 @@ steps:
       VersionPolicyName: rush
   - script: 'node libraries/rush-lib/scripts/plugins-prepublish.js'
     displayName: 'Prepublish workaround for rush-lib'
-  - script: 'node webpack/module-minifier-plugin-5/scripts/prepublish.js'
-    displayName: 'Prepublish workaround for module-minifier-plugin@5'
+    # TEMPORARILY DISABLED, SEE https://github.com/microsoft/rushstack/pull/3460
+    # - script: 'node webpack/module-minifier-plugin-5/scripts/prepublish.js'
+    #  displayName: 'Prepublish workaround for module-minifier-plugin@5'
   - template: templates/publish.yaml
     parameters:
       VersionPolicyName: noRush


### PR DESCRIPTION
PR https://github.com/microsoft/rushstack/pull/3460 was trying to work around a publishing pipeline failure by disabling publishing of  `"@rushstack/module-minifier-plugin"`.  We need to disable the corresponding CI step as well.