### PR TITLE
[rush-lib] Add RUSH_PNPM_VERIFY_STORE_INTEGRITY environment variable

### DIFF
--- a/common/changes/@microsoft/rush/verify-store-integrity_2022-08-31-01-09.json
+++ b/common/changes/@microsoft/rush/verify-store-integrity_2022-08-31-01-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Define an environment variable RUSH_PNPM_VERIFY_STORE_INTEGRITY that can be used to enable or disable PNPM's store integrity verification during installation for performance.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -157,6 +157,7 @@ export class EnvironmentConfiguration {
     // (undocumented)
     static parseBooleanEnvironmentVariable(name: string, value: string | undefined): boolean | undefined;
     static get pnpmStorePathOverride(): string | undefined;
+    static get pnpmVerifyStoreIntegrity(): boolean | undefined;
     static reset(): void;
     static get rushGlobalFolderOverride(): string | undefined;
     static get rushTempFolderOverride(): string | undefined;
@@ -178,6 +179,7 @@ export enum EnvironmentVariableNames {
     RUSH_INVOKED_FOLDER = "RUSH_INVOKED_FOLDER",
     RUSH_PARALLELISM = "RUSH_PARALLELISM",
     RUSH_PNPM_STORE_PATH = "RUSH_PNPM_STORE_PATH",
+    RUSH_PNPM_VERIFY_STORE_INTEGRITY = "RUSH_PNPM_VERIFY_STORE_INTEGRITY",
     RUSH_PREVIEW_VERSION = "RUSH_PREVIEW_VERSION",
     RUSH_TAR_BINARY_PATH = "RUSH_TAR_BINARY_PATH",
     RUSH_TEMP_FOLDER = "RUSH_TEMP_FOLDER",

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -80,6 +80,13 @@ export enum EnvironmentVariableNames {
   RUSH_PNPM_STORE_PATH = 'RUSH_PNPM_STORE_PATH',
 
   /**
+   * When using PNPM as the package manager, this variable can be used to control whether or not PNPM
+   * validates the integrity of the PNPM store during installation. The value of this environment variable must be
+   * `1` (for true) or `0` (for false). If not specified, defaults to the value in .npmrc.
+   */
+  RUSH_PNPM_VERIFY_STORE_INTEGRITY = 'RUSH_PNPM_VERIFY_STORE_INTEGRITY',
+
+  /**
    * This environment variable can be used to specify the `--target-folder` parameter
    * for the "rush deploy" command.
    */
@@ -181,6 +188,8 @@ export class EnvironmentConfiguration {
 
   private static _pnpmStorePathOverride: string | undefined;
 
+  private static _pnpmVerifyStoreIntegrity: boolean | undefined;
+
   private static _rushGlobalFolderOverride: string | undefined;
 
   private static _buildCacheCredential: string | undefined;
@@ -239,6 +248,15 @@ export class EnvironmentConfiguration {
   public static get pnpmStorePathOverride(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._pnpmStorePathOverride;
+  }
+
+  /**
+   * If specified, enables or disables integrity verification of the pnpm store during install.
+   * See {@link EnvironmentVariableNames.RUSH_PNPM_VERIFY_STORE_INTEGRITY}
+   */
+  public static get pnpmVerifyStoreIntegrity(): boolean | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._pnpmVerifyStoreIntegrity;
   }
 
   /**
@@ -370,6 +388,12 @@ export class EnvironmentConfiguration {
               value && !options.doNotNormalizePaths
                 ? EnvironmentConfiguration._normalizeDeepestParentFolderPath(value) || value
                 : value;
+            break;
+          }
+
+          case EnvironmentVariableNames.RUSH_PNPM_VERIFY_STORE_INTEGRITY: {
+            EnvironmentConfiguration._pnpmVerifyStoreIntegrity =
+              value === '1' ? true : value === '0' ? false : undefined;
             break;
           }
 

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -567,6 +567,11 @@ export abstract class BaseInstallManager {
         args.push('--store', this._rushConfiguration.pnpmOptions.pnpmStorePath);
       }
 
+      const { pnpmVerifyStoreIntegrity } = EnvironmentConfiguration;
+      if (pnpmVerifyStoreIntegrity !== undefined) {
+        args.push(`--verify-store-integrity`, `${pnpmVerifyStoreIntegrity}`);
+      }
+
       const { configuration: experiments } = this._rushConfiguration.experimentsConfiguration;
 
       if (experiments.usePnpmFrozenLockfileForRushInstall && !this._options.allowShrinkwrapUpdates) {

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -428,6 +428,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
+      const { pnpmVerifyStoreIntegrity } = EnvironmentConfiguration;
+      if (pnpmVerifyStoreIntegrity !== undefined) {
+        args.push(`--verify-store-integrity`, `${pnpmVerifyStoreIntegrity}`);
+      }
+
       for (const arg of this.options.pnpmFilterArguments) {
         args.push(arg);
       }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -428,11 +428,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
-      const { pnpmVerifyStoreIntegrity } = EnvironmentConfiguration;
-      if (pnpmVerifyStoreIntegrity !== undefined) {
-        args.push(`--verify-store-integrity`, `${pnpmVerifyStoreIntegrity}`);
-      }
-
       for (const arg of this.options.pnpmFilterArguments) {
         args.push(arg);
       }


### PR DESCRIPTION
## Summary
Adds an environment variable `RUSH_PNPM_VERIFY_STORE_INTEGRITY` that can be used to enable or disable PNPM's store integrity verification checks during the installation process.

## Details
Reasons to disable are for performance, or if you are deliberately tampering with your local PNPM store for test purposes.

## How it was tested
Local runs in a test repository.