### PR TITLE
[rush-lib] Fix parallelism percentage parsing

### DIFF
--- a/common/changes/@microsoft/rush/fix-parallelism-percentage_2022-09-12-23-51.json
+++ b/common/changes/@microsoft/rush/fix-parallelism-percentage_2022-09-12-23-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix \"--parallelism XX%\" parsing to return a finite number of CPU cores.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -127,7 +127,7 @@ export class OperationExecutionManager {
             );
           }
 
-          const workers: number = Math.floor((parallelismAsNumber / 100) * numberOfCores);
+          const workers: number = Math.floor((parsedPercentage / 100) * numberOfCores);
           this._parallelism = Math.max(workers, 1);
         } else if (!isNaN(parallelismAsNumber)) {
           this._parallelism = Math.max(parallelismAsNumber, 1);


### PR DESCRIPTION
## Summary
Currently passing a percentage to the `--parallelism` sets max parallelism to `NaN`, which is treated as `Infinity`.
Fixes the parser to set it to a finite number of cores.

## Details
Parser was using the wrong parsed value in the calculation.

## How it was tested
Local run of `rush build -v -p 99%`, confirmed received n-1 cores. Passed other percentage values and confirmed the corresponding core count.