### PR TITLE
[rush-lib] Stricter syntax for Rush project tag names

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-stricter-project-tag-names_2022-08-20-00-01.json
+++ b/common/changes/@microsoft/rush/octogonz-stricter-project-tag-names_2022-08-20-00-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Make the project tag name syntax more strict to avoid error-prone names such as \"tag:$PATH\" or \"tag://\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -391,7 +391,7 @@
     * to projects. If this property is not specified, any tag is allowed. This
     * list is useful in preventing typos when specifying tags for projects.
     */
-  /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "apps", "Web", "tools" ],
+  /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "apps", "frontend-team", "1.0.0-release" ],
 
   /**
    * (Required) This is the inventory of projects to be managed by Rush.

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -387,11 +387,13 @@
   /*[LINE "HYPOTHETICAL"]*/ "hotfixChangeEnabled": false,
 
   /**
-    * This is an optional, but recommended, list of available tags that can be applied
-    * to projects. If this property is not specified, any tag is allowed. This
-    * list is useful in preventing typos when specifying tags for projects.
+    * This is an optional, but recommended, list of allowed tags that can be applied to Rush projects
+    * using the "tags" setting in this file.  This list is useful for preventing mistakes such as misspelling,
+    * and it also provides a centralized place to document your tags.  If "allowedProjectTags" list is
+    * not specified, then any valid tag is allowed.  A tag name must be one or more words separated
+    * by hyphens, where a word may contain lowercase letters, digits, and the period character.
     */
-  /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "apps", "frontend-team", "1.0.0-release" ],
+  /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "tools", "frontend-team", "1.0.0-release" ],
 
   /**
    * (Required) This is the inventory of projects to be managed by Rush.
@@ -483,21 +485,21 @@
        * command "rush list --only tag:my-custom-tag".  The tag name must be one or more words separated
        * by hyphens, where a word may contain lowercase letters, digits, and the period character.
        */
-      /*[LINE "HYPOTHETICAL"]*/ "tags": ["apps", "web"]
+      /*[LINE "HYPOTHETICAL"]*/ "tags": [ "1.0.0-release", "frontend-team" ]
     },
 
     {
       "packageName": "my-controls",
       "projectFolder": "libraries/my-controls",
       "reviewCategory": "production",
-      "tags": ["libraries", "web"]
+      "tags": [ "frontend-team" ]
     },
 
     {
       "packageName": "my-toolchain",
       "projectFolder": "tools/my-toolchain",
       "reviewCategory": "tools",
-      "tags": ["tools"]
+      "tags": [ "tools" ]
     }
     /*[END "DEMO"]*/
   ]

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -478,10 +478,11 @@
       /*[LINE "HYPOTHETICAL"]*/ "versionPolicyName": "",
 
       /**
-        * An optional set of custom tags that can be used to select this project. For example,
-        * adding "my-custom-tag" will allow this project to be selected by the
-        * command "rush list --only tag:my-custom-tag"
-        */
+       * An optional set of custom tags that can be used to select this project.  For example,
+       * adding "my-custom-tag" will allow this project to be selected by the
+       * command "rush list --only tag:my-custom-tag".  The tag name must be one or more words separated
+       * by hyphens, where a word may contain lowercase letters, digits, and the period character.
+       */
       /*[LINE "HYPOTHETICAL"]*/ "tags": ["apps", "web"]
     },
 

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -390,8 +390,9 @@
     * This is an optional, but recommended, list of allowed tags that can be applied to Rush projects
     * using the "tags" setting in this file.  This list is useful for preventing mistakes such as misspelling,
     * and it also provides a centralized place to document your tags.  If "allowedProjectTags" list is
-    * not specified, then any valid tag is allowed.  A tag name must be one or more words separated
-    * by hyphens, where a word may contain lowercase letters, digits, and the period character.
+    * not specified, then any valid tag is allowed.  A tag name must be one or more words
+    * separated by hyphens or slashes, where a word may contain lowercase ASCII letters, digits,
+    * ".", and "@" characters.
     */
   /*[LINE "HYPOTHETICAL"]*/ "allowedProjectTags": [ "tools", "frontend-team", "1.0.0-release" ],
 
