### PR TITLE
[rush-lib] components package.json JSON format validation & version adherence to semver validation

### DIFF
--- a/common/changes/@microsoft/rush/package-json-validation_2022-07-28-22-42.json
+++ b/common/changes/@microsoft/rush/package-json-validation_2022-07-28-22-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Added package.json strict JSON validation & version adherence to semver check",
+      "comment": "Add validation to ensure package.json files are strict JSON and the \"version\" field is strict SemVer",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/package-json-validation_2022-07-28-22-42.json
+++ b/common/changes/@microsoft/rush/package-json-validation_2022-07-28-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Added package.json strict JSON validation & version adherence to semver check",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/package-json-validation_2022-07-28-22-42.json
+++ b/common/changes/@rushstack/node-core-library/package-json-validation_2022-07-28-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "API change to JSONFile.ts:load function allowing for optional strict JSON validation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/package-json-validation_2022-07-28-22-42.json
+++ b/common/changes/@rushstack/node-core-library/package-json-validation_2022-07-28-22-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "API change to JSONFile.ts:load function allowing for optional strict JSON validation",
+      "comment": "Introduce JsonSyntax option for JsonFile.load() and related APIs",
       "type": "patch"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -460,6 +460,15 @@ export interface IImportResolvePackageOptions extends IImportResolveOptions {
 }
 
 // @public
