### PR TITLE
Update the .gitignore template to ignore files generated by IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,11 +58,22 @@ jspm_packages/
 # OS X temporary files
 .DS_Store
 
+# IntelliJ IDEA project files; if you want to commit IntelliJ settings, this recipe may be helpful:
+# https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+.idea/
+*.iml
+
+# Visual Studio Code
+.vscode
+
 # Rush temporary files
 common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
 **/.rush/temp/
+
+# Heft temporary files
+.heft
 
 # Common toolchain intermediate files
 temp
@@ -74,9 +85,3 @@ lib-commonjs
 dist
 *.scss.ts
 *.sass.ts
-
-# Visual Studio Code
-.vscode
-
-# Heft
-.heft

--- a/common/changes/@microsoft/rush/octogonz-gitignore-intellij_2022-09-12-22-50.json
+++ b/common/changes/@microsoft/rush/octogonz-gitignore-intellij_2022-09-12-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the \"rush init\" template to include .gitignore patterns for IntellJ IDEA",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/[dot]gitignore
+++ b/libraries/rush-lib/assets/rush-init/[dot]gitignore
@@ -58,11 +58,16 @@ jspm_packages/
 # OS X temporary files
 .DS_Store
 
+# IntelliJ IDEA project files; if you want to commit IntelliJ settings, this recipe may be helpful:
+# https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+.idea/
+*.iml
+
 # Rush temporary files
 common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
 **/.rush/temp/
 
-# Heft
+# Heft temporary files
 .heft


### PR DESCRIPTION
## Summary

This work was split off from PR https://github.com/microsoft/rushstack/pull/3602

Properly tracking IntelliJ project settings in Git requires a [fairly complex](https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore) `.gitignore` recipe based on [the JetBrains docs](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839).

However, [this thread](https://t.co/8T3C5Dejjo) makes a reasonable case that `.idea` and `*.iml` can be completely ignored in a typical Git repository, unless the developers specifically want to do work to support shared templates.

Thus I agree with the @fwienber's approach from PR https://github.com/microsoft/rushstack/pull/3602.  And furthermore, I think it's a helpful default for the `rush init` template.


<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
