### PR TITLE
correct loader load theme styles hoisting

### DIFF
--- a/common/changes/@microsoft/loader-load-themed-styles/selarkin-correct-loader-load-theme-styles-hoisting_2022-06-28-02-07.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/selarkin-correct-loader-load-theme-styles-hoisting_2022-06-28-02-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/loader-load-themed-styles",
-      "comment": "add optional peerdeps meta for types",
+      "comment": "Include a missing optional peer dependency on @types/webpack.",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/loader-load-themed-styles/selarkin-correct-loader-load-theme-styles-hoisting_2022-06-28-02-07.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/selarkin-correct-loader-load-theme-styles-hoisting_2022-06-28-02-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "add optional peerdeps meta for types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles"
+}

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -34,7 +34,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/loader-utils": "1.1.3",
     "@types/node": "12.20.24",
-    "@types/webpack": "4.41.32",
-    "webpack": "~4.44.2"
+    "@types/webpack": "4.41.32"
   }
 }

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -15,6 +15,11 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build"
   },
+  "peerDependenciesMeta": {
+    "@types/webpack": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@microsoft/load-themed-styles": "workspace:*",
     "loader-utils": "~1.1.0"
@@ -26,6 +31,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/loader-utils": "1.1.3",
     "@types/node": "12.20.24",
-    "@types/webpack": "4.41.32"
+    "@types/webpack": "4.41.32",
+    "webpack": "~4.44.2"
   }
 }

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -20,6 +20,9 @@
       "optional": true
     }
   },
+  "peerDependencies": {
+    "@types/webpack": "^4"
+  },
   "dependencies": {
     "@microsoft/load-themed-styles": "workspace:*",
     "loader-utils": "~1.1.0"


### PR DESCRIPTION
Similar to PR #3474, 

loader-load-theme-styles seems to be still causing hoisting issues in node_modules. Any dependency not expressly declared in package.json (or corrected via pnpmfile) will not be available to projects.