### PR TITLE
[rush-lib] Fix Set config.ignoreCompatibilityDb when rush installation

### DIFF
--- a/common/changes/@microsoft/rush/feng-set-ignore-compatibility-db-true-when-installation_2022-08-08-05-48.json
+++ b/common/changes/@microsoft/rush/feng-set-ignore-compatibility-db-true-when-installation_2022-08-08-05-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "rush install/update should always set `config.ignoreCompatibilityDb` and print warning if the rush.json pnpmVersion specifies a version affected by this problem.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -40,6 +40,11 @@ import { WebClient, WebClientResponse } from '../../utilities/WebClient';
 import { SetupPackageRegistry } from '../setup/SetupPackageRegistry';
 import { PnpmfileConfiguration } from '../pnpm/PnpmfileConfiguration';
 
+/**
+ * Pnpm don't support --ignore-compatibility-db, so use --config.ignoreCompatibilityDb for now.
+ */
+export const pnpmIgnoreCompatibilityDbParameter: string = '--config.ignoreCompatibilityDb';
+
 export interface IInstallManagerOptions {
   /**
    * Whether the global "--debug" flag was specified.
@@ -610,9 +615,9 @@ export abstract class BaseInstallManager {
       }
       if (
         semver.gte(this._rushConfiguration.packageManagerToolVersion, '7.9.0') ||
-        semver.gte(this._rushConfiguration.packageManagerToolVersion, '6.34.0')
+        semver.satisfies(this._rushConfiguration.packageManagerToolVersion, '^6.34.0')
       ) {
-        args.push('--ignore-compatibility-db');
+        args.push(pnpmIgnoreCompatibilityDbParameter);
       }
     } else if (this._rushConfiguration.packageManager === 'yarn') {
       args.push('--link-folder', 'yarn-link');

--- a/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
+++ b/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
@@ -4,7 +4,11 @@ import * as path from 'path';
 import { ConsoleTerminalProvider } from '@rushstack/node-core-library';
 
 import { PurgeManager } from '../PurgeManager';
-import { BaseInstallManager, IInstallManagerOptions } from '../base/BaseInstallManager';
+import {
+  BaseInstallManager,
+  IInstallManagerOptions,
+  pnpmIgnoreCompatibilityDbParameter
+} from '../base/BaseInstallManager';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { RushGlobalFolder } from '../../api/RushGlobalFolder';
@@ -77,19 +81,20 @@ describe('BaseInstallManager Test', () => {
 
     const argsPnpmV6: string[] = [];
     fakeBaseInstallManager6.pushConfigurationArgs(argsPnpmV6, options);
-
+    expect(argsPnpmV6).not.toContain(pnpmIgnoreCompatibilityDbParameter);
     expect(mockWrite.mock.calls[0][0]).toContain(
       "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
     );
 
     const argsPnpmV7: string[] = [];
     fakeBaseInstallManager7.pushConfigurationArgs(argsPnpmV7, options);
+    expect(argsPnpmV7).not.toContain(pnpmIgnoreCompatibilityDbParameter);
     expect(mockWrite.mock.calls[0][0]).toContain(
       "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
     );
   });
 
-  it('pnpm version gte 6.34.0 || gte 7.9.0 should add --ignore-compatibility-db', () => {
+  it(`pnpm version ^6.34.0 || gte 7.9.0 should add ${pnpmIgnoreCompatibilityDbParameter}`, () => {
     const rushJsonFile: string = path.resolve(__dirname, 'ignoreCompatibilityDb/rush3.json');
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFile);
     const purgeManager: typeof PurgeManager.prototype = new PurgeManager(rushConfiguration, rushGlobalFolder);
@@ -102,14 +107,12 @@ describe('BaseInstallManager Test', () => {
       options
     );
 
-    const expected = ['--ignore-compatibility-db'];
-
     const mockWrite = jest.fn();
     jest.spyOn(ConsoleTerminalProvider.prototype, 'write').mockImplementation(mockWrite);
 
     const args: string[] = [];
     fakeBaseInstallManager.pushConfigurationArgs(args, options);
-    expect(args).toEqual(expect.arrayContaining(expected));
+    expect(args).toContain(pnpmIgnoreCompatibilityDbParameter);
 
     if (mockWrite.mock.calls.length) {
       expect(mockWrite.mock.calls[0][0]).not.toContain(


### PR DESCRIPTION
Background
When using different versions of pnpm to install in TTFE Monorepo. There are unwanted package changes in lockfile. The reason is that pnpm bundled @yarnpkg/package-extensions, which mysteriously installs unrelated packages.

Related issue:

https://github.com/pnpm/pnpm/issues/5132

Zoltan, added a new "ignore-compatibility-db" settings to disable this behaviour 6.34.0 and 7.9.0-0

For Rush.js side, we do the following things:

"rush install/update" should always set "config.ignoreCompatibilityDb". Because Pnpm only support "ignore-compatibility-db" in .npmrc.  It's unconditional because Rush's recommended way to use compatibility db would be to copy+paste the settings to "pnpm.packageExtensions" or "pnpmfile.cjs". (The rules must be stored in Git rather than installed via NPM).
Rush should print some kind of warning if the rush.json pnpmVersion specifies a version affected by this problem.
The affected versions are ">=6.32.12" and >= 7.0.1, and then < 6.34.0 and < 7.9.0-0 version

The message will be like: Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132