### PR TITLE
[rush-lib] Fix issue with adding packages to nested project

### DIFF
--- a/common/changes/@microsoft/rush/will-rush-add-nested-package_2022-08-26-22-10.json
+++ b/common/changes/@microsoft/rush/will-rush-add-nested-package_2022-08-26-22-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Packages are now sorted in decreasing order of their paths so nested packages are located before root packages.",
+      "comment": "Fix an issue where \"rush add\" sometimes did not work correctly if a project is nested under another project's folder",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/will-rush-add-nested-package_2022-08-26-22-10.json
+++ b/common/changes/@microsoft/rush/will-rush-add-nested-package_2022-08-26-22-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Packages are now sorted in decreasing order of their paths so nested packages are located before root packages.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/will-rush-add-nested-package_2022-08-30-21-35.json
+++ b/common/changes/@rushstack/node-core-library/will-rush-add-nested-package_2022-08-30-21-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/config/heft.json
+++ b/libraries/node-core-library/config/heft.json
@@ -1,0 +1,160 @@
+/**
+ * Defines configuration used by core Heft.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft.schema.json",
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
+   * settings to be shared across multiple projects.
+   */
+  "extends": "@rushstack/heft-node-rig/profiles/default/config/heft.json",
+
+  "eventActions": [
+    // {
+    //   /**
+    //    * (Required) The kind of built-in operation that should be performed.
+    //    * The "deleteGlobs" action deletes files or folders that match the specified glob patterns.
+    //    */
+    //   "actionKind": "deleteGlobs",
+    //
+    //   /**
+    //    * (Required) The Heft stage when this action should be performed.  Note that heft.json event actions
+    //    * are scheduled after any plugin tasks have processed the event.  For example, a "compile" event action
+    //    * will be performed after the TypeScript compiler has been invoked.
+    //    *
+    //    * Options: "clean", "pre-compile", "compile", "bundle", "post-build"
+    //    */
+    //   "heftEvent": "clean",
+    //
+    //   /**
+    //    * (Required) A user-defined tag whose purpose is to allow configs to replace/delete handlers that
+    //    * were added by other configs.
+    //    */
+    //   "actionId": "my-example-action",
+    //
+    //   /**
+    //    * (Required) Glob patterns to be deleted. The paths are resolved relative to the project folder.
+    //    * Documentation for supported glob syntaxes: https://www.npmjs.com/package/fast-glob
+    //    */
+    //   "globsToDelete": [
+    //     "dist",
+    //     "lib",
+    //     "lib-esnext",
+    //     "temp"
+    //   ]
+    // },
+    //
+    // {
+    //   /**
+    //    * (Required) The kind of built-in operation that should be performed.
+    //    * The "copyFiles" action copies files that match the specified patterns.
+    //    */
+    //   "actionKind": "copyFiles",
+    //
+    //   /**
+    //    * (Required) The Heft stage when this action should be performed.  Note that heft.json event actions
+    //    * are scheduled after any plugin tasks have processed the event.  For example, a "compile" event action
+    //    * will be performed after the TypeScript compiler has been invoked.
+    //    *
+    //    * Options: "pre-compile", "compile", "bundle", "post-build"
+    //    */
+    //   "heftEvent": "pre-compile",
+    //
+    //   /**
+    //    * (Required) A user-defined tag whose purpose is to allow configs to replace/delete handlers that
+    //    * were added by other configs.
+    //    */
+    //   "actionId": "my-example-action",
+    //
+    //   /**
+    //    * (Required) An array of copy operations to run perform during the specified Heft event.
+    //    */
+    //   "copyOperations": [
+    //     {
+    //       /**
+    //        * (Required) The base folder that files will be copied from, relative to the project root.
+    //        * Settings such as "includeGlobs" and "excludeGlobs" will be resolved relative
+    //        * to this folder.
+    //        * NOTE: Assigning "sourceFolder" does not by itself select any files to be copied.
+    //        */
+    //       "sourceFolder": "src",
+    //
+    //       /**
+    //        * (Required) One or more folders that files will be copied into, relative to the project root.
+    //        * If you specify more than one destination folder, Heft will read the input files only once, using
+    //        * streams to efficiently write multiple outputs.
+    //        */
+    //       "destinationFolders": ["dist/assets"],
+    //
+    //       /**
+    //        * If specified, this option recursively scans all folders under "sourceFolder" and includes any files
+    //        * that match the specified extensions.  (If "fileExtensions" and "includeGlobs" are both
+    //        * specified, their selections are added together.)
+    //        */
+    //       "fileExtensions": [".jpg", ".png"],
+    //
+    //       /**
+    //        * A list of glob patterns that select files to be copied.  The paths are resolved relative
+    //        * to "sourceFolder".
+    //        * Documentation for supported glob syntaxes: https://www.npmjs.com/package/fast-glob
+    //        */
+    //       "includeGlobs": ["assets/*.md"],
+    //
+    //       /**
+    //        * A list of glob patterns that exclude files/folders from being copied.  The paths are resolved relative
+    //        * to "sourceFolder".  These exclusions eliminate items that were selected by the "includeGlobs"
+    //        * or "fileExtensions" setting.
+    //        */
+    //       "excludeGlobs": [],
+    //
+    //       /**
+    //        * Normally, when files are selected under a child folder, a corresponding folder will be created in
+    //        * the destination folder.  Specify flatten=true to discard the source path and copy all matching files
+    //        * to the same folder.  If two files have the same name an error will be reported.
+    //        * The default value is false.
+    //        */
+    //       "flatten": false,
+    //
+    //       /**
+    //        * If true, filesystem hard links will be created instead of copying the file.  Depending on the
+    //        * operating system, this may be faster. (But note that it may cause unexpected behavior if a tool
+    //        * modifies the link.)  The default value is false.
+    //        */
+    //       "hardlink": false
+    //     }
+    //   ]
+    // }
+
+    {
+      "actionKind": "copyFiles",
+      "heftEvent": "pre-compile",
+      "actionId": "copy-test-assets",
+
+      "copyOperations": [
+        {
+          "sourceFolder": "src",
+          "destinationFolders": ["lib"],
+          "fileExtensions": [".lock"]
+        }
+      ]
+    }
+  ],
+
+  /**
+   * The list of Heft plugins to be loaded.
+   */
+  "heftPlugins": [
+    // {
+    //  /**
+    //   * The path to the plugin package.
+    //   */
+    //  "plugin": "path/to/my-plugin",
+    //
+    //  /**
+    //   * An optional object that provides additional settings that may be defined by the plugin.
+    //   */
+    //  // "options": { }
+    // }
+  ]
+}

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -11,6 +11,9 @@ function setLockFileGetProcessStartTime(fn: (process: number) => string | undefi
   (LockFile as any)._getStartTime = fn;
 }
 
