### PR TITLE
[rush] Allow configuration of watch debounce timeout

### DIFF
--- a/common/changes/@microsoft/rush/watch-perf_2022-08-12-22-50.json
+++ b/common/changes/@microsoft/rush/watch-perf_2022-08-12-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add ability to configure watch debounce timeout as \"watchOptions.debounceMilliseconds\" in phased commands.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/libraries/rush-lib/src/api/CommandLineConfiguration.ts
@@ -91,6 +91,10 @@ export interface IPhasedCommandConfig extends IPhasedCommandWithoutPhasesJson, I
    */
   watchPhases: Set<IPhase>;
   /**
+   * How many milliseconds to wait after receiving a file system notification before executing in watch mode.
+   */
+  watchDebounceMilliseconds?: number;
+  /**
    * If set to `true`, then this phased command will always perform an install before executing, regardless of CLI flags.
    * If set to `false`, then Rush will define a built-in "--install" CLI flag for this command.
    * If undefined, then Rush does not define a built-in "--install" CLI flag for this command and no installation is performed.
@@ -326,6 +330,7 @@ export class CommandLineConfiguration {
 
             if (watchOptions) {
               normalizedCommand.alwaysWatch = watchOptions.alwaysWatch;
+              normalizedCommand.watchDebounceMilliseconds = watchOptions.debounceMilliseconds;
 
               // No implicit phase dependency expansion for watch mode.
               for (const phaseName of watchOptions.watchPhases) {

--- a/libraries/rush-lib/src/api/CommandLineJson.ts
+++ b/libraries/rush-lib/src/api/CommandLineJson.ts
@@ -47,6 +47,7 @@ export interface IPhasedCommandJson extends IPhasedCommandWithoutPhasesJson {
   phases: string[];
   watchOptions?: {
     alwaysWatch: boolean;
+    debounceMilliseconds?: number;
     watchPhases: string[];
   };
   installOptions?: {

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -394,6 +394,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
         initialPhases: command.phases,
         watchPhases: command.watchPhases,
+        watchDebounceMilliseconds: command.watchDebounceMilliseconds ?? 1000,
         phases: commandLineConfiguration.phases,
 
         alwaysWatch: command.alwaysWatch,

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -38,7 +38,7 @@ import { IExecutionResult } from '../../logic/operations/IOperationExecutionResu
 import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
 
 /**
- * Constructor parameters for BulkScriptAction.
+ * Constructor parameters for PhasedScriptAction.
  */
 export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPhasedCommandConfig> {
   enableParallelism: boolean;
@@ -51,6 +51,8 @@ export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPh
 
   alwaysWatch: boolean;
   alwaysInstall: boolean | undefined;
+
+  watchDebounceMilliseconds: number | undefined;
 }
 
 interface IRunPhasesOptions {
@@ -101,6 +103,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   private readonly _disableBuildCache: boolean;
   private readonly _initialPhases: ReadonlySet<IPhase>;
   private readonly _watchPhases: ReadonlySet<IPhase>;
+  private readonly _watchDebounceMilliseconds: number;
   private readonly _alwaysWatch: boolean;
   private readonly _alwaysInstall: boolean | undefined;
   private readonly _knownPhases: ReadonlyMap<string, IPhase>;
@@ -121,6 +124,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     this._disableBuildCache = options.disableBuildCache;
     this._initialPhases = options.initialPhases;
     this._watchPhases = options.watchPhases;
+    this._watchDebounceMilliseconds = options.watchDebounceMilliseconds ?? 1000;
     this._alwaysWatch = options.alwaysWatch;
     this._alwaysInstall = options.alwaysInstall;
     this._knownPhases = options.phases;
@@ -304,7 +308,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     const { ProjectWatcher } = await import('../../logic/ProjectWatcher');
 
     const projectWatcher: typeof ProjectWatcher.prototype = new ProjectWatcher({
-      debounceMilliseconds: 1000,
+      debounceMilliseconds: this._watchDebounceMilliseconds,
       rushConfiguration: this.rushConfiguration,
       projectsToWatch,
       terminal,

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -376,11 +376,11 @@ export class ProjectChangeAnalyzer {
       let i: number = 0;
       for (const projectDeps of projectHashDeps.values()) {
         const projectDependencyManifestPath: string = projectDependencyManifestPaths[i];
-        if (!hashes.has(projectDependencyManifestPath)) {
+        const hash: string | undefined = hashes.get(projectDependencyManifestPath);
+        if (hash === undefined) {
           throw new InternalError(`Expected to get a hash for ${projectDependencyManifestPath}`);
         }
 
-        const hash: string = hashes.get(projectDependencyManifestPath)!;
         projectDeps.set(projectDependencyManifestPath, hash);
         i++;
       }

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -200,6 +200,11 @@
                   "description": "Indicates that this command will always watch for changes after the initial execution, as if the \"--watch\" CLI flag was passed.",
                   "type": "boolean"
                 },
+                "debounceMilliseconds": {
+                  "title": "Debounce Timeout in Milliseconds",
+                  "description": "When watching, how long to wait after the last encountered file system event before execution. If another file system event occurs in this interval, the timeout will reset.",
+                  "type": "number"
+                },
                 "watchPhases": {
                   "title": "Watch Phases",
                   "description": "List *exactly* the phases that should be run in watch mode for this command. If this property is specified and non-empty, after the phases defined in the \"phases\" property run, a file watcher will be started to watch projects for changes, and will run the phases listed in this property on changed projects.",


### PR DESCRIPTION
## Summary
Makes the debounce timeout after detecting file changes in watch mode configurable via `command-line.json` on a per-command basis. Default value is 1 second.

## Details
Adds a configuration value `debounceMilliseconds` in the `watchOptions` section of phased commands. This value (default `1000`) sets how long after the last detected file system event the watcher will wait before starting a build. If another file system event fires during the timeout, the timer gets reset.

## How it was tested
Configured the `rush start` command in `rushstack` to have a higher timeout (10 seconds) and verified the latency. Then tested with a lower timeout (100 milliseconds) and verified the quicker response.