### PR TITLE
[api-extractor] Fix error for export star from ambient module

### DIFF
--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.md
@@ -11,6 +11,7 @@ export class A {
 
 export * from "api-extractor-lib1-test";
 export * from "api-extractor-lib2-test";
+export * from "fs";
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/rollup.d.ts
@@ -5,5 +5,6 @@ export declare class A {
 
 export * from "api-extractor-lib1-test";
 export * from "api-extractor-lib2-test";
+export * from "fs";
 
 export { }

--- a/build-tests/api-extractor-scenarios/src/exportStar2/index.ts
+++ b/build-tests/api-extractor-scenarios/src/exportStar2/index.ts
@@ -4,3 +4,4 @@
 export * from './reexportStar';
 
 export * from 'api-extractor-lib2-test';
+export * from 'fs';

--- a/common/changes/@microsoft/api-extractor/hotfix-export-star-ambient_2022-07-10-10-22.json
+++ b/common/changes/@microsoft/api-extractor/hotfix-export-star-ambient_2022-07-10-10-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix error for export star from ambient module",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Handle `export * from '<ambient module>'` when rollup `.d.ts`.

For example, there has `export * from 'fs'` statement in the [`@types/fs-extra`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/fs-extra/index.d.ts#L21), and the `fs` is an ambient module of `@types/node`, we will get the following error when running api-extractor: 

```bash
InternalError: Internal Error: getResolvedModule() could not resolve module name "fs"
```

Ref issue: #3335 
Ref PR: #3339 

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

The solutions is, catch the resolve error and fallback to append a fake external `AstModule`, then handle it in the `_collectAllExportsRecursive` method.

Why use `try...catch`? The `TypeScriptHelpers.isAmbient` cannot working for this, is there a more precise way than `try...catch`?

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Add `export * from 'fs'` into `build-tests/api-extractor-scenarios/src/exportStar2/index.ts`, and make sure it can be rollup successfully.

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
