### PR TITLE
[rush] Fix last install flag not updating autoinstallers

### DIFF
--- a/common/changes/@microsoft/rush/will-fix-last-install-flag_2022-09-13-21-16.json
+++ b/common/changes/@microsoft/rush/will-fix-last-install-flag_2022-09-13-21-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Autodetect if an autoinstaller's flag is outdated or node_modules folder is missing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/will-fix-last-install-flag_2022-09-13-21-16.json
+++ b/common/changes/@microsoft/rush/will-fix-last-install-flag_2022-09-13-21-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Autodetect if an autoinstaller's flag is outdated or node_modules folder is missing",
+      "comment": "Fix an error that ocurred if an autoinstaller's  \"node_modules\" folder was manually deleted (GitHub #2987)",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -109,10 +109,15 @@ export class Autoinstaller {
       rushJsonFolder: this._rushConfiguration.rushJsonFolder
     });
 
-    if (!lastInstallFlag.isValid() || lock.dirtyWhenAcquired) {
-      // Example: ../common/autoinstallers/my-task/node_modules
-      const nodeModulesFolder: string = path.join(autoinstallerFullPath, 'node_modules');
+    // Example: ../common/autoinstallers/my-task/node_modules
+    const nodeModulesFolder = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
+    const isLastInstallFlagDirty =
+      !lastInstallFlag.isValid() ||
+      !Utilities.isFileTimestampCurrent(FileSystem.getStatistics(lastInstallFlag.path).mtime, [
+        nodeModulesFolder
+      ]);
 
+    if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
       if (FileSystem.exists(nodeModulesFolder)) {
         this._logIfConsoleOutputIsNotRestricted('Deleting old files from ' + nodeModulesFolder);
         FileSystem.ensureEmptyFolder(nodeModulesFolder);

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -110,7 +110,7 @@ export class Autoinstaller {
     });
 
     // Example: ../common/autoinstallers/my-task/node_modules
-    const nodeModulesFolder: string = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
+    const nodeModulesFolder: string = `${autoinstallerFullPath}/${RushConstants.nodeModulesFolderName}`;
     const isLastInstallFlagDirty: boolean =
       !lastInstallFlag.isValid() ||
       !FileSystem.exists(`${nodeModulesFolder}/rush-autoinstaller.flag`);

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -111,9 +111,8 @@ export class Autoinstaller {
 
     // Example: ../common/autoinstallers/my-task/node_modules
     const nodeModulesFolder: string = `${autoinstallerFullPath}/${RushConstants.nodeModulesFolderName}`;
-    const isLastInstallFlagDirty: boolean =
-      !lastInstallFlag.isValid() ||
-      !FileSystem.exists(`${nodeModulesFolder}/rush-autoinstaller.flag`);
+    const flagPath: string = `${nodeModulesFolder}/rush-autoinstaller.flag`;
+    const isLastInstallFlagDirty: boolean = !lastInstallFlag.isValid() || !FileSystem.exists(flagPath);
 
     if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
       if (FileSystem.exists(nodeModulesFolder)) {
@@ -137,7 +136,7 @@ export class Autoinstaller {
       lastInstallFlag.create();
 
       FileSystem.writeFile(
-        `${nodeModulesFolder}/rush-autoinstaller.flag`,
+        flagPath,
         'If this file is deleted, Rush will assume that the node_modules folder has been cleaned and will reinstall it.'
       );
 

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -137,7 +137,7 @@ export class Autoinstaller {
       lastInstallFlag.create();
 
       FileSystem.writeFile(
-        path.join(nodeModulesFolder, 'rush-autoinstaller.log'),
+        `${nodeModulesFolder}/rush-autoinstaller.flag`,
         'If this file is deleted, Rush will assume that the node_modules folder has been cleaned and will reinstall it.'
       );
 

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -110,8 +110,8 @@ export class Autoinstaller {
     });
 
     // Example: ../common/autoinstallers/my-task/node_modules
-    const nodeModulesFolder = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
-    const isLastInstallFlagDirty =
+    const nodeModulesFolder: string = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
+    const isLastInstallFlagDirty: boolean =
       !lastInstallFlag.isValid() ||
       !Utilities.isFileTimestampCurrent(FileSystem.getStatistics(lastInstallFlag.path).mtime, [
         nodeModulesFolder

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -113,9 +113,7 @@ export class Autoinstaller {
     const nodeModulesFolder: string = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
     const isLastInstallFlagDirty: boolean =
       !lastInstallFlag.isValid() ||
-      !Utilities.isFileTimestampCurrent(FileSystem.getStatistics(lastInstallFlag.path).mtime, [
-        nodeModulesFolder
-      ]);
+      !FileSystem.exists(path.join(nodeModulesFolder, 'rush-autoinstaller.log'));
 
     if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
       if (FileSystem.exists(nodeModulesFolder)) {
@@ -137,6 +135,14 @@ export class Autoinstaller {
 
       // Create file: ../common/autoinstallers/my-task/.rush/temp/last-install.flag
       lastInstallFlag.create();
+
+      FileSystem.writeFile(
+        path.join(nodeModulesFolder, 'rush-autoinstaller.log'),
+        'If this file is deleted, Rush will assume that the node_modules folder has been cleaned and will reinstall it.',
+        {
+          ensureFolderExists: false
+        }
+      );
 
       this._logIfConsoleOutputIsNotRestricted('Auto install completed successfully\n');
     } else {

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -113,7 +113,7 @@ export class Autoinstaller {
     const nodeModulesFolder: string = path.join(autoinstallerFullPath, RushConstants.nodeModulesFolderName);
     const isLastInstallFlagDirty: boolean =
       !lastInstallFlag.isValid() ||
-      !FileSystem.exists(path.join(nodeModulesFolder, 'rush-autoinstaller.log'));
+      !FileSystem.exists(`${nodeModulesFolder}/rush-autoinstaller.flag`);
 
     if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
       if (FileSystem.exists(nodeModulesFolder)) {

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -138,10 +138,7 @@ export class Autoinstaller {
 
       FileSystem.writeFile(
         path.join(nodeModulesFolder, 'rush-autoinstaller.log'),
-        'If this file is deleted, Rush will assume that the node_modules folder has been cleaned and will reinstall it.',
-        {
-          ensureFolderExists: false
-        }
+        'If this file is deleted, Rush will assume that the node_modules folder has been cleaned and will reinstall it.'
       );
 
       this._logIfConsoleOutputIsNotRestricted('Auto install completed successfully\n');


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes #2987 

(summary from issue)
The problem is that Rush tracks installation status using the file common/autoinstallers/rush-prettier/.rush/temp/last-install.flag; as long as this file appears up to date, Rush will assume that the node_modules folder is in good shape.

👉 This conflicts with commonplace intuition that node_modules folders are always safe to delete.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
We now use a similar outdated check to the install check in [BaseInstallManager.ts](https://github.com/microsoft/rushstack/blob/3516f99350aea88245a9d40fa1e82d3069e92c06/apps/rush-lib/src/logic/base/BaseInstallManager.ts#L285-L289) to detect if the node_modules folder is outdated or missing
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually tested with steps provided in the issue

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
