### PR TITLE
[api-extractor] Extract initializer information from relevant API items

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,10 @@
 			"name": "Rush Debug",
 			"type": "node",
 			"request": "launch",
-			"program": "${workspaceRoot}/libraries/rush-lib/lib/start.js",
+			"program": "${workspaceRoot}/apps/rush/lib/start-dev.js",
 			"stopOnEntry": true,
 			"args": [
-				"rebuild",
-				"-o",
-				"api-extractor-scenarios"
+				"start"
 			],
 			"cwd": "${workspaceRoot}",
 			"runtimeExecutable": null,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,12 @@
 			"name": "Rush Debug",
 			"type": "node",
 			"request": "launch",
-			"program": "${workspaceRoot}/apps/rush/lib/start-dev.js",
+			"program": "${workspaceRoot}/libraries/rush-lib/lib/start.js",
 			"stopOnEntry": true,
 			"args": [
-				"start"
+				"rebuild",
+				"-o",
+				"api-extractor-scenarios"
 			],
 			"cwd": "${workspaceRoot}",
 			"runtimeExecutable": null,

--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -40,7 +40,8 @@ import {
   IResolveDeclarationReferenceResult,
   ApiTypeAlias,
   ExcerptToken,
-  ApiOptionalMixin
+  ApiOptionalMixin,
+  ApiInitializerMixin
 } from '@microsoft/api-extractor-model';
 
 import { CustomDocNodes } from '../nodes/CustomDocNodeKind';
@@ -732,13 +733,7 @@ export class MarkdownDocumenter {
               new DocPlainText({ configuration, text: Utilities.getConciseSignature(apiEnumMember) })
             ])
           ]),
-
-          new DocTableCell({ configuration }, [
-            new DocParagraph({ configuration }, [
-              new DocCodeSpan({ configuration, code: apiEnumMember.initializerExcerpt.text })
-            ])
-          ]),
-
+          this._createInitializerCell(apiEnumMember),
           this._createDescriptionCell(apiEnumMember)
         ])
       );
@@ -1028,6 +1023,22 @@ export class MarkdownDocumenter {
 
     if (apiItem instanceof ApiPropertyItem) {
       section.appendNode(this._createParagraphForTypeExcerpt(apiItem.propertyTypeExcerpt));
+    }
+
+    return new DocTableCell({ configuration }, section.nodes);
+  }
+
+  private _createInitializerCell(apiItem: ApiItem): DocTableCell {
+    const configuration: TSDocConfiguration = this._tsdocConfiguration;
+
+    const section: DocSection = new DocSection({ configuration });
+
+    if (ApiInitializerMixin.isBaseClassOf(apiItem)) {
+      if (apiItem.initializerExcerpt) {
+        section.appendNodeInParagraph(
+          new DocCodeSpan({ configuration, code: apiItem.initializerExcerpt.text })
+        );
+      }
     }
 
     return new DocTableCell({ configuration }, section.nodes);

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -456,7 +456,7 @@ export class YamlDocumenter {
         yamlItem.type = 'field';
         const enumMember: ApiEnumMember = apiItem as ApiEnumMember;
 
-        if (enumMember.initializerExcerpt.text.length > 0) {
+        if (enumMember.initializerExcerpt && enumMember.initializerExcerpt.text.length > 0) {
           yamlItem.numericValue = enumMember.initializerExcerpt.text;
         }
 

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -829,24 +829,28 @@ export class ApiModelGenerator {
     let apiProperty: ApiProperty | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiProperty;
 
     if (apiProperty === undefined) {
+      const declaration: ts.Declaration = astDeclaration.declaration;
       const nodesToCapture: IExcerptBuilderNodeToCapture[] = [];
 
       const propertyTypeTokenRange: IExcerptTokenRange = ExcerptBuilder.createEmptyTokenRange();
       let propertyTypeNode: ts.TypeNode | undefined;
 
-      if (
-        ts.isPropertyDeclaration(astDeclaration.declaration) ||
-        ts.isGetAccessorDeclaration(astDeclaration.declaration)
-      ) {
-        propertyTypeNode = astDeclaration.declaration.type;
+      if (ts.isPropertyDeclaration(declaration) || ts.isGetAccessorDeclaration(declaration)) {
+        propertyTypeNode = declaration.type;
       }
 
-      if (ts.isSetAccessorDeclaration(astDeclaration.declaration)) {
+      if (ts.isSetAccessorDeclaration(declaration)) {
         // Note that TypeScript always reports an error if a setter does not have exactly one parameter.
-        propertyTypeNode = astDeclaration.declaration.parameters[0].type;
+        propertyTypeNode = declaration.parameters[0].type;
       }
 
       nodesToCapture.push({ node: propertyTypeNode, tokenRange: propertyTypeTokenRange });
+
+      let initializerTokenRange: IExcerptTokenRange | undefined = undefined;
+      if (ts.isPropertyDeclaration(declaration) && declaration.initializer) {
+        initializerTokenRange = ExcerptBuilder.createEmptyTokenRange();
+        nodesToCapture.push({ node: declaration.initializer, tokenRange: initializerTokenRange });
+      }
 
       const excerptTokens: IExcerptToken[] = this._buildExcerptTokens(astDeclaration, nodesToCapture);
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
@@ -866,7 +870,8 @@ export class ApiModelGenerator {
         isOptional,
         isReadonly,
         excerptTokens,
-        propertyTypeTokenRange
+        propertyTypeTokenRange,
+        initializerTokenRange
       });
       parentApiItem.addMember(apiProperty);
     } else {
@@ -985,6 +990,12 @@ export class ApiModelGenerator {
       const variableTypeTokenRange: IExcerptTokenRange = ExcerptBuilder.createEmptyTokenRange();
       nodesToCapture.push({ node: variableDeclaration.type, tokenRange: variableTypeTokenRange });
 
+      let initializerTokenRange: IExcerptTokenRange | undefined = undefined;
+      if (variableDeclaration.initializer) {
+        initializerTokenRange = ExcerptBuilder.createEmptyTokenRange();
+        nodesToCapture.push({ node: variableDeclaration.initializer, tokenRange: initializerTokenRange });
+      }
+
       const excerptTokens: IExcerptToken[] = this._buildExcerptTokens(astDeclaration, nodesToCapture);
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
       const docComment: tsdoc.DocComment | undefined = apiItemMetadata.tsdocComment;
@@ -997,6 +1008,7 @@ export class ApiModelGenerator {
         releaseTag,
         excerptTokens,
         variableTypeTokenRange,
+        initializerTokenRange,
         isReadonly
       });
 

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -502,8 +502,11 @@ export class ApiModelGenerator {
 
       const nodesToCapture: IExcerptBuilderNodeToCapture[] = [];
 
-      const initializerTokenRange: IExcerptTokenRange = ExcerptBuilder.createEmptyTokenRange();
-      nodesToCapture.push({ node: enumMember.initializer, tokenRange: initializerTokenRange });
+      let initializerTokenRange: IExcerptTokenRange | undefined = undefined;
+      if (enumMember.initializer) {
+        initializerTokenRange = ExcerptBuilder.createEmptyTokenRange();
+        nodesToCapture.push({ node: enumMember.initializer, tokenRange: initializerTokenRange });
+      }
 
       const excerptTokens: IExcerptToken[] = this._buildExcerptTokens(astDeclaration, nodesToCapture);
       const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -1070,12 +1070,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "One",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "One"
             },
             {
               "kind": "EnumMember",
@@ -1091,12 +1091,12 @@
                   "text": "2"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Two",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Two"
             },
             {
               "kind": "EnumMember",
@@ -1112,12 +1112,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Zero",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Zero"
             }
           ]
         },
@@ -1149,12 +1149,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Left",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Left"
             },
             {
               "kind": "EnumMember",
@@ -1170,12 +1170,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Right",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Right"
             }
           ]
         },

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ancillaryDeclarations/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ancillaryDeclarations/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -372,12 +372,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "One",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "One"
             },
             {
               "kind": "EnumMember",
@@ -393,12 +393,12 @@
                   "text": "2"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Two",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Two"
             },
             {
               "kind": "EnumMember",
@@ -414,12 +414,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Zero",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Zero"
             }
           ]
         },
