### PR TITLE
[eslint-patch] Use original resolver if patched resolver fails.

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-patch-fallback_2022-09-14-07-30.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-patch-fallback_2022-09-14-07-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Use original resolver if patched resolver fails.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-patch/eslint-patch-fallback_2022-09-14-07-30.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-patch-fallback_2022-09-14-07-30.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/eslint-patch",
       "comment": "Use original resolver if patched resolver fails.",
-      "type": "major"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/eslint-patch"

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -209,8 +209,15 @@ if (!ConfigArrayFactory.__patched) {
       const originalResolve = ModuleResolver.resolve;
       try {
         ModuleResolver.resolve = function (moduleName: string, relativeToPath: string) {
-          // resolve using importerPath instead of relativeToPath
-          return originalResolve.call(this, moduleName, importerPath);
+          try {
+            // resolve using importerPath instead of relativeToPath
+            return originalResolve.call(this, moduleName, importerPath);
+          } catch (e) {
+            if (isModuleResolutionError(e)) {
+              return originalResolve.call(this, moduleName, relativeToPath);
+            }
+            throw e;
+          }
         };
         return originalLoadPlugin.apply(this, arguments);
       } finally {
@@ -223,8 +230,15 @@ if (!ConfigArrayFactory.__patched) {
       const originalResolve = ModuleResolver.resolve;
       try {
         ModuleResolver.resolve = function (moduleName: string, relativeToPath: string) {
-          // resolve using ctx.filePath instead of relativeToPath
-          return originalResolve.call(this, moduleName, ctx.filePath);
+          try {
+            // resolve using ctx.filePath instead of relativeToPath
+            return originalResolve.call(this, moduleName, ctx.filePath);
+          } catch (e) {
+            if (isModuleResolutionError(e)) {
+              return originalResolve.call(this, moduleName, relativeToPath);
+            }
+            throw e;
+          }
         };
         return originalLoadPlugin.apply(this, arguments);
       } finally {


### PR DESCRIPTION
## Summary

Projects that rely on eslint's original behaviour may break if `eslint-patch` is introduced as a dependency anywhere in its dependency tree. Projects build atop [Create React App](https://github.com/facebook/create-react-app) for example (the most recent major release adds `eslint-patch` as a dependency).

This change prevents such projects from breaking.

## Example

As an example of a configuration that would break, consider this `.eslintc` that is shared between two or more projects:

```yaml
# ../common-eslintrc.yml
extends:
    - plugin:mocha/recommended

plugins:
    - mocha
```

Assuming each project has an eslintrc file that extends this one, you could then run eslint (separately installed in each project) and eslint would load the mocha plugin installed for each project.

## Details

I doubt this change will cause issues for many projects, if any. But I could not convince myself this was not a breaking change, so I marked it as such. If ya'll decide you want this change, and none of us can think of a reasonable way this will break existing users, I think we should demote it to a minor change.

## How it was tested

This same change to [a slice of this monorepo](https://github.com/itsjohncs/eslint-patch-with-fallback) is being used instead of `eslint-patch` in a private codebase that broke with the introduction of `eslint-patch`.

I did not test the package the `rush` tool built when applying the change to this monorepo.