### PR TITLE
[rush-lib] Add "beforeInstall" hook

### DIFF
--- a/common/changes/@microsoft/rush/before-install-hook_2022-09-02-23-03.json
+++ b/common/changes/@microsoft/rush/before-install-hook_2022-09-02-23-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"beforeInstall\" hook to the plugin API, for plugins to examine the environment immediately before \"rush install\" or \"rush update\" invoke the package manager.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -891,6 +891,7 @@ export class _RushGlobalFolder {
 
 // @beta
 export class RushLifecycleHooks {
+    beforeInstall: AsyncSeriesHook<IGlobalCommand>;
     flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]>;
     initialize: AsyncSeriesHook<IRushCommand>;
     runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand>;

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -68,7 +68,9 @@ export class InstallAction extends BaseInstallAction {
       maxInstallAttempts: this._maxInstallAttempts.value!,
       // These are derived independently of the selection for command line brevity
       pnpmFilterArguments: await this._selectionParameters!.getPnpmFilterArgumentsAsync(terminal),
-      checkOnly: this._checkOnlyParameter.value
+      checkOnly: this._checkOnlyParameter.value,
+
+      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this)
     };
   }
 }

--- a/libraries/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAction.ts
@@ -81,7 +81,9 @@ export class UpdateAction extends BaseInstallAction {
       // it is safe to assume that the value is not null
       maxInstallAttempts: this._maxInstallAttempts.value!,
       pnpmFilterArguments: [],
-      checkOnly: false
+      checkOnly: false,
+
+      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this)
     };
   }
 }

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -115,6 +115,11 @@ export interface IInstallManagerOptions {
    * These restrict the scope of a workspace installation.
    */
   pnpmFilterArguments: string[];
+
+  /**
+   * Callback to invoke between preparing the common/temp folder and running installation.
+   */
+  beforeInstallAsync?: () => Promise<void>;
 }
 
 /**
@@ -245,6 +250,11 @@ export abstract class BaseInstallManager {
       // Since we're going to be tampering with common/node_modules, delete the "rush link" flag file if it exists;
       // this ensures that a full "rush link" is required next time
       this._commonTempLinkFlag.clear();
+
+      // Give plugins an opportunity to act before invoking the installation process
+      if (this.options.beforeInstallAsync !== undefined) {
+        await this.options.beforeInstallAsync();
+      }
 
       // Perform the actual install
       await this.installAsync(cleanInstall);

--- a/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -82,6 +82,14 @@ export class RushLifecycleHooks {
   }, 'runPhasedCommand');
 
   /**
+   * The hook to run between preparing the common/temp folder and invoking the package manager during "rush install" or "rush update".
+   */
+  public beforeInstall: AsyncSeriesHook<IGlobalCommand> = new AsyncSeriesHook<IGlobalCommand>(
+    ['command'],
+    'beforeInstall'
+  );
+
+  /**
    * A hook to allow plugins to hook custom logic to process telemetry data.
    */
   public flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]> = new AsyncParallelHook(


### PR DESCRIPTION
## Summary
Adds a new top-level hook "beforeInstall" to the Rush plugin SDK. This hook is invoked between the Rush install setup checks and when it actually invokes the package manager.

## Details
This hook can be used to, for example, impose additional validation of the inputs to the package manager, such as bounding the maximum number of versions of a package in `common-versions.json` or similar.

## How it was tested
Local runs of `rush install`