### PR TITLE
[rush-lib] Set default max install attempts to 1

### DIFF
--- a/common/changes/@microsoft/rush/set_default_max-install-attempts_to_1_2022-06-26-12-16.json
+++ b/common/changes/@microsoft/rush/set_default_max-install-attempts_to_1_2022-06-26-12-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Reduce default maxInstallAttempts to 1",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -589,7 +589,7 @@ Optional arguments:
                         a file when using this command.
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
-                        attempts. The default value is 3.
+                        attempts. The default value is 1.
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.
@@ -1135,7 +1135,7 @@ Optional arguments:
                         a file when using this command.
   --max-install-attempts NUMBER
                         Overrides the default maximum number of install 
-                        attempts. The default value is 3.
+                        attempts. The default value is 1.
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
                         in rush.json. Make sure you know what you are 
                         skipping.

--- a/libraries/rush-lib/src/logic/RushConstants.ts
+++ b/libraries/rush-lib/src/logic/RushConstants.ts
@@ -73,7 +73,7 @@ export class RushConstants {
   /**
    * Number of installation attempts
    */
-  public static readonly defaultMaxInstallAttempts: number = 3;
+  public static readonly defaultMaxInstallAttempts: number = 1;
 
   /**
    * The filename ("pnpm-lock.yaml") used to store an installation plan for the PNPM package manger


### PR DESCRIPTION
## Summary

Right now, rush update by default retries 3 times before failing. That is problematic, as most of the time it fails, it fails for a good reason that won't go away when retrying (e.g. missing peerDeps or mismatching versions).

Fixes #3482 

## Details

I reduced the max install attempts to 1.

## How it was tested

There's a snapshot test that changed.