### PR TITLE
[localization-plugin-5] Fix unit tests on Windows

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/localization-plugin-portable-resolution_2022-06-27-21-45.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/localization-plugin-portable-resolution_2022-06-27-21-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Ensure localization file path resolution can handle a UNIX file system on a Windows host, as is used by the unit tests.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/webpack/localization-plugin-5/src/LocalizationPlugin.ts
+++ b/webpack/localization-plugin-5/src/LocalizationPlugin.ts
@@ -583,6 +583,9 @@ export class LocalizationPlugin implements WebpackPluginInstance {
       // END options.localizedData.passthroughLocale
 
       // START options.localizedData.translatedStrings
+      const resolveRelativeToContext: (relative: string) => string = (
+        configuration.context?.startsWith('/') ? path.posix.resolve : path.resolve
+      ).bind(0, configuration.context!);
       const { translatedStrings } = localizedData;
       this._resolvedTranslatedStringsFromOptions.clear();
       if (translatedStrings) {
@@ -606,7 +609,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
           this._resolvedTranslatedStringsFromOptions.set(localeName, resolvedFromOptionsForLocale);
 
           for (const [locFilePath, locFileDataFromOptions] of Object.entries(locale)) {
-            const normalizedLocFilePath: string = path.resolve(configuration.context!, locFilePath);
+            const normalizedLocFilePath: string = resolveRelativeToContext(locFilePath);
 
             if (resolvedFromOptionsForLocale.has(normalizedLocFilePath)) {
               errors.push(
@@ -620,7 +623,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
 
             const normalizedLocFileDataFromOptions: ILocaleFileData =
               typeof locFileDataFromOptions === 'string'
-                ? path.resolve(configuration.context!, locFileDataFromOptions)
+                ? resolveRelativeToContext(locFileDataFromOptions)
                 : locFileDataFromOptions;
 
             resolvedFromOptionsForLocale.set(normalizedLocFilePath, normalizedLocFileDataFromOptions);


### PR DESCRIPTION
## Summary
Ensures that the snapshot tests for the webpack 5 localization plugin work when running on Windows.

## Details
Modifies the path normalization algorithm to use POSIX path resolution if the value of the webpack `context` is a POSIX absolute path (i.e. starts with `/`).

## How it was tested
Ran unit tests on Windows.
PR build runs unit tests on Linux.