### PR TITLE
[heft] Add .d.ts shims for secondary module kinds

### DIFF
--- a/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/TypeScriptBuilder.ts
@@ -1047,6 +1047,11 @@ export class TypeScriptBuilder extends SubprocessRunnerBase<ITypeScriptBuilderCo
       tsconfig.options.tsBuildInfoFile = this._tsCacheFilePath;
     }
 
+    if (tsconfig.options.declaration && !tsconfig.options.declarationDir) {
+      // Explicitly set the declarationDir for multi-emit tracking
+      tsconfig.options.declarationDir = tsconfig.options.outDir;
+    }
+
     return tsconfig;
   }
 

--- a/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
+++ b/apps/heft/src/plugins/TypeScriptPlugin/internalTypings/TypeScriptInternals.ts
@@ -37,6 +37,13 @@ export interface IExtendedSourceFile extends TTypescript.SourceFile {
    * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/types.ts#L3011
    */
   version: string;
+
+  /**
+   * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/types.ts#L657
+   */
+  symbol: {
+    exports: Map<string, unknown>;
+  };
 }
 
 /**
@@ -138,6 +145,16 @@ export interface IExtendedTypeScript {
     fileName: string,
     referencePath?: string
   ): string;
+
+  /**
+   * https://github.com/microsoft/TypeScript/blob/7f022c58fb8b7253f23c49f0d9eee6fde82b477b/src/compiler/path.ts#L808
+   */
+  getRelativePathFromDirectory(fromDirectory: string, to: string, ignoreCase: boolean): string;
+
+  /**
+   * https://github.com/microsoft/TypeScript/blob/7f022c58fb8b7253f23c49f0d9eee6fde82b477b/src/compiler/path.ts#L263
+   */
+  getDirectoryPath(path: string): string;
 
   Diagnostics: {
     // https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/diagnosticMessages.json#L4252-L4255

--- a/common/changes/@rushstack/heft/typescript-dts-shims_2022-07-14-23-20.json
+++ b/common/changes/@rushstack/heft/typescript-dts-shims_2022-07-14-23-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add code to emit .d.ts shims in secondary output directories that redirect to the main declarationDir.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary
Modifies the multi-emit logic for the Heft TypeScript plugin to generate `.d.ts` shim files for non-primary output kinds, that redirect to the primary .d.ts files.

## Details
Creates shim files containing:
```ts
export * from '../path/to/declaration';
// If a default export exists
export { default as default } from '../path/to/declaration';
```

## How it was tested
Enabled multi-emit and isolatedModules in the node rig temporarily. Verified output content.