### PR TITLE
[node-core-library] Add `FileSystem.isDirectoryError` 

### DIFF
--- a/common/changes/@rushstack/node-core-library/user-danade-AddIsDirectoryError_2022-06-27-21-54.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-AddIsDirectoryError_2022-06-27-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add FileSystem.isDirectoryError utility function to determine if an error has the code \"EISDIR\". This error code may be returned (for example) when attempting to delete a folder as if it were a file using the FileSystem.deleteFile API.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -1510,6 +1510,9 @@ export class FileSystem {
       } else if (FileSystem.isUnlinkNotPermittedError(error)) {
         // eslint-disable-line @typescript-eslint/no-use-before-define
         error.message = `File or folder could not be deleted: ${error.path}\n${error.message}`;
+      } else if (FileSystem.isDirectoryError(error)) {
+        // eslint-disable-line @typescript-eslint/no-use-before-define
+        error.message = `Target is a folder, not a file: ${error.path}\n${error.message}`;
       }
     }
   }

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -1371,6 +1371,13 @@ export class FileSystem {
   }
 
   /**
+   * Returns true if the error object indicates the target is a directory (`EISDIR`).
+   */
+  public static isDirectoryError(error: Error): boolean {
+    return FileSystem.isErrnoException(error) && error.code === 'EISDIR';
+  }
+
+  /**
    * Returns true if the error object indicates that the `unlink` system call failed
    * due to a permissions issue (`EPERM`).
    */


### PR DESCRIPTION
## Summary

Add `FileSystem.isDirectoryError()` utility method to determine when an error with code `EISDIR` is thrown.

## Details

There are some cases where a target path is assumed to be a file instead of a folder when executing. In these cases, it may be more efficient to catch the error case and then try the directory-specific operations rather than checking the file type beforehand (such as mass-deletion of children within a folder). This utility method adds this ability, and also updates the error message to be more useful when encountered by `FileSystem` API methods.
