### PR TITLE
Drop Node 12 support from this repo.

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -7,8 +7,6 @@ jobs:
     condition: succeeded()
     strategy:
       matrix:
-        'NodeJs 12':
-          NodeVersion: 12
         'NodeJs 14':
           NodeVersion: 14
         'NodeJs 16':

--- a/rush.json
+++ b/rush.json
@@ -124,7 +124,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases


### PR DESCRIPTION
Node 12 is out of support, so this repo doesn't need to keep testing it.