@@ -577,12 +577,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "One",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "One"
             },
             {
               "kind": "EnumMember",
@@ -598,12 +598,12 @@
                   "text": "2"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Two",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Two"
             },
             {
               "kind": "EnumMember",
@@ -619,12 +619,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Zero",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Zero"
             }
           ]
         },
@@ -774,12 +774,12 @@
                 "startIndex": 0,
                 "endIndex": 0
               },
-              "isStatic": false,
-              "isProtected": false,
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "isStatic": false,
+              "isProtected": false
             },
             {
               "kind": "Property",
@@ -860,16 +860,16 @@
               "text": "\"hello\""
             }
           ],
+          "initializerTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "VARIABLE_WITHOUT_EXPLICIT_TYPE",
           "variableTypeTokenRange": {
             "startIndex": 0,
             "endIndex": 0
-          },
-          "initializerTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
           }
         }
       ]

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -323,6 +323,28 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "Variable",
+          "canonicalReference": "api-extractor-scenarios!CONST_VARIABLE:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "CONST_VARIABLE: "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            }
+          ],
+          "isReadonly": true,
+          "releaseTag": "Public",
+          "name": "CONST_VARIABLE",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
+        },
+        {
           "kind": "Enum",
           "canonicalReference": "api-extractor-scenarios!ConstEnum:enum",
           "docComment": "/**\n * @public\n */\n",
@@ -504,6 +526,28 @@
               }
             }
           ]
+        },
+        {
+          "kind": "Variable",
+          "canonicalReference": "api-extractor-scenarios!nonConstVariable:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "nonConstVariable: "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            }
+          ],
+          "isReadonly": false,
+          "releaseTag": "Public",
+          "name": "nonConstVariable",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
         },
         {
           "kind": "Enum",
@@ -711,7 +755,15 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "readonly someReadonlyProp = 5;"
+                  "text": "readonly someReadonlyProp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "5"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
                 }
               ],
               "isReadonly": true,
@@ -723,7 +775,11 @@
                 "endIndex": 0
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
             },
             {
               "kind": "Property",
@@ -792,22 +848,26 @@
         },
         {
           "kind": "Variable",
-          "canonicalReference": "api-extractor-scenarios!VARIABLE:var",
+          "canonicalReference": "api-extractor-scenarios!VARIABLE_WITHOUT_EXPLICIT_TYPE:var",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "VARIABLE: "
+              "text": "VARIABLE_WITHOUT_EXPLICIT_TYPE = "
             },
             {
               "kind": "Content",
-              "text": "string"
+              "text": "\"hello\""
             }
           ],
           "isReadonly": true,
           "releaseTag": "Public",
