### PR TITLE
[rush-lib] Enhance telemetry with individual operation times, graph, and machine info

### DIFF
--- a/common/changes/@microsoft/rush/enhanced-telemetry_2022-08-23-22-57.json
+++ b/common/changes/@microsoft/rush/enhanced-telemetry_2022-08-23-22-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Update telemetry to machine architecture information, and phased command telemetry to have details of the dependency graph and individual build times and statuses.",
+      "comment": "Add machine architecture information, dependency graph information, and individual build times and statuses to the telemetry file.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/enhanced-telemetry_2022-08-23-22-57.json
+++ b/common/changes/@microsoft/rush/enhanced-telemetry_2022-08-23-22-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update telemetry to machine architecture information, and phased command telemetry to have details of the dependency graph and individual build times and statuses.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -497,9 +497,9 @@ export interface ITelemetryMachineInfo {
 // @beta (undocumented)
 export interface ITelemetryOperationResult {
     dependencies: string[];
-    endSeconds?: number;
+    endTimestamp?: number;
     result: string;
-    startSeconds?: number;
+    startTimestamp?: number;
 }
 
 // @public

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -476,11 +476,30 @@ export interface ITelemetryData {
     readonly extraData?: {
         [key: string]: string | number | boolean;
     };
+    readonly machineInfo?: ITelemetryMachineInfo;
     readonly name: string;
+    readonly operationResults?: Record<string, ITelemetryOperationResult>;
     readonly platform?: string;
     readonly result: 'Succeeded' | 'Failed';
     readonly rushVersion?: string;
     readonly timestamp?: number;
+}
+
+// @beta (undocumented)
+export interface ITelemetryMachineInfo {
+    machineArchitecture: string;
+    machineCores: number;
+    machineCPU: string;
+    machineFreeMemoryMiB: number;
+    machineTotalMemoryMiB: number;
+}
+
+// @beta (undocumented)
+export interface ITelemetryOperationResult {
+    dependencies: string[];
+    endSeconds?: number;
+    result: string;
+    startSeconds?: number;
 }
 
 // @public

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -36,6 +36,7 @@ import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
 import { OperationStatus } from '../../logic/operations/OperationStatus';
 import { IExecutionResult } from '../../logic/operations/IOperationExecutionResult';
 import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
+import type { ITelemetryOperationResult } from '../../logic/Telemetry';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -527,6 +528,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
 
     if (this.parser.telemetry) {
+      const operationResults: Record<string, ITelemetryOperationResult> = {};
+
       const extraData: IPhasedCommandTelemetry = {
         // Fields preserved across the command invocation
         ...this._selectionParameters.getTelemetry(),
@@ -546,11 +549,37 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       };
 
       if (result) {
+        const nonSilentDependenciesByOperation: Map<Operation, Set<string>> = new Map();
+        function getNonSilentDependencies(operation: Operation): ReadonlySet<string> {
+          let realDependencies: Set<string> | undefined = nonSilentDependenciesByOperation.get(operation);
+          if (!realDependencies) {
+            nonSilentDependenciesByOperation.set(operation, (realDependencies = new Set()));
+            for (const dependency of operation.dependencies) {
+              if (dependency.runner!.silent) {
+                for (const deepDependency of getNonSilentDependencies(dependency)) {
+                  realDependencies.add(deepDependency);
+                }
+              } else {
+                realDependencies.add(dependency.name!);
+              }
+            }
+          }
+          return realDependencies;
+        }
+
         for (const [operation, operationResult] of result.operationResults) {
           if (operation.runner?.silent) {
             // Architectural operation. Ignore.
             continue;
           }
+
+          const { startTime, endTime } = operationResult.stopwatch;
+          operationResults[operation.name!] = {
+            startSeconds: startTime === undefined ? startTime : Math.round(startTime) / 1000,
+            endSeconds: endTime === undefined ? endTime : Math.round(endTime) / 1000,
+            result: operationResult.status,
+            dependencies: Array.from(getNonSilentDependencies(operation)).sort()
+          };
 
           extraData.countAll++;
           switch (operationResult.status) {
@@ -586,7 +615,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         name: this.actionName,
         durationInSeconds: stopwatch.duration,
         result: success ? 'Succeeded' : 'Failed',
-        extraData
+        extraData,
+        operationResults
       });
 
       this.parser.flushTelemetry();

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -575,8 +575,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
           const { startTime, endTime } = operationResult.stopwatch;
           operationResults[operation.name!] = {
-            startSeconds: startTime === undefined ? startTime : Math.round(startTime) / 1000,
-            endSeconds: endTime === undefined ? endTime : Math.round(endTime) / 1000,
+            startTimestamp: startTime,
+            endTimestamp: endTime,
             result: operationResult.status,
             dependencies: Array.from(getNonSilentDependencies(operation)).sort()
           };

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -109,6 +109,6 @@ export { ICloudBuildCacheProvider } from './logic/buildCache/ICloudBuildCachePro
 
 export { ICredentialCacheOptions, ICredentialCacheEntry, CredentialCache } from './logic/CredentialCache';
 
-export { ITelemetryData } from './logic/Telemetry';
+export type { ITelemetryData, ITelemetryMachineInfo, ITelemetryOperationResult } from './logic/Telemetry';
 
 export { IStopwatchResult } from './utilities/Stopwatch';

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -1,12 +1,64 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as os from 'os';
 import * as path from 'path';
 import { FileSystem, FileSystemStats, JsonFile } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { Rush } from '../api/Rush';
 import { RushSession } from '../pluginFramework/RushSession';
+
+/**
+ * @beta
+ */
+export interface ITelemetryMachineInfo {
+  /**
+   * The CPU architecture
+   * @example 'AMD64'
+   */
+  machineArchitecture: string;
+  /**
+   * The CPU
+   */
+  machineCPU: string;
+  /**
+   * The number of logical CPU cores.
+   */
+  machineCores: number;
+  /**
+   * The total amount of RAM on the machine, in MiB.
+   */
+  machineTotalMemoryMiB: number;
+  /**
+   * The amount of free RAM on the machine at the end of execution, in MiB.
+   */
+  machineFreeMemoryMiB: number;
+}
+
+/**
+ * @beta
+ */
+export interface ITelemetryOperationResult {
+  /**
+   * The names of operations that this operation depends on.
+   */
+  dependencies: string[];
+  /**
+   * The status code for the operation.
+   */
+  result: string;
+  /**
+   * A second-resolution timestamp when the operation started.
+   * If the operation was blocked, will be `undefined`.
+   */
+  startSeconds?: number;
+  /**
+   * A second-resolution timestamp when the operation finished.
+   * If the operation was blocked, will be `undefined`.
+   */
+  endSeconds?: number;
+}
 
 /**
  * @beta
@@ -26,7 +78,7 @@ export interface ITelemetryData {
    */
   readonly result: 'Succeeded' | 'Failed';
   /**
-   * The timestamp of the telemetry logging
+   * The millisecond-resolution timestamp of the telemetry logging
    * @example 1648001893024
    */
   readonly timestamp?: number;
@@ -41,9 +93,19 @@ export interface ITelemetryData {
    */
   readonly rushVersion?: string;
   readonly extraData?: { [key: string]: string | number | boolean };
+  /**
+   * Detailed information about the host machine.
+   */
+  readonly machineInfo?: ITelemetryMachineInfo;
+  /**
+   * Only applicable to phased commands. Provides detailed results by operation.
+   * Keys are operation names, values contain result, timing information, and dependencies.
+   */
+  readonly operationResults?: Record<string, ITelemetryOperationResult>;
 }
 
 const MAX_FILE_COUNT: number = 100;
+const ONE_MEGABYTE_IN_BYTES: 1048576 = 1048576;
 
 export class Telemetry {
   private _enabled: boolean;
@@ -69,6 +131,13 @@ export class Telemetry {
     }
     const data: ITelemetryData = {
       ...telemetryData,
+      machineInfo: telemetryData.machineInfo || {
+        machineArchitecture: os.arch(),
+        machineCPU: os.cpus()[0].model,
+        machineCores: os.cpus().length,
+        machineTotalMemoryMiB: Math.round(os.totalmem() / ONE_MEGABYTE_IN_BYTES),
+        machineFreeMemoryMiB: Math.round(os.freemem() / ONE_MEGABYTE_IN_BYTES)
+      },
       timestamp: telemetryData.timestamp || new Date().getTime(),
       platform: telemetryData.platform || process.platform,
       rushVersion: telemetryData.rushVersion || Rush.version

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -49,15 +49,15 @@ export interface ITelemetryOperationResult {
    */
   result: string;
   /**
-   * A second-resolution timestamp when the operation started.
+   * A timestamp in milliseconds (from `performance.now()`)when the operation started.
    * If the operation was blocked, will be `undefined`.
    */
-  startSeconds?: number;
+  startTimestamp?: number;
   /**
-   * A second-resolution timestamp when the operation finished.
+   * A timestamp in milliseconds (from `performance.now()`) when the operation finished.
    * If the operation was blocked, will be `undefined`.
    */
-  endSeconds?: number;
+  endTimestamp?: number;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/test/Telemetry.test.ts
+++ b/libraries/rush-lib/src/logic/test/Telemetry.test.ts
@@ -3,7 +3,7 @@
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { Rush } from '../../api/Rush';
-import { Telemetry, ITelemetryData } from '../Telemetry';
+import { Telemetry, ITelemetryData, ITelemetryMachineInfo } from '../Telemetry';
 import { RushSession } from '../../pluginFramework/RushSession';
 import { ConsoleTerminalProvider, JsonFile } from '@rushstack/node-core-library';
 
@@ -39,7 +39,8 @@ describe(Telemetry.name, () => {
       result: 'Succeeded',
       timestamp: new Date().getTime(),
       platform: process.platform,
-      rushVersion: Rush.version
+      rushVersion: Rush.version,
+      machineInfo: {} as ITelemetryMachineInfo
     };
 
     const logData2: ITelemetryData = {
@@ -48,7 +49,8 @@ describe(Telemetry.name, () => {
       result: 'Failed',
       timestamp: new Date().getTime(),
       platform: process.platform,
-      rushVersion: Rush.version
+      rushVersion: Rush.version,
+      machineInfo: {} as ITelemetryMachineInfo
     };
 
     telemetry.log(logData1);
@@ -91,7 +93,8 @@ describe(Telemetry.name, () => {
       result: 'Succeeded',
       timestamp: new Date().getTime(),
       platform: process.platform,
-      rushVersion: Rush.version
+      rushVersion: Rush.version,
+      machineInfo: {} as ITelemetryMachineInfo
     };
 
     telemetry.log(logData);

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -4,6 +4,7 @@
 import * as child_process from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
+import { performance } from 'perf_hooks';
 import {
   JsonFile,
   IPackageJson,
@@ -147,8 +148,7 @@ export class Utilities {
    * Node.js equivalent of performance.now().
    */
   public static getTimeInMs(): number {
-    const [seconds, nanoseconds] = process.hrtime();
-    return seconds * 1000 + nanoseconds / 1000000;
+    return performance.now();
   }
 
   /**
@@ -156,11 +156,7 @@ export class Utilities {
    */
   public static getSetAsArray<T>(set: Set<T>): T[] {
     // When ES6 is supported, we can use Array.from() instead.
-    const result: T[] = [];
-    set.forEach((value: T) => {
-      result.push(value);
-    });
-    return result;
+    return Array.from(set);
   }
 
   /**


### PR DESCRIPTION
## Summary
Adds additional information to the standard rush telemetry files, namely detailed machine architecture info (core count, OS, CPU model, RAM), and the operation graph.

Carve out from #3589 to separate concerns.

## Details
Example output from `rush retest -t eslint-plugin`:
```json
[
  {
    "name": "retest",
    "durationInSeconds": 14.688612599968911,
    "result": "Succeeded",
    "extraData": {
      "command_from": "false",
      "command_impactedBy": "false",
      "command_impactedByExcept": "false",
      "command_only": "false",
      "command_to": "true",
      "command_toExcept": "false",
      "command_fromVersionPolicy": "false",
      "command_toVersionPolicy": "false",
      "--timeline": "false",
      "--to": "eslint-plugin",
      "--to-except": "",
      "--from": "",
      "--only": "",
      "--impacted-by": "",
      "--impacted-by-except": "",
      "--to-version-policy": "",
      "--from-version-policy": "",
      "--verbose": "true",
      "--ignore-hooks": "false",
      "--no-color": "false",
      "--update-snapshots": "false",
      "--production": "false",
      "isWatch": false,
      "isInitial": true,
      "countAll": 4,
      "countSuccess": 4,
      "countSuccessWithWarnings": 0,
      "countFailure": 0,
      "countBlocked": 0,
      "countFromCache": 0,
      "countSkipped": 0,
      "countNoOp": 0
    },
    "operationResults": {
      "@rushstack/eslint-plugin (build)": {
        "startSeconds": 3.781,
        "endSeconds": 11.432,
        "result": "SUCCESS",
        "dependencies": [
          "@rushstack/tree-pattern (build)"
        ]
      },
      "@rushstack/tree-pattern (build)": {
        "startSeconds": 0.426,
        "endSeconds": 3.779,
        "result": "SUCCESS",
        "dependencies": []
      },
      "@rushstack/eslint-plugin (test)": {
        "startSeconds": 11.432,
        "endSeconds": 14.982,
        "result": "SUCCESS",
        "dependencies": [
          "@rushstack/eslint-plugin (build)"
        ]
      },
      "@rushstack/tree-pattern (test)": {
        "startSeconds": 3.78,
        "endSeconds": 4.747,
        "result": "SUCCESS",
        "dependencies": [
          "@rushstack/tree-pattern (build)"
        ]
      }
    },
    "machineInfo": {
      "machineArchitecture": "x64",
      "machineCPU": "Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz",
      "machineCores": 8,
      "machineTotalMemoryMiB": 16001,
      "machineFreeMemoryMiB": 11995
    },
    "timestamp": 1661295823893,
    "platform": "linux",
    "rushVersion": "5.76.1"
  }
]
```

## How it was tested
Enabled telemetry in the rushstack repo and ran various commands to test.