### PR TITLE
[ts-command-line] Add support for parameter scopes

### DIFF
--- a/common/changes/@rushstack/ts-command-line/user-danade-Synonyms2_2022-06-15-22-36.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-Synonyms2_2022-06-15-22-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/ts-command-line",
-      "comment": "Add documented synonyms to parameters. Similar to undocumented synonyms, synonyms can be used to reference the same command-line parameter by a different name.",
+      "comment": "Add parameter scopes. Parameter scopes allow for behind-the-scenes conflict resolution between parameters with the same long name. For example, when provided scope \"my-scope\", a parameter can be referenced on the CLI as \"--my-parameter\" or as \"--my-scope:my-parameter\". In the case that multiple parameters are registered with the same long name but different scopes, the parameters can only be referenced by their scoped long names, eg. \"--my-scope:my-parameter\" and \"--my-other-scope:my-parameter\".",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/ts-command-line/user-danade-Synonyms2_2022-06-15-22-36.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-Synonyms2_2022-06-15-22-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Add documented synonyms to parameters. Similar to undocumented synonyms, synonyms can be used to reference the same command-line parameter by a different name.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -162,6 +162,7 @@ export abstract class CommandLineParameterProvider {
     getIntegerListParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerListParameter;
     getIntegerParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerParameter;
     getParameterStringMap(): Record<string, string>;
+    getScopedLongName(parameter: CommandLineParameter): string;
     getStringListParameter(parameterLongName: string, parameterScope?: string): CommandLineStringListParameter;
     getStringParameter(parameterLongName: string, parameterScope?: string): CommandLineStringParameter;
     protected abstract onDefineParameters(): void;

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -167,12 +167,13 @@ export abstract class CommandLineParameterProvider {
     protected abstract onDefineParameters(): void;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     get parametersProcessed(): boolean;
+    parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult;
     // @internal (undocumented)
     protected _processParsedData(parserOptions: ICommandLineParserOptions, data: _ICommandLineParserData): void;
     // @internal (undocumented)
     _registerDefinedParameters(): void;
     // @internal (undocumented)
-    protected _registerParameter(parameter: CommandLineParameter, isConflicting: boolean): void;
+    protected _registerParameter(parameter: CommandLineParameter, useScopedLongName: boolean): void;
     get remainder(): CommandLineRemainder | undefined;
     renderHelpText(): string;
     renderUsageText(): string;
@@ -335,6 +336,12 @@ export interface ICommandLineStringDefinition extends IBaseCommandLineDefinition
 
 // @public
 export interface ICommandLineStringListDefinition extends IBaseCommandLineDefinitionWithArgument {
+}
+
+// @public
+export interface IScopedLongNameParseResult {
+    longName: string;
+    scope: string | undefined;
 }
 
 // @public

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -123,6 +123,7 @@ export abstract class CommandLineParameter {
     // @internal
     abstract _setValue(data: any): void;
     readonly shortName: string | undefined;
+    readonly synonyms: string[] | undefined;
     readonly undocumentedSynonyms: string[] | undefined;
     // (undocumented)
     protected validateDefaultValue(hasDefaultValue: boolean): void;
@@ -251,12 +252,14 @@ export class DynamicCommandLineParser extends CommandLineParser {
 
 // @public
 export interface IBaseCommandLineDefinition {
+    customNameValidator?: (name: string) => boolean;
     description: string;
     environmentVariable?: string;
     parameterGroup?: string | typeof SCOPING_PARAMETER_GROUP;
     parameterLongName: string;
     parameterShortName?: string;
     required?: boolean;
+    synonyms?: string[];
     undocumentedSynonyms?: string[];
 }
 

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -116,6 +116,7 @@ export abstract class CommandLineParameter {
     abstract get kind(): CommandLineParameterKind;
     readonly longName: string;
     readonly parameterGroup: string | typeof SCOPING_PARAMETER_GROUP | undefined;
+    readonly parameterScope: string | undefined;
     // @internal
     _parserKey: string | undefined;
     protected reportInvalidData(data: any): never;
@@ -123,7 +124,6 @@ export abstract class CommandLineParameter {
     // @internal
     abstract _setValue(data: any): void;
     readonly shortName: string | undefined;
-    readonly synonyms: string[] | undefined;
     readonly undocumentedSynonyms: string[] | undefined;
     // (undocumented)
     protected validateDefaultValue(hasDefaultValue: boolean): void;
@@ -156,19 +156,23 @@ export abstract class CommandLineParameterProvider {
     defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter;
     // @internal
     protected abstract _getArgumentParser(): argparse.ArgumentParser;
-    getChoiceListParameter(parameterLongName: string): CommandLineChoiceListParameter;
-    getChoiceParameter(parameterLongName: string): CommandLineChoiceParameter;
-    getFlagParameter(parameterLongName: string): CommandLineFlagParameter;
-    getIntegerListParameter(parameterLongName: string): CommandLineIntegerListParameter;
-    getIntegerParameter(parameterLongName: string): CommandLineIntegerParameter;
+    getChoiceListParameter(parameterLongName: string, parameterScope?: string): CommandLineChoiceListParameter;
+    getChoiceParameter(parameterLongName: string, parameterScope?: string): CommandLineChoiceParameter;
+    getFlagParameter(parameterLongName: string, parameterScope?: string): CommandLineFlagParameter;
+    getIntegerListParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerListParameter;
+    getIntegerParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerParameter;
     getParameterStringMap(): Record<string, string>;
-    getStringListParameter(parameterLongName: string): CommandLineStringListParameter;
-    getStringParameter(parameterLongName: string): CommandLineStringParameter;
+    getStringListParameter(parameterLongName: string, parameterScope?: string): CommandLineStringListParameter;
+    getStringParameter(parameterLongName: string, parameterScope?: string): CommandLineStringParameter;
     protected abstract onDefineParameters(): void;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     get parametersProcessed(): boolean;
     // @internal (undocumented)
     protected _processParsedData(parserOptions: ICommandLineParserOptions, data: _ICommandLineParserData): void;
+    // @internal (undocumented)
+    _registerDefinedParameters(): void;
+    // @internal (undocumented)
+    protected _registerParameter(parameter: CommandLineParameter, isConflicting: boolean): void;
     get remainder(): CommandLineRemainder | undefined;
     renderHelpText(): string;
     renderUsageText(): string;
@@ -193,6 +197,8 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
     // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
     protected onExecute(): Promise<void>;
+    // @internal (undocumented)
+    _registerDefinedParameters(): void;
     selectedAction: CommandLineAction | undefined;
     tryGetAction(actionName: string): CommandLineAction | undefined;
 }
@@ -252,14 +258,13 @@ export class DynamicCommandLineParser extends CommandLineParser {
 
 // @public
 export interface IBaseCommandLineDefinition {
-    customNameValidator?: (name: string) => boolean;
     description: string;
     environmentVariable?: string;
     parameterGroup?: string | typeof SCOPING_PARAMETER_GROUP;
     parameterLongName: string;
+    parameterScope?: string;
     parameterShortName?: string;
     required?: boolean;
-    synonyms?: string[];
     undocumentedSynonyms?: string[];
 }
 

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -121,6 +121,7 @@ export abstract class CommandLineParameter {
     _parserKey: string | undefined;
     protected reportInvalidData(data: any): never;
     readonly required: boolean;
+    readonly scopedLongName: string | undefined;
     // @internal
     abstract _setValue(data: any): void;
     readonly shortName: string | undefined;
@@ -162,7 +163,6 @@ export abstract class CommandLineParameterProvider {
     getIntegerListParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerListParameter;
     getIntegerParameter(parameterLongName: string, parameterScope?: string): CommandLineIntegerParameter;
     getParameterStringMap(): Record<string, string>;
-    getScopedLongName(parameter: CommandLineParameter): string;
     getStringListParameter(parameterLongName: string, parameterScope?: string): CommandLineStringListParameter;
     getStringParameter(parameterLongName: string, parameterScope?: string): CommandLineStringParameter;
     protected abstract onDefineParameters(): void;

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -41,6 +41,7 @@ export { CommandLineRemainder } from './parameters/CommandLineRemainder';
 
 export {
   CommandLineParameterProvider,
+  IScopedLongNameParseResult,
   ICommandLineParserData as _ICommandLineParserData
 } from './providers/CommandLineParameterProvider';
 

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -36,6 +36,9 @@ export abstract class CommandLineParameter {
   // Example: "-d"
   private static _shortNameRegExp: RegExp = /^-[a-zA-Z]$/;
 
+  // Example: "My-Scope"
+  private static _scopeRegExp: RegExp = /^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)$/;
+
   // "Environment variable names used by the utilities in the Shell and Utilities volume of
   // IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore)
   // from the characters defined in Portable Character Set and do not begin with a digit."
@@ -95,6 +98,15 @@ export abstract class CommandLineParameter {
         throw new Error(
           `Invalid name: "${this.shortName}". The parameter short name must be` +
             ` a dash followed by a single upper-case or lower-case letter (e.g. "-a")`
+        );
+      }
+    }
+
+    if (this.parameterScope) {
+      if (!CommandLineParameter._scopeRegExp.test(this.parameterScope)) {
+        throw new Error(
+          `Invalid scope: "${this.parameterScope}". The parameter scope must only use alpha-numeric characters ` +
+            'and dash delimiters (e.g. "My-Scope")'
         );
       }
     }

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -57,6 +57,9 @@ export abstract class CommandLineParameter {
   /** {@inheritDoc IBaseCommandLineDefinition.parameterGroup} */
   public readonly parameterGroup: string | typeof SCOPING_PARAMETER_GROUP | undefined;
 
+  /** {@inheritDoc IBaseCommandLineDefinition.parameterScope} */
+  public readonly parameterScope: string | undefined;
+
   /** {@inheritDoc IBaseCommandLineDefinition.description} */
   public readonly description: string;
 
@@ -66,9 +69,6 @@ export abstract class CommandLineParameter {
   /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
 
-  /** {@inheritDoc IBaseCommandLineDefinition.synonyms} */
-  public readonly synonyms: string[] | undefined;
-
   /** {@inheritDoc IBaseCommandLineDefinition.undocumentedSynonyms } */
   public readonly undocumentedSynonyms: string[] | undefined;
 
@@ -77,25 +77,17 @@ export abstract class CommandLineParameter {
     this.longName = definition.parameterLongName;
     this.shortName = definition.parameterShortName;
     this.parameterGroup = definition.parameterGroup;
+    this.parameterScope = definition.parameterScope;
     this.description = definition.description;
     this.required = !!definition.required;
     this.environmentVariable = definition.environmentVariable;
-    this.synonyms = definition.synonyms;
     this.undocumentedSynonyms = definition.undocumentedSynonyms;
 
-    const longNameValidator: (value: string) => boolean =
-      definition.customNameValidator ??
-      ((longName: string) => CommandLineParameter._longNameRegExp.test(longName));
-
-    for (const longName of [this.longName, ...(this.synonyms || [])]) {
-      if (!longNameValidator(longName)) {
-        throw new Error(
-          `Invalid name: "${longName}".` +
-            (definition.customNameValidator
-              ? ''
-              : ' The parameter long name must be lower-case and use dash delimiters (e.g. "--do-a-thing")')
-        );
-      }
+    if (!CommandLineParameter._longNameRegExp.test(this.longName)) {
+      throw new Error(
+        `Invalid name: "${this.longName}". The parameter long name must be lower-case and use dash ` +
+          'delimiters (e.g. "--do-a-thing")'
+      );
     }
 
     if (this.shortName) {
@@ -132,12 +124,10 @@ export abstract class CommandLineParameter {
             `Invalid name: "${undocumentedSynonym}". Undocumented synonyms must not be the same` +
               ` as the the long name.`
           );
-        } else if (!longNameValidator(undocumentedSynonym)) {
+        } else if (!CommandLineParameter._longNameRegExp.test(undocumentedSynonym)) {
           throw new Error(
-            `Invalid name: "${undocumentedSynonym}".` +
-              (definition.customNameValidator
-                ? ''
-                : ' All undocumented synonyms name must be lower-case and use dash delimiters (e.g. "--do-a-thing")')
+            `Invalid name: "${undocumentedSynonym}". All undocumented synonyms name must be lower-case and ` +
+              'use dash delimiters (e.g. "--do-a-thing")'
           );
         }
       }

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -66,6 +66,9 @@ export abstract class CommandLineParameter {
   /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
 
+  /** {@inheritDoc IBaseCommandLineDefinition.synonyms} */
+  public readonly synonyms: string[] | undefined;
+
   /** {@inheritDoc IBaseCommandLineDefinition.undocumentedSynonyms } */
   public readonly undocumentedSynonyms: string[] | undefined;
 
@@ -77,13 +80,22 @@ export abstract class CommandLineParameter {
     this.description = definition.description;
     this.required = !!definition.required;
     this.environmentVariable = definition.environmentVariable;
+    this.synonyms = definition.synonyms;
     this.undocumentedSynonyms = definition.undocumentedSynonyms;
 
-    if (!CommandLineParameter._longNameRegExp.test(this.longName)) {
-      throw new Error(
-        `Invalid name: "${this.longName}". The parameter long name must be` +
-          ` lower-case and use dash delimiters (e.g. "--do-a-thing")`
-      );
+    const longNameValidator: (value: string) => boolean =
+      definition.customNameValidator ??
+      ((longName: string) => CommandLineParameter._longNameRegExp.test(longName));
+
+    for (const longName of [this.longName, ...(this.synonyms || [])]) {
+      if (!longNameValidator(longName)) {
+        throw new Error(
+          `Invalid name: "${longName}".` +
+            (definition.customNameValidator
+              ? ''
+              : ' The parameter long name must be lower-case and use dash delimiters (e.g. "--do-a-thing")')
+        );
+      }
     }
 
     if (this.shortName) {
@@ -114,20 +126,18 @@ export abstract class CommandLineParameter {
     }
 
     if (this.undocumentedSynonyms && this.undocumentedSynonyms.length > 0) {
-      if (this.required) {
-        throw new Error('Undocumented synonyms are not allowed on required parameters.');
-      }
-
       for (const undocumentedSynonym of this.undocumentedSynonyms) {
         if (this.longName === undocumentedSynonym) {
           throw new Error(
-            `Invalid name: "${undocumentedSynonym}". Undocumented Synonyms must not be the same` +
+            `Invalid name: "${undocumentedSynonym}". Undocumented synonyms must not be the same` +
               ` as the the long name.`
           );
-        } else if (!CommandLineParameter._longNameRegExp.test(undocumentedSynonym)) {
+        } else if (!longNameValidator(undocumentedSynonym)) {
           throw new Error(
-            `Invalid name: "${undocumentedSynonym}". All undocumented Synonyms name must be` +
-              ` lower-case and use dash delimiters (e.g. "--do-a-thing")`
+            `Invalid name: "${undocumentedSynonym}".` +
+              (definition.customNameValidator
+                ? ''
+                : ' All undocumented synonyms name must be lower-case and use dash delimiters (e.g. "--do-a-thing")')
           );
         }
       }

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -25,6 +25,14 @@ export interface IBaseCommandLineDefinition {
   parameterGroup?: string | typeof SCOPING_PARAMETER_GROUP;
 
   /**
+   * An optional parameter scope name, used to add a scope-prefixed parameter synonym,
+   * e.g. "--scope:do-something". Scopes provide additional flexibility for parameters
+   * in conflict resolution since when a scope is specified, parameters that have
+   * conflicting long names will be defined using only the scope-prefixed name.
+   */
+  parameterScope?: string;
+
+  /**
    * Documentation for the parameter that will be shown when invoking the tool with "--help"
    */
   description: string;
@@ -71,17 +79,6 @@ export interface IBaseCommandLineDefinition {
   environmentVariable?: string;
 
   /**
-   * Specifies additional names for this parameter that are accepted and displayed in the
-   * command line help.
-   *
-   * @remarks
-   * This option can be used in cases where a command-line parameter may have alternate names
-   * that the developer wants to advertise. Only the `parameterLongName` syntax is currently
-   * allowed.
-   */
-  synonyms?: string[];
-
-  /**
    * Specifies additional names for this parameter that are accepted but not displayed
    * in the command line help.
    *
@@ -91,16 +88,6 @@ export interface IBaseCommandLineDefinition {
    * still be using the old name. Only the `parameterLongName` syntax is currently allowed.
    */
   undocumentedSynonyms?: string[];
-
-  /**
-   * Specifies a custom validator to use for long name and undocumented synonym validation.
-   *
-   * @remarks
-   * Used with care. The default validator will enforce lower-case alpha-numeric characters
-   * and dashes. Custom validators may allow for more complex and unexpected syntax for
-   * paramter names.
-   */
-  customNameValidator?: (name: string) => boolean;
 }
 
 /**

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -71,6 +71,17 @@ export interface IBaseCommandLineDefinition {
   environmentVariable?: string;
 
   /**
+   * Specifies additional names for this parameter that are accepted and displayed in the
+   * command line help.
+   *
+   * @remarks
+   * This option can be used in cases where a command-line parameter may have alternate names
+   * that the developer wants to advertise. Only the `parameterLongName` syntax is currently
+   * allowed.
+   */
+  synonyms?: string[];
+
+  /**
    * Specifies additional names for this parameter that are accepted but not displayed
    * in the command line help.
    *
@@ -80,6 +91,16 @@ export interface IBaseCommandLineDefinition {
    * still be using the old name. Only the `parameterLongName` syntax is currently allowed.
    */
   undocumentedSynonyms?: string[];
+
+  /**
+   * Specifies a custom validator to use for long name and undocumented synonym validation.
+   *
+   * @remarks
+   * Used with care. The default validator will enforce lower-case alpha-numeric characters
+   * and dashes. Custom validators may allow for more complex and unexpected syntax for
+   * paramter names.
+   */
+  customNameValidator?: (name: string) => boolean;
 }
 
 /**

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -348,9 +348,7 @@ export abstract class CommandLineParameterProvider {
   public getParameterStringMap(): Record<string, string> {
     const parameterMap: Record<string, string> = {};
     for (const parameter of this.parameters) {
-      const parameterName: string = parameter.parameterScope
-        ? this._generateScopedLongName(parameter)
-        : parameter.longName;
+      const parameterName: string = this.getScopedLongName(parameter);
       switch (parameter.kind) {
         case CommandLineParameterKind.Flag:
         case CommandLineParameterKind.Choice:
@@ -380,6 +378,21 @@ export abstract class CommandLineParameterProvider {
       }
     }
     return parameterMap;
+  }
+
+  /**
+   * Returns the scoped long name for the specified parameter. If no scope is specified, the long name
+   * will be returned as-is.
+   */
+  public getScopedLongName(parameter: CommandLineParameter): string {
+    if (!parameter.parameterScope) {
+      return parameter.longName;
+    }
+
+    // Parameter long name is guranteed to start with '--' since this is validated in the
+    // CommandLineParameter constructor.
+    const unprefixedLongName: string = parameter.longName.slice(2);
+    return `--${parameter.parameterScope}:${unprefixedLongName}`;
   }
 
   /**
@@ -502,7 +515,7 @@ export abstract class CommandLineParameterProvider {
 
     // Add the scoped long name if it exists
     if (parameter.parameterScope) {
-      names.push(this._generateScopedLongName(parameter));
+      names.push(this.getScopedLongName(parameter));
     }
 
     let finalDescription: string = parameter.description;
@@ -590,17 +603,6 @@ export abstract class CommandLineParameterProvider {
 
   private _generateKey(): string {
     return 'key_' + (CommandLineParameterProvider._keyCounter++).toString();
-  }
-
-  private _generateScopedLongName(parameter: CommandLineParameter): string {
-    if (!parameter.parameterScope) {
-      throw new Error(`Cannot generate scoped long name for parameter without scope "${parameter.longName}"`);
-    }
-
-    // Parameter long name is guranteed to start with '--' since this is validated in the
-    // CommandLineParameter constructor.
-    const unprefixedLongName: string = parameter.longName.slice(2);
-    return `--${parameter.parameterScope}:${unprefixedLongName}`;
   }
 
   private _getParameter<T extends CommandLineParameter>(

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -88,21 +88,6 @@ export abstract class CommandLineParameterProvider {
   }
 
   /**
-   * Returns an object with the parsed scope (if present) and the long name of the parameter.
-   */
-  public static parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult {
-    const result: RegExpExecArray | null =
-      CommandLineParameterProvider._possiblyScopedLongNameRegex.exec(scopedLongName);
-    if (!result || !result.groups) {
-      throw new Error(`The parameter long name "${scopedLongName}" is not valid.`);
-    }
-    return {
-      longName: `--${result.groups[CommandLineParameterProvider._longNameGroupName]}`,
-      scope: result.groups[CommandLineParameterProvider._scopeGroupName]
-    };
-  }
-
-  /**
    * Returns a collection of the parameters that were defined for this object.
    */
   public get parameters(): ReadonlyArray<CommandLineParameter> {
@@ -395,6 +380,21 @@ export abstract class CommandLineParameterProvider {
     return parameterMap;
   }
 
+  /**
+   * Returns an object with the parsed scope (if present) and the long name of the parameter.
+   */
+  public parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult {
+    const result: RegExpExecArray | null =
+      CommandLineParameterProvider._possiblyScopedLongNameRegex.exec(scopedLongName);
+    if (!result || !result.groups) {
+      throw new Error(`The parameter long name "${scopedLongName}" is not valid.`);
+    }
+    return {
+      longName: `--${result.groups[CommandLineParameterProvider._longNameGroupName]}`,
+      scope: result.groups[CommandLineParameterProvider._scopeGroupName]
+    };
+  }
+
   /** @internal */
   public _registerDefinedParameters(): void {
     if (this._parametersRegistered) {
@@ -596,7 +596,7 @@ export abstract class CommandLineParameterProvider {
     parameterScope?: string
   ): T {
     // Support the parameter long name being prefixed with the scope
-    const { scope, longName } = CommandLineParameterProvider.parseScopedLongName(parameterLongName);
+    const { scope, longName } = this.parseScopedLongName(parameterLongName);
     parameterLongName = longName;
     parameterScope = scope || parameterScope;
 

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -394,6 +394,9 @@ export abstract class CommandLineParameterProvider {
       names.push(parameter.shortName);
     }
     names.push(parameter.longName);
+    if (parameter.synonyms) {
+      names.push(...parameter.synonyms);
+    }
 
     parameter._parserKey = this._generateKey();
 

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -197,6 +197,9 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
 
       this._validateDefinitions();
 
+      // Register the parameters before we print help or parse the CLI
+      this._registerDefinedParameters();
+
       if (!args) {
         // 0=node.exe, 1=script name
         args = process.argv.slice(2);
@@ -238,6 +241,14 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
       }
 
       throw err;
+    }
+  }
+
+  /** @internal */
+  public _registerDefinedParameters(): void {
+    super._registerDefinedParameters();
+    for (const action of this._actions) {
+      action._registerDefinedParameters();
     }
   }
 

--- a/libraries/ts-command-line/src/test/CommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParser.test.ts
@@ -48,6 +48,7 @@ class TestCommandLine extends CommandLineParser {
 describe(CommandLineParser.name, () => {
   it('executes an action', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
+    commandLineParser._registerDefinedParameters();
 
     await commandLineParser.execute(['do:the-job', '--flag']);
 

--- a/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
@@ -37,6 +37,8 @@ function createParser(): DynamicCommandLineParser {
     description: 'The action remainder'
   });
 
+  commandLineParser._registerDefinedParameters();
+
   return commandLineParser;
 }
 

--- a/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { CommandLineAction } from '../providers/CommandLineAction';
+import { CommandLineStringParameter } from '../parameters/CommandLineStringParameter';
+import { CommandLineParser } from '../providers/CommandLineParser';
+
+class TestAction extends CommandLineAction {
+  public done: boolean = false;
+  private _unscopedArg!: CommandLineStringParameter;
+  private _scope1Arg!: CommandLineStringParameter;
+  private _scope2Arg!: CommandLineStringParameter;
+  private _nonConflictingArg!: CommandLineStringParameter;
+
+  public constructor() {
+    super({
+      actionName: 'do:the-job',
+      summary: 'does the job',
+      documentation: 'a longer description'
+    });
+  }
+
+  protected async onExecute(): Promise<void> {
+    expect(this._unscopedArg.value).toEqual('unscopedvalue');
+    expect(this._scope1Arg.value).toEqual('scope1value');
+    expect(this._scope2Arg.value).toEqual('scope2value');
+    expect(this._nonConflictingArg.value).toEqual('nonconflictingvalue');
+    this.done = true;
+  }
+
+  protected onDefineParameters(): void {
+    // Used to validate that conflicting parameters with different scopes return different values
+    this._unscopedArg = this.defineStringParameter({
+      parameterLongName: '--arg',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    // Used to validate that conflicting parameters with different scopes return different values
+    this._scope1Arg = this.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope1',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    // Used to validate that conflicting parameters with different scopes return different values
+    this._scope2Arg = this.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope2',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    // Used to validate that non-conflicting args can be reference by both the unscoped and the
+    // scoped parameter names
+    this._nonConflictingArg = this.defineStringParameter({
+      parameterLongName: '--non-conflicting-arg',
+      parameterScope: 'scope3',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+  }
+}
+
+class TestCommandLine extends CommandLineParser {
+  public constructor() {
+    super({
+      toolFilename: 'example',
+      toolDescription: 'An example project'
+    });
+
+    this.addAction(new TestAction());
+  }
+
+  protected onDefineParameters(): void {
+    // no parameters
+  }
+}
+
+describe(`Conflicting ${CommandLineParser.name}`, () => {
+  it('executes an action', async () => {
+    const commandLineParser: TestCommandLine = new TestCommandLine();
+
+    await commandLineParser.execute([
+      'do:the-job',
+      '--arg',
+      'unscopedvalue',
+      '--scope1:arg',
+      'scope1value',
+      '--scope2:arg',
+      'scope2value',
+      '--non-conflicting-arg',
+      'nonconflictingvalue'
+    ]);
+
+    expect(commandLineParser.selectedAction).toBeDefined();
+    expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');
+
+    const action: TestAction = commandLineParser.selectedAction as TestAction;
+    expect(action.done).toBe(true);
+
+    expect(action.renderHelpText()).toMatchSnapshot();
+    expect(action.getParameterStringMap()).toMatchSnapshot();
+  });
+});

--- a/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
@@ -97,14 +97,14 @@ describe(`Conflicting ${CommandLineParser.name}`, () => {
 
     let result: IScopedLongNameParseResult = commandLineParser.parseScopedLongName('--scope1:arg');
     expect(result.scope).toEqual('scope1');
-    expect(result.longName).toEqual('arg');
+    expect(result.longName).toEqual('--arg');
 
     result = commandLineParser.parseScopedLongName('--arg');
     expect(result.scope).toBeUndefined();
-    expect(result.longName).toEqual('arg');
+    expect(result.longName).toEqual('--arg');
 
     result = commandLineParser.parseScopedLongName('--my-scope:my-arg');
     expect(result.scope).toEqual('my-scope');
-    expect(result.longName).toEqual('my-arg');
+    expect(result.longName).toEqual('--my-arg');
   });
 });

--- a/libraries/ts-command-line/src/test/__snapshots__/ConflictingCommandLineParser.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/ConflictingCommandLineParser.test.ts.snap
@@ -1,15 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Conflicting CommandLineParser executes an action 1`] = `
-"usage: example do:the-job [-h] [--arg ARG] [--scope1:arg ARG]
-                          [--scope2:arg ARG] [--non-conflicting-arg ARG]
+"usage: example do:the-job [-h] [--scope1:arg ARG] [--scope2:arg ARG]
+                          [--non-conflicting-arg ARG]
                           
 
 a longer description
 
 Optional arguments:
   -h, --help            Show this help message and exit.
-  --arg ARG             The argument
   --scope1:arg ARG      The argument
   --scope2:arg ARG      The argument
   --non-conflicting-arg ARG, --scope3:non-conflicting-arg ARG
@@ -19,7 +18,6 @@ Optional arguments:
 
 exports[`Conflicting CommandLineParser executes an action 2`] = `
 Object {
-  "--arg": "\\"unscopedvalue\\"",
   "--scope1:arg": "\\"scope1value\\"",
   "--scope2:arg": "\\"scope2value\\"",
   "--scope3:non-conflicting-arg": "\\"nonconflictingvalue\\"",

--- a/libraries/ts-command-line/src/test/__snapshots__/ConflictingCommandLineParser.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/ConflictingCommandLineParser.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Conflicting CommandLineParser executes an action 1`] = `
+"usage: example do:the-job [-h] [--arg ARG] [--scope1:arg ARG]
+                          [--scope2:arg ARG] [--non-conflicting-arg ARG]
+                          
+
+a longer description
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  --arg ARG             The argument
+  --scope1:arg ARG      The argument
+  --scope2:arg ARG      The argument
+  --non-conflicting-arg ARG, --scope3:non-conflicting-arg ARG
+                        The argument
+"
+`;
+
+exports[`Conflicting CommandLineParser executes an action 2`] = `
+Object {
+  "--arg": "\\"unscopedvalue\\"",
+  "--scope1:arg": "\\"scope1value\\"",
+  "--scope2:arg": "\\"scope2value\\"",
+  "--scope3:non-conflicting-arg": "\\"nonconflictingvalue\\"",
+}
+`;


### PR DESCRIPTION
## Summary

Adds support for parameter scopes to ts-command-line parameters.

## Details

Parameter scopes allow a parameter to be mapped to both it's provided `longName` as well as a scope-prefixed synonym of the form `--<scope>:<longName>`. This allows for multiple parameters with the same `longName` to be specified, as long as they belong to different scopes. In this scenario, the parameters will _only_ be registered under the scope-prefixed name, avoiding parameter conflicts. This is particularly useful for dynamically-populated command-line parameters.

For example, if parameter `--parameter` is specified with scope `scope1`, and another `--parameter` is specified with scope `scope2`, then the parameter will be available on the command line as `--scope1:parameter` and `--scope2:parameter`.

The feature is implemented by lazy registration of parameters on a `CommandLineParameterProvider`. In this way, all parameters can be defined and de-conflicted prior to argparse registration.

## How it was tested

Forked off of PR #3468 where it was tested extensively against the rest of the Rushstack monorepo.