+// lib/test
+const libTestFolder: string = path.resolve(__dirname, '../../lib/test');
+
 describe(LockFile.name, () => {
   afterEach(() => {
     setLockFileGetProcessStartTime(getProcessStartTime);
@@ -113,7 +116,7 @@ describe(LockFile.name, () => {
 
       test('can acquire and close a clean lockfile', () => {
         // ensure test folder is clean
-        const testFolder: string = path.join(__dirname, '1');
+        const testFolder: string = path.join(libTestFolder, '1');
         FileSystem.ensureEmptyFolder(testFolder);
 
         const resourceName: string = 'test';
@@ -139,7 +142,7 @@ describe(LockFile.name, () => {
 
       test('cannot acquire a lock if another valid lock exists', () => {
         // ensure test folder is clean
-        const testFolder: string = path.join(__dirname, '2');
+        const testFolder: string = path.join(libTestFolder, '2');
         FileSystem.ensureEmptyFolder(testFolder);
 
         const otherPid: number = 999999999;
@@ -169,7 +172,7 @@ describe(LockFile.name, () => {
       });
       test('cannot acquire a lock if another valid lock exists with the same start time', () => {
         // ensure test folder is clean
-        const testFolder: string = path.join(__dirname, '3');
+        const testFolder: string = path.join(libTestFolder, '3');
         FileSystem.ensureEmptyFolder(testFolder);
 
         const otherPid: number = 1; // low pid so the other lock is before us
@@ -214,7 +217,7 @@ describe(LockFile.name, () => {
 
     test('will not acquire if existing lock is there', () => {
       // ensure test folder is clean
-      const testFolder: string = path.join(__dirname, '1');
+      const testFolder: string = path.join(libTestFolder, '1');
       FileSystem.deleteFolder(testFolder);
       FileSystem.ensureFolder(testFolder);
 
@@ -232,9 +235,8 @@ describe(LockFile.name, () => {
 
     test('can acquire and close a dirty lockfile', () => {
       // ensure test folder is clean
-      const testFolder: string = path.join(__dirname, '1');
-      FileSystem.deleteFolder(testFolder);
-      FileSystem.ensureFolder(testFolder);
+      const testFolder: string = path.join(libTestFolder, '1');
+      FileSystem.ensureEmptyFolder(testFolder);
 
       // Create a lockfile that is still hanging around on disk,
       const resourceName: string = 'test';
@@ -256,9 +258,8 @@ describe(LockFile.name, () => {
 
     test('can acquire and close a clean lockfile', () => {
       // ensure test folder is clean
-      const testFolder: string = path.join(__dirname, '1');
-      FileSystem.deleteFolder(testFolder);
-      FileSystem.ensureFolder(testFolder);
+      const testFolder: string = path.join(libTestFolder, '1');
+      FileSystem.ensureEmptyFolder(testFolder);
 
       const resourceName: string = 'test';
       const lockFileName: string = LockFile.getLockFilePath(testFolder, resourceName);

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1752,6 +1752,7 @@ export class RushConfiguration {
    * If the path is not under any project's folder, returns undefined.
    */
   public tryGetProjectForPath(currentFolderPath: string): RushConfigurationProject | undefined {
+    // TODO: Improve the method in which a package is found, perhaps without having to sort / loop though the entire package list
     const resolvedPath: string = path.resolve(currentFolderPath);
     const sortedProjects: RushConfigurationProject[] = this.projects.sort(
       (a, b) => b.projectFolder.length - a.projectFolder.length

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1753,7 +1753,10 @@ export class RushConfiguration {
    */
   public tryGetProjectForPath(currentFolderPath: string): RushConfigurationProject | undefined {
     const resolvedPath: string = path.resolve(currentFolderPath);
-    for (const project of this.projects) {
+    const sortedProjects: RushConfigurationProject[] = this.projects.sort(
+      (a, b) => b.projectFolder.length - a.projectFolder.length
+    );
+    for (const project of sortedProjects) {
       if (Path.isUnderOrEqual(resolvedPath, project.projectFolder)) {
         return project;
       }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This loop in the `tryGetProjectForPath()` function assumes that a project folder cannot be nested under another project folder. In special cases it is possible for this to happen and if it does, depending on the order the root level project may be selected instead of the intended nested project.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Packages are now sorted in decreasing length of their paths so nested packages are now located before root level packages.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually tested on the TikTok monorepo, resolves the issue that was originally discovered.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