-          "name": "VARIABLE",
+          "name": "VARIABLE_WITHOUT_EXPLICIT_TYPE",
           "variableTypeTokenRange": {
+            "startIndex": 0,
+            "endIndex": 0
+          },
+          "initializerTokenRange": {
             "startIndex": 1,
             "endIndex": 2
           }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.md
@@ -23,6 +23,9 @@ export class ClassWithTypeLiterals {
 }
 
 // @public (undocumented)
+export const CONST_VARIABLE: string;
+
+// @public (undocumented)
 export const enum ConstEnum {
     // (undocumented)
     One = 1,
@@ -45,6 +48,9 @@ export namespace NamespaceContainingVariable {
     let // (undocumented)
     constVariable: object[];
 }
+
+// @public (undocumented)
+export let nonConstVariable: string;
 
 // @public (undocumented)
 export enum RegularEnum {
@@ -71,7 +77,7 @@ export class SimpleClass {
 }
 
 // @public (undocumented)
-export const VARIABLE: string;
+export const VARIABLE_WITHOUT_EXPLICIT_TYPE = "hello";
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/rollup.d.ts
@@ -18,6 +18,9 @@ export declare class ClassWithTypeLiterals {
 }
 
 /** @public */
+export declare const CONST_VARIABLE: string;
+
+/** @public */
 export declare const enum ConstEnum {
     Zero = 0,
     One = 1,
@@ -34,6 +37,9 @@ export declare namespace NamespaceContainingVariable {
     let variable: object[];
     let constVariable: object[];
 }
+
+/** @public */
+export declare let nonConstVariable: string;
 
 /** @public */
 export declare enum RegularEnum {
@@ -63,6 +69,6 @@ export declare class SimpleClass {
 }
 
 /** @public */
-export declare const VARIABLE: string;
+export declare const VARIABLE_WITHOUT_EXPLICIT_TYPE = "hello";
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/bundledPackages/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/dynamicImportType3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ecmaScriptPrivateFields/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ecmaScriptPrivateFields/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/enumSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/enumSorting/api-extractor-scenarios.api.json
@@ -200,12 +200,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Zero",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Zero"
             },
             {
               "kind": "EnumMember",
@@ -221,12 +221,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "One",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "One"
             },
             {
               "kind": "EnumMember",
@@ -242,12 +242,12 @@
                   "text": "2"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Two",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Two"
             }
           ]
         },
@@ -279,12 +279,12 @@
                   "text": "0"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Zero",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Zero"
             },
             {
               "kind": "EnumMember",
@@ -300,12 +300,12 @@
                   "text": "1"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "One",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "One"
             },
             {
               "kind": "EnumMember",
@@ -321,12 +321,12 @@
                   "text": "2"
                 }
               ],
-              "releaseTag": "Public",
-              "name": "Two",
               "initializerTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              }
+              },
+              "releaseTag": "Public",
+              "name": "Two"
             }
           ]
         }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/enumSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/enumSorting/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/excerptTokens/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/excerptTokens/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportStarAs2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternalDefault/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/functionOverload/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importType/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/internationalCharacters/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/namedDefaultImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/namedDefaultImport/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
@@ -230,16 +230,16 @@
               "text": "\"foo\""
             }
           ],
+          "initializerTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "FOO",
           "variableTypeTokenRange": {
             "startIndex": 0,
             "endIndex": 0
-          },
-          "initializerTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
           }
         },
         {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
@@ -223,7 +223,11 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "FOO = \"foo\""
+              "text": "FOO = "
+            },
+            {
+              "kind": "Content",
+              "text": "\"foo\""
             }
           ],
           "isReadonly": true,
@@ -232,6 +236,10 @@
           "variableTypeTokenRange": {
             "startIndex": 0,
             "endIndex": 0
+          },
+          "initializerTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
           }
         },
         {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/readonlyDeclarations/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/spanSorting/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf2/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf3/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -2,7 +2,7 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1007,
+    "schemaVersion": 1008,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",

--- a/build-tests/api-extractor-scenarios/src/apiItemKinds/variables.ts
+++ b/build-tests/api-extractor-scenarios/src/apiItemKinds/variables.ts
@@ -2,7 +2,13 @@
 // See LICENSE in the project root for license information.
 
 /** @public */
-export const VARIABLE: string = 'hello';
+export const CONST_VARIABLE: string = 'hello';
+
+/** @public */
+export let nonConstVariable: string = 'hello';
+
+/** @public */
+export const VARIABLE_WITHOUT_EXPLICIT_TYPE = 'hello';
 
 /** @public */
 export namespace NamespaceContainingVariable {

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.8.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.1.tgz_eslint@8.7.0+typescript@4.6.4
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.8.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.10.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.4
       typescript: 4.6.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.8.tgz
+      '@rushstack/heft': file:rushstack-heft-0.45.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.1.tgz_eslint@8.7.0+typescript@4.6.4
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.8.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.10.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.4
       typescript: 4.6.4
@@ -460,7 +460,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /cross-spawn/7.0.3:
@@ -1803,17 +1803,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.45.8.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.8.tgz}
+  file:../temp/tarballs/rushstack-heft-0.45.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.10.tgz}
     name: '@rushstack/heft'
