### PR TITLE
Update @rushstack/heft-sass-plugin to be compatible with multi-phase Heft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,5 @@ dist
 .vscode
 
 # Heft
+.cache
 .heft

--- a/heft-plugins/heft-sass-plugin/.npmignore
+++ b/heft-plugins/heft-sass-plugin/.npmignore
@@ -28,3 +28,4 @@
 #--------------------------------------------
 
 # (Add your project-specific overrides here)
+!heft-plugin.json

--- a/heft-plugins/heft-sass-plugin/heft-plugin.json
+++ b/heft-plugins/heft-sass-plugin/heft-plugin.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
+
+  "taskPlugins": [
+    {
+      "pluginName": "SassTypingsPlugin",
+      "entryPoint": "./lib/SassTypingsPlugin"
+    }
+  ]
+}

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -12,10 +12,10 @@
   "types": "dist/heft-sass-plugin.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "heft build --clean",
     "start": "heft test --clean --watch",
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build"
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean"
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.45.14"

--- a/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassTypingsPlugin.ts
@@ -3,14 +3,13 @@
 
 import type {
   HeftConfiguration,
-  HeftSession,
-  IBuildStageContext,
+  IHeftTaskSession,
   IHeftPlugin,
-  IPreCompileSubstage,
-  ScopedLogger
+  IHeftTaskCleanHookOptions,
+  IHeftTaskRunHookOptions,
+  IScopedLogger
 } from '@rushstack/heft';
 import { ConfigurationFile, PathResolutionMethod } from '@rushstack/heft-config-file';
-import { JsonSchema } from '@rushstack/node-core-library';
 
 import { ISassConfiguration, SassTypingsGenerator } from './SassTypingsGenerator';
 import { Async } from './utilities/Async';
@@ -21,38 +20,31 @@ const PLUGIN_NAME: string = 'SassTypingsPlugin';
 const PLUGIN_SCHEMA_PATH: string = `${__dirname}/schemas/heft-sass-plugin.schema.json`;
 const SASS_CONFIGURATION_LOCATION: string = 'config/sass.json';
 
-export class SassTypingsPlugin implements IHeftPlugin {
+export default class SassTypingsPlugin implements IHeftPlugin {
   private static _sassConfigurationLoader: ConfigurationFile<ISassConfigurationJson> | undefined;
-
-  public readonly pluginName: string = PLUGIN_NAME;
-  public readonly optionsSchema: JsonSchema = JsonSchema.fromFile(PLUGIN_SCHEMA_PATH);
 
   /**
    * Generate typings for Sass files before TypeScript compilation.
    */
-  public apply(heftSession: HeftSession, heftConfiguration: HeftConfiguration): void {
-    heftSession.hooks.build.tap(PLUGIN_NAME, (build: IBuildStageContext) => {
-      build.hooks.preCompile.tap(PLUGIN_NAME, (preCompile: IPreCompileSubstage) => {
-        preCompile.hooks.run.tapPromise(PLUGIN_NAME, async () => {
-          await this._runSassTypingsGeneratorAsync(
-            heftSession,
-            heftConfiguration,
-            build.properties.watchMode
-          );
-        });
-      });
+  public apply(taskSession: IHeftTaskSession, heftConfiguration: HeftConfiguration): void {
+    taskSession.hooks.clean.tapPromise(PLUGIN_NAME, async (cleanOptions: IHeftTaskCleanHookOptions) => {
+      // No-op. Currently relies on the TypeScript plugin to clean up the generated typings.
+    });
+
+    taskSession.hooks.run.tapPromise(PLUGIN_NAME, async (runOptions: IHeftTaskRunHookOptions) => {
+      // TODO: Handle watch mode
+      await this._runSassTypingsGeneratorAsync(taskSession, heftConfiguration, false);
     });
   }
 
   private async _runSassTypingsGeneratorAsync(
-    heftSession: HeftSession,
+    taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
     isWatchMode: boolean
   ): Promise<void> {
-    const logger: ScopedLogger = heftSession.requestScopedLogger('sass-typings-generator');
     const sassConfiguration: ISassConfiguration = await this._loadSassConfigurationAsync(
       heftConfiguration,
-      logger
+      taskSession.logger
     );
     const sassTypingsGenerator: SassTypingsGenerator = new SassTypingsGenerator({
       buildFolder: heftConfiguration.buildFolder,
@@ -61,13 +53,16 @@ export class SassTypingsPlugin implements IHeftPlugin {
 
     await sassTypingsGenerator.generateTypingsAsync();
     if (isWatchMode) {
-      Async.runWatcherWithErrorHandling(async () => await sassTypingsGenerator.runWatcherAsync(), logger);
+      Async.runWatcherWithErrorHandling(
+        async () => await sassTypingsGenerator.runWatcherAsync(),
+        taskSession.logger
+      );
     }
   }
 
   private async _loadSassConfigurationAsync(
     heftConfiguration: HeftConfiguration,
-    logger: ScopedLogger
+    logger: IScopedLogger
   ): Promise<ISassConfiguration> {
     const { buildFolder } = heftConfiguration;
     const sassConfigurationJson: ISassConfigurationJson | undefined =

--- a/heft-plugins/heft-sass-plugin/src/index.ts
+++ b/heft-plugins/heft-sass-plugin/src/index.ts
@@ -7,10 +7,4 @@
  * @packageDocumentation
  */
 
-import type { IHeftPlugin } from '@rushstack/heft';
-import { SassTypingsPlugin } from './SassTypingsPlugin';
-
-/**
- * @internal
- */
-export default new SassTypingsPlugin() as IHeftPlugin;
+export {};

--- a/heft-plugins/heft-sass-plugin/src/utilities/Async.ts
+++ b/heft-plugins/heft-sass-plugin/src/utilities/Async.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { ScopedLogger } from '@rushstack/heft';
+import type { IScopedLogger } from '@rushstack/heft';
 
 export class Async {
-  public static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: ScopedLogger): void {
+  public static runWatcherWithErrorHandling(fn: () => Promise<void>, scopedLogger: IScopedLogger): void {
     try {
       fn().catch((e) => scopedLogger.emitError(e));
     } catch (e) {


### PR DESCRIPTION
## Summary

Updates the Sass Heft plugin to be compatible with multi-phase Heft. No "rush update" performed as this change will not produce a passing build without other packages being converted.