### PR TITLE
[load-themed-styles] Target ES2017

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/load-themed-styles-es6_2022-09-13-19-52.json
+++ b/common/changes/@microsoft/load-themed-styles/load-themed-styles-es6_2022-09-13-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Switch compilation target to ES2017",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles"
+}

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "importHelpers": false,
     "module": "commonjs",
+    "target": "ES2017",
     "types": ["heft-jest", "webpack-env"]
   }
 }


### PR DESCRIPTION
## Summary
Updates the compilation target of `@microsoft/load-themed-styles` to ES2017 as a new major version release.
Fixes #3488

## Details
Prevents references to `this` in the global scope of `@microsoft/load-themed-styles`.

## How it was tested
Validation of compiled output.