### PR TITLE
[rush] Update the rush init template to disable hoisting of packages.

### DIFF
--- a/common/changes/@microsoft/rush/disable-hoisting-in-init-template_2022-07-18-23-32.json
+++ b/common/changes/@microsoft/rush/disable-hoisting-in-init-template_2022-07-18-23-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the `common/config/rush/.npmrc` file in the `rush init` template to disble hoisting of any packages during `rush install`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
@@ -20,3 +20,9 @@
 #
 registry=https://registry.npmjs.org/
 always-auth=false
+
+# Don't hoist in common/temp/node_modules
+public-hoist-pattern=
+# Don't hoist in common/temp/node_modules/.pnpm/node_modules
+hoist=false
+hoist-pattern=


### PR DESCRIPTION
## Summary

Mitigates https://github.com/microsoft/rushstack/issues/3535 in new repos configured with `rush init`.

## Details

These options are documented here: https://pnpm.io/npmrc#dependency-hoisting-settings

## How it was tested

This repo is already configured with these options. Tested by running `rush init` and using npm and yarn and verified they don't error with these options specified.