@@ -482,8 +483,9 @@
       /**
        * An optional set of custom tags that can be used to select this project.  For example,
        * adding "my-custom-tag" will allow this project to be selected by the
-       * command "rush list --only tag:my-custom-tag".  The tag name must be one or more words separated
-       * by hyphens, where a word may contain lowercase letters, digits, and the period character.
+       * command "rush list --only tag:my-custom-tag".  The tag name must be one or more words
+       * separated by hyphens or slashes, where a word may contain lowercase ASCII letters, digits,
+       * ".", and "@" characters.
        */
       /*[LINE "HYPOTHETICAL"]*/ "tags": [ "1.0.0-release", "frontend-team" ]
     },

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -492,7 +492,13 @@ export class RushConfigurationProject {
   }
 
   /**
-   * The set of tags applied to this project.
+   * An optional set of custom tags that can be used to select this project.
+   *
+   * @remarks
+   * For example, adding `my-custom-tag` will allow this project to be selected by the
+   * command `rush list --only tag:my-custom-tag`.  The tag name must be one or more words separated
+   * by hyphens, where a word may contain lowercase letters, digits, and the period character.
+   *
    * @beta
    */
   public get tags(): ReadonlySet<string> {

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -237,11 +237,11 @@
       "type": "boolean"
     },
     "allowedProjectTags": {
-      "description": "This is an optional, but recommended, list of allowed tags that can be applied to Rush projects using the \"tags\" setting in this file.  This list is useful for preventing mistakes such as misspelling, and it also provides a centralized place to document your tags.  If \"allowedProjectTags\" list is not specified, then any valid tag is allowed.  A tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
+      "description": "This is an optional, but recommended, list of allowed tags that can be applied to Rush projects using the \"tags\" setting in this file.  This list is useful for preventing mistakes such as misspelling, and it also provides a centralized place to document your tags.  If \"allowedProjectTags\" list is not specified, then any valid tag is allowed.  A tag name must be one or more words separated by hyphens or slashes, where a word may contain lowercase ASCII letters, digits, \".\", and \"@\" characters.",
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[a-z0-9.]+(-[a-z0-9.]+)*$"
+        "pattern": "^[a-z0-9.@]+([-/][a-z0-9.@]+)*$"
       }
     },
     "projects": {
@@ -293,11 +293,11 @@
             "type": "string"
           },
           "tags": {
-            "description": "An optional set of custom tags that can be used to select this project. For example, adding \"my-custom-tag\" will allow this project to be selected by the command \"rush list --only tag:my-custom-tag\". The tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
+            "description": "An optional set of custom tags that can be used to select this project. For example, adding \"my-custom-tag\" will allow this project to be selected by the command \"rush list --only tag:my-custom-tag\". The tag name must be one or more words separated by hyphens or slashes, where a word may contain lowercase ASCII letters, digits, \".\", and \"@\" characters.",
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-z0-9.]+(-[a-z0-9.]+)*$"
+              "pattern": "^[a-z0-9.@]+([-/][a-z0-9.@]+)*$"
             }
           }
         },

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -237,11 +237,11 @@
       "type": "boolean"
     },
     "allowedProjectTags": {
-      "description": "This is an optional, but recommended, list of available tags that can be applied to projects. If this property is not specified, any tag is allowed. This list is useful in preventing typos when specifying tags for projects.",
+      "description": "This is an optional, but recommended, list of available tags that can be applied to projects. If this property is not specified, any tag is allowed. This list is useful in preventing typos when specifying tags for projects. A tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[A-Za-z0-9_@/.$-]+$"
+        "pattern": "^[a-z0-9.]+(-[a-z0-9.]+)*$"
       }
     },
     "projects": {
@@ -293,11 +293,11 @@
             "type": "string"
           },
           "tags": {
-            "description": "An optional set of custom tags that can be used to select this project. For example, adding \"my-custom-tag\" will allow this project to be selected by the command \"rush list --only tag:my-custom-tag\".",
+            "description": "An optional set of custom tags that can be used to select this project. For example, adding \"my-custom-tag\" will allow this project to be selected by the command \"rush list --only tag:my-custom-tag\". The tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[A-Za-z0-9_@/.$-]+$"
+              "pattern": "^[a-z0-9.]+(-[a-z0-9.]+)*$"
             }
           }
         },

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -237,7 +237,7 @@
       "type": "boolean"
     },
     "allowedProjectTags": {
-      "description": "This is an optional, but recommended, list of available tags that can be applied to projects. If this property is not specified, any tag is allowed. This list is useful in preventing typos when specifying tags for projects. A tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
+      "description": "This is an optional, but recommended, list of allowed tags that can be applied to Rush projects using the \"tags\" setting in this file.  This list is useful for preventing mistakes such as misspelling, and it also provides a centralized place to document your tags.  If \"allowedProjectTags\" list is not specified, then any valid tag is allowed.  A tag name must be one or more words separated by hyphens, where a word may contain lowercase letters, digits, and the period character.",
       "type": "array",
       "items": {
         "type": "string",


### PR DESCRIPTION


## Summary

PR https://github.com/microsoft/rushstack/pull/3300 recently introduced support for project tags.  However the syntax for tag names is not strict enough.

## Details

**The old RegExp:** `"^[A-Za-z0-9_@/.$-]+$"`

This allows syntaxes such as:
```
rush build --to tag:.
rush build --to tag:@
rush build --to tag://
rush build --to tag:CrAzYcAsE
rush build --to tag:--cli-case
rush build --to tag:camelCase
rush build --to tag:$PATH
```

This is bad experience for users:

- If I'm defining my first tag in **rush.json**, what should it look like?  `MY_TAG`? `myTag`? `MyTag`? `my-tag`? We're not too opinionated about which syntax to choose for our monorepo, but we do want a ***consistent*** syntax everywhere.  The unopinionated RegExp pushes this design problem onto me as a user. My team has to discuss it and decide an answer, which is now likely to be inconsistent with some other group's monorepo, a jarring experience for people who contribute to multiple repos.

- Capital letters are error-prone:  Since the name is case-sensitive, everyone has to memorize the correct case, which is a bit of extra work.  Or if we made the name be case-insensitive, then every custom script that compares tags must remember to perform case-insensitive comparisons, or else there's a hidden bug.

- Punctuation is error-prone:  For example, if I do ``spawn(`rush list --only tag:${item.rushTagName}`)``, this code will fail to process `tag:$PATH` due to shell expansion. (This is technically a string injection security vulnerability.) To fix that, I need to write extra code to escape the special characters. But that is not trivial -- we must go read the Rush spec to figure out which characters are special, and in fact the shell escapes are different on Windows vs Mac.

- Loose specs make it harder to spot mistakes.  With a strict spec, I have a mental "norm" for what a tag looks like.  If I see something like `rush list --only tag:$PATH` in a log file, I can instantly recognize that something is wrong.

Each of these observations represents a downside of flexibility, a design cost that we can choose to accept or not.  The reason to accept such costs would be if there was some great benefit for flexible names.  I can't think of any great benefits that would justify these costs.  (One possible benefit would be making it easier to map external IDs to Rush tag names, for example an email address or filename, without having to normalize by discarding unsupported characters and appending suffixes to avoid collisions.  But to really meet that requirement, we'd need to allow a rather broad set of punctuation characters, which really magnifies these costs. For the scenario of Rush tagging, it doesn't seem worth it.)


**The new RegExp:** `"^[a-z0-9.]+(-[a-z0-9.]+)*$"`

This allows syntaxes such as:
```
rush build --to tag:one
rush build --to tag:one-two-three
rush build --to tag:api-extractor.com
rush build --to tag:1.2.3
```

**Thesis:** This syntax provides just enough characters to meet the needs of all common tagging scenarios, while completely eliminating any concerns about shell escaping or character casing.