### PR TITLE
[typings-generator] Allow typings to be output to secondary folders.

### DIFF
--- a/build-tests/localization-plugin-test-03/webpack.config.js
+++ b/build-tests/localization-plugin-test-03/webpack.config.js
@@ -117,6 +117,7 @@ function generateConfiguration(mode, outputFolderName) {
         },
         typingsOptions: {
           generatedTsFolder: path.resolve(__dirname, 'temp', 'loc-json-ts'),
+          secondaryGeneratedTsFolders: ['lib'],
           sourceRoot: path.resolve(__dirname, 'src'),
           exportAsDefault: true
         },

--- a/common/changes/@rushstack/heft-sass-plugin/typings-generator-outputs_2022-06-25-00-38.json
+++ b/common/changes/@rushstack/heft-sass-plugin/typings-generator-outputs_2022-06-25-00-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Add an option to output typings to additional output folders.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/localization-utilities/typings-generator-outputs_2022-06-25-00-31.json
+++ b/common/changes/@rushstack/localization-utilities/typings-generator-outputs_2022-06-25-00-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Add an option to output typings to additional output folders.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/changes/@rushstack/localization-utilities/typings-generator-outputs_2022-06-25-00-38.json
+++ b/common/changes/@rushstack/localization-utilities/typings-generator-outputs_2022-06-25-00-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/changes/@rushstack/typings-generator/typings-generator-outputs_2022-06-25-00-31.json
+++ b/common/changes/@rushstack/typings-generator/typings-generator-outputs_2022-06-25-00-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "Add an option to output typings to additional output folders.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator"
+}

--- a/common/changes/@rushstack/typings-generator/typings-generator-outputs_2022-06-25-00-38.json
+++ b/common/changes/@rushstack/typings-generator/typings-generator-outputs_2022-06-25-00-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/typings-generator-outputs_2022-06-25-00-44.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/typings-generator-outputs_2022-06-25-00-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-localization-plugin",
+      "comment": "Add an option to output typings to additional output folders.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin"
+}

--- a/common/reviews/api/localization-utilities.api.md
+++ b/common/reviews/api/localization-utilities.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { ITerminal } from '@rushstack/node-core-library';
+import { ITypingsGeneratorBaseOptions } from '@rushstack/typings-generator';
 import { NewlineKind } from '@rushstack/node-core-library';
 import { StringValuesTypingsGenerator } from '@rushstack/typings-generator';
 
@@ -76,13 +77,9 @@ export interface IPseudolocaleOptions {
 }
 
 // @public (undocumented)
