### PR TITLE
[webpack5-module-minifier-plugin] Fix typings field

### DIFF
--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/module-minifier-5-types_2022-07-27-00-57.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/module-minifier-5-types_2022-07-27-00-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "Fix typings reference.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/webpack/module-minifier-plugin-5/package.json
+++ b/webpack/module-minifier-plugin-5/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.15",
   "description": "This plugin splits minification of webpack compilations into smaller units.",
   "main": "lib/index.js",
-  "typings": "dist/module-minifier-plugin.d.ts",
+  "typings": "dist/webpack5-module-minifier-plugin.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Fixes the target of the `typings` field in `@rushstack/webpack5-module-minifier-plugin`.

## Details
Update required after the package publish target changed.

## How it was tested
Local build.
