### PR TITLE
[rush] Add validation for "shouldPublish" / "private: true"

### DIFF
--- a/common/changes/@microsoft/rush/enelson-should-publish_2022-07-10-04-59.json
+++ b/common/changes/@microsoft/rush/enelson-should-publish_2022-07-10-04-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Validate that if shouldPublish is set, private is not set",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -174,6 +174,13 @@ export class RushConfigurationProject {
     this._skipRushCheck = !!projectJson.skipRushCheck;
     this._versionPolicyName = projectJson.versionPolicyName;
 
+    if (this._shouldPublish && this._packageJson.private) {
+      throw new Error(
+        `The project "${projectJson.packageName}" specifies "shouldPublish": true, ` +
+          `but the package.json file specifies "private": true.`
+      );
+    }
+
     this._publishFolder = this._projectFolder;
     if (projectJson.publishFolder) {
       this._publishFolder = path.join(this._publishFolder, projectJson.publishFolder);


### PR DESCRIPTION
## Summary

More than once now, we've had a situation where a developer creates a new published library or tool in the monorepo, everything is reviewed and merged successfully, and then later that day the publishing pipeline fails -- because the new package has `shouldPublish: true`, but the `package.json` file (due to copy/paste fail) has `private: true`.

If Rush validated this immediately, the way it does several other fields in `rush.json`/`package.json`, it would be detectable before the PR is merged.

## Details

Followed basic pattern for existing validations inside the constructor.

I think this implementation fits the bill pretty well _if you use rush to publish as designed_.

This change could be a regression for users that use `shouldPublish: true` to activate rush changefile / changelog use cases, but don't publish the package to _NPM_ (maybe they publish to some other type of registry). If we do have such users, then there would need to be a way to override or bypass this error... or maybe in this case, even if they don't publish to NPM, the `private: true` setting is misleading and should error anyway? Open to input on this point.

## How it was tested

 - Tested that behavior works as expected by toggling rush.json / package.json fields in our monorepo.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
