### PR TITLE
Update `api-extractor-template.json` and reorder some property signatures.

### DIFF
--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -358,6 +358,35 @@ export interface IConfigFile {
   bundledPackages?: string[];
 
   /**
+   * Specifies what type of newlines API Extractor should use when writing output files.
+   *
+   * @remarks
+   * By default, the output files will be written with Windows-style newlines.
+   * To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   */
+  newlineKind?: 'crlf' | 'lf' | 'os';
+
+  /**
+   * Set to true when invoking API Extractor's test harness.
+   * @remarks
+   * When `testMode` is true, the `toolVersion` field in the .api.json file is assigned an empty string
+   * to prevent spurious diffs in output files tracked for tests.
+   */
+  testMode?: boolean;
+
+  /**
+   * Specifies how API Extractor sorts members of an enum when generating api.json.
+   *
+   * @remarks
+   * By default, the output files will be sorted alphabetically, which is "by-name".
+   * To keep the ordering in the source code, specify "preserve".
+   *
+   * @defaultValue `by-name`
+   */
+  enumMemberOrder?: EnumMemberOrder;
+
+  /**
    * {@inheritDoc IConfigCompiler}
    */
   compiler?: IConfigCompiler;
@@ -385,36 +414,7 @@ export interface IConfigFile {
   tsdocMetadata?: IConfigTsdocMetadata;
 
   /**
-   * Specifies what type of newlines API Extractor should use when writing output files.
-   *
-   * @remarks
-   * By default, the output files will be written with Windows-style newlines.
-   * To use POSIX-style newlines, specify "lf" instead.
-   * To use the OS's default newline kind, specify "os".
-   */
-  newlineKind?: 'crlf' | 'lf' | 'os';
-
-  /**
    * {@inheritDoc IExtractorMessagesConfig}
    */
   messages?: IExtractorMessagesConfig;
-
-  /**
-   * Set to true when invoking API Extractor's test harness.
-   * @remarks
-   * When `testMode` is true, the `toolVersion` field in the .api.json file is assigned an empty string
-   * to prevent spurious diffs in output files tracked for tests.
-   */
-  testMode?: boolean;
-
-  /**
-   * Specifies how API Extractor sorts members of an enum when generating api.json.
-   * 
-   * @remarks
-   * By default, the output files will be sorted alphabetically, which is "by-name".
-   * To keep the ordering in the source code, specify "preserve".
-   *
-   * @defaultValue `by-name`
-   */
-   enumMemberOrder?: EnumMemberOrder;
 }

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -373,4 +373,24 @@
       // . . .
     }
   }
+
+  /**
+   * Set to true when invoking API Extractor's test harness.
+   *
+   * When `testMode` is true, the `toolVersion` field in the .api.json file is assigned an empty string
+   * to prevent spurious diffs in output files tracked for tests.
+   *
+   * DEFAULT VALUE: "false"
+   */
+  // "testMode": false,
+
+  /**
+   * Specifies how API Extractor sorts members of an enum when generating api.json.
+   *
+   * By default, the output files will be sorted alphabetically, which is "by-name".
+   * To keep the ordering in the source code, specify "preserve".
+   *
+   * DEFAULT VALUE: "by-name"
+   */
+  // enumMemberOrder?: EnumMemberOrder
 }

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -63,6 +63,31 @@
   "bundledPackages": [],
 
   /**
+   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   *
+   * DEFAULT VALUE: "crlf"
+   */
+  // "newlineKind": "crlf",
+
+  /**
+   * Set to true when invoking API Extractor's test harness. When `testMode` is true, the `toolVersion` field in the
+   * .api.json file is assigned an empty string to prevent spurious diffs in output files tracked for tests.
+   *
+   * DEFAULT VALUE: "false"
+   */
+  // "testMode": false,
+
+  /**
+   * Specifies how API Extractor sorts members of an enum when generating api.json. By default, the output files
+   * will be sorted alphabetically, which is "by-name". To keep the ordering in the source code, specify "preserve".
+   *
+   * DEFAULT VALUE: "by-name"
+   */
+  // enumMemberOrder?: EnumMemberOrder,
+
+  /**
    * Determines how the TypeScript compiler engine will be invoked by API Extractor.
    */
   "compiler": {
@@ -272,15 +297,6 @@
   },
 
   /**
-   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
-   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
-   * To use the OS's default newline kind, specify "os".
-   *
-   * DEFAULT VALUE: "crlf"
-   */
-  // "newlineKind": "crlf",
-
-  /**
    * Configures how API Extractor reports error and warning messages produced during analysis.
    *
    * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.
@@ -373,24 +389,4 @@
       // . . .
     }
   }
-
-  /**
-   * Set to true when invoking API Extractor's test harness.
-   *
-   * When `testMode` is true, the `toolVersion` field in the .api.json file is assigned an empty string
-   * to prevent spurious diffs in output files tracked for tests.
-   *
-   * DEFAULT VALUE: "false"
-   */
-  // "testMode": false,
-
-  /**
-   * Specifies how API Extractor sorts members of an enum when generating api.json.
-   *
-   * By default, the output files will be sorted alphabetically, which is "by-name".
-   * To keep the ordering in the source code, specify "preserve".
-   *
-   * DEFAULT VALUE: "by-name"
-   */
-  // enumMemberOrder?: EnumMemberOrder
 }

--- a/common/changes/@microsoft/api-extractor/api-extractor-docs_2022-07-06-23-04.json
+++ b/common/changes/@microsoft/api-extractor/api-extractor-docs_2022-07-06-23-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Update api-extractor-template.json to \"testMode\" and \"enumMemberOrder\" comment sections.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
Moved all top-level settings to the same place in `api-extractor-template.json` and associated interfaces.

See associated https://github.com/microsoft/api-extractor.com-website/pull/49.