-    version: 0.45.8
+    version: 0.45.10
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.8.6.tgz
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.45.7.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.12.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.11.1.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.12.0.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -1868,10 +1868,10 @@ packages:
     version: 0.2.4
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.11.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.11.1.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.12.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.12.0.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.11.1
+    version: 4.12.0
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/common/changes/@microsoft/api-documenter/initializer_2022-06-25-19-42.json
+++ b/common/changes/@microsoft/api-documenter/initializer_2022-06-25-19-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Minor change to support the new ApiInitializerMixin mixin.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor-model/initializer_2022-06-18-13-49.json
+++ b/common/changes/@microsoft/api-extractor-model/initializer_2022-06-18-13-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Add a new initializerTokenRange field to ApiProperty and ApiVariable items.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/initializer_2022-06-18-13-49.json
+++ b/common/changes/@microsoft/api-extractor/initializer_2022-06-18-13-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "API Extractor now populates an initializerTokenRange field for ApiProperty and ApiVariable items.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -476,8 +476,15 @@ export class ApiProperty extends ApiProperty_base {
     get containerKey(): string;
     // (undocumented)
     static getContainerKey(name: string, isStatic: boolean): string;
+    readonly initializerExcerpt: Excerpt | undefined;
     // @override (undocumented)
     get kind(): ApiItemKind;
