### PR TITLE
[node-core-library] Remove node < 11 sort

### DIFF
--- a/apps/api-extractor/src/collector/MessageRouter.ts
+++ b/apps/api-extractor/src/collector/MessageRouter.ts
@@ -4,7 +4,7 @@
 import colors from 'colors';
 import * as ts from 'typescript';
 import * as tsdoc from '@microsoft/tsdoc';
-import { Sort, InternalError, LegacyAdapters } from '@rushstack/node-core-library';
+import { Sort, InternalError } from '@rushstack/node-core-library';
 
 import { AstDeclaration } from '../analyzer/AstDeclaration';
 import { AstSymbol } from '../analyzer/AstSymbol';
@@ -635,7 +635,7 @@ export class MessageRouter {
    * Sorts an array of messages according to a reasonable ordering
    */
   private _sortMessagesForOutput(messages: ExtractorMessage[]): void {
-    LegacyAdapters.sortStable(messages, (a, b) => {
+    messages.sort((a, b) => {
       let diff: number;
       // First sort by file name
       diff = Sort.compareByValue(a.sourceFilePath, b.sourceFilePath);

--- a/common/changes/@microsoft/api-extractor-model/node-default-target_2022-08-22-22-10.json
+++ b/common/changes/@microsoft/api-extractor-model/node-default-target_2022-08-22-22-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Remove use of LegacyAdapters.sortStable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/node-default-target_2022-08-22-22-10.json
+++ b/common/changes/@microsoft/api-extractor/node-default-target_2022-08-22-22-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Remove use of LegacyAdapters.sortStable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/node-core-library/node-default-target_2022-08-22-22-10.json
+++ b/common/changes/@rushstack/node-core-library/node-default-target_2022-08-22-22-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Deprecate LegacyAdapters.sortStable and remove support for NodeJS < 11. If you are using NodeJS < 11, this is a breaking change.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1686,14 +1686,12 @@ importers:
       '@types/node': 12.20.24
       '@types/resolve': 1.17.1
       '@types/semver': 7.3.5
-      '@types/timsort': 0.3.0
       colors: ~1.2.1
       fs-extra: ~7.0.1
       import-lazy: ~4.0.0
       jju: ~1.4.0
       resolve: ~1.17.0
       semver: ~7.3.0
-      timsort: ~0.3.0
       z-schema: ~5.0.2
     dependencies:
       '@types/node': 12.20.24
@@ -1703,7 +1701,6 @@ importers:
       jju: 1.4.0
       resolve: 1.17.0
       semver: 7.3.7
-      timsort: 0.3.0
       z-schema: 5.0.3
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -1714,7 +1711,6 @@ importers:
       '@types/jju': 1.4.1
       '@types/resolve': 1.17.1
       '@types/semver': 7.3.5
-      '@types/timsort': 0.3.0
 
   ../../libraries/package-deps-hash:
     specifiers:
@@ -7179,10 +7175,6 @@ packages:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
       '@types/node': 12.20.24
-    dev: true
-
-  /@types/timsort/0.3.0:
-    resolution: {integrity: sha512-SFjNmiiq4uCs9eXvxbaJMa8pnmlepV8dT2p0nCfdRL1h/UU7ZQFsnCLvtXRHTb3rnyILpQz4Kh8JoTqvDdgxYw==}
     dev: true
 
   /@types/tunnel/0.0.1:
@@ -18679,6 +18671,7 @@ packages:
 
   /timsort/0.3.0:
     resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
+    dev: true
 
   /tiny-lru/7.0.6:
     resolution: {integrity: sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "cbd21b0d7df471c98d131b4da57ccf42b4e01395",
+  "pnpmShrinkwrapHash": "4d6e5e67bed9cdd954bad49e75c121160092f083",
   "preferredVersionsHash": "d15f901c51f5b82ae0cc4cc0a2cdc9a5e451367c"
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -691,6 +691,7 @@ export class LegacyAdapters {
     // (undocumented)
     static convertCallbackToPromise<TResult, TError, TArg1, TArg2, TArg3, TArg4>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4, cb: LegacyCallback<TResult, TError>) => void, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
     static scrubError(error: Error | string | any): Error;
+    // @deprecated
     static sortStable<T>(array: T[], compare?: (a: T, b: T) => number): void;
 }
 
@@ -805,8 +806,8 @@ export class ProtectableMap<K, V> {
 // @public
 export class Sort {
     static compareByValue(x: any, y: any): number;
-    static isSorted<T>(array: T[], comparer?: (x: any, y: any) => number): boolean;
-    static isSortedBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
+    static isSorted<T>(collection: Iterable<T>, comparer?: (x: any, y: any) => number): boolean;
+    static isSortedBy<T>(collection: Iterable<T>, keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
     static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): void;
     static sortMapKeys<K, V>(map: Map<K, V>, keyComparer?: (x: K, y: K) => number): void;
     static sortSet<T>(set: Set<T>, comparer?: (x: T, y: T) => number): void;

--- a/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -16,7 +16,7 @@ import { ApiClass } from '../model/ApiClass';
 import { ApiInterface } from '../model/ApiInterface';
 import { ExcerptToken, ExcerptTokenKind } from './Excerpt';
 import { IFindApiItemsResult, IFindApiItemsMessage, FindApiItemsMessageId } from './IFindApiItemsResult';
-import { InternalError, LegacyAdapters } from '@rushstack/node-core-library';
+import { InternalError } from '@rushstack/node-core-library';
 import { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
 import { HeritageType } from '../model/HeritageType';
 import { IResolveDeclarationReferenceResult } from '../model/ModelReferenceResolver';
@@ -231,7 +231,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
     /** @override */
     public get members(): ReadonlyArray<ApiItem> {
       if (!this[_membersSorted] && !this[_preserveMemberOrder]) {
-        LegacyAdapters.sortStable(this[_members], (x, y) => x.getSortKey().localeCompare(y.getSortKey()));
+        this[_members].sort((x, y) => x.getSortKey().localeCompare(y.getSortKey()));
         this[_membersSorted] = true;
       }
 
@@ -433,9 +433,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
         //
         // interface FooBar extends Foo, Bar {}
         // ```
-        LegacyAdapters.sortStable(extendedItems, (x: ApiItem, y: ApiItem) =>
-          x.getSortKey().localeCompare(y.getSortKey())
-        );
+        extendedItems.sort((x: ApiItem, y: ApiItem) => x.getSortKey().localeCompare(y.getSortKey()));
 
         toVisit.push(...extendedItems);
         next = toVisit.shift();
@@ -448,9 +446,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
       for (const members of membersByKind.values()) {
         items.push(...members);
       }
-      LegacyAdapters.sortStable(items, (x: ApiItem, y: ApiItem) =>
-        x.getSortKey().localeCompare(y.getSortKey())
-      );
+      items.sort((x: ApiItem, y: ApiItem) => x.getSortKey().localeCompare(y.getSortKey()));
 
       return {
         items,

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -23,7 +23,6 @@
     "jju": "~1.4.0",
     "resolve": "~1.17.0",
     "semver": "~7.3.0",
-    "timsort": "~0.3.0",
     "z-schema": "~5.0.2"
   },
   "devDependencies": {
@@ -34,7 +33,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/jju": "1.4.1",
     "@types/resolve": "1.17.1",
-    "@types/semver": "7.3.5",
-    "@types/timsort": "0.3.0"
+    "@types/semver": "7.3.5"
   }
 }

--- a/libraries/node-core-library/src/LegacyAdapters.ts
+++ b/libraries/node-core-library/src/LegacyAdapters.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { sort as timsort } from 'timsort';
-import * as semver from 'semver';
-
 /**
  * Callback used by {@link LegacyAdapters}.
  * @public
@@ -16,8 +13,6 @@ export type LegacyCallback<TResult, TError> = (error: TError | null | undefined,
  * @public
  */
 export class LegacyAdapters {
-  private static _useTimsort: boolean | undefined = undefined;
-
   /**
    * This function wraps a function with a callback in a promise.
    */
@@ -106,18 +101,12 @@ export class LegacyAdapters {
    * Prior to Node 11.x, the `Array.sort()` algorithm is not guaranteed to be stable.
    * If you need a stable sort, you can use `sortStable()` as a workaround.
    *
+   * @deprecated
+   * Use native Array.sort(), since Node &lt; 14 is no longer supported
    * @remarks
    * On NodeJS 11.x and later, this method simply calls the native `Array.sort()`.
-   * For earlier versions, it uses an implementation of Timsort, which is the same algorithm used by modern NodeJS.
    */
   public static sortStable<T>(array: T[], compare?: (a: T, b: T) => number): void {
-    if (LegacyAdapters._useTimsort === undefined) {
-      LegacyAdapters._useTimsort = semver.major(process.versions.node) < 11;
-    }
-    if (LegacyAdapters._useTimsort) {
-      timsort(array, compare);
-    } else {
-      Array.prototype.sort.call(array, compare);
-    }
+    Array.prototype.sort.call(array, compare);
   }
 }

--- a/libraries/node-core-library/src/Sort.ts
+++ b/libraries/node-core-library/src/Sort.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { LegacyAdapters } from './LegacyAdapters';
-
 /**
  * Operations for sorting collections.
- *
- * @remarks
- * NOTE: Prior to Node 11.x, the `Array.sort()` algorithm is not guaranteed to be stable.  For maximum
- * compatibility, consider using {@link LegacyAdapters.sortStable} instead of `Array.sort()`.
  *
  * @public
  */
@@ -82,16 +76,19 @@ export class Sort {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     comparer: (x: any, y: any) => number = Sort.compareByValue
   ): void {
-    LegacyAdapters.sortStable(array, (x, y) => comparer(keySelector(x), keySelector(y)));
+    array.sort((x, y) => comparer(keySelector(x), keySelector(y)));
   }
 
   /**
-   * Returns true if the array is already sorted.
+   * Returns true if the collection is already sorted.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public static isSorted<T>(array: T[], comparer: (x: any, y: any) => number = Sort.compareByValue): boolean {
+  public static isSorted<T>(
+    collection: Iterable<T>,
+    comparer: (x: any, y: any) => number = Sort.compareByValue
+  ): boolean {
     let previous: T | undefined = undefined;
-    for (const element of array) {
+    for (const element of collection) {
       if (comparer(previous, element) > 0) {
         return false;
       }
@@ -101,7 +98,7 @@ export class Sort {
   }
 
   /**
-   * Returns true if the array is already sorted by the specified key.
+   * Returns true if the collection is already sorted by the specified key.
    *
    * @example
    *
@@ -111,14 +108,14 @@ export class Sort {
    * ```
    */
   public static isSortedBy<T>(
-    array: T[],
+    collection: Iterable<T>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     keySelector: (element: T) => any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     comparer: (x: any, y: any) => number = Sort.compareByValue
   ): boolean {
     let previousKey: T | undefined = undefined;
-    for (const element of array) {
+    for (const element of collection) {
       const key: T = keySelector(element);
       if (comparer(previousKey, key) > 0) {
         return false;
@@ -183,14 +180,13 @@ export class Sort {
     keySelector: (element: T) => any,
     keyComparer: (x: T, y: T) => number = Sort.compareByValue
   ): void {
-    const array: T[] = Array.from(set);
-
     // Sorting a set is expensive, so first check whether it's already sorted.
-    if (Sort.isSortedBy(array, keySelector, keyComparer)) {
+    if (Sort.isSortedBy(set, keySelector, keyComparer)) {
       return;
     }
 
-    LegacyAdapters.sortStable(array, (x, y) => keyComparer(keySelector(x), keySelector(y)));
+    const array: T[] = Array.from(set);
+    array.sort((x, y) => keyComparer(keySelector(x), keySelector(y)));
 
     set.clear();
     for (const item of array) {
@@ -214,14 +210,13 @@ export class Sort {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static sortSet<T>(set: Set<T>, comparer: (x: T, y: T) => number = Sort.compareByValue): void {
-    const array: T[] = Array.from(set);
-
     // Sorting a set is expensive, so first check whether it's already sorted.
-    if (Sort.isSorted(array, comparer)) {
+    if (Sort.isSorted(set, comparer)) {
       return;
     }
 
-    LegacyAdapters.sortStable(array, (x, y) => comparer(x, y));
+    const array: T[] = Array.from(set);
+    array.sort((x, y) => comparer(x, y));
 
     set.clear();
     for (const item of array) {

--- a/libraries/node-core-library/src/Sort.ts
+++ b/libraries/node-core-library/src/Sort.ts
@@ -82,9 +82,9 @@ export class Sort {
   /**
    * Returns true if the collection is already sorted.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static isSorted<T>(
     collection: Iterable<T>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     comparer: (x: any, y: any) => number = Sort.compareByValue
   ): boolean {
     let previous: T | undefined = undefined;


### PR DESCRIPTION
## Summary
Reroutes `LegacyAdapters.sortStable` to always call `Array.prototype.sort`, since node 12 and below are EOL and all currently maintained LTS versions use stable sorting.

## Details
Disables the node version check to remove the dependency on `semver` and `timsort`.

## How it was tested
Unit tests.