### PR TITLE
[node-core-libary] Update `PackageJsonLookup` to only resolve to `package.json` files that contain a `"name"` field.

### DIFF
--- a/common/changes/@rushstack/node-core-library/fix-2070_2022-07-28-18-09.json
+++ b/common/changes/@rushstack/node-core-library/fix-2070_2022-07-28-18-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Require at least a \"name\" field in package.json files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/fix-2070_2022-07-28-18-09.json
+++ b/common/changes/@rushstack/node-core-library/fix-2070_2022-07-28-18-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Require at least a \"name\" field in package.json files",
+      "comment": "Update `PackageJsonLookup` to only resolve to `package.json` files that contain a `\"name\"` field. See GitHub issue #2070",
       "type": "patch"
     }
   ],

--- a/libraries/node-core-library/src/PackageJsonLookup.ts
+++ b/libraries/node-core-library/src/PackageJsonLookup.ts
@@ -22,6 +22,34 @@ export interface IPackageJsonLookupParameters {
   loadExtraFields?: boolean;
 }
 
+type TryLoadPackageJsonInternalErrorCode =
+  | 'MISSING_NAME_FIELD'
+  | 'FILE_NOT_FOUND'
+  | 'MISSING_VERSION_FIELD'
+  | 'OTHER_ERROR';
+
+interface ITryLoadPackageJsonInternalSuccessResult {
+  packageJson: IPackageJson;
+  error?: never;
+}
+
+interface ITryLoadPackageJsonInternalFailureResult {
+  error: TryLoadPackageJsonInternalErrorCode;
+}
+interface ITryLoadPackageJsonInternalKnownFailureResult extends ITryLoadPackageJsonInternalFailureResult {
+  error: 'MISSING_NAME_FIELD' | 'FILE_NOT_FOUND';
+}
+
+interface ITryLoadPackageJsonInternalUnknownFailureResult extends ITryLoadPackageJsonInternalFailureResult {
+  error: 'OTHER_ERROR';
+  errorObject: Error;
+}
+
+type ITryLoadPackageJsonInternalResult =
+  | ITryLoadPackageJsonInternalSuccessResult
+  | ITryLoadPackageJsonInternalKnownFailureResult
+  | ITryLoadPackageJsonInternalUnknownFailureResult;
+
 /**
  * This class provides methods for finding the nearest "package.json" for a folder
  * and retrieving the name of the package.  The results are cached.
@@ -235,41 +263,77 @@ export class PackageJsonLookup {
    * if the `version` field is missing from the package.json file.
    */
   public loadNodePackageJson(jsonFilename: string): INodePackageJson {
-    const packageJson: INodePackageJson | undefined = this._tryLoadNodePackageJson(jsonFilename);
+    return this._loadPackageJsonInner(jsonFilename);
+  }
 
