### PR TITLE
[heft] Fix an issue with the --locale parameter.

### DIFF
--- a/apps/heft/src/stages/BuildStage.ts
+++ b/apps/heft/src/stages/BuildStage.ts
@@ -233,10 +233,11 @@ export class BuildStage extends StageBase<BuildStageHooks, IBuildStageProperties
   public static getOptionsFromStandardParameters(
     standardParameters: IBuildStageStandardParameters
   ): Omit<IBuildStageOptions, 'watchMode' | 'serveMode'> {
+    const localesParameterValues: readonly string[] = standardParameters.localesParameter.values;
     return {
       production: standardParameters.productionFlag.value,
       lite: standardParameters.liteFlag.value,
-      locales: standardParameters.localesParameter.values,
+      locales: localesParameterValues.length > 0 ? localesParameterValues : undefined,
       maxOldSpaceSize: standardParameters.maxOldSpaceSizeParameter.value,
       typescriptMaxWriteParallelism: standardParameters.typescriptMaxWriteParallelismParameter.value
     };

--- a/common/changes/@rushstack/heft/fix-locales-parameter-quirk_2022-07-02-23-57.json
+++ b/common/changes/@rushstack/heft/fix-locales-parameter-quirk_2022-07-02-23-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue with the `locales` build property. The property is now undefined if no `--locale` parameters are specified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
When I changed the `--locale` parameter to a string list parameter, I didn't only set the `locales` build property if the parameter was actually specified. This made updating dependent plugins somewhat confusing, as one could no longer just check if `locales` was `undefined` to see that none had been specified.

This PR changes that back to be more similar to how it worked before by setting an array of locales in the `locales` property iff locales were actually specified on the CLI.