### PR TITLE
[node-core-library] Add an Async.runWithRetriesAsync API to run and a retry an async function that may intermittently fail.

### DIFF
--- a/common/changes/@rushstack/node-core-library/runWithRetriesAsync_2022-08-01-01-22.json
+++ b/common/changes/@rushstack/node-core-library/runWithRetriesAsync_2022-08-01-01-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add an Async.runWithRetriesAsync API to run and a retry an async function that may intermittently fail.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/runWithRetriesAsync_2022-08-01-01-22.json
+++ b/common/changes/@rushstack/node-core-library/runWithRetriesAsync_2022-08-01-01-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add an Async.runWithRetriesAsync API to run and a retry an async function that may intermittently fail.",
+      "comment": "Add an Async.runWithRetriesAsync() API to run and a retry an async function that may intermittently fail.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -33,6 +33,7 @@ export class AnsiEscape {
 export class Async {
     static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
+    static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
 }
 
@@ -593,6 +594,16 @@ export interface IProtectableMapParameters<K, V> {
     onClear?: (source: ProtectableMap<K, V>) => void;
     onDelete?: (source: ProtectableMap<K, V>, key: K) => void;
     onSet?: (source: ProtectableMap<K, V>, key: K, value: V) => V;
+}
+
+// @beta (undocumented)
+export interface IRunWithRetriesOptions<TResult> {
+    // (undocumented)
+    action: () => Promise<TResult> | TResult;
+    // (undocumented)
+    maxRetries: number;
+    // (undocumented)
+    retryDelayMs?: number;
 }
 
 // @beta (undocumented)

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -9,7 +9,7 @@
 
 export { AlreadyReportedError } from './AlreadyReportedError';
 export { AnsiEscape, IAnsiEscapeConvertForTestsOptions } from './Terminal/AnsiEscape';
-export { Async, IAsyncParallelismOptions } from './Async';
+export { Async, IAsyncParallelismOptions, IRunWithRetriesOptions } from './Async';
 export { Brand } from './PrimitiveTypes';
 export { FileConstants, FolderConstants } from './Constants';
 export { Enum } from './Enum';

--- a/libraries/node-core-library/src/test/__snapshots__/Async.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/Async.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Async runWithRetriesAsync Correctly handles a sync function that always throws and allows several retries 1`] = `"error"`;
+
+exports[`Async runWithRetriesAsync Correctly handles a sync function that throws and does not allow retries 1`] = `"error"`;
+
+exports[`Async runWithRetriesAsync Correctly handles an async function that always throws and allows several retries 1`] = `"error"`;
+
+exports[`Async runWithRetriesAsync Correctly handles an async function that throws and does not allow retries 1`] = `"error"`;


### PR DESCRIPTION
This is useful for operations that may fail occasionally like network requests or deletion of files/folders that may be locked by something like an editor.