-    if (!packageJson) {
-      throw new Error(`Error reading "${jsonFilename}":\n  The required field "name" was not found`);
+  private _loadPackageJsonInner(jsonFilename: string): IPackageJson;
+  private _loadPackageJsonInner(
+    jsonFilename: string,
+    errorsToIgnore: Set<TryLoadPackageJsonInternalErrorCode>
+  ): IPackageJson | undefined;
+  private _loadPackageJsonInner(
+    jsonFilename: string,
+    errorsToIgnore?: Set<TryLoadPackageJsonInternalErrorCode>
+  ): IPackageJson | undefined {
+    const loadResult: ITryLoadPackageJsonInternalResult = this._tryLoadNodePackageJsonInner(jsonFilename);
+
+    if (loadResult.error && errorsToIgnore?.has(loadResult.error)) {
+      return undefined;
     }
 
-    return packageJson;
+    switch (loadResult.error) {
+      case 'FILE_NOT_FOUND': {
+        throw new Error(`Input file not found: ${jsonFilename}`);
+      }
+
+      case 'MISSING_NAME_FIELD': {
+        throw new Error(`Error reading "${jsonFilename}":\n  The required field "name" was not found`);
+      }
+
+      case 'OTHER_ERROR': {
+        throw loadResult.errorObject;
+      }
+
+      default: {
+        return loadResult.packageJson;
+      }
+    }
   }
 
   /**
    * Try to load a package.json file as an INodePackageJson,
    * returning undefined if the found file does not contain a `name` field.
    */
-  private _tryLoadNodePackageJson(jsonFilename: string): INodePackageJson | undefined {
-    if (!FileSystem.exists(jsonFilename)) {
-      // TODO: Return a more rich object noting that the file doesn't exist. Something called
-      // "tryLoad..." shouldn't throw in this case.
-      throw new Error(`Input file not found: ${jsonFilename}`);
-    }
-
+  private _tryLoadNodePackageJsonInner(jsonFilename: string): ITryLoadPackageJsonInternalResult {
     // Since this will be a cache key, follow any symlinks and get an absolute path
     // to minimize duplication.  (Note that duplication can still occur due to e.g. character case.)
-    const normalizedFilePath: string = FileSystem.getRealPath(jsonFilename);
+    let normalizedFilePath: string;
+    try {
+      normalizedFilePath = FileSystem.getRealPath(jsonFilename);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e)) {
+        return {
+          error: 'FILE_NOT_FOUND'
+        };
+      } else {
+        return {
+          error: 'OTHER_ERROR',
+          errorObject: e
+        };
+      }
+    }
 
     let packageJson: IPackageJson | undefined = this._packageJsonCache.get(normalizedFilePath);
 
     if (!packageJson) {
-      const loadedPackageJson: IPackageJson = JsonFile.load(normalizedFilePath) as IPackageJson;
+      const loadedPackageJson: IPackageJson = JsonFile.load(normalizedFilePath);
 
       // Make sure this is really a package.json file.  CommonJS has fairly strict requirements,
       // but NPM only requires "name" and "version"
       if (!loadedPackageJson.name) {
-        // TODO: Return a more rich object noting that the reason we didn't load this `package.json` is because it
-        // doesn't contain a `"name"` field.
-        return undefined;
+        return {
+          error: 'MISSING_NAME_FIELD'
+        };
       }
 
       if (this._loadExtraFields) {
@@ -299,7 +363,9 @@ export class PackageJsonLookup {
       this._packageJsonCache.set(normalizedFilePath, packageJson);
     }
 
-    return packageJson;
+    return {
+      packageJson
+    };
   }
 
   // Recursive part of the algorithm from tryGetPackageFolderFor()
@@ -311,14 +377,14 @@ export class PackageJsonLookup {
     }
 
     // Is resolvedFileOrFolderPath itself a folder with a valid package.json file?  If so, return it.
-    const packageJsonFilePath: string = path.join(resolvedFileOrFolderPath, FileConstants.PackageJson);
-    // TODO: Remove this redundant `FileSystem.exists` call.
-    if (FileSystem.exists(packageJsonFilePath)) {
-      const packageJson: INodePackageJson | undefined = this._tryLoadNodePackageJson(packageJsonFilePath);
-      if (packageJson) {
-        this._packageFolderCache.set(resolvedFileOrFolderPath, resolvedFileOrFolderPath);
-        return resolvedFileOrFolderPath;
-      }
+    const packageJsonFilePath: string = `${resolvedFileOrFolderPath}/${FileConstants.PackageJson}`;
+    const packageJson: IPackageJson | undefined = this._loadPackageJsonInner(
+      packageJsonFilePath,
+      new Set(['FILE_NOT_FOUND', 'MISSING_NAME_FIELD'])
+    );
+    if (packageJson) {
+      this._packageFolderCache.set(resolvedFileOrFolderPath, resolvedFileOrFolderPath);
+      return resolvedFileOrFolderPath;
     }
 
     // Otherwise go up one level

--- a/libraries/node-core-library/src/PackageJsonLookup.ts
+++ b/libraries/node-core-library/src/PackageJsonLookup.ts
@@ -244,10 +244,14 @@ export class PackageJsonLookup {
     return packageJson;
   }
 
-  // Try to load a package.json file as an INodePackageJson,
-  // returning undefined if the found file does not contain a `name` field.
+  /**
+   * Try to load a package.json file as an INodePackageJson,
+   * returning undefined if the found file does not contain a `name` field.
+   */
   private _tryLoadNodePackageJson(jsonFilename: string): INodePackageJson | undefined {
     if (!FileSystem.exists(jsonFilename)) {
+      // TODO: Return a more rich object noting that the file doesn't exist. Something called
+      // "tryLoad..." shouldn't throw in this case.
       throw new Error(`Input file not found: ${jsonFilename}`);
     }
 
@@ -263,6 +267,8 @@ export class PackageJsonLookup {
       // Make sure this is really a package.json file.  CommonJS has fairly strict requirements,
       // but NPM only requires "name" and "version"
       if (!loadedPackageJson.name) {
+        // TODO: Return a more rich object noting that the reason we didn't load this `package.json` is because it
+        // doesn't contain a `"name"` field.
         return undefined;
       }
 
@@ -306,6 +312,7 @@ export class PackageJsonLookup {
 
     // Is resolvedFileOrFolderPath itself a folder with a valid package.json file?  If so, return it.
     const packageJsonFilePath: string = path.join(resolvedFileOrFolderPath, FileConstants.PackageJson);
+    // TODO: Remove this redundant `FileSystem.exists` call.
     if (FileSystem.exists(packageJsonFilePath)) {
       const packageJson: INodePackageJson | undefined = this._tryLoadNodePackageJson(packageJsonFilePath);
       if (packageJson) {

--- a/libraries/node-core-library/src/PackageJsonLookup.ts
+++ b/libraries/node-core-library/src/PackageJsonLookup.ts
@@ -292,10 +292,18 @@ export class PackageJsonLookup {
       return this._packageFolderCache.get(resolvedFileOrFolderPath);
     }
 
-    // Is resolvedFileOrFolderPath itself a folder with a package.json file?  If so, return it.
-    if (FileSystem.exists(path.join(resolvedFileOrFolderPath, FileConstants.PackageJson))) {
-      this._packageFolderCache.set(resolvedFileOrFolderPath, resolvedFileOrFolderPath);
-      return resolvedFileOrFolderPath;
+    // Is resolvedFileOrFolderPath itself a folder with a valid package.json file?  If so, return it.
+    const packageJsonFilePath: string = path.join(resolvedFileOrFolderPath, FileConstants.PackageJson);
+    if (FileSystem.exists(packageJsonFilePath)) {
+      try {
+        this.loadNodePackageJson(packageJsonFilePath);
+        this._packageFolderCache.set(resolvedFileOrFolderPath, resolvedFileOrFolderPath);
+        return resolvedFileOrFolderPath;
+      } catch (error) {
+        if (!/The required field "name" was not found/.test(error.message)) {
+          throw error;
+        }
+      }
     }
 
     // Otherwise go up one level

--- a/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
+++ b/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
@@ -54,5 +54,22 @@ describe(PackageJsonLookup.name, () => {
 
       expect(foundFile).toEqual(path.join(foundFolder || '', FileConstants.PackageJson));
     });
+
+    test(`${PackageJsonLookup.prototype.tryGetPackageFolderFor.name} test package with inner package.json with no name`, () => {
+      const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
+      const sourceFilePath: string = path.join(
+        __dirname,
+        './test-data/example-subdir-package-no-name/src/ExampleFile.txt'
+      );
+
+      // Example: C:\rushstack\libraries\node-core-library\src\test\example-subdir-package-no-name
+      const foundFolder: string | undefined = packageJsonLookup.tryGetPackageFolderFor(sourceFilePath);
+      expect(foundFolder).toBeDefined();
+      expect(foundFolder!.search(/[\\/]example-subdir-package-no-name$/i)).toBeGreaterThan(0);
+
+      const foundFile: string | undefined = packageJsonLookup.tryGetPackageJsonFilePathFor(sourceFilePath);
+
+      expect(foundFile).toEqual(path.join(foundFolder || '', FileConstants.PackageJson));
+    });
   });
 });

--- a/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/package.json
+++ b/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "example-package",
+  "nonstandardField": 456
+}

--- a/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/src/ExampleFile.txt
+++ b/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/src/ExampleFile.txt
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * AEDoc for AliasClass
+ * @public
+ */
+export class AliasClass {
+  private readOnlyNumber: number;
+
+  /**
+   * AEDoc for aliasFunc()
+   * @internal
+   */
+  public _aliasFunc(): void {
+    console.log('this is an internal API');
+  }
+
+  public aliasField: number;
+
+  public get shouldBeReadOnly(): number {
+    return this.readOnlyNumber;
+  }
+}
+
+class PrivateAliasClass {
+  public test(): void {
+  }
+}

--- a/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/src/package.json
+++ b/libraries/node-core-library/src/test/test-data/example-subdir-package-no-name/src/package.json
@@ -1,0 +1,3 @@
+{
+  "nonstandardField": 123
+}


### PR DESCRIPTION
## Summary

Fixes #2070 

PackageJsonLookup is erroneously presuming that all package.json files include a `"name"` field, and will complain when attempting to load a package.json file that does not include that field.

In the [npm docs on the file format](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#name), it's quite clear that the name+version requirements only apply to published packages:
> If you don't plan to publish your package, the name and version fields are optional.

This means that when e.g. a third-party dependency follows the guidance given for the `"type"` field in the [Node.js documentation](https://nodejs.org/api/packages.html#type), it's not possible to successfully run api-extractor.

## Details

To fix this, each package.json file is loaded during lookup before returning it as valid, and in case the load fails with the `The required field "name" was not found` error, the lookup continues in the parent directory.

This should have no real-world effect on performance, as practically all such lookups are immediately followed by a load, which will then use the result cached during the lookup.

## How it was tested

A test case is added to validate this behaviour.