+    // Warning: (ae-forgotten-export) The symbol "IApiPropertyJson" needs to be exported by the entry point index.d.ts
+    //
+    // @override (undocumented)
+    static onDeserializeInto(options: Partial<IApiPropertyOptions>, context: DeserializerContext, jsonObject: IApiPropertyJson): void;
+    // @override (undocumented)
+    serializeInto(jsonObject: Partial<IApiPropertyJson>): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ApiPropertyItem_base" needs to be exported by the entry point index.d.ts
@@ -633,6 +640,7 @@ export class ApiVariable extends ApiVariable_base {
     get containerKey(): string;
     // (undocumented)
     static getContainerKey(name: string): string;
+    readonly initializerExcerpt?: Excerpt;
     // @override (undocumented)
     get kind(): ApiItemKind;
     // Warning: (ae-forgotten-export) The symbol "IApiVariableJson" needs to be exported by the entry point index.d.ts
@@ -822,6 +830,8 @@ export interface IApiPropertyItemOptions extends IApiNameMixinOptions, IApiRelea
 
 // @public
 export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiProtectedMixinOptions, IApiStaticMixinOptions {
+    // (undocumented)
+    initializerTokenRange?: IExcerptTokenRange;
 }
 
 // @public
@@ -882,6 +892,8 @@ export interface IApiTypeParameterOptions {
 
 // @public
 export interface IApiVariableOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiReadonlyMixinOptions, IApiDeclaredItemOptions {
+    // (undocumented)
+    initializerTokenRange?: IExcerptTokenRange;
     // (undocumented)
     variableTypeTokenRange: IExcerptTokenRange;
 }

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -168,15 +168,8 @@ export class ApiEnumMember extends ApiEnumMember_base {
     get containerKey(): string;
     // (undocumented)
     static getContainerKey(name: string): string;
-    readonly initializerExcerpt: Excerpt;
     // @override (undocumented)
     get kind(): ApiItemKind;
-    // Warning: (ae-forgotten-export) The symbol "IApiEnumMemberJson" needs to be exported by the entry point index.d.ts
-    //
-    // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiEnumMemberOptions>, context: DeserializerContext, jsonObject: IApiEnumMemberJson): void;
-    // @override (undocumented)
-    serializeInto(jsonObject: Partial<IApiEnumMemberJson>): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ApiFunction_base" needs to be exported by the entry point index.d.ts
@@ -207,6 +200,23 @@ export class ApiIndexSignature extends ApiIndexSignature_base {
     static getContainerKey(overloadIndex: number): string;
     // @override (undocumented)
     get kind(): ApiItemKind;
+}
+
+// @public
+export function ApiInitializerMixin<TBaseClass extends IApiItemConstructor>(baseClass: TBaseClass): TBaseClass & (new (...args: any[]) => ApiInitializerMixin);
+
+// @public
+export interface ApiInitializerMixin extends ApiItem {
+    readonly initializerExcerpt?: Excerpt;
+    // Warning: (ae-forgotten-export) The symbol "IApiInitializerMixinJson" needs to be exported by the entry point index.d.ts
+    //
+    // @override (undocumented)
+    serializeInto(jsonObject: Partial<IApiInitializerMixinJson>): void;
+}
+
+// @public
+export namespace ApiInitializerMixin {
+    export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiInitializerMixin;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ApiInterface_base" needs to be exported by the entry point index.d.ts
@@ -476,15 +486,8 @@ export class ApiProperty extends ApiProperty_base {
     get containerKey(): string;
     // (undocumented)
     static getContainerKey(name: string, isStatic: boolean): string;
-    readonly initializerExcerpt: Excerpt | undefined;
     // @override (undocumented)
     get kind(): ApiItemKind;
-    // Warning: (ae-forgotten-export) The symbol "IApiPropertyJson" needs to be exported by the entry point index.d.ts
-    //
-    // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiPropertyOptions>, context: DeserializerContext, jsonObject: IApiPropertyJson): void;
-    // @override (undocumented)
-    serializeInto(jsonObject: Partial<IApiPropertyJson>): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ApiPropertyItem_base" needs to be exported by the entry point index.d.ts
@@ -640,7 +643,6 @@ export class ApiVariable extends ApiVariable_base {
     get containerKey(): string;
     // (undocumented)
     static getContainerKey(name: string): string;
-    readonly initializerExcerpt?: Excerpt;
     // @override (undocumented)
     get kind(): ApiItemKind;
     // Warning: (ae-forgotten-export) The symbol "IApiVariableJson" needs to be exported by the entry point index.d.ts
@@ -728,9 +730,7 @@ export interface IApiEntryPointOptions extends IApiItemContainerMixinOptions, IA
 }
 
 // @public
-export interface IApiEnumMemberOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
-    // (undocumented)
-    initializerTokenRange: IExcerptTokenRange;
+export interface IApiEnumMemberOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions, IApiInitializerMixinOptions {
 }
 
 // @public
@@ -743,6 +743,12 @@ export interface IApiFunctionOptions extends IApiNameMixinOptions, IApiTypeParam
 
 // @public
 export interface IApiIndexSignatureOptions extends IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiReturnTypeMixinOptions, IApiDeclaredItemOptions {
+}
+
+// @public
+export interface IApiInitializerMixinOptions extends IApiItemOptions {
+    // (undocumented)
+    initializerTokenRange?: IExcerptTokenRange;
 }
 
 // @public
@@ -829,9 +835,7 @@ export interface IApiPropertyItemOptions extends IApiNameMixinOptions, IApiRelea
 }
 
 // @public
-export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiProtectedMixinOptions, IApiStaticMixinOptions {
-    // (undocumented)
-    initializerTokenRange?: IExcerptTokenRange;
+export interface IApiPropertyOptions extends IApiPropertyItemOptions, IApiProtectedMixinOptions, IApiStaticMixinOptions, IApiInitializerMixinOptions {
 }
 
 // @public
@@ -891,9 +895,7 @@ export interface IApiTypeParameterOptions {
 }
 
 // @public
-export interface IApiVariableOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiReadonlyMixinOptions, IApiDeclaredItemOptions {
-    // (undocumented)
-    initializerTokenRange?: IExcerptTokenRange;
+export interface IApiVariableOptions extends IApiNameMixinOptions, IApiReleaseTagMixinOptions, IApiReadonlyMixinOptions, IApiDeclaredItemOptions, IApiInitializerMixinOptions {
     // (undocumented)
     variableTypeTokenRange: IExcerptTokenRange;
 }

--- a/libraries/api-extractor-model/src/index.ts
+++ b/libraries/api-extractor-model/src/index.ts
@@ -38,6 +38,7 @@ export { IApiStaticMixinOptions, ApiStaticMixin } from './mixins/ApiStaticMixin'
 export { IApiNameMixinOptions, ApiNameMixin } from './mixins/ApiNameMixin';
 export { IApiOptionalMixinOptions, ApiOptionalMixin } from './mixins/ApiOptionalMixin';
 export { IApiReadonlyMixinOptions, ApiReadonlyMixin } from './mixins/ApiReadonlyMixin';
+export { IApiInitializerMixinOptions, ApiInitializerMixin } from './mixins/ApiInitializerMixin';
 
 export { ExcerptTokenKind, IExcerptTokenRange, IExcerptToken, ExcerptToken, Excerpt } from './mixins/Excerpt';
 export { Constructor, PropertiesOf } from './mixins/Mixin';

--- a/libraries/api-extractor-model/src/mixins/ApiInitializerMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiInitializerMixin.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.s
+
+import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
+import { IExcerptTokenRange, Excerpt } from './Excerpt';
+import { ApiDeclaredItem } from '../items/ApiDeclaredItem';
+import { InternalError } from '@rushstack/node-core-library';
+import { DeserializerContext } from '../model/DeserializerContext';
+
+/**
+ * Constructor options for {@link (IApiInitializerMixinOptions:interface)}.
+ * @public
+ */
+export interface IApiInitializerMixinOptions extends IApiItemOptions {
+  initializerTokenRange?: IExcerptTokenRange;
+}
+
+export interface IApiInitializerMixinJson extends IApiItemJson {
+  initializerTokenRange?: IExcerptTokenRange;
+}
+
+const _initializerExcerpt: unique symbol = Symbol('ApiInitializerMixin._initializerExcerpt');
+
+/**
+ * The mixin base class for API items that can have an initializer.
+ *
+ * @remarks
+ *
+ * This is part of the {@link ApiModel} hierarchy of classes, which are serializable representations of
+ * API declarations.  The non-abstract classes (e.g. `ApiClass`, `ApiEnum`, `ApiInterface`, etc.) use
+ * TypeScript "mixin" functions (e.g. `ApiDeclaredItem`, `ApiItemContainerMixin`, etc.) to add various
+ * features that cannot be represented as a normal inheritance chain (since TypeScript does not allow a child class
+ * to extend more than one base class).  The "mixin" is a TypeScript merged declaration with three components:
+ * the function that generates a subclass, an interface that describes the members of the subclass, and
+ * a namespace containing static members of the class.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ApiInitializerMixin extends ApiItem {
+  /**
+   * An {@link Excerpt} that describes the item's initializer.
+   */
+  readonly initializerExcerpt?: Excerpt;
+
+  /** @override */
+  serializeInto(jsonObject: Partial<IApiInitializerMixinJson>): void;
+}
+
+/**
+ * Mixin function for {@link (ApiInitializerMixin:interface)}.
+ *
+ * @param baseClass - The base class to be extended
+ * @returns A child class that extends baseClass, adding the {@link (ApiInitializerMixin:interface)} functionality.
+ *
+ * @public
+ */
+export function ApiInitializerMixin<TBaseClass extends IApiItemConstructor>(
+  baseClass: TBaseClass
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): TBaseClass & (new (...args: any[]) => ApiInitializerMixin) {
+  class MixedClass extends baseClass implements ApiInitializerMixin {
+    public [_initializerExcerpt]?: Excerpt;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public constructor(...args: any[]) {
+      super(...args);
+
+      const options: IApiInitializerMixinOptions = args[0];
+
+      if (this instanceof ApiDeclaredItem) {
+        if (options.initializerTokenRange) {
+          this[_initializerExcerpt] = this.buildExcerpt(options.initializerTokenRange);
+        }
+      } else {
+        throw new InternalError(
+          'ApiInitializerMixin expects a base class that inherits from ApiDeclaredItem'
+        );
+      }
+    }
+
+    /** @override */
+    public static onDeserializeInto(
+      options: Partial<IApiInitializerMixinOptions>,
+      context: DeserializerContext,
+      jsonObject: IApiInitializerMixinJson
+    ): void {
+      baseClass.onDeserializeInto(options, context, jsonObject);
+
+      options.initializerTokenRange = jsonObject.initializerTokenRange;
+    }
+
+    public get initializerExcerpt(): Excerpt | undefined {
+      return this[_initializerExcerpt];
+    }
+
+    /** @override */
+    public serializeInto(jsonObject: Partial<IApiInitializerMixinJson>): void {
+      super.serializeInto(jsonObject);
+
+      // Note that JSON does not support the "undefined" value, so we simply omit the field entirely if it is undefined
+      if (this.initializerExcerpt) {
+        jsonObject.initializerTokenRange = this.initializerExcerpt.tokenRange;
+      }
+    }
+  }
+
+  return MixedClass;
+}
+
+/**
+ * Static members for {@link (ApiInitializerMixin:interface)}.
+ * @public
+ */
+export namespace ApiInitializerMixin {
+  /**
+   * A type guard that tests whether the specified `ApiItem` subclass extends the `ApiInitializerMixin` mixin.
+   *
+   * @remarks
+   *
+   * The JavaScript `instanceof` operator cannot be used to test for mixin inheritance, because each invocation of
+   * the mixin function produces a different subclass.  (This could be mitigated by `Symbol.hasInstance`, however
+   * the TypeScript type system cannot invoke a runtime test.)
+   */
+  export function isBaseClassOf(apiItem: ApiItem): apiItem is ApiInitializerMixin {
+    return apiItem.hasOwnProperty(_initializerExcerpt);
+  }
+}

--- a/libraries/api-extractor-model/src/model/ApiEnumMember.ts
+++ b/libraries/api-extractor-model/src/model/ApiEnumMember.ts
@@ -8,11 +8,10 @@ import {
   Component
 } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
 import { ApiItemKind } from '../items/ApiItem';
-import { ApiDeclaredItem, IApiDeclaredItemOptions, IApiDeclaredItemJson } from '../items/ApiDeclaredItem';
+import { ApiDeclaredItem, IApiDeclaredItemOptions } from '../items/ApiDeclaredItem';
 import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiReleaseTagMixin';
-import { Excerpt, IExcerptTokenRange } from '../mixins/Excerpt';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
-import { DeserializerContext } from './DeserializerContext';
+import { ApiInitializerMixin, IApiInitializerMixinOptions } from '../mixins/ApiInitializerMixin';
 
 /**
  * Constructor options for {@link ApiEnumMember}.
@@ -21,9 +20,8 @@ import { DeserializerContext } from './DeserializerContext';
 export interface IApiEnumMemberOptions
   extends IApiNameMixinOptions,
     IApiReleaseTagMixinOptions,
-    IApiDeclaredItemOptions {
-  initializerTokenRange: IExcerptTokenRange;
-}
+    IApiDeclaredItemOptions,
+    IApiInitializerMixinOptions {}
 
 /**
  * Options for customizing the sort order of {@link ApiEnum} members.
@@ -53,10 +51,6 @@ export enum EnumMemberOrder {
   Preserve = 'preserve'
 }
 
-export interface IApiEnumMemberJson extends IApiDeclaredItemJson {
-  initializerTokenRange: IExcerptTokenRange;
-}
-
 /**
  * Represents a member of a TypeScript enum declaration.
  *
@@ -77,32 +71,14 @@ export interface IApiEnumMemberJson extends IApiDeclaredItemJson {
  *
  * @public
  */
-export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem)) {
-  /**
-   * An {@link Excerpt} that describes the value of the enum member.
-   */
-  public readonly initializerExcerpt: Excerpt;
-
+export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiInitializerMixin(ApiDeclaredItem))) {
   public constructor(options: IApiEnumMemberOptions) {
     super(options);
-
-    this.initializerExcerpt = this.buildExcerpt(options.initializerTokenRange);
   }
 
   public static getContainerKey(name: string): string {
     // No prefix needed, because ApiEnumMember is the only possible member of an ApiEnum
     return name;
-  }
-
-  /** @override */
-  public static onDeserializeInto(
-    options: Partial<IApiEnumMemberOptions>,
-    context: DeserializerContext,
-    jsonObject: IApiEnumMemberJson
-  ): void {
-    super.onDeserializeInto(options, context, jsonObject);
-
-    options.initializerTokenRange = jsonObject.initializerTokenRange;
   }
 
   /** @override */
@@ -113,13 +89,6 @@ export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredIt
   /** @override */
   public get containerKey(): string {
     return ApiEnumMember.getContainerKey(this.name);
-  }
-
-  /** @override */
-  public serializeInto(jsonObject: Partial<IApiEnumMemberJson>): void {
-    super.serializeInto(jsonObject);
-
-    jsonObject.initializerTokenRange = this.initializerExcerpt.tokenRange;
   }
 
   /** @beta @override */

--- a/libraries/api-extractor-model/src/model/ApiProperty.ts
+++ b/libraries/api-extractor-model/src/model/ApiProperty.ts
@@ -10,9 +10,8 @@ import {
 import { ApiItemKind } from '../items/ApiItem';
 import { ApiProtectedMixin, IApiProtectedMixinOptions } from '../mixins/ApiProtectedMixin';
 import { ApiStaticMixin, IApiStaticMixinOptions } from '../mixins/ApiStaticMixin';
-import { DeserializerContext } from '../model/DeserializerContext';
-import { ApiPropertyItem, IApiPropertyItemJson, IApiPropertyItemOptions } from '../items/ApiPropertyItem';
-import { Excerpt, IExcerptTokenRange } from '../mixins/Excerpt';
+import { ApiInitializerMixin, IApiInitializerMixinOptions } from '../mixins/ApiInitializerMixin';
+import { ApiPropertyItem, IApiPropertyItemOptions } from '../items/ApiPropertyItem';
 
 /**
  * Constructor options for {@link ApiProperty}.
@@ -21,13 +20,8 @@ import { Excerpt, IExcerptTokenRange } from '../mixins/Excerpt';
 export interface IApiPropertyOptions
   extends IApiPropertyItemOptions,
     IApiProtectedMixinOptions,
-    IApiStaticMixinOptions {
-  initializerTokenRange?: IExcerptTokenRange;
-}
-
-export interface IApiPropertyJson extends IApiPropertyItemJson {
-  initializerTokenRange?: IExcerptTokenRange;
-}
+    IApiStaticMixinOptions,
+    IApiInitializerMixinOptions {}
 
 /**
  * Represents a TypeScript property declaration that belongs to an `ApiClass`.
@@ -63,29 +57,9 @@ export interface IApiPropertyJson extends IApiPropertyItemJson {
  *
  * @public
  */
-export class ApiProperty extends ApiProtectedMixin(ApiStaticMixin(ApiPropertyItem)) {
-  /**
-   * An {@link Excerpt} that describes the property's initializer.
-   */
-  public readonly initializerExcerpt: Excerpt | undefined;
-
+export class ApiProperty extends ApiProtectedMixin(ApiStaticMixin(ApiInitializerMixin(ApiPropertyItem))) {
   public constructor(options: IApiPropertyOptions) {
     super(options);
-
-    if (options.initializerTokenRange) {
-      this.initializerExcerpt = this.buildExcerpt(options.initializerTokenRange);
-    }
-  }
-
-  /** @override */
-  public static onDeserializeInto(
-    options: Partial<IApiPropertyOptions>,
-    context: DeserializerContext,
-    jsonObject: IApiPropertyJson
-  ): void {
-    super.onDeserializeInto(options, context, jsonObject);
-
-    options.initializerTokenRange = jsonObject.initializerTokenRange;
   }
 
   public static getContainerKey(name: string, isStatic: boolean): string {
@@ -104,16 +78,6 @@ export class ApiProperty extends ApiProtectedMixin(ApiStaticMixin(ApiPropertyIte
   /** @override */
   public get containerKey(): string {
     return ApiProperty.getContainerKey(this.name, this.isStatic);
-  }
-
-  /** @override */
-  public serializeInto(jsonObject: Partial<IApiPropertyJson>): void {
-    super.serializeInto(jsonObject);
-
-    // Note that JSON does not support the "undefined" value, so we simply omit the field entirely if it is undefined
-    if (this.initializerExcerpt) {
-      jsonObject.initializerTokenRange = this.initializerExcerpt.tokenRange;
-    }
   }
 
   /** @beta @override */

--- a/libraries/api-extractor-model/src/model/ApiVariable.ts
+++ b/libraries/api-extractor-model/src/model/ApiVariable.ts
@@ -25,10 +25,12 @@ export interface IApiVariableOptions
     IApiReadonlyMixinOptions,
     IApiDeclaredItemOptions {
   variableTypeTokenRange: IExcerptTokenRange;
+  initializerTokenRange?: IExcerptTokenRange;
 }
 
 export interface IApiVariableJson extends IApiDeclaredItemJson {
   variableTypeTokenRange: IExcerptTokenRange;
+  initializerTokenRange?: IExcerptTokenRange;
 }
 
 /**
@@ -57,10 +59,19 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiReadonlyMixi
    */
   public readonly variableTypeExcerpt: Excerpt;
 
+  /**
+   * An {@link Excerpt} that describes the variable's initializer.
+   */
+  public readonly initializerExcerpt?: Excerpt;
+
   public constructor(options: IApiVariableOptions) {
     super(options);
 
     this.variableTypeExcerpt = this.buildExcerpt(options.variableTypeTokenRange);
+
+    if (options.initializerTokenRange) {
+      this.initializerExcerpt = this.buildExcerpt(options.initializerTokenRange);
+    }
   }
 
   /** @override */
@@ -72,6 +83,7 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiReadonlyMixi
     super.onDeserializeInto(options, context, jsonObject);
 
     options.variableTypeTokenRange = jsonObject.variableTypeTokenRange;
+    options.initializerTokenRange = jsonObject.initializerTokenRange;
   }
 
   public static getContainerKey(name: string): string {
@@ -93,6 +105,11 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiReadonlyMixi
     super.serializeInto(jsonObject);
 
     jsonObject.variableTypeTokenRange = this.variableTypeExcerpt.tokenRange;
+
+    // Note that JSON does not support the "undefined" value, so we simply omit the field entirely if it is undefined
+    if (this.initializerExcerpt) {
+      jsonObject.initializerTokenRange = this.initializerExcerpt.tokenRange;
+    }
   }
 
   /** @beta @override */

--- a/libraries/api-extractor-model/src/model/Deserializer.ts
+++ b/libraries/api-extractor-model/src/model/Deserializer.ts
@@ -12,7 +12,7 @@ import { ApiInterface, IApiInterfaceOptions, IApiInterfaceJson } from './ApiInte
 import { ApiPropertySignature, IApiPropertySignatureOptions } from './ApiPropertySignature';
 import { ApiMethodSignature, IApiMethodSignatureOptions } from './ApiMethodSignature';
 import { ApiProperty, IApiPropertyOptions } from './ApiProperty';
-import { ApiEnumMember, IApiEnumMemberOptions, IApiEnumMemberJson } from './ApiEnumMember';
+import { ApiEnumMember, IApiEnumMemberOptions } from './ApiEnumMember';
 import { ApiEnum, IApiEnumOptions } from './ApiEnum';
 import { IApiPropertyItemJson } from '../items/ApiPropertyItem';
 import { ApiConstructor, IApiConstructorOptions } from './ApiConstructor';
@@ -49,7 +49,7 @@ export class Deserializer {
         ApiEnum.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiEnum(options as IApiEnumOptions);
       case ApiItemKind.EnumMember:
-        ApiEnumMember.onDeserializeInto(options, context, jsonObject as IApiEnumMemberJson);
+        ApiEnumMember.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiEnumMember(options as IApiEnumMemberOptions);
       case ApiItemKind.Function:
         ApiFunction.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);

--- a/libraries/api-extractor-model/src/model/DeserializerContext.ts
+++ b/libraries/api-extractor-model/src/model/DeserializerContext.ts
@@ -61,12 +61,20 @@ export enum ApiJsonSchemaVersion {
   V_1007 = 1007,
 
   /**
+   * Add an `initializerTokenRange` field to `ApiProperty` and `ApiVariable` to track the item's
+   * initializer.
+   *
+   * When loading older JSON files, this range is empty.
+   */
+  V_1008 = 1008,
+
+  /**
    * The current latest .api.json schema version.
    *
    * IMPORTANT: When incrementing this number, consider whether `OLDEST_SUPPORTED` or `OLDEST_FORWARDS_COMPATIBLE`
    * should be updated.
    */
-  LATEST = V_1007,
+  LATEST = V_1008,
 
   /**
    * The oldest .api.json schema version that is still supported for backwards compatibility.


### PR DESCRIPTION
## Problem

TypeScript doesn't write type annotations for certain API items in certain scenarios. Consider the following:

```
export class SomeClass {
    readonly foo = 5;
}

export const BAR = false;
```

The generated `.d.ts` output for these items is as follows:

```
export declare class SomeClass {
    readonly foo = 5;
}
export declare const BAR = false;

```

Observe the lack of type annotations in the `.d.ts`. TypeScript presumably thinks they are unnecessary because these are "readonly" items whose initializers carry all relevant type information. That is, the type of `foo` is `5`, and the type of `BAR` is `false`.

However, API Extractor doesn't currently extract initializer information, and so ultimately these items just have empty `propertyTypeTokenRange` and `variableTypeTokenRange` fields. This means that on a documentation site, we can't surface any information about these items' types/initializers. We can do better.

## Solution

This PR introduces a new field `initializerTokenRange` to `ApiProperty` and `ApiVariable` to track an item's initializer. This field is omitted if there is no initializer so as to not clutter the `.api.json`. From my testing, `ApiProperty`, `ApiVariable`, and `ApiEnumMember` were the only API item kinds that could have initializers in the `.d.ts`, and the latter already has `initializerTokenRange`.

This new field is added by a new `ApiInitializerMixin` that is applied to these three API item kinds.

## How it was tested

I added relevant test cases to the api-extractor-scenario test case, ran `rush build`, and checked in the updated golden `.api.json` files (which looked good).
