### PR TITLE
[rush] Rename cyclicDependencyProjects to decoupledLocalDependencies

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.2.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.14.tgz
+      '@rushstack/heft': file:rushstack-heft-0.46.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.2.tgz_eslint@8.7.0+typescript@4.6.4
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.14.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.46.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.4
       typescript: 4.6.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-2.6.2.tgz
-      '@rushstack/heft': file:rushstack-heft-0.45.14.tgz
+      '@rushstack/heft': file:rushstack-heft-0.46.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.6.3
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-2.6.2.tgz_eslint@8.7.0+typescript@4.6.4
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.45.14.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.46.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.6.4
       typescript: 4.6.4
@@ -1804,15 +1804,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.45.14.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.45.14.tgz}
+  file:../temp/tarballs/rushstack-heft-0.46.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.46.0.tgz}
     name: '@rushstack/heft'
-    version: 0.45.14
+    version: 0.46.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.8.9.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.48.0.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.8.10.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.49.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.13.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.12.1.tgz
       '@types/tapable': 1.0.6
@@ -1827,21 +1827,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.8.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.8.9.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.8.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.8.10.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.8.9
+    version: 0.8.10
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.48.0.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.49.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.13.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.48.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.48.0.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.49.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.49.0.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.48.0
+    version: 3.49.0
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5

--- a/common/changes/@microsoft/rush/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@microsoft/rush/will-issue-547_2022-07-01-17-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
+      "comment": "(BREAKING API CHANGE) Rename cyclicDependencyProjects to decoupledLocalDependencies",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@microsoft/rush/will-issue-547_2022-07-01-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/will-issue-547_2022-07-01-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/will-issue-547_2022-07-01-17-58.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin-packlets",
-      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
-      "type": "minor"
+      "comment": "",
+      "type": "none"
     }
   ],
   "packageName": "@rushstack/eslint-plugin-packlets"

--- a/common/changes/@rushstack/eslint-plugin-security/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin-security/will-issue-547_2022-07-01-17-58.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin-security",
-      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
-      "type": "minor"
+      "comment": "",
+      "type": "none"
     }
   ],
   "packageName": "@rushstack/eslint-plugin-security"

--- a/common/changes/@rushstack/eslint-plugin-security/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin-security/will-issue-547_2022-07-01-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin/will-issue-547_2022-07-01-17-58.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin",
-      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
-      "type": "minor"
+      "comment": "",
+      "type": "none"
     }
   ],
   "packageName": "@rushstack/eslint-plugin"

--- a/common/changes/@rushstack/eslint-plugin/will-issue-547_2022-07-01-17-58.json
+++ b/common/changes/@rushstack/eslint-plugin/will-issue-547_2022-07-01-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Rename cyclicDependencyProjects to decoupledLocalDependencies",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -777,6 +777,8 @@ export class RushConfigurationProject {
     // @internal
     constructor(options: IRushConfigurationProjectOptions);
     get consumingProjects(): ReadonlySet<RushConfigurationProject>;
