### PR TITLE
Upgrade node-forge to 1.3.1

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/upgrade-node-forge_2022-07-13-18-09.json
+++ b/common/changes/@rushstack/debug-certificate-manager/upgrade-node-forge_2022-07-13-18-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Upgrade node-forge to 1.3.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1555,12 +1555,12 @@ importers:
       '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@types/node-forge': 0.10.2
-      node-forge: ~0.10.0
+      '@types/node-forge': 1.0.4
+      node-forge: ~1.3.1
       sudo: ~1.0.3
     dependencies:
       '@rushstack/node-core-library': link:../node-core-library
-      node-forge: 0.10.0
+      node-forge: 1.3.1
       sudo: 1.0.3
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -1568,7 +1568,7 @@ importers:
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@types/node-forge': 0.10.2
+      '@types/node-forge': 1.0.4
 
   ../../libraries/heft-config-file:
     specifiers:
@@ -6999,8 +6999,8 @@ packages:
       '@types/node': 12.20.24
       form-data: 3.0.1
 
-  /@types/node-forge/0.10.2:
-    resolution: {integrity: sha512-nEWO3mkJ1j7eGxGUu32jaGFJj+YSvUt/zG4sEAXbUDbjkQMf9u98Bf3peC4oGFR3zA1n3M3KaXcw6xQyZpl5jg==}
+  /@types/node-forge/1.0.4:
+    resolution: {integrity: sha512-UpX8LTRrarEZPQvQqF5/6KQAqZolOVckH7txWdlsWIJrhBFFtwEUTcqeDouhrJl6t0F7Wg5cyUOAqqF8a6hheg==}
     dependencies:
       '@types/node': 12.20.24
     dev: true
@@ -15069,11 +15069,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-
-  /node-forge/0.10.0:
-    resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
-    engines: {node: '>= 6.0.0'}
-    dev: false
 
   /node-forge/1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b9f69e99bdf1d598831ea90911305c15a5d15e28",
+  "pnpmShrinkwrapHash": "e7471b6ff2ef2d38196f13a9dcc7838b73bd75da",
   "preferredVersionsHash": "d2a5d015a5e5f4861bc36581c3c08cb789ed7fab"
 }

--- a/libraries/debug-certificate-manager/package.json
+++ b/libraries/debug-certificate-manager/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
-    "node-forge": "~0.10.0",
+    "node-forge": "~1.3.1",
     "sudo": "~1.0.3"
   },
   "devDependencies": {
@@ -25,6 +25,6 @@
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "12.20.24",
-    "@types/node-forge": "0.10.2"
+    "@types/node-forge": "1.0.4"
   }
 }


### PR DESCRIPTION
## Summary
Upgrades the dependency on `node-forge` from `0.10.0` to `1.3.1` in `@rushstack/debug-certificate-manager`.

## Details
See above.

## How it was tested
Untrusted and retrusted the dev cert using the dev cert plugin.