### PR TITLE
[heft-jest-plugin] Hide disabling Jest cache behind an environment variable

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-DisableJestCacheEnvVar_2022-08-30-23-52.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-DisableJestCacheEnvVar_2022-08-30-23-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Hide disabling Jest cache behind environment variable \"HEFT_JEST_DISABLE_CACHE\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/includes/jestScriptTransformerPatch.js
+++ b/heft-plugins/heft-jest-plugin/includes/jestScriptTransformerPatch.js
@@ -13,8 +13,14 @@ const fs = require('fs');
 // reading and writing of cache files.
 
 const patchName = path.basename(__filename);
+const HEFT_JEST_DISABLE_CACHE_ENV_VARIABLE = 'HEFT_JEST_DISABLE_CACHE';
 
 function applyPatch() {
+  // Only apply the patch if the environment variable is set
+  if (!process.env[HEFT_JEST_DISABLE_CACHE_ENV_VARIABLE]) {
+    return;
+  }
+
   try {
     let contextFolder = __dirname;
     // Resolve the "@jest/core" package relative to heft-jest-plugin

--- a/heft-plugins/heft-jest-plugin/includes/jestScriptTransformerPatch.js
+++ b/heft-plugins/heft-jest-plugin/includes/jestScriptTransformerPatch.js
@@ -83,6 +83,8 @@ function patchScriptTransformer(scriptPath) {
       scriptContent.slice(0, startIndex) +
       `${originalFunctionContent}\n` +
       `const ${functionName} = (...args) => {\n` +
+      `  // Patched by @rushstack/heft-jest-plugin. For more information, see:\n` +
+      `  // https://github.com/microsoft/rushstack/pull/3606\n` +
       `  if (process.env['${HEFT_JEST_DISABLE_CACHE_ENV_VARIABLE}']) {\n` +
       `    return;\n` +
       `  }\n` +


### PR DESCRIPTION
## Summary
Hides the disabling of Jest cache read/writes behind an environment variable, to avoid touching the Jest install unless explicitly requested. Follow-on PR for #3606 