### PR TITLE
[api-extractor] Allow for loading the `ExtractorConfig` without validating existence of target typings

### DIFF
--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -139,9 +139,10 @@ export interface IExtractorConfigPrepareOptions {
   /**
    * When preparing the configuration object, folder and file paths referenced in the configuration are checked
    * for existence, and an error is reported if they are not found.  This option can be used to disable this
-   * check. This may be useful when preparing a configuration file for an un-built project.
+   * check for the main entry point module. This may be useful when preparing a configuration file for an
+   * un-built project.
    */
-  ignoreMissingConfigTargets?: boolean;
+  ignoreMissingEntryPoint?: boolean;
 }
 
 interface IExtractorConfigParameters {
@@ -739,7 +740,7 @@ export class ExtractorConfig {
           // Use the manually specified "<lookup>" value
           projectFolder = options.projectFolderLookupToken;
 
-          if (!options.ignoreMissingConfigTargets && !FileSystem.exists(options.projectFolderLookupToken)) {
+          if (!FileSystem.exists(options.projectFolderLookupToken)) {
             throw new Error(
               'The specified "projectFolderLookupToken" path does not exist: ' +
                 options.projectFolderLookupToken
@@ -778,7 +779,7 @@ export class ExtractorConfig {
       } else {
         ExtractorConfig._rejectAnyTokensInPath(configObject.projectFolder, 'projectFolder');
 
-        if (!options.ignoreMissingConfigTargets && !FileSystem.exists(configObject.projectFolder)) {
+        if (!FileSystem.exists(configObject.projectFolder)) {
           throw new Error('The specified "projectFolder" path does not exist: ' + configObject.projectFolder);
         }
 
@@ -812,7 +813,7 @@ export class ExtractorConfig {
         );
       }
 
-      if (!options.ignoreMissingConfigTargets && !FileSystem.exists(mainEntryPointFilePath)) {
+      if (!options.ignoreMissingEntryPoint && !FileSystem.exists(mainEntryPointFilePath)) {
         throw new Error('The "mainEntryPointFilePath" path does not exist: ' + mainEntryPointFilePath);
       }
 
@@ -833,7 +834,7 @@ export class ExtractorConfig {
         if (!tsconfigFilePath) {
           throw new Error('Either the "tsconfigFilePath" or "overrideTsconfig" setting must be specified');
         }
-        if (!options.ignoreMissingConfigTargets && !FileSystem.exists(tsconfigFilePath)) {
+        if (!FileSystem.exists(tsconfigFilePath)) {
           throw new Error('The file referenced by "tsconfigFilePath" does not exist: ' + tsconfigFilePath);
         }
       }

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -135,6 +135,13 @@ export interface IExtractorConfigPrepareOptions {
    * `@microsoft/api-extractor/extends/tsdoc-base.json`.
    */
   tsdocConfigFile?: TSDocConfigFile;
+
+  /**
+   * When preparing the configuration object, folder and file paths referenced in the configuration are checked
+   * for existence, and an error is reported if they are not found.  This option can be used to disable this
+   * check. This may be useful when preparing a configuration file for an un-built project.
+   */
+  ignoreMissingConfigTargets?: boolean;
 }
 
 interface IExtractorConfigParameters {
@@ -732,7 +739,7 @@ export class ExtractorConfig {
           // Use the manually specified "<lookup>" value
           projectFolder = options.projectFolderLookupToken;
 
-          if (!FileSystem.exists(options.projectFolderLookupToken)) {
+          if (!options.ignoreMissingConfigTargets && !FileSystem.exists(options.projectFolderLookupToken)) {
             throw new Error(
               'The specified "projectFolderLookupToken" path does not exist: ' +
                 options.projectFolderLookupToken
@@ -771,7 +778,7 @@ export class ExtractorConfig {
       } else {
         ExtractorConfig._rejectAnyTokensInPath(configObject.projectFolder, 'projectFolder');
 
-        if (!FileSystem.exists(configObject.projectFolder)) {
+        if (!options.ignoreMissingConfigTargets && !FileSystem.exists(configObject.projectFolder)) {
           throw new Error('The specified "projectFolder" path does not exist: ' + configObject.projectFolder);
         }
 
@@ -805,7 +812,7 @@ export class ExtractorConfig {
         );
       }
 
-      if (!FileSystem.exists(mainEntryPointFilePath)) {
+      if (!options.ignoreMissingConfigTargets && !FileSystem.exists(mainEntryPointFilePath)) {
         throw new Error('The "mainEntryPointFilePath" path does not exist: ' + mainEntryPointFilePath);
       }
 
@@ -826,7 +833,7 @@ export class ExtractorConfig {
         if (!tsconfigFilePath) {
           throw new Error('Either the "tsconfigFilePath" or "overrideTsconfig" setting must be specified');
         }
-        if (!FileSystem.exists(tsconfigFilePath)) {
+        if (!options.ignoreMissingConfigTargets && !FileSystem.exists(tsconfigFilePath)) {
           throw new Error('The file referenced by "tsconfigFilePath" does not exist: ' + tsconfigFilePath);
         }
       }

--- a/common/changes/@microsoft/api-extractor/user-danade-ApiExtractorConfigLoad_2022-06-15-22-45.json
+++ b/common/changes/@microsoft/api-extractor/user-danade-ApiExtractorConfigLoad_2022-06-15-22-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add support for loading the ExtractorConfig without validating the existence of target typings files",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/user-danade-ApiExtractorConfigLoad_2022-06-15-22-45.json
+++ b/common/changes/@microsoft/api-extractor/user-danade-ApiExtractorConfigLoad_2022-06-15-22-45.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Add support for loading the ExtractorConfig without validating the existence of target typings files",
+      "comment": "Add support for the \"ignoreMissingEntryPoint\" ExtractorConfig option to allow for loading an ExtractorConfig before the target project is built.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -240,6 +240,7 @@ export interface IExtractorConfigLoadForFolderOptions {
 export interface IExtractorConfigPrepareOptions {
     configObject: IConfigFile;
     configObjectFullPath: string | undefined;
+    ignoreMissingConfigTargets?: boolean;
     packageJson?: INodePackageJson | undefined;
     packageJsonFullPath: string | undefined;
     projectFolderLookupToken?: string;

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -240,7 +240,7 @@ export interface IExtractorConfigLoadForFolderOptions {
 export interface IExtractorConfigPrepareOptions {
     configObject: IConfigFile;
     configObjectFullPath: string | undefined;
-    ignoreMissingConfigTargets?: boolean;
+    ignoreMissingEntryPoint?: boolean;
     packageJson?: INodePackageJson | undefined;
     packageJsonFullPath: string | undefined;
     projectFolderLookupToken?: string;


### PR DESCRIPTION
## Summary

Allow for loading the `ExtractorConfig` without validating existence of target typings.

## Details

There are some scenarios where loading up the API-Extractor configuration is required prior to the existence of the typings files that API Extractor sources from (such as obtaining output folder paths and ensuring they are empty). This PR adds the option `ignoreMissingConfigTargets` which can be passed into the `ExtractorConfig` options at load time to avoid validating the existence of the target files.

## How it was tested

Forked off of PR https://github.com/microsoft/rushstack/pull/3468 where it was tested extensively against the rest of the Rushstack monorepo.