+    // @deprecated
+    get cyclicDependencyProjects(): Set<string>;
     get decoupledLocalDependencies(): Set<string>;
     get dependencyProjects(): ReadonlySet<RushConfigurationProject>;
     // @deprecated

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -777,7 +777,7 @@ export class RushConfigurationProject {
     // @internal
     constructor(options: IRushConfigurationProjectOptions);
     get consumingProjects(): ReadonlySet<RushConfigurationProject>;
-    get cyclicDependencyProjects(): Set<string>;
+    get decoupledLocalDependencies(): Set<string>;
     get dependencyProjects(): ReadonlySet<RushConfigurationProject>;
     // @deprecated
     get downstreamDependencyProjects(): string[];

--- a/eslint/eslint-plugin-packlets/.eslintrc.js.disabled
+++ b/eslint/eslint-plugin-packlets/.eslintrc.js.disabled
@@ -1,5 +1,5 @@
 NOTE: We do not invoke ESLint on this project's source files, because ESLint's module resolution (as of 6.x) is naive
 and fairly brittle.  It gets confused between the dependencies of this project, versus the dependencies of
 @rushstack/eslint-config (which imports the previously published version of this project).  Normally we solve
-this problem by using Rush's "cyclicDependencyProjects" feature, but that fails because ESLint does not correctly
+this problem by using Rush's "decoupledLocalDependencies" feature, but that fails because ESLint does not correctly
 implement NodeJS module resolution.

--- a/eslint/eslint-plugin-security/.eslintrc.js.disabled
+++ b/eslint/eslint-plugin-security/.eslintrc.js.disabled
@@ -1,5 +1,5 @@
 NOTE: We do not invoke ESLint on this project's source files, because ESLint's module resolution (as of 6.x) is naive
 and fairly brittle.  It gets confused between the dependencies of this project, versus the dependencies of
 @rushstack/eslint-config (which imports the previously published version of this project).  Normally we solve
-this problem by using Rush's "cyclicDependencyProjects" feature, but that fails because ESLint does not correctly
+this problem by using Rush's "decoupledLocalDependencies" feature, but that fails because ESLint does not correctly
 implement NodeJS module resolution.

--- a/eslint/eslint-plugin/.eslintrc.js.disabled
+++ b/eslint/eslint-plugin/.eslintrc.js.disabled
@@ -1,5 +1,5 @@
 NOTE: We do not invoke ESLint on this project's source files, because ESLint's module resolution (as of 6.x) is naive
 and fairly brittle.  It gets confused between the dependencies of this project, versus the dependencies of
 @rushstack/eslint-config (which imports the previously published version of this project).  Normally we solve
-this problem by using Rush's "cyclicDependencyProjects" feature, but that fails because ESLint does not correctly
+this problem by using Rush's "decoupledLocalDependencies" feature, but that fails because ESLint does not correctly
 implement NodeJS module resolution.

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -422,8 +422,8 @@
       "reviewCategory": "production",
 
       /**
-       * A list of Rush project names that are allowed to be installed from NPM
-       * instead of locally linking the folder.
+       * A list of Rush project names that are to be installed from NPM
+       * instead of linking to the local project.
        *
        * If a project's package.json specifies a dependency that is another Rush project
        * in the monorepo workspace, normally Rush will locally link its folder instead of

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -422,9 +422,27 @@
       "reviewCategory": "production",
 
       /**
-       * A list of local projects that appear as devDependencies for this project, but cannot be
-       * locally linked because it would create a cyclic dependency; instead, the last published
-       * version will be installed in the Common folder.
+       * A list of Rush project names that are allowed to be installed from NPM
+       * instead of locally linking the folder.
+       *
+       * If a project's package.json specifies a dependency that is another Rush project
+       * in the monorepo workspace, normally Rush will locally link its folder instead of
+       * installing from NPM.  If you are using PNPM workspaces, this is indicated by
+       * a SemVer range such as "workspace:^1.2.3".  To prevent mistakes, Rush reports
+       * an error if the "workspace:" protocol is missing.
+       *
+       * Locally linking ensures that regressions are caught as early as possible and is
+       * a key benefit of monorepos.  However there are occasional situations where
+       * installing from NPM is needed.  A classic example is a cyclic dependency.
+       * Imagine three Rush projects: "my-toolchain" depends on "my-tester", which depends
+       * on "my-library".  Suppose that we add "my-toolchain" to the "devDependencies"
+       * of "my-library" so it can be built by our toolchain.  This cycle creates
+       * a problem -- Rush can't build a project using a not-yet-built dependency.
+       * We can solve it by adding "my-toolchain" to the "decoupledLocalDependencies"
+       * of "my-library", so it builds using the last published release.  Choose carefully
+       * which package to decouple; some choices are much easier to manage than others.
+       *
+       * (In older Rush releases, this setting was called "cyclicDependencyProjects".)
        */
       "decoupledLocalDependencies": [
         /*[LINE "HYPOTHETICAL"]*/ "my-toolchain"

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -426,7 +426,7 @@
        * locally linked because it would create a cyclic dependency; instead, the last published
        * version will be installed in the Common folder.
        */
-      "cyclicDependencyProjects": [
+      "decoupledLocalDependencies": [
         /*[LINE "HYPOTHETICAL"]*/ "my-toolchain"
       ],
 

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -804,11 +804,11 @@ export class RushConfiguration {
     }
 
     for (const project of this._projects) {
-      project.cyclicDependencyProjects.forEach((cyclicDependencyProject: string) => {
-        if (!this.getProjectByName(cyclicDependencyProject)) {
+      project.decoupledLocalDependencies.forEach((decoupledLocalDependency: string) => {
+        if (!this.getProjectByName(decoupledLocalDependency)) {
           throw new Error(
-            `In rush.json, the "${cyclicDependencyProject}" project does not exist,` +
-              ` but was referenced by the cyclicDependencyProjects for ${project.packageName}`
+            `In rush.json, the "${decoupledLocalDependency}" project does not exist,` +
+              ` but was referenced by the decoupledLocalDependencies for ${project.packageName}`
           );
         }
       });

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -808,7 +808,7 @@ export class RushConfiguration {
         if (!this.getProjectByName(decoupledLocalDependency)) {
           throw new Error(
             `In rush.json, the "${decoupledLocalDependency}" project does not exist,` +
-              ` but was referenced by the decoupledLocalDependencies for ${project.packageName}`
+              ` but was referenced by the decoupledLocalDependencies (previously cyclicDependencyProjects) for ${project.packageName}`
           );
         }
       });

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -19,7 +19,8 @@ export interface IRushConfigurationProjectJson {
   packageName: string;
   projectFolder: string;
   reviewCategory?: string;
-  cyclicDependencyProjects: string[];
+  decoupledLocalDependencies: string[];
+  cyclicDependencyProjects?: string[];
   versionPolicyName?: string;
   shouldPublish?: boolean;
   skipRushCheck?: boolean;
@@ -65,7 +66,7 @@ export class RushConfigurationProject {
   private readonly _packageJsonEditor: PackageJsonEditor;
   private readonly _tempProjectName: string;
   private readonly _unscopedTempProjectName: string;
-  private readonly _cyclicDependencyProjects: Set<string>;
+  private readonly _decoupledLocalDependencies: Set<string>;
   private readonly _versionPolicyName: string | undefined;
   private readonly _shouldPublish: boolean;
   private readonly _skipRushCheck: boolean;
@@ -157,10 +158,16 @@ export class RushConfigurationProject {
     // Example: "my-project-2"
     this._unscopedTempProjectName = PackageNameParsers.permissive.getUnscopedName(tempProjectName);
 
-    this._cyclicDependencyProjects = new Set<string>();
-    if (projectJson.cyclicDependencyProjects) {
-      for (const cyclicDependencyProject of projectJson.cyclicDependencyProjects) {
-        this._cyclicDependencyProjects.add(cyclicDependencyProject);
+    this._decoupledLocalDependencies = new Set<string>();
+    if (projectJson.cyclicDependencyProjects || projectJson.decoupledLocalDependencies) {
+      if (projectJson.cyclicDependencyProjects && projectJson.decoupledLocalDependencies) {
+        throw new Error(
+          'A project cannot have both decoupledLocalDependencies as well as cyclicDependencyProjects. Please only use the decoupledLocalDependencies instead.'
+        );
+      }
+      for (const cyclicDependencyProject of projectJson.cyclicDependencyProjects ||
+        projectJson.decoupledLocalDependencies) {
+        this._decoupledLocalDependencies.add(cyclicDependencyProject);
       }
     }
     this._shouldPublish = !!projectJson.shouldPublish;
@@ -257,8 +264,8 @@ export class RushConfigurationProject {
    *
    * These are package names that would be found by RushConfiguration.getProjectByName().
    */
-  public get cyclicDependencyProjects(): Set<string> {
-    return this._cyclicDependencyProjects;
+  public get decoupledLocalDependencies(): Set<string> {
+    return this._decoupledLocalDependencies;
   }
 
   /**
@@ -301,7 +308,7 @@ export class RushConfigurationProject {
             // Skip if we can't find the local project or it's a cyclic dependency
             const localProject: RushConfigurationProject | undefined =
               this._rushConfiguration.getProjectByName(dependency);
-            if (localProject && !this._cyclicDependencyProjects.has(dependency)) {
+            if (localProject && !this._decoupledLocalDependencies.has(dependency)) {
               // Set the value if it's a workspace project, or if we have a local project and the semver is satisfied
               const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
               switch (dependencySpecifier.specifierType) {

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -162,7 +162,7 @@ export class RushConfigurationProject {
     if (projectJson.cyclicDependencyProjects || projectJson.decoupledLocalDependencies) {
       if (projectJson.cyclicDependencyProjects && projectJson.decoupledLocalDependencies) {
         throw new Error(
-          'A project cannot have both decoupledLocalDependencies as well as cyclicDependencyProjects. Please only use the decoupledLocalDependencies instead.'
+          'A project configuration cannot have both decoupledLocalDependencies as well as cyclicDependencyProjects fields. Please only use the decoupledLocalDependencies configuration instead.'
         );
       }
       for (const cyclicDependencyProject of projectJson.cyclicDependencyProjects ||

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -269,6 +269,19 @@ export class RushConfigurationProject {
   }
 
   /**
+   * A list of local projects that appear as devDependencies for this project, but cannot be
+   * locally linked because it would create a cyclic dependency; instead, the last published
+   * version will be installed in the Common folder.
+   *
+   * These are package names that would be found by RushConfiguration.getProjectByName().
+   *
+   * @deprecated Use `decoupledLocalDependencies` instead, as it better describes the purpose of the data.
+   */
+  public get cyclicDependencyProjects(): Set<string> {
+    return this._decoupledLocalDependencies;
+  }
+
+  /**
    * An array of projects within the Rush configuration which directly depend on this package.
    * @deprecated Use `consumingProjectNames` instead, as it has Set semantics, which better reflect the nature
    * of the data.

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -162,7 +162,7 @@ export class RushConfigurationProject {
     if (projectJson.cyclicDependencyProjects || projectJson.decoupledLocalDependencies) {
       if (projectJson.cyclicDependencyProjects && projectJson.decoupledLocalDependencies) {
         throw new Error(
-          'A project configuration cannot have both decoupledLocalDependencies as well as cyclicDependencyProjects fields. Please only use the decoupledLocalDependencies configuration instead.'
+          'A project configuration cannot specify both "decoupledLocalDependencies" and "cyclicDependencyProjects". Please use "decoupledLocalDependencies" only -- the other name is deprecated.'
         );
       }
       for (const cyclicDependencyProject of projectJson.cyclicDependencyProjects ||

--- a/libraries/rush-lib/src/api/test/VersionMismatchFinder.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionMismatchFinder.test.ts
@@ -23,7 +23,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -36,7 +36,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -56,7 +56,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -69,7 +69,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -93,7 +93,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>(['@types/foo'])
+      decoupledLocalDependencies: new Set<string>(['@types/foo'])
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -106,7 +106,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -126,7 +126,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -139,7 +139,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -160,7 +160,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -173,7 +173,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectC: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'C',
@@ -186,7 +186,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectD: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'D',
@@ -199,7 +199,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([
@@ -231,7 +231,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -244,7 +244,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectC: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'C',
@@ -257,7 +257,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB, projectC]);
@@ -282,7 +282,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -295,7 +295,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -320,7 +320,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -333,7 +333,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -352,7 +352,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -365,7 +365,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder([projectA, projectB]);
@@ -389,7 +389,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderProject({
       packageName: 'B',
@@ -402,7 +402,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
 
     const alternatives: Map<string, ReadonlyArray<string>> = new Map<string, ReadonlyArray<string>>();
@@ -427,7 +427,7 @@ describe(VersionMismatchFinder.name, () => {
         } as any,
         'foo.json'
       ),
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     } as any as RushConfigurationProject);
     const projectB: VersionMismatchFinderEntity = new VersionMismatchFinderCommonVersions(
       CommonVersionsConfiguration.loadFromFile(`${__dirname}/jsonFiles/common-versions.json`)

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -98,7 +98,7 @@ export class DependencyAnalyzer {
           this._rushConfiguration.getProjectByName(dependencyName);
         if (localProject) {
           if (
-            !project.cyclicDependencyProjects.has(dependencyName) &&
+            !project.decoupledLocalDependencies.has(dependencyName) &&
             semver.satisfies(localProject.packageJson.version, dependencyVersion)
           ) {
             // For now, ignore local dependencies (that aren't cyclic dependencies).

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -553,7 +553,7 @@ export class PackageJsonUpdater {
           continue;
         }
 
-        if (foundProject.cyclicDependencyProjects.has(rushProject.packageName)) {
+        if (foundProject.decoupledLocalDependencies.has(rushProject.packageName)) {
           continue;
         }
 
@@ -595,7 +595,7 @@ export class PackageJsonUpdater {
 
     const project: RushConfigurationProject = projects[0];
 
-    if (project.cyclicDependencyProjects.has(foundProject.packageName)) {
+    if (project.decoupledLocalDependencies.has(foundProject.packageName)) {
       return undefined;
     }
 

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -456,7 +456,7 @@ export class PublishUtilities {
     dependencyName: string
   ): boolean {
     const packageConfig: RushConfigurationProject | undefined = allPackages.get(packageName);
-    return !!packageConfig && packageConfig.cyclicDependencyProjects.has(dependencyName);
+    return !!packageConfig && packageConfig.decoupledLocalDependencies.has(dependencyName);
   }
 
   private static _updateDependencies(

--- a/libraries/rush-lib/src/logic/VersionManager.ts
+++ b/libraries/rush-lib/src/logic/VersionManager.ts
@@ -291,7 +291,7 @@ export class VersionManager {
     let updated: boolean = false;
     this._updatedProjects.forEach((updatedDependentProject, updatedDependentProjectName) => {
       if (dependencies[updatedDependentProjectName]) {
-        if (rushProject.cyclicDependencyProjects.has(updatedDependentProjectName)) {
+        if (rushProject.decoupledLocalDependencies.has(updatedDependentProjectName)) {
           // Skip if cyclic
           console.log(`Found cyclic ${rushProject.packageName} ${updatedDependentProjectName}`);
           return;

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -226,8 +226,8 @@ export class RushInstallManager extends BaseInstallManager {
           this.rushConfiguration.getProjectByName(packageName);
 
         if (localProject) {
-          // Don't locally link if it's listed in the cyclicDependencyProjects
-          if (!rushProject.cyclicDependencyProjects.has(packageName)) {
+          // Don't locally link if it's listed in the decoupledLocalDependencies
+          if (!rushProject.decoupledLocalDependencies.has(packageName)) {
             // Also, don't locally link if the SemVer doesn't match
             const localProjectVersion: string = localProject.packageJsonEditor.version;
             if (semver.satisfies(localProjectVersion, packageVersion)) {

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -158,7 +158,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           (dependencySpecifier.specifierType === DependencySpecifierType.Version ||
             dependencySpecifier.specifierType === DependencySpecifierType.Range) &&
           referencedLocalProject &&
-          !rushProject.cyclicDependencyProjects.has(name)
+          !rushProject.decoupledLocalDependencies.has(name)
         ) {
           // Make sure that this version is intended to target a local package. If not, then we will fail since it
           // is not explicitly specified as a cyclic dependency.

--- a/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -23,7 +23,7 @@ interface IQueueItem {
   // A symlinked virtual package that we will create somewhere under "this-project/node_modules"
   localPackage: NpmPackage;
 
-  // If we encounter a dependency listed in cyclicDependencyProjects, this will be set to the root
+  // If we encounter a dependency listed in decoupledLocalDependencies, this will be set to the root
   // of the localPackage subtree where we will stop creating local links.
   cyclicSubtreeRoot: NpmPackage | undefined;
 }
@@ -141,7 +141,7 @@ export class NpmLinkManager extends BaseLinkManager {
       // where "this-project" corresponds to the "project" parameter for linkProject().
       const localPackage: NpmPackage = queueItem.localPackage;
 
-      // If we encounter a dependency listed in cyclicDependencyProjects, this will be set to the root
+      // If we encounter a dependency listed in decoupledLocalDependencies, this will be set to the root
       // of the localPackage subtree where we will stop creating local links.
       const cyclicSubtreeRoot: NpmPackage | undefined = queueItem.cyclicSubtreeRoot;
 
@@ -163,10 +163,10 @@ export class NpmLinkManager extends BaseLinkManager {
           // to create a local link?
           if (cyclicSubtreeRoot) {
             // DO NOT create a local link, because this is part of an existing
-            // cyclicDependencyProjects subtree
-          } else if (project.cyclicDependencyProjects.has(dependency.name)) {
+            // decoupledLocalDependencies subtree
+          } else if (project.decoupledLocalDependencies.has(dependency.name)) {
             // DO NOT create a local link, because we are starting a new
-            // cyclicDependencyProjects subtree
+            // decoupledLocalDependencies subtree
             startingCyclicSubtree = true;
           } else if (
             dependency.kind !== PackageDependencyKind.LocalLink &&
@@ -232,7 +232,7 @@ export class NpmLinkManager extends BaseLinkManager {
             // Perform normal module resolution.
             resolution = localPackage.resolveOrCreate(dependency.name);
           } else {
-            // We are inside a cyclicDependencyProjects subtree (i.e. cyclicSubtreeRoot != undefined),
+            // We are inside a decoupledLocalDependencies subtree (i.e. cyclicSubtreeRoot != undefined),
             // and the dependency is a local project (i.e. matchedRushPackage != undefined), so
             // we use a special module resolution strategy that places everything under the
             // cyclicSubtreeRoot.

--- a/libraries/rush-lib/src/logic/npm/NpmPackage.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmPackage.ts
@@ -184,7 +184,7 @@ export class NpmPackage extends BasePackage {
    * or was found with an incompatible version.
    *
    * "cyclicSubtreeRoot" is a special optional parameter that specifies a different
-   * root for the tree; the cyclicDependencyProjects feature uses this to isolate
+   * root for the tree; the decoupledLocalDependencies feature uses this to isolate
    * certain devDependencies in their own subtree.
    */
   public resolveOrCreate(dependencyName: string, cyclicSubtreeRoot?: NpmPackage): IResolveOrCreateResult {

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -142,7 +142,7 @@ function calculateCriticalPathLength(
           .map((visitedTask) => visitedTask.name)
           .reverse()
           .join('\n  -> ') +
-        '\nConsider using the cyclicDependencyProjects option for rush.json.'
+        '\nConsider using the decoupledLocalDependencies option for rush.json.'
     );
   }
 

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/AsyncOperationQueue.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/AsyncOperationQueue.test.ts.snap
@@ -7,5 +7,5 @@ exports[`AsyncOperationQueue detects cyles 1`] = `
   -> d
   -> b
   -> a
-Consider using the cyclicDependencyProjects option for rush.json."
+Consider using the decoupledLocalDependencies option for rush.json."
 `;

--- a/libraries/rush-lib/src/logic/test/packages/rush.json
+++ b/libraries/rush-lib/src/logic/test/packages/rush.json
@@ -93,7 +93,7 @@
       "projectFolder": "cyclic-dep-explicit-2",
       "reviewCategory": "third-party",
       "shouldPublish": true,
-      "cyclicDependencyProjects": ["cyclic-dep-explicit-1"]
+      "decoupledLocalDependencies": ["cyclic-dep-explicit-1"]
     }
   ]
 }

--- a/libraries/rush-lib/src/logic/test/workspacePackages/rush.json
+++ b/libraries/rush-lib/src/logic/test/workspacePackages/rush.json
@@ -93,7 +93,7 @@
       "projectFolder": "cyclic-dep-explicit-2",
       "reviewCategory": "third-party",
       "shouldPublish": true,
-      "cyclicDependencyProjects": ["cyclic-dep-explicit-1"]
+      "decoupledLocalDependencies": ["cyclic-dep-explicit-1"]
     }
   ]
 }

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -249,7 +249,7 @@ export class VersionMismatchFinder {
           if (dependency.dependencyType !== DependencyType.Peer) {
             const version: string = dependency.version!;
 
-            const isCyclic: boolean = project.cyclicDependencyProjects.has(dependency.name);
+            const isCyclic: boolean = project.decoupledLocalDependencies.has(dependency.name);
 
             if (this._isVersionAllowedAlternative(dependency.name, version)) {
               return;

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
@@ -12,7 +12,7 @@ export class VersionMismatchFinderCommonVersions extends VersionMismatchFinderEn
   public constructor(commonVersionsConfiguration: CommonVersionsConfiguration) {
     super({
       friendlyName: `preferred versions from ${RushConstants.commonVersionsFilename}`,
-      cyclicDependencyProjects: new Set<string>()
+      decoupledLocalDependencies: new Set<string>()
     });
 
     this._fileManager = commonVersionsConfiguration;

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderEntity.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderEntity.ts
@@ -5,18 +5,18 @@ import { PackageJsonDependency, DependencyType } from '../../api/PackageJsonEdit
 
 export interface IVersionMismatchFinderEntityOptions {
   friendlyName: string;
-  cyclicDependencyProjects: Set<string>;
+  decoupledLocalDependencies: Set<string>;
   skipRushCheck?: boolean;
 }
 
 export abstract class VersionMismatchFinderEntity {
   public readonly friendlyName: string;
-  public readonly cyclicDependencyProjects: Set<string>;
+  public readonly decoupledLocalDependencies: Set<string>;
   public readonly skipRushCheck: boolean | undefined;
 
   public constructor(options: IVersionMismatchFinderEntityOptions) {
     this.friendlyName = options.friendlyName;
-    this.cyclicDependencyProjects = options.cyclicDependencyProjects;
+    this.decoupledLocalDependencies = options.decoupledLocalDependencies;
     this.skipRushCheck = options.skipRushCheck;
   }
 

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderProject.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderProject.ts
@@ -12,7 +12,7 @@ export class VersionMismatchFinderProject extends VersionMismatchFinderEntity {
   public constructor(project: RushConfigurationProject) {
     super({
       friendlyName: project.packageName,
-      cyclicDependencyProjects: project.cyclicDependencyProjects,
+      decoupledLocalDependencies: project.decoupledLocalDependencies,
       skipRushCheck: project.skipRushCheck
     });
 

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -263,7 +263,7 @@
             "type": "string"
           },
           "cyclicDependencyProjects": {
-            "description": "[depreciated] A list of local projects that appear as devDependencies for this project, but cannot be locally linked because it would create a cyclic dependency; instead, the last published version will be installed in the Common folder.",
+            "description": "(Deprecated) This field was renamed to \"decoupledLocalDependencies\".",
             "type": "array",
             "items": {
               "type": "string"

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -263,6 +263,13 @@
             "type": "string"
           },
           "cyclicDependencyProjects": {
+            "description": "[depreciated] A list of local projects that appear as devDependencies for this project, but cannot be locally linked because it would create a cyclic dependency; instead, the last published version will be installed in the Common folder.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "decoupledLocalDependencies": {
             "description": "A list of local projects that appear as devDependencies for this project, but cannot be locally linked because it would create a cyclic dependency; instead, the last published version will be installed in the Common folder.",
             "type": "array",
             "items": {

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -26,7 +26,7 @@ export class BumpCyclicsAction extends CommandLineAction {
     const cyclicDependencyNames: Set<string> = new Set<string>();
 
     for (const project of rushConfiguration.projects) {
-      for (const cyclicDependencyProject of project.cyclicDependencyProjects) {
+      for (const cyclicDependencyProject of project.decoupledLocalDependencies) {
         cyclicDependencyNames.add(cyclicDependencyProject);
       }
     }
@@ -46,7 +46,7 @@ export class BumpCyclicsAction extends CommandLineAction {
     terminal.writeLine();
 
     for (const project of rushConfiguration.projects) {
-      for (const cyclicDependencyProject of project.cyclicDependencyProjects) {
+      for (const cyclicDependencyProject of project.decoupledLocalDependencies) {
         const version: string = cyclicDependencyVersions.get(cyclicDependencyProject)!;
         if (project.packageJsonEditor.tryGetDependency(cyclicDependencyProject)) {
           project.packageJsonEditor.addOrUpdateDependency(

--- a/rush.json
+++ b/rush.json
@@ -407,7 +407,7 @@
     //    * locally linked because it would create a cyclic dependency; instead, the last published
     //    * version will be installed in the Common folder.
     //    */
-    //   "cyclicDependencyProjects": [
+    //   "decoupledLocalDependencies": [
     //     // "my-toolchain"
     //   ],
     //


### PR DESCRIPTION
## Summary
The previous name cyclicDependencyProjects was primarily used to handle cyclic dependency references, but there are other instances in which a developer may want to use this configuration, for example:

1. An intermediary state during a migration: For example, we're upgrading projects to the latest version of a library, but it's impractical to do all that work in a single MR. For a short time, some projects build using an old version of the library (from NPM) whereas the already migrated projects build using the latest "workspace:" version
2. A retired project: An old project is kept alive in the "master" branch, but it is not being actively developed any more. To avoid having to constantly upgrade its dependencies, we may choose to install older versions.

Considering these cases, the "cyclic" name may not be the most intuitive setting name, instead we can opt to use the decoupledLocalDependencies suggested in the issue.

Fixes #547 

## Details

This change changes all references in the rushstack repo to use the new decoupledLocalDependencies syntax, except for where it is handling the backwards compatibility:

This change offers backwards compatibility, so that developers can continue using the cyclicDependencyProjects setting as well as the new decoupledLocalDependencies, although an error will be thrown if both are included in the project configuration.

This change does not impact performance

## How it was tested
Manual Testing:
Invoked the process of 'rush install' + 'rush build' with the rush-example repo, and confirmed that local linking was avoided with the decoupledLocalDependencies configuration. Also confirmed that an error will be thrown when both cyclicDependencyProjects and decoupledLocalDependencies configurations are added.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
