### PR TITLE
[rush-lib] Fix Set ignore-compatibility-db=true when rush installation

### DIFF
--- a/common/changes/@microsoft/rush/feng-set-ignore-compatibility-db-true-when-installation_2022-08-04-09-37.json
+++ b/common/changes/@microsoft/rush/feng-set-ignore-compatibility-db-true-when-installation_2022-08-04-09-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "\"rush install/update\" should always set \"ignore-compatibility-db=true\" and print warning if the rush.json pnpmVersion specifies a version affected by this problem. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -12,7 +12,10 @@ import {
   PosixModeBits,
   NewlineKind,
   AlreadyReportedError,
-  FileSystemStats
+  FileSystemStats,
+  ConsoleTerminalProvider,
+  Terminal,
+  ITerminalProvider
 } from '@rushstack/node-core-library';
 import { PrintUtilities } from '@rushstack/terminal';
 
@@ -123,6 +126,9 @@ export abstract class BaseInstallManager {
 
   private _options: IInstallManagerOptions;
 
+  private readonly _terminalProvider: ITerminalProvider;
+  private readonly _terminal: Terminal;
+
   public constructor(
     rushConfiguration: RushConfiguration,
     rushGlobalFolder: RushGlobalFolder,
@@ -136,6 +142,9 @@ export abstract class BaseInstallManager {
 
     this._commonTempInstallFlag = LastInstallFlagFactory.getCommonTempFlag(rushConfiguration);
     this._commonTempLinkFlag = LastLinkFlagFactory.getCommonTempFlag(rushConfiguration);
+
+    this._terminalProvider = new ConsoleTerminalProvider();
+    this._terminal = new Terminal(this._terminalProvider);
   }
 
   protected get rushConfiguration(): RushConfiguration {
@@ -584,6 +593,26 @@ export abstract class BaseInstallManager {
         if (this._rushConfiguration.pnpmOptions.strictPeerDependencies) {
           args.push('--strict-peer-dependencies');
         }
+      }
+
+      if (
+        semver.satisfies(
+          this._rushConfiguration.packageManagerToolVersion,
+          '6.32.12 - 6.33.x || 7.0.1 - 7.8.x'
+        )
+      ) {
+        this._terminal.writeWarningLine(
+          'Warning: Your rush.json specifies a pnpmVersion with a known issue ' +
+            'that may cause unintended version selections.' +
+            " It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. " +
+            'For details see: https://rushjs.io/link/pnpm-issue-5132'
+        );
+      }
+      if (
+        semver.gte(this._rushConfiguration.packageManagerToolVersion, '7.9.0') ||
+        semver.gte(this._rushConfiguration.packageManagerToolVersion, '6.34.0')
+      ) {
+        args.push('--ignore-compatibility-db');
       }
     } else if (this._rushConfiguration.packageManager === 'yarn') {
       args.push('--link-folder', 'yarn-link');

--- a/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
+++ b/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+import * as path from 'path';
+import { ConsoleTerminalProvider } from '@rushstack/node-core-library';
+
+import { PurgeManager } from '../PurgeManager';
+import { BaseInstallManager, IInstallManagerOptions } from '../base/BaseInstallManager';
+
+import { RushConfiguration } from '../../api/RushConfiguration';
+import { RushGlobalFolder } from '../../api/RushGlobalFolder';
+
+class FakeBaseInstallManager extends BaseInstallManager {
+  public constructor(
+    rushConfiguration: RushConfiguration,
+    rushGlobalFolder: RushGlobalFolder,
+    purgeManager: PurgeManager,
+    options: IInstallManagerOptions
+  ) {
+    super(rushConfiguration, rushGlobalFolder, purgeManager, options);
+  }
+
+  protected prepareCommonTempAsync(): Promise<{
+    shrinkwrapIsUpToDate: boolean;
+    shrinkwrapWarnings: string[];
+  }> {
+    return Promise.resolve({ shrinkwrapIsUpToDate: true, shrinkwrapWarnings: [] });
+  }
+
+  protected installAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected postInstallAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+  public pushConfigurationArgs(args: string[], options: IInstallManagerOptions): void {
+    return super.pushConfigurationArgs(args, options);
+  }
+}
+
+describe('BaseInstallManager Test', () => {
+  const rushGlobalFolder: RushGlobalFolder = new RushGlobalFolder();
+
+  it('pnpm version in 6.32.12 - 6.33.x || 7.0.1 - 7.8.x should output warning', () => {
+    const rushJsonFilePnpmV6: string = path.resolve(__dirname, 'ignoreCompatibilityDb/rush1.json');
+    const rushJsonFilePnpmV7: string = path.resolve(__dirname, 'ignoreCompatibilityDb/rush2.json');
+    const rushConfigurationV6: RushConfiguration =
+      RushConfiguration.loadFromConfigurationFile(rushJsonFilePnpmV6);
+    const rushConfigurationV7: RushConfiguration =
+      RushConfiguration.loadFromConfigurationFile(rushJsonFilePnpmV7);
+    const purgeManager6: typeof PurgeManager.prototype = new PurgeManager(
+      rushConfigurationV6,
+      rushGlobalFolder
+    );
+    const purgeManager7: typeof PurgeManager.prototype = new PurgeManager(
+      rushConfigurationV7,
+      rushGlobalFolder
+    );
+    const options: IInstallManagerOptions = {} as IInstallManagerOptions;
+
+    const fakeBaseInstallManager6: FakeBaseInstallManager = new FakeBaseInstallManager(
+      rushConfigurationV6,
+      rushGlobalFolder,
+      purgeManager6,
+      options
+    );
+
+    const fakeBaseInstallManager7: FakeBaseInstallManager = new FakeBaseInstallManager(
+      rushConfigurationV7,
+      rushGlobalFolder,
+      purgeManager7,
+      options
+    );
+
+    const mockWrite = jest.fn();
+    jest.spyOn(ConsoleTerminalProvider.prototype, 'write').mockImplementation(mockWrite);
+
+    const argsPnpmV6: string[] = [];
+    fakeBaseInstallManager6.pushConfigurationArgs(argsPnpmV6, options);
+
+    expect(mockWrite.mock.calls[0][0]).toContain(
+      "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
+    );
+
+    const argsPnpmV7: string[] = [];
+    fakeBaseInstallManager7.pushConfigurationArgs(argsPnpmV7, options);
+    expect(mockWrite.mock.calls[0][0]).toContain(
+      "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
+    );
+  });
+
+  it('pnpm version gte 6.34.0 || gte 7.9.0 should add --ignore-compatibility-db', () => {
+    const rushJsonFile: string = path.resolve(__dirname, 'ignoreCompatibilityDb/rush3.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFile);
+    const purgeManager: typeof PurgeManager.prototype = new PurgeManager(rushConfiguration, rushGlobalFolder);
+    const options: IInstallManagerOptions = {} as IInstallManagerOptions;
+
+    const fakeBaseInstallManager: FakeBaseInstallManager = new FakeBaseInstallManager(
+      rushConfiguration,
+      rushGlobalFolder,
+      purgeManager,
+      options
+    );
+
+    const expected = ['--ignore-compatibility-db'];
+
+    const mockWrite = jest.fn();
+    jest.spyOn(ConsoleTerminalProvider.prototype, 'write').mockImplementation(mockWrite);
+
+    const args: string[] = [];
+    fakeBaseInstallManager.pushConfigurationArgs(args, options);
+    expect(args).toEqual(expect.arrayContaining(expected));
+
+    if (mockWrite.mock.calls.length) {
+      expect(mockWrite.mock.calls[0][0]).not.toContain(
+        "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
+      );
+    }
+  });
+});

--- a/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush1.json
+++ b/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush1.json
@@ -1,0 +1,8 @@
+{
+  "pnpmVersion": "6.33.12",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": []
+}

--- a/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush2.json
+++ b/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush2.json
@@ -1,0 +1,8 @@
+{
+  "pnpmVersion": "7.5.12",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": []
+}

--- a/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush3.json
+++ b/libraries/rush-lib/src/logic/test/ignoreCompatibilityDb/rush3.json
@@ -1,0 +1,8 @@
+{
+  "pnpmVersion": "7.9.0",
+  "rushVersion": "0.0.0",
+  "projectFolderMinDepth": 1,
+  "ensureConsistentVersions": true,
+
+  "projects": []
+}


### PR DESCRIPTION
Background
When using different versions of pnpm to install in TTFE Monorepo. There are unwanted package changes in lockfile. The reason is that pnpm bundled @yarnpkg/package-extensions, which mysteriously installs unrelated packages.

Related issue:

[PNPM mysteriously installs unrelated packages · Issue #5132 · pnpm/pnpm (github.com)](https://github.com/pnpm/pnpm/issues/5132)


Zoltan, added a new "ignore-compatibility-db" settings to disable this behaviour 6.34.0 and 7.9.0-0

For Rush.js side, we do the following things:

"rush install/update" should always set "ignore-compatibility-db=true". It's unconditional because Rush's recommended way to use compatibility db would be to copy+paste the settings to "pnpm.packageExtensions" or "pnpmfile.cjs". (The rules must be stored in Git rather than installed via NPM).
Rush should print some kind of warning if the rush.json pnpmVersion specifies a version affected by this problem.
 
The affected versions are ">=6.32.12" and >= 7.0.1, and then < 6.34.0 and <  7.9.0-0 version
 
The message will be like: Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132