-export interface ITypingsGeneratorOptions {
+export interface ITypingsGeneratorOptions extends ITypingsGeneratorBaseOptions {
     // (undocumented)
     exportAsDefault?: boolean;
-    // (undocumented)
-    generatedTsFolder: string;
-    // (undocumented)
-    globsToIgnore?: string[];
     // (undocumented)
     ignoreMissingResxComments?: boolean | undefined;
     // (undocumented)
@@ -91,10 +88,6 @@ export interface ITypingsGeneratorOptions {
     processComment?: (comment: string | undefined, resxFilePath: string, stringName: string) => string | undefined;
     // (undocumented)
     resxNewlineNormalization?: NewlineKind | undefined;
-    // (undocumented)
-    srcFolder: string;
-    // (undocumented)
-    terminal?: ITerminal;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -27,23 +27,29 @@ export interface IStringValueTypings {
 }
 
 // @public (undocumented)
-export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> {
+export interface ITypingsGeneratorBaseOptions {
+    // (undocumented)
+    generatedTsFolder: string;
+    // (undocumented)
+    globsToIgnore?: string[];
+    // (undocumented)
+    secondaryGeneratedTsFolders?: string[];
+    // (undocumented)
+    srcFolder: string;
+    // (undocumented)
+    terminal?: ITerminal;
+}
+
+// @public (undocumented)
+export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> extends ITypingsGeneratorBaseOptions {
     // (undocumented)
     fileExtensions: string[];
     // @deprecated (undocumented)
     filesToIgnore?: string[];
     // (undocumented)
-    generatedTsFolder: string;
-    // (undocumented)
     getAdditionalOutputFiles?: (relativePath: string) => string[];
     // (undocumented)
-    globsToIgnore?: string[];
-    // (undocumented)
     parseAndGenerateTypings: (fileContents: string, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
-    // (undocumented)
-    srcFolder: string;
-    // (undocumented)
-    terminal?: ITerminal;
 }
 
 // @public

--- a/common/reviews/api/webpack4-localization-plugin.api.md
+++ b/common/reviews/api/webpack4-localization-plugin.api.md
@@ -134,6 +134,7 @@ export interface ITypingsGenerationOptions {
     // @deprecated (undocumented)
     ignoreString?: (resxFilePath: string, stringName: string) => boolean;
     processComment?: (comment: string | undefined, resxFilePath: string, stringName: string) => string | undefined;
+    secondaryGeneratedTsFolders?: string[];
     sourceRoot?: string;
 }
 

--- a/heft-plugins/heft-sass-plugin/src/SassTypingsGenerator.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassTypingsGenerator.ts
@@ -25,6 +25,11 @@ export interface ISassConfiguration {
   generatedTsFolder?: string;
 
   /**
+   * Optional additional folders to which Sass typings should be output.
+   */
+  secondaryGeneratedTsFolders?: string[];
+
+  /**
    * Output directories for compiled CSS
    */
   cssOutputFolders?: string[] | undefined;
@@ -103,6 +108,7 @@ export class SassTypingsGenerator extends StringValuesTypingsGenerator {
       exportAsDefaultInterfaceName,
       fileExtensions,
       filesToIgnore: sassConfiguration.excludeFiles,
+      secondaryGeneratedTsFolders: sassConfiguration.secondaryGeneratedTsFolders,
 
       getAdditionalOutputFiles: getCssPaths,
 

--- a/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
@@ -11,6 +11,7 @@ import type {
 } from '@rushstack/heft';
 import { ConfigurationFile, PathResolutionMethod } from '@rushstack/heft-config-file';
 import { JsonSchema } from '@rushstack/node-core-library';
+
 import { ISassConfiguration, SassTypingsGenerator } from './SassTypingsGenerator';
 import { Async } from './utilities/Async';
 

--- a/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
@@ -27,6 +27,14 @@
       "description": "Output directory for generated Sass typings."
     },
 
+    "secondaryGeneratedTsFolders": {
+      "type": "array",
+      "description": "Optional additional folders to which Sass typings should be output.",
+      "items": {
+        "type": "string"
+      }
+    },
+
     "exportAsDefault": {
       "type": "boolean",
       "description": "Determines whether export values are wrapped in a default property, or not."

--- a/heft-plugins/heft-sass-plugin/src/schemas/templates/sass.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/templates/sass.json
@@ -25,6 +25,11 @@
   // "generatedTsFolder": "temp/sass-ts/",
 
   /**
+   * Optional additional folders to which Sass typings should be output.
+   */
+  // "secondaryGeneratedTsFolders": [],
+
+  /**
    * Determines whether export values are wrapped in a default property, or not.
    *
    * Default value: true

--- a/libraries/localization-utilities/src/TypingsGenerator.ts
+++ b/libraries/localization-utilities/src/TypingsGenerator.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { StringValuesTypingsGenerator, IStringValueTyping } from '@rushstack/typings-generator';
-import { ITerminal, NewlineKind } from '@rushstack/node-core-library';
+import {
+  StringValuesTypingsGenerator,
+  IStringValueTyping,
+  ITypingsGeneratorBaseOptions
+} from '@rushstack/typings-generator';
+import { NewlineKind } from '@rushstack/node-core-library';
 
 import type { IgnoreStringFunction, ILocalizationFile } from './interfaces';
 import { parseLocFile } from './LocFileParser';
@@ -10,12 +14,8 @@ import { parseLocFile } from './LocFileParser';
 /**
  * @public
  */
-export interface ITypingsGeneratorOptions {
-  srcFolder: string;
-  generatedTsFolder: string;
-  terminal?: ITerminal;
+export interface ITypingsGeneratorOptions extends ITypingsGeneratorBaseOptions {
   exportAsDefault?: boolean;
-  globsToIgnore?: string[];
   resxNewlineNormalization?: NewlineKind | undefined;
   ignoreMissingResxComments?: boolean | undefined;
   ignoreString?: IgnoreStringFunction;

--- a/libraries/typings-generator/src/index.ts
+++ b/libraries/typings-generator/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { ITypingsGeneratorOptions, TypingsGenerator } from './TypingsGenerator';
+export { ITypingsGeneratorBaseOptions, ITypingsGeneratorOptions, TypingsGenerator } from './TypingsGenerator';
 
 export {
   IStringValueTyping,

--- a/webpack/localization-plugin-4/src/LocalizationPlugin.ts
+++ b/webpack/localization-plugin-4/src/LocalizationPlugin.ts
@@ -167,6 +167,17 @@ export class LocalizationPlugin implements Webpack.Plugin {
           this._options.typingsOptions.sourceRoot
         );
       }
+
+      const secondaryGeneratedTsFolders: string[] | undefined =
+        this._options.typingsOptions.secondaryGeneratedTsFolders;
+      if (secondaryGeneratedTsFolders) {
+        for (let i: number = 0; i < secondaryGeneratedTsFolders.length; i++) {
+          const secondaryGeneratedTsFolder: string = secondaryGeneratedTsFolders[i];
+          if (!path.isAbsolute(secondaryGeneratedTsFolder)) {
+            secondaryGeneratedTsFolders[i] = path.resolve(compiler.context, secondaryGeneratedTsFolder);
+          }
+        }
+      }
     }
 
     // https://github.com/webpack/webpack-dev-server/pull/1929/files#diff-15fb51940da53816af13330d8ce69b4eR66
@@ -179,6 +190,7 @@ export class LocalizationPlugin implements Webpack.Plugin {
       typingsPreprocessor = new TypingsGenerator({
         srcFolder: this._options.typingsOptions.sourceRoot || compiler.context,
         generatedTsFolder: this._options.typingsOptions.generatedTsFolder,
+        secondaryGeneratedTsFolders: this._options.typingsOptions.secondaryGeneratedTsFolders,
         exportAsDefault: this._options.typingsOptions.exportAsDefault,
         globsToIgnore: this._options.globsToIgnore,
         ignoreString: this._options.ignoreString,

--- a/webpack/localization-plugin-4/src/interfaces.ts
+++ b/webpack/localization-plugin-4/src/interfaces.ts
@@ -33,6 +33,11 @@ export interface ITypingsGenerationOptions {
   generatedTsFolder: string;
 
   /**
+   * Optional additional folders into which `.d.ts` files for loc files should be dropped.
+   */
+  secondaryGeneratedTsFolders?: string[];
+
+  /**
    * This optional property overrides the compiler context for discovery of localization files
    * for which typings should be generated.
    */


### PR DESCRIPTION
## Summary

Allows typings to be output to additional folders.

## How it was tested

Added a test case in `localization-plugin-test-03`.