### PR TITLE
[rush-lib] Disable build cache for operations with no operationSettings

### DIFF
--- a/common/changes/@microsoft/rush/build-cache-no-settings_2022-06-22-18-30.json
+++ b/common/changes/@microsoft/rush/build-cache-no-settings_2022-06-22-18-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable build cache for operations with no corresponding operationSettings entry in rush-project.json, and provide a clear message about why.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -421,13 +421,17 @@ export class ShellOperationRunner implements IOperationRunner {
           } else {
             const operationSettings: IOperationSettings | undefined =
               projectConfiguration.operationSettingsByOperationName.get(this._commandName);
-            if (operationSettings?.disableBuildCacheForOperation) {
+            if (!operationSettings) {
+              terminal.writeVerboseLine(
+                `This project does not define the caching behavior of the "${this._commandName}" command, so caching has been disabled.`
+              );
+            } else if (operationSettings.disableBuildCacheForOperation) {
               terminal.writeVerboseLine(
                 `Caching has been disabled for this project's "${this._commandName}" command.`
               );
             } else {
               const projectOutputFolderNames: ReadonlyArray<string> =
-                operationSettings?.outputFolderNames || [];
+                operationSettings.outputFolderNames || [];
               this._projectBuildCache = await ProjectBuildCache.tryGetProjectBuildCache({
                 projectConfiguration,
                 projectOutputFolderNames,


### PR DESCRIPTION
## Summary
Fixes #3490

## Details
If no entry is provided for a given operation in `operationSettings`, assumes the build cache is disabled for that operation, rather than assuming caching is enabled with no outputs.

## How it was tested
Removed the entry from heft-jest-plugin temporarily, ran a build and verified the warning message.