### PR TITLE
[api-documenter] Classes should also populate Yaml type parameters

### DIFF
--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -577,11 +577,11 @@ export class YamlDocumenter {
         }
         yamlItem.inheritance = this._renderInheritance(uid, apiItem.extendsTypes);
       }
+    }
 
-      const typeParameters: IYamlParameter[] = this._populateYamlTypeParameters(uid, apiItem);
-      if (typeParameters.length) {
-        yamlItem.syntax = { typeParameters };
-      }
+    const typeParameters: IYamlParameter[] = this._populateYamlTypeParameters(uid, apiItem);
+    if (typeParameters.length) {
+      yamlItem.syntax = { typeParameters };
     }
 
     if (apiItem.tsdocComment) {

--- a/common/changes/@microsoft/api-documenter/type-parameters_2022-07-21-12-50.json
+++ b/common/changes/@microsoft/api-documenter/type-parameters_2022-07-21-12-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Populate Yaml type parameters for classes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
## Summary

This was an existing bug that was originally found when working on https://github.com/microsoft/rushstack/pull/3469 and pulled out into its own fix PR. See this thread: https://github.com/microsoft/rushstack/pull/3469#discussion_r923930778.

## Details

No additional details.

## How it was tested

I manually validated that `_writeYamlFile` writes the appropriate content. Unfortunately, the checked in `.yml` files don't change because of the `convertUDPYamlToSDP` function that strips out some of the Yaml content.