### PR TITLE
[rush] Separate the initial repo analysis from the first project's build.

### DIFF
--- a/common/changes/@microsoft/rush/separate-repo-analysis_2022-07-03-23-08.json
+++ b/common/changes/@microsoft/rush/separate-repo-analysis_2022-07-03-23-08.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Put the repo analysis in a separate step to before operations begin to not aftifically extend the amount of time the first project appears to take to run.",
+      "comment": "Reorder some initialization logic so that Rush's change analysis is not counted as part of the build time for the first project",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/separate-repo-analysis_2022-07-03-23-08.json
+++ b/common/changes/@microsoft/rush/separate-repo-analysis_2022-07-03-23-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Put the repo analysis in a separate step to before operations begin to not aftifically extend the amount of time the first project appears to take to run.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -650,6 +650,10 @@ export type PnpmStoreOptions = 'local' | 'global';
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {
     constructor(rushConfiguration: RushConfiguration);
+    // Warning: (ae-forgotten-export) The symbol "IRawRepoState" needs to be exported by the entry point index.d.ts
+    //
+    // @internal (undocumented)
+    _ensureInitialized(terminal: ITerminal): IRawRepoState | undefined;
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
     getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -217,6 +217,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       customParametersByName.set(configParameter.longName, parserParameter);
     }
 
+    const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const initialCreateOperationsContext: ICreateOperationsContext = {
       buildCacheConfiguration,
       customParameters: customParametersByName,
@@ -225,7 +226,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       isWatch,
       rushConfiguration: this.rushConfiguration,
       phaseSelection: new Set(this._initialPhases),
-      projectChangeAnalyzer: new ProjectChangeAnalyzer(this.rushConfiguration),
+      projectChangeAnalyzer,
       projectSelection,
       projectsInUnknownState: projectSelection
     };
@@ -243,6 +244,14 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       stopwatch,
       terminal
     };
+
+    terminal.write('Analyzing repo state... ');
+    const repoStateStopwatch: Stopwatch = new Stopwatch();
+    repoStateStopwatch.start();
+    projectChangeAnalyzer._ensureInitialized(terminal);
+    repoStateStopwatch.stop();
+    terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
+    terminal.writeLine();
 
     await this._runInitialPhases(internalOptions);
 

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -93,15 +93,13 @@ export class ProjectChangeAnalyzer {
       return filteredProjectData;
     }
 
-    if (this._data === UNINITIALIZED) {
-      this._data = this._getData(terminal);
-    }
+    const data: IRawRepoState | undefined = this._ensureInitialized(terminal);
 
-    if (!this._data) {
+    if (!data) {
       return undefined;
     }
 
-    const { projectState, rootDir } = this._data;
+    const { projectState, rootDir } = data;
 
     if (projectState === undefined) {
       return undefined;
@@ -121,6 +119,17 @@ export class ProjectChangeAnalyzer {
 
     this._filteredData.set(project, filteredProjectData);
     return filteredProjectData;
+  }
+
+  /**
+   * @internal
+   */
+  public _ensureInitialized(terminal: ITerminal): IRawRepoState | undefined {
+    if (this._data === UNINITIALIZED) {
+      this._data = this._getData(terminal);
+    }
+
+    return this._data;
   }
 
   /**


### PR DESCRIPTION
## Summary

Currently, running `rush build --to rush-lib` in this repo prints a log that looks like this (annotations added):

```
Rush Multi-Project Build Tool 5.75.0 - https://rushjs.io
Node.js version is 14.19.1 (LTS)

Found configuration in E:\code\rushstack8\rush.json

Starting "rush build"

Executing a maximum of 8 simultaneous processes...

==[ @rushstack/tree-pattern (build) ]=============================[ 1 of 23 ]==
<< ABOUT A 1 SECOND WAIT >>
"@rushstack/tree-pattern (build)" was restored from the build cache.

==[ @rushstack/eslint-patch (build) ]=============================[ 2 of 23 ]==
"@rushstack/eslint-patch (build)" was restored from the build cache.

==[ @rushstack/eslint-plugin-security (build) ]===================[ 3 of 23 ]==
"@rushstack/eslint-plugin-security (build)" was restored from the build cache.

...
```

The 1-second wait during the first project's build is Rush getting the current repo state. In this repo, it isn't too bad, but in larger repos, it can take a few seconds.

This PR explicitly initializes `ProjectChangeAnalyzer` before projects start to run to not artificially add time to the first project's apparent execution. With this PR, the log looks like this:

```diff
Rush Multi-Project Build Tool 5.75.0 (unmanaged) - https://rushjs.io
Node.js version is 14.19.1 (LTS)

Found configuration in E:\code\rushstack8\rush.json

Starting "rush build"

+Analyzing repo state... DONE (1.01 seconds)
+
Executing a maximum of 8 simultaneous processes...

==[ @rushstack/tree-pattern (build) ]=============================[ 1 of 19 ]==
-<< ABOUT A 1 SECOND WAIT >>
"@rushstack/tree-pattern (build)" was restored from the build cache.

==[ @rushstack/eslint-patch (build) ]=============================[ 2 of 19 ]==
"@rushstack/eslint-patch (build)" was restored from the build cache.

==[ @rushstack/eslint-plugin-security (build) ]===================[ 3 of 19 ]==
"@rushstack/eslint-plugin-security (build)" was restored from the build cache.

...
```

## How it was tested

Tested by running builds in this repo and another, much larger repo.