### PR TITLE
[api-extractor-model] Improve `IFindApiItemsMessage` and fix two minor bugs with `findMembersWithInheritance`

### DIFF
--- a/common/changes/@microsoft/api-extractor-model/inheritance-docs-fixes_2022-07-20-21-52.json
+++ b/common/changes/@microsoft/api-extractor-model/inheritance-docs-fixes_2022-07-20-21-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Improve IFindApiItemMessage and fix two small bugs with ApiItemContainerMixin.findMembersWithInheritance()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -692,8 +692,8 @@ export enum ExcerptTokenKind {
 // @beta
 export enum FindApiItemsMessageId {
     DeclarationResolutionFailed = "declaration-resolution-failed",
-    MissingApiModel = "missing-api-model",
-    UnexpectedExcerptTokens = "unexpected-excerpt-tokens",
+    ExtendsClauseMissingReference = "extends-clause-missing-reference",
+    NoAssociatedApiModel = "no-associated-api-model",
     UnsupportedKind = "unsupported-kind"
 }
 

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -689,7 +689,7 @@ export enum ExcerptTokenKind {
     Reference = "Reference"
 }
 
-// @beta
+// @public
 export enum FindApiItemsMessageId {
     DeclarationResolutionFailed = "declaration-resolution-failed",
     ExtendsClauseMissingReference = "extends-clause-missing-reference",

--- a/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -17,6 +17,7 @@ import { ApiInterface } from '../model/ApiInterface';
 import { ExcerptToken, ExcerptTokenKind } from './Excerpt';
 import { IFindApiItemsResult, IFindApiItemsMessage, FindApiItemsMessageId } from './IFindApiItemsResult';
 import { InternalError, LegacyAdapters } from '@rushstack/node-core-library';
+import { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
 import { HeritageType } from '../model/HeritageType';
 import { IResolveDeclarationReferenceResult } from '../model/ModelReferenceResolver';
 
@@ -354,6 +355,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
             text: `Unable to analyze references of API item ${next.displayName} because it is of unsupported kind ${next.kind}`
           });
           maybeIncompleteResult = true;
+          next = toVisit.shift();
           continue;
         }
 
@@ -394,7 +396,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
             continue;
           }
 