+export interface IJsonFileLoadAndValidateOptions extends IJsonFileParseOptions, IJsonSchemaValidateOptions {
+}
+
+// @public
+export interface IJsonFileParseOptions {
+    jsonSyntax?: JsonSyntax;
+}
+
+// @public
 export interface IJsonFileSaveOptions extends IJsonFileStringifyOptions {
     ensureFolderExists?: boolean;
     onlyIfChanged?: boolean;
@@ -638,13 +647,13 @@ export interface ITerminalProvider {
 export class JsonFile {
     // @internal (undocumented)
     static _formatPathForError: (path: string) => string;
-    static load(jsonFilename: string): JsonObject;
-    static loadAndValidate(jsonFilename: string, jsonSchema: JsonSchema, options?: IJsonSchemaValidateOptions): JsonObject;
-    static loadAndValidateAsync(jsonFilename: string, jsonSchema: JsonSchema, options?: IJsonSchemaValidateOptions): Promise<JsonObject>;
-    static loadAndValidateWithCallback(jsonFilename: string, jsonSchema: JsonSchema, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): JsonObject;
-    static loadAndValidateWithCallbackAsync(jsonFilename: string, jsonSchema: JsonSchema, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): Promise<JsonObject>;
-    static loadAsync(jsonFilename: string): Promise<JsonObject>;
-    static parseString(jsonContents: string): JsonObject;
+    static load(jsonFilename: string, options?: IJsonFileParseOptions): JsonObject;
+    static loadAndValidate(jsonFilename: string, jsonSchema: JsonSchema, options?: IJsonFileLoadAndValidateOptions): JsonObject;
+    static loadAndValidateAsync(jsonFilename: string, jsonSchema: JsonSchema, options?: IJsonFileLoadAndValidateOptions): Promise<JsonObject>;
+    static loadAndValidateWithCallback(jsonFilename: string, jsonSchema: JsonSchema, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void, options?: IJsonFileLoadAndValidateOptions): JsonObject;
+    static loadAndValidateWithCallbackAsync(jsonFilename: string, jsonSchema: JsonSchema, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void, options?: IJsonFileLoadAndValidateOptions): Promise<JsonObject>;
+    static loadAsync(jsonFilename: string, options?: IJsonFileParseOptions): Promise<JsonObject>;
+    static parseString(jsonContents: string, options?: IJsonFileParseOptions): JsonObject;
     static save(jsonObject: JsonObject, jsonFilename: string, options?: IJsonFileSaveOptions): boolean;
     static saveAsync(jsonObject: JsonObject, jsonFilename: string, options?: IJsonFileSaveOptions): Promise<boolean>;
     static stringify(jsonObject: JsonObject, options?: IJsonFileStringifyOptions): string;
@@ -666,6 +675,13 @@ export class JsonSchema {
     get shortName(): string;
     validateObject(jsonObject: JsonObject, filenameForErrors: string, options?: IJsonSchemaValidateOptions): void;
     validateObjectWithCallback(jsonObject: JsonObject, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): void;
+}
+
+// @public
+export enum JsonSyntax {
+    Json5 = "json5",
+    JsonWithComments = "jsonWithComments",
+    Strict = "strict"
 }
 
 // @public

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -113,10 +113,14 @@ export class JsonFile {
   /**
    * Loads a JSON file.
    */
-  public static load(jsonFilename: string): JsonObject {
+  public static load(jsonFilename: string, validateStrictJsonFormat?: boolean): JsonObject {
     try {
       const contents: string = FileSystem.readFile(jsonFilename);
-      return jju.parse(contents);
+      const parserOptions: jju.ParseOptions = {};
+      if (validateStrictJsonFormat) {
+        parserOptions.mode = 'json';
+      }
+      return jju.parse(contents, parserOptions);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw error;

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -39,7 +39,92 @@ export type JsonObject = any;
 export type JsonNull = null;
 
 /**
- * Options for JsonFile.stringify()
+ * Specifies the variant of JSON syntax to be used.
+ *
+ * @public
+ */
+export enum JsonSyntax {
+  /**
+   * Specifies the exact RFC 8259 format as implemented by the `JSON.parse()` system API.
+   * This format was designed for machine generated inputs such as an HTTP payload.
+   * It is not a recommend choice for human-authored files, because it does not support
+   * code comments.
+   *
+   * @remarks
+   *
+   * A well-known quote from Douglas Crockford, the inventor of JSON:
+   *
+   * "I removed comments from JSON because I saw people were using them to hold parsing directives,
+   * a practice which would have destroyed interoperability.  I know that the lack of comments makes
+   * some people sad, but it shouldn't.  Suppose you are using JSON to keep configuration files,
+   * which you would like to annotate.  Go ahead and insert all the comments you like.
+   * Then pipe it through JSMin before handing it to your JSON parser."
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8259 | RFC 8259}
+   */
+  Strict = 'strict',
+
+  /**
+   * `JsonSyntax.JsonWithComments` is the recommended format for human-authored config files.
+   * It is a minimal extension to `JsonSyntax.Strict` adding support for code comments
+   * using `//` and `/*`.
+   *
+   * @remarks
+   *
+   * VS Code calls this format `jsonc`, but it should not be confused with unrelated file formats
+   * and libraries that also use the name "JSONC".
+   *
+   * To fix VS Code syntax highlighting, add this setting:
+   * `"files.associations": { "*.json": "jsonc" }`
+   *
+   * To fix GitHub syntax highlighting, add this to your `.gitattributes`:
+   * `*.json linguist-language=JSON-with-Comments`
+   */
+  JsonWithComments = 'jsonWithComments',
+
+  /**
+   * JSON5 is a project that proposes a JSON-like format supplemented with ECMAScript 5.1
+   * notations for objects, numbers, comments, and more.
+   *
+   * @remarks
+   * Files using this format should use the `.json5` file extension instead of `.json`.
+   *
+   * JSON5 has substantial differences from JSON: object keys may be unquoted, trailing commas
+   * are allowed, and strings may span multiple lines.  Whereas `JsonSyntax.JsonWithComments` can
+   * be cheaply converted to standard JSON by stripping comments, parsing JSON5 requires a
+   * nontrivial algorithm that may not be easily available in some contexts or programming languages.
+   *
+   * @see {@link https://json5.org/ | JSON5 project website}
+   */
+  Json5 = 'json5'
+}
+
+/**
+ * Options for {@link JsonFile.parseString}, {@link JsonFile.load}, and {@link JsonFile.loadAsync}.
+ *
+ * @public
+ */
+export interface IJsonFileParseOptions {
+  /**
+   * Specifies the variant of JSON syntax to be used.
+   *
+   * @defaultValue
+   * `JsonSyntax.Json5`
+   *
+   * NOTE: This default will be changed to `JsonSyntax.JsonWithComments` in a future release.
+   */
+  jsonSyntax?: JsonSyntax;
+}
+
+/**
+ * Options for {@link JsonFile.loadAndValidate} and {@link JsonFile.loadAndValidateAsync}
+ *
+ * @public
+ */
+export interface IJsonFileLoadAndValidateOptions extends IJsonFileParseOptions, IJsonSchemaValidateOptions {}
+
+/**
+ * Options for {@link JsonFile.stringify}
  *
  * @public
  */
@@ -50,8 +135,19 @@ export interface IJsonFileStringifyOptions {
   newlineConversion?: NewlineKind;
 
   /**
-   * If true, conforms to the standard behavior of JSON.stringify() when a property has the value `undefined`.
-   * Specifically, the key will be dropped from the emitted object.
+   * By default, `JsonFile.stringify()` validates that the object does not contain any
+   * keys whose value is `undefined`.  To disable this validation, set `ignoreUndefinedValues=true`
+   * which causes such keys to be silently discarded, consistent with the system `JSON.stringify()`.
+   *
+   * @remarks
+   *
+   * The JSON file format can represent `null` values ({@link JsonNull}) but not `undefined` values.
+   * In ECMAScript code however, we generally avoid `null` and always represent empty states
+   * as `undefined`, because it is the default value of missing/uninitialized variables.
+   * (In practice, distinguishing "null" versus "uninitialized" has more drawbacks than benefits.)
+   * This poses a problem when serializing ECMAScript objects that contain `undefined` members.
+   * As a safeguard, `JsonFile` will report an error if any `undefined` values are encountered
+   * during serialization.  Set `ignoreUndefinedValues=true` to disable this safeguard.
    */
   ignoreUndefinedValues?: boolean;
 
@@ -72,7 +168,7 @@ export interface IJsonFileStringifyOptions {
 }
 
 /**
- * Options for JsonFile.saveJsonFile()
+ * Options for {@link JsonFile.save} and {@link JsonFile.saveAsync}.
  *
  * @public
  */
@@ -113,14 +209,11 @@ export class JsonFile {
   /**
    * Loads a JSON file.
    */
-  public static load(jsonFilename: string, validateStrictJsonFormat?: boolean): JsonObject {
+  public static load(jsonFilename: string, options?: IJsonFileParseOptions): JsonObject {
     try {
       const contents: string = FileSystem.readFile(jsonFilename);
-      const parserOptions: jju.ParseOptions = {};
-      if (validateStrictJsonFormat) {
-        parserOptions.mode = 'json';
-      }
-      return jju.parse(contents, parserOptions);
+      const parseOptions: jju.ParseOptions = JsonFile._buildJjuParseOptions(options);
+      return jju.parse(contents, parseOptions);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw error;
@@ -137,10 +230,11 @@ export class JsonFile {
   /**
    * An async version of {@link JsonFile.load}.
    */
-  public static async loadAsync(jsonFilename: string): Promise<JsonObject> {
+  public static async loadAsync(jsonFilename: string, options?: IJsonFileParseOptions): Promise<JsonObject> {
     try {
       const contents: string = await FileSystem.readFileAsync(jsonFilename);
-      return jju.parse(contents);
+      const parseOptions: jju.ParseOptions = JsonFile._buildJjuParseOptions(options);
+      return jju.parse(contents, parseOptions);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw error;
@@ -157,8 +251,9 @@ export class JsonFile {
   /**
    * Parses a JSON file's contents.
    */
-  public static parseString(jsonContents: string): JsonObject {
-    return jju.parse(jsonContents);
+  public static parseString(jsonContents: string, options?: IJsonFileParseOptions): JsonObject {
+    const parseOptions: jju.ParseOptions = JsonFile._buildJjuParseOptions(options);
+    return jju.parse(jsonContents, parseOptions);
   }
 
   /**
@@ -167,9 +262,9 @@ export class JsonFile {
   public static loadAndValidate(
     jsonFilename: string,
     jsonSchema: JsonSchema,
-    options?: IJsonSchemaValidateOptions
+    options?: IJsonFileLoadAndValidateOptions
   ): JsonObject {
-    const jsonObject: JsonObject = JsonFile.load(jsonFilename);
+    const jsonObject: JsonObject = JsonFile.load(jsonFilename, options);
     jsonSchema.validateObject(jsonObject, jsonFilename, options);
 
     return jsonObject;
@@ -181,9 +276,9 @@ export class JsonFile {
   public static async loadAndValidateAsync(
     jsonFilename: string,
     jsonSchema: JsonSchema,
-    options?: IJsonSchemaValidateOptions
+    options?: IJsonFileLoadAndValidateOptions
   ): Promise<JsonObject> {
-    const jsonObject: JsonObject = await JsonFile.loadAsync(jsonFilename);
+    const jsonObject: JsonObject = await JsonFile.loadAsync(jsonFilename, options);
     jsonSchema.validateObject(jsonObject, jsonFilename, options);
 
     return jsonObject;
@@ -197,9 +292,10 @@ export class JsonFile {
   public static loadAndValidateWithCallback(
     jsonFilename: string,
     jsonSchema: JsonSchema,
-    errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void
+    errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void,
+    options?: IJsonFileLoadAndValidateOptions
   ): JsonObject {
-    const jsonObject: JsonObject = JsonFile.load(jsonFilename);
+    const jsonObject: JsonObject = JsonFile.load(jsonFilename, options);
     jsonSchema.validateObjectWithCallback(jsonObject, errorCallback);
 
     return jsonObject;
@@ -211,9 +307,10 @@ export class JsonFile {
   public static async loadAndValidateWithCallbackAsync(
     jsonFilename: string,
     jsonSchema: JsonSchema,
-    errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void
+    errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void,
+    options?: IJsonFileLoadAndValidateOptions
   ): Promise<JsonObject> {
-    const jsonObject: JsonObject = await JsonFile.loadAsync(jsonFilename);
+    const jsonObject: JsonObject = await JsonFile.loadAsync(jsonFilename, options);
     jsonSchema.validateObjectWithCallback(jsonObject, errorCallback);
 
     return jsonObject;
@@ -476,5 +573,26 @@ export class JsonFile {
       result.push(Text.replaceAll(line, '\r', ''));
     }
     return lines.join('\n') + '\n';
+  }
+
+  private static _buildJjuParseOptions(options: IJsonFileParseOptions | undefined): jju.ParseOptions {
+    if (!options) {
+      options = {};
+    }
+    const parseOptions: jju.ParseOptions = {};
+    switch (options.jsonSyntax) {
+      case JsonSyntax.Strict:
+        parseOptions.mode = 'json';
+        break;
+      case JsonSyntax.JsonWithComments:
+        parseOptions.mode = 'cjson';
+        break;
+      case JsonSyntax.Json5:
+      default:
+        parseOptions.mode = 'json5';
+        break;
+    }
+
+    return parseOptions;
   }
 }

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -37,7 +37,16 @@ export {
   IImportResolvePackageOptions
 } from './Import';
 export { InternalError } from './InternalError';
-export { JsonObject, JsonFile, JsonNull, IJsonFileSaveOptions, IJsonFileStringifyOptions } from './JsonFile';
+export {
+  JsonObject,
+  JsonNull,
+  JsonSyntax,
+  IJsonFileParseOptions,
+  IJsonFileLoadAndValidateOptions,
+  IJsonFileStringifyOptions,
+  IJsonFileSaveOptions,
+  JsonFile
+} from './JsonFile';
 export {
   JsonSchema,
   IJsonSchemaErrorInfo,

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -149,6 +149,13 @@ export class RushConfigurationProject {
       );
     }
 
+    if (!semver.valid(this._packageJson.version)) {
+      throw new Error(
+        `The package version "${this._packageJson.version}" specified in file` +
+          ` "${packageJsonFilename}" does not meet semver specification`
+      );
+    }
+
     this._packageJsonEditor = PackageJsonEditor.fromObject(this._packageJson, packageJsonFilename);
 
     this._tempProjectName = tempProjectName;

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import * as semver from 'semver';
-import { JsonFile, IPackageJson, FileSystem, FileConstants } from '@rushstack/node-core-library';
+import { JsonFile, IPackageJson, FileSystem, FileConstants, JsonSyntax } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { VersionPolicy, LockStepVersionPolicy } from './VersionPolicy';
@@ -106,7 +106,7 @@ export class RushConfigurationProject {
     const packageJsonFilename: string = path.join(this._projectFolder, FileConstants.PackageJson);
 
     try {
-      this._packageJson = JsonFile.load(packageJsonFilename, true);
+      this._packageJson = JsonFile.load(packageJsonFilename, { jsonSyntax: JsonSyntax.Strict });
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -106,7 +106,7 @@ export class RushConfigurationProject {
     const packageJsonFilename: string = path.join(this._projectFolder, FileConstants.PackageJson);
 
     try {
-      this._packageJson = JsonFile.load(packageJsonFilename);
+      this._packageJson = JsonFile.load(packageJsonFilename, true);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(


### PR DESCRIPTION
## Summary
This PR seeks to solve 2 issues:
- rush repo components' package.json version not in semver format fails when listed as a dependency with `workspace:*` in another project - https://github.com/microsoft/rushstack/issues/2678
- when running `rush update` and there are parsing errors in a component's package.json, pnpm does not provide stderr/stdio feedback - only exit code 1, which is not descriptive to the user. The `rush update` error message is `ERROR: Error: The command failed with exit code 1`

## Details
- The component version is manually checked for being in semver format after `package.json` is loaded.
- Package.json parsing of rush repos' subprojects' validates strict JSON format - no comments, syntactically correct.

## How it was tested
- building a project containing 2 components A and B, where A imports B's `workspace:*` version. 2 tests cases:
  - B's package.json version is set to `1.0` (new error message shown, graceful exit)
  - B's package.json version is set to `1.0.0`(runs ok, graceful exit)
- building a project where a component's `package.json` is malformed JSON - with comments or extra/missing commas.


    
- [x] 👉 STEP 7: Don't forget to run "rush change": https://rushjs.io/pages/best_practices/change_logs/


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