-          const canonicalReference = firstReferenceToken.canonicalReference!;
+          const canonicalReference: DeclarationReference = firstReferenceToken.canonicalReference!;
           const apiItemResult: IResolveDeclarationReferenceResult = apiModel.resolveDeclarationReference(
             canonicalReference,
             undefined
@@ -404,7 +406,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
           if (!apiItem) {
             messages.push({
               messageId: FindApiItemsMessageId.DeclarationResolutionFailed,
-              text: `Unable to resolve canonical reference within API item ${next.displayName}: ${apiItemResult.errorMessage}`
+              text: `Unable to resolve declaration reference within API item ${next.displayName}: ${apiItemResult.errorMessage}`
             });
             maybeIncompleteResult = true;
             continue;

--- a/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -278,6 +278,21 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
       const messages: IFindApiItemsMessage[] = [];
       let maybeIncompleteResult: boolean = false;
 
+      // For API items that don't support inheritance, this method just returns the item's
+      // immediate members.
+      switch (this.kind) {
+        case ApiItemKind.Class:
+        case ApiItemKind.Interface:
+          break;
+        default: {
+          return {
+            items: this.members.concat(),
+            messages,
+            maybeIncompleteResult
+          };
+        }
+      }
+
       const membersByName: Map<string, ApiItem[]> = new Map();
       const membersByKind: Map<ApiItemKind, ApiItem[]> = new Map();
 
@@ -336,10 +351,10 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
         if (extendsTypes === undefined) {
           messages.push({
             messageId: FindApiItemsMessageId.UnsupportedKind,
-            text: `Item ${next.displayName} is of unsupported kind ${next.kind}.`
+            text: `Unable to analyze references of API item ${next.displayName} because it is of unsupported kind ${next.kind}`
           });
           maybeIncompleteResult = true;
-          break;
+          continue;
         }
 
         for (const extendsType of extendsTypes) {
@@ -362,8 +377,8 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
 
           if (!firstReferenceToken) {
             messages.push({
-              messageId: FindApiItemsMessageId.UnexpectedExcerptTokens,
-              text: `Encountered unexpected excerpt tokens in ${next.displayName}. Excerpt: ${extendsType.excerpt.text}.`
+              messageId: FindApiItemsMessageId.ExtendsClauseMissingReference,
+              text: `Unable to analyze extends clause ${extendsType.excerpt.text} of API item ${next.displayName} because no canonical reference was found`
             });
             maybeIncompleteResult = true;
             continue;
@@ -372,15 +387,16 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
           const apiModel: ApiModel | undefined = this.getAssociatedModel();
           if (!apiModel) {
             messages.push({
-              messageId: FindApiItemsMessageId.MissingApiModel,
-              text: `Unable to get the associated model of ${next.displayName}.`
+              messageId: FindApiItemsMessageId.NoAssociatedApiModel,
+              text: `Unable to analyze references of API item ${next.displayName} because it is not associated with an ApiModel`
             });
             maybeIncompleteResult = true;
             continue;
           }
 
+          const canonicalReference = firstReferenceToken.canonicalReference!;
           const apiItemResult: IResolveDeclarationReferenceResult = apiModel.resolveDeclarationReference(
-            firstReferenceToken.canonicalReference!,
+            canonicalReference,
             undefined
           );
 
@@ -388,7 +404,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
           if (!apiItem) {
             messages.push({
               messageId: FindApiItemsMessageId.DeclarationResolutionFailed,
-              text: `Declaration resolution failed for ${next.displayName}. Error message: ${apiItemResult.errorMessage}.`
+              text: `Unable to resolve canonical reference within API item ${next.displayName}: ${apiItemResult.errorMessage}`
             });
             maybeIncompleteResult = true;
             continue;

--- a/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
+++ b/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
@@ -45,7 +45,7 @@ export interface IFindApiItemsMessage {
  */
 export enum FindApiItemsMessageId {
   /**
-   * "Unable to resolve canonical reference within API item ___: ___"
+   * "Unable to resolve declaration reference within API item ___: ___"
    */
   DeclarationResolutionFailed = 'declaration-resolution-failed',
 

--- a/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
+++ b/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
@@ -45,22 +45,22 @@ export interface IFindApiItemsMessage {
  */
 export enum FindApiItemsMessageId {
   /**
-   * "Declaration resolution failed for ___. Error message: ___."
+   * "Unable to resolve canonical reference within API item ___: ___"
    */
   DeclarationResolutionFailed = 'declaration-resolution-failed',
 
   /**
-   * "Unable to get the associated model of ___."
+   * "Unable to analyze extends clause ___ of API item ___ because no canonical reference was found."
    */
-  MissingApiModel = 'missing-api-model',
+  ExtendsClauseMissingReference = 'extends-clause-missing-reference',
 
   /**
-   * "Encountered unexpected excerpt tokens in ___. Excerpt: ___."
+   * "Unable to analyze references of API item ___ because it is not associated with an ApiModel"
    */
-  UnexpectedExcerptTokens = 'unexpected-excerpt-tokens',
+  NoAssociatedApiModel = 'no-associated-api-model',
 
   /**
-   * Item ___ is of unsupported kind ___."
+   * "Unable to analyze references of API item ___ because it is of unsupported kind ___"
    */
   UnsupportedKind = 'unsupported-kind'
 }

--- a/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
+++ b/libraries/api-extractor-model/src/mixins/IFindApiItemsResult.ts
@@ -41,7 +41,7 @@ export interface IFindApiItemsMessage {
 
 /**
  * Unique identifiers for messages returned as part of `IFindApiItemsResult`.
- * @beta
+ * @public
  */
 export enum FindApiItemsMessageId {
   /**


### PR DESCRIPTION
## Summary

This PR is a follow-up to https://github.com/microsoft/rushstack/pull/3469 to improve `IFindApiItemsMessage` and fix two minor bugs with `findMembersWithInheritance`.

## Details

* Took a stab at addressing some of @octogonz's feedback left on https://github.com/microsoft/rushstack/pull/3469 post-merge re `IFindApiItemsMessage` messages.
* Graduated `IFindApiItemsMessageId` from `@beta` --> `@public`.
* **Bug fix:** Previously, when `findMembersWithInheritance` was run on a non-class/interface, it would return just the immediate members but then report an "unsupported kind" message. This was decided to not quite make sense per the conversation at https://github.com/microsoft/rushstack/pull/3469#discussion_r925967431. Thus, now when `findMembersWithInheritance` is run on a non-class/interface, it returns the immediate members and doesn't report any messages/incompleteness.
* **Bug fix:** Consider the following scenario:

  ```
  export interface IInterface1 {}
  export type InterfaceLikeTypeAlias = {}
  export interface IInterface2 extends InterfaceLikeTypeAlias, IInterface1 {}
  ```
  
  Previously, when the `findMembersWithInheritance` logic first processed `InterfaceLikeTypeAlias`, it would report an "unsupported kind" message and *break out of the central while loop*, thus accidentally not processing `IInterface1`. Now, instead of breaking out of the while loop, we continue. I added a test to https://github.com/microsoft/rushstack/pull/3543 to validate the correct behavior.

## How it was tested

Tested with https://github.com/microsoft/rushstack/pull/3543.
