### PR TITLE
[rush] Update the @azure/identity and @azure/storage-blob packages to remove a hardcoded GUID.

### DIFF
--- a/common/changes/@microsoft/rush/update-azure-identity_2022-09-15-00-22.json
+++ b/common/changes/@microsoft/rush/update-azure-identity_2022-09-15-00-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Upgrade the @azure/identity and @azure/storage-blob packages.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/update-azure-identity_2022-09-15-00-22.json
+++ b/common/changes/@microsoft/rush/update-azure-identity_2022-09-15-00-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Upgrade the @azure/identity and @azure/storage-blob packages.",
+      "comment": "Upgrade the @azure/identity and @azure/storage-blob packages to eliminate a deprecation message during installation.",
       "type": "none"
     }
   ],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -76,7 +76,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/lodash': 4.14.116
       '@types/node': 12.20.24
@@ -131,7 +131,7 @@ importers:
       '@microsoft/api-extractor': link:../api-extractor
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/argparse': 1.0.38
       '@types/eslint': 8.2.0
       '@types/glob': 7.1.1
@@ -346,20 +346,20 @@ importers:
       webpack: ~4.44.2
     devDependencies:
       '@babel/core': 7.17.12
-      '@storybook/addon-actions': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-essentials': 6.4.22_080f81680065a93ec6d94c5585c6099f
-      '@storybook/addon-links': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/cli': 6.4.22_ac692b7e1502ac73c0200bf6b3bf5bd4
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addon-actions': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-essentials': 6.4.22_bahyc2aamwut5rwzjrkylrqjt4
+      '@storybook/addon-links': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/cli': 6.4.22_vrusw7qvakwhhqbabp3lhp232q
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
-      '@storybook/react': 6.4.22_279426ed692d8796c508f05ab6d378ec
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/react': 6.4.22_e6kcn3ljfwdznrii6bnlnu3y5q
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/react': 16.14.23
       '@types/react-dom': 16.9.14
       '@types/webpack-env': 1.13.0
-      babel-loader: 8.2.5_e04bbe8bd1c2fc6b62228a758534df6e
+      babel-loader: 8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny
       css-loader: 5.2.7_webpack@4.44.2
       jest: 27.4.7_@types+node@12.20.24
       react: 16.13.1
@@ -661,7 +661,7 @@ importers:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       eslint: 7.30.0
       typescript: 4.7.4
 
@@ -863,7 +863,7 @@ importers:
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
       tslint: 5.20.1_typescript@4.7.4
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.7.4
+      tslint-microsoft-contrib: 6.2.0_wpgmeabxiyvgmqrq46pditq7ku
       typescript: 4.7.4
 
   ../../build-tests/heft-node-everything-test:
@@ -891,7 +891,7 @@ importers:
       heft-example-plugin-01: link:../heft-example-plugin-01
       heft-example-plugin-02: link:../heft-example-plugin-02
       tslint: 5.20.1_typescript@4.7.4
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.7.4
+      tslint-microsoft-contrib: 6.2.0_wpgmeabxiyvgmqrq46pditq7ku
       typescript: 4.7.4
 
   ../../build-tests/heft-parameter-plugin:
@@ -969,7 +969,7 @@ importers:
       eslint: 8.7.0
       html-webpack-plugin: 4.5.2_webpack@4.44.2
       postcss: 8.4.14
-      postcss-loader: 4.1.0_postcss@8.4.14+webpack@4.44.2
+      postcss-loader: 4.1.0_5acfmy7ci7uo46t3nkxjtzzdua
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
       sass: 1.3.2
@@ -999,7 +999,7 @@ importers:
       '@types/webpack-env': 1.13.0
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.7.4
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.7.4
+      tslint-microsoft-contrib: 6.2.0_wpgmeabxiyvgmqrq46pditq7ku
       typescript: 4.7.4
 
   ../../build-tests/heft-web-rig-library-test:
@@ -1038,7 +1038,7 @@ importers:
       eslint: 8.7.0
       file-loader: 6.0.0_webpack@4.44.2
       tslint: 5.20.1_typescript@4.7.4
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.7.4
+      tslint-microsoft-contrib: 6.2.0_wpgmeabxiyvgmqrq46pditq7ku
       typescript: 4.7.4
       webpack: 4.44.2
 
@@ -1072,7 +1072,7 @@ importers:
       eslint: 8.7.0
       html-webpack-plugin: 5.5.0_webpack@5.68.0
       tslint: 5.20.1_typescript@4.7.4
-      tslint-microsoft-contrib: 6.2.0_tslint@5.20.1+typescript@4.7.4
+      tslint-microsoft-contrib: 6.2.0_wpgmeabxiyvgmqrq46pditq7ku
       typescript: 4.7.4
       webpack: 5.68.0
 
@@ -1110,7 +1110,7 @@ importers:
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 4.5.0
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 4.9.3_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 4.9.3_spfcq5ngldu5cvjikbre424ry4
 
   ../../build-tests/localization-plugin-test-02:
     specifiers:
@@ -1142,7 +1142,7 @@ importers:
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 4.5.0
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 4.9.3_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 4.9.3_spfcq5ngldu5cvjikbre424ry4
 
   ../../build-tests/localization-plugin-test-03:
     specifiers:
@@ -1168,7 +1168,7 @@ importers:
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-bundle-analyzer: 4.5.0
       webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-dev-server: 4.9.3_93ca2875a658e9d1552850624e6b91c7
+      webpack-dev-server: 4.9.3_spfcq5ngldu5cvjikbre424ry4
 
   ../../build-tests/rush-amazon-s3-build-cache-plugin-integration-test:
     specifiers:
@@ -1263,9 +1263,9 @@ importers:
       '@rushstack/eslint-plugin': link:../eslint-plugin
       '@rushstack/eslint-plugin-packlets': link:../eslint-plugin-packlets
       '@rushstack/eslint-plugin-security': link:../eslint-plugin-security
-      '@typescript-eslint/eslint-plugin': 5.30.3_25d6ff0ef0a03b2bd4ba63c6e16211db
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
-      '@typescript-eslint/parser': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/eslint-plugin': 5.30.3_exlp6dxqua5sxvf2mpdocyqr3m
+      '@typescript-eslint/experimental-utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
+      '@typescript-eslint/parser': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
       eslint-plugin-promise: 6.0.0_eslint@8.7.0
       eslint-plugin-react: 7.27.1_eslint@8.7.0
@@ -1281,7 +1281,7 @@ importers:
       '@types/node': 12.20.24
     devDependencies:
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/node': 12.20.24
 
   ../../eslint/eslint-plugin:
@@ -1300,15 +1300,15 @@ importers:
       typescript: ~4.7.4
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
     devDependencies:
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/eslint': 8.2.0
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
       eslint: 8.7.0
       typescript: 4.7.4
@@ -1329,15 +1329,15 @@ importers:
       typescript: ~4.7.4
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
     devDependencies:
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/eslint': 8.2.0
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
       eslint: 8.7.0
       typescript: 4.7.4
@@ -1358,15 +1358,15 @@ importers:
       typescript: ~4.7.4
     dependencies:
       '@rushstack/tree-pattern': link:../../libraries/tree-pattern
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
     devDependencies:
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/eslint': 8.2.0
       '@types/estree': 0.0.50
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      '@typescript-eslint/parser': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
       eslint: 8.7.0
       typescript: 4.7.4
@@ -1518,7 +1518,7 @@ importers:
       webpack-dev-server: ~4.9.3
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
-      webpack-dev-server: 4.9.3_d24edb78ae5618d495d4654f5525d84c
+      webpack-dev-server: 4.9.3_2jhnw6fokymnjfoumvhvkjoyjq
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -1563,7 +1563,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
 
@@ -1607,7 +1607,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
 
@@ -1705,7 +1705,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/fs-extra': 7.0.0
       '@types/heft-jest': 1.0.1
       '@types/jju': 1.4.1
@@ -1746,7 +1746,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       '@types/resolve': 1.17.1
@@ -1961,9 +1961,9 @@ importers:
       eslint: ~7.30.0
       typescript: ~4.7.4
     devDependencies:
-      '@rushstack/eslint-config': 3.0.0_eslint@7.30.0+typescript@4.7.4
+      '@rushstack/eslint-config': 3.0.0_dqcs7jp2455ottgzcolweyyngu
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
       eslint: 7.30.0
@@ -1988,7 +1988,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-node-rig': 1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-node-rig': 1.10.0_kq7lgh6yjy6wpp44nn5hlisomu
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
 
@@ -2142,9 +2142,9 @@ importers:
       jest-environment-jsdom: 27.4.6
       mini-css-extract-plugin: 2.5.3_webpack@5.68.0
       postcss: 8.4.14
-      postcss-loader: 6.2.1_postcss@8.4.14+webpack@5.68.0
+      postcss-loader: 6.2.1_yo2uikd3tnzhibf7mpy6pnymra
       sass: 1.49.11
-      sass-loader: 12.4.0_sass@1.49.11+webpack@5.68.0
+      sass-loader: 12.4.0_ldtenuersk6xjw5tkzwiywgimy
       source-map-loader: 3.0.1_webpack@5.68.0
       style-loader: 3.3.1_webpack@5.68.0
       terser-webpack-plugin: 5.3.3_webpack@5.68.0
@@ -2185,8 +2185,8 @@ importers:
 
   ../../rush-plugins/rush-azure-storage-build-cache-plugin:
     specifiers:
-      '@azure/identity': ~1.0.0
-      '@azure/storage-blob': ~12.3.0
+      '@azure/identity': ~2.1.0
+      '@azure/storage-blob': ~12.11.0
       '@microsoft/rush-lib': workspace:*
       '@rushstack/eslint-config': workspace:*
       '@rushstack/heft': workspace:*
@@ -2197,8 +2197,8 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
     dependencies:
-      '@azure/identity': 1.0.3
-      '@azure/storage-blob': 12.3.0
+      '@azure/identity': 2.1.0
+      '@azure/storage-blob': 12.11.0
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@rushstack/rush-sdk': link:../../libraries/rush-sdk
       '@rushstack/terminal': link:../../libraries/terminal
@@ -2517,7 +2517,7 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.13
 
-  /@aws-cdk/aws-apigatewayv2-alpha/2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32:
+  /@aws-cdk/aws-apigatewayv2-alpha/2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi:
     resolution: {integrity: sha512-NHm+Jet4Iz1YDEo7lik4ItfGU1w97jCqNKilET0kcPndtxynDJNVpD1O0ycOb9L6hhLtpT5I7Llutt9Dy5gjYA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2528,7 +2528,7 @@ packages:
       constructs: 10.0.130
     dev: true
 
-  /@aws-cdk/aws-apigatewayv2-authorizers-alpha/2.7.0-alpha.0_59c765b7c3e0b1d8c04b0737d28976c7:
+  /@aws-cdk/aws-apigatewayv2-authorizers-alpha/2.7.0-alpha.0_lhdwln6d4cy5rqcla435fclwy4:
     resolution: {integrity: sha512-03VMs0IKvcm5xLan0PI+gczSQZfmYBJruqjB5Fn+VvH57kU7vu75Kgjs6gUc6CpoI38MH7QdamLs9eP9AvL/HQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2536,12 +2536,12 @@ packages:
       aws-cdk-lib: ^2.7.0
       constructs: ^10.0.0
     dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32
+      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi
       aws-cdk-lib: 2.7.0_constructs@10.0.130
       constructs: 10.0.130
     dev: true
 
-  /@aws-cdk/aws-apigatewayv2-integrations-alpha/2.7.0-alpha.0_59c765b7c3e0b1d8c04b0737d28976c7:
+  /@aws-cdk/aws-apigatewayv2-integrations-alpha/2.7.0-alpha.0_lhdwln6d4cy5rqcla435fclwy4:
     resolution: {integrity: sha512-QayWlBXdnAXjDghrYHO/vHsViPx/mLb2Tx5xdGM5sgIICNAnnY3WBbZZC4WLIli3bnc22cxwFWGCWHuM/vfj5A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2549,12 +2549,12 @@ packages:
       aws-cdk-lib: ^2.7.0
       constructs: ^10.0.0
     dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32
+      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi
       aws-cdk-lib: 2.7.0_constructs@10.0.130
       constructs: 10.0.130
     dev: true
 
-  /@aws-cdk/aws-appsync-alpha/2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32:
+  /@aws-cdk/aws-appsync-alpha/2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi:
     resolution: {integrity: sha512-4XyRBZG+hlAmyYv+xTJ1picE3eR9ImdbLpm/znde56/lOqOVBryP/h8xXL3EOAbOknqp7cnXAnjgV7BUOxLOdQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2618,11 +2618,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/core-asynciterator-polyfill/1.0.2:
-    resolution: {integrity: sha512-3rkP4LnnlWawl0LZptJOdXNrT/fHp2eQMadoasa6afspXdpGrtPZuAQc2PD0cpgyuoXtUWyC3tv7xfntjGS5Dw==}
-    engines: {node: '>=12.0.0'}
-    dev: false
-
   /@azure/core-auth/1.3.2:
     resolution: {integrity: sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==}
     engines: {node: '>=12.0.0'}
@@ -2631,18 +2626,41 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/core-http/1.2.6:
-    resolution: {integrity: sha512-odtH7UMKtekc5YQ86xg9GlVHNXR6pq2JgJ5FBo7/jbOjNGdBqcrIVrZx2bevXVJz/uUTSx6vUf62gzTXTfqYSQ==}
-    engines: {node: '>=8.0.0'}
+  /@azure/core-auth/1.4.0:
+    resolution: {integrity: sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-asynciterator-polyfill': 1.0.2
+      tslib: 2.3.1
+    dev: false
+
+  /@azure/core-client/1.6.1:
+    resolution: {integrity: sha512-mZ1MSKhZBYoV8GAWceA+PEJFWV2VpdNSpxxcj1wjIAOi00ykRuIQChT99xlQGZWLY3/NApWhSImlFwsmCEs4vA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.9.2
+      '@azure/core-tracing': 1.0.1
+      '@azure/core-util': 1.1.0
+      '@azure/logger': 1.0.3
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@azure/core-http/2.2.7:
+    resolution: {integrity: sha512-TyGMeDm90mkRS8XzSQbSMD+TqnWL1XKGCh0x0QVGMD8COH2yU0q5SaHm/IBEBkzcq0u73NhS/p57T3KVSgUFqQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.3.2
-      '@azure/core-tracing': 1.0.0-preview.11
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/core-util': 1.1.0
       '@azure/logger': 1.0.3
       '@types/node-fetch': 2.6.2
-      '@types/tunnel': 0.0.1
-      form-data: 3.0.1
+      '@types/tunnel': 0.0.3
+      form-data: 4.0.0
       node-fetch: 2.6.7
       process: 0.11.10
       tough-cookie: 4.0.0
@@ -2654,17 +2672,13 @@ packages:
       - encoding
     dev: false
 
-  /@azure/core-lro/1.0.5:
-    resolution: {integrity: sha512-0EFCFZxARrIoLWMIRt4vuqconRVIO2Iin7nFBfJiYCCbKp5eEmxutNk8uqudPmG0XFl5YqlVh68/al/vbE5OOg==}
-    engines: {node: '>=8.0.0'}
+  /@azure/core-lro/2.3.1:
+    resolution: {integrity: sha512-nQ+Xnm9g1EWcmbqgxJGmkNHfOHRUmrbYIlRT4KjluzhHQooaGO55m/h6wCX0ho3Jte2ZNBzZPJRmi6yBWeb3yA==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-http': 1.2.6
-      '@azure/core-tracing': 1.0.0-preview.11
-      events: 3.3.0
+      '@azure/logger': 1.0.3
       tslib: 2.3.1
-    transitivePeerDependencies:
-      - encoding
     dev: false
 
   /@azure/core-paging/1.3.0:
@@ -2674,47 +2688,68 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/core-tracing/1.0.0-preview.11:
-    resolution: {integrity: sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==}
-    engines: {node: '>=8.0.0'}
+  /@azure/core-rest-pipeline/1.9.2:
+    resolution: {integrity: sha512-8rXI6ircjenaLp+PkOFpo37tQ1PQfztZkfVj97BIF3RPxHAsoVSgkJtu3IK/bUEWcb7HzXSoyBe06M7ODRkRyw==}
+    engines: {node: '>=12.0.0'}
     dependencies:
-      '@opencensus/web-types': 0.0.7
-      '@opentelemetry/api': 1.0.0-rc.0
-      tslib: 2.3.1
-    dev: false
-
-  /@azure/core-tracing/1.0.0-preview.7:
-    resolution: {integrity: sha512-pkFCw6OiJrpR+aH1VQe6DYm3fK2KWCC5Jf3m/Pv1RxF08M1Xm08RCyQ5Qe0YyW5L16yYT2nnV48krVhYZ6SGFA==}
-    dependencies:
-      '@opencensus/web-types': 0.0.7
-      '@opentelemetry/types': 0.2.0
-      tslib: 1.14.1
-    dev: false
-
-  /@azure/core-tracing/1.0.0-preview.9:
-    resolution: {integrity: sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@opencensus/web-types': 0.0.7
-      '@opentelemetry/api': 0.10.2
-      tslib: 2.3.1
-    dev: false
-
-  /@azure/identity/1.0.3:
-    resolution: {integrity: sha512-yWoOL3WjbD1sAYHdx4buFCGd9mCIHGzlTHgkhhLrmMpBztsfp9ejo5LRPYIV2Za4otfJzPL4kH/vnSLTS/4WYA==}
-    dependencies:
-      '@azure/core-http': 1.2.6
-      '@azure/core-tracing': 1.0.0-preview.7
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-tracing': 1.0.1
+      '@azure/core-util': 1.1.0
       '@azure/logger': 1.0.3
-      '@opentelemetry/types': 0.2.0
-      events: 3.3.0
-      jws: 3.2.2
-      msal: 1.4.16
-      qs: 6.10.5
-      tslib: 1.14.1
-      uuid: 3.4.0
+      form-data: 4.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      tslib: 2.3.1
+      uuid: 8.3.2
     transitivePeerDependencies:
-      - encoding
+      - supports-color
+    dev: false
+
+  /@azure/core-tracing/1.0.0-preview.13:
+    resolution: {integrity: sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@opentelemetry/api': 1.2.0
+      tslib: 2.3.1
+    dev: false
+
+  /@azure/core-tracing/1.0.1:
+    resolution: {integrity: sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
+  /@azure/core-util/1.1.0:
+    resolution: {integrity: sha512-+i93lNJNA3Pl3KSuC6xKP2jTL4YFeDfO6VNOaYdk0cppZcLCxt811gS878VsqsCisaltdhl9lhMzK5kbxCiF4w==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
+  /@azure/identity/2.1.0:
+    resolution: {integrity: sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.3.2
+      '@azure/core-client': 1.6.1
+      '@azure/core-rest-pipeline': 1.9.2
+      '@azure/core-tracing': 1.0.1
+      '@azure/core-util': 1.1.0
+      '@azure/logger': 1.0.3
+      '@azure/msal-browser': 2.28.3
+      '@azure/msal-common': 7.4.1
+      '@azure/msal-node': 1.14.0
+      events: 3.3.0
+      jws: 4.0.0
+      open: 8.4.0
+      stoppable: 1.1.0
+      tslib: 2.3.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@azure/logger/1.0.3:
@@ -2724,16 +2759,37 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@azure/storage-blob/12.3.0:
-    resolution: {integrity: sha512-nCySzNfm782pEW3sg9GHj1zE4gBeVVMeEBdWb4MefifrCwQQOoz5cXZTNFiUJAJqAO+/72r2UjZcUwHk/QmzkA==}
+  /@azure/msal-browser/2.28.3:
+    resolution: {integrity: sha512-2SdyH2el3s8BzPURf9RK17BvvXvaMEGpLc3D9WilZcmjJqP4nStVH7Ogwr/SNTuGV48FUhqEkP0RxDvzuFJSIw==}
+    engines: {node: '>=0.8.0'}
+    dependencies:
+      '@azure/msal-common': 7.4.1
+    dev: false
+
+  /@azure/msal-common/7.4.1:
+    resolution: {integrity: sha512-zxcxg9pRdgGTS5mrRJeQvwA8aIjD8qSGzaAiz5SeTVkyhtjB0AeFnAcvBOKHv/TkswWNfYKpERxsXOAKXkXk0w==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /@azure/msal-node/1.14.0:
+    resolution: {integrity: sha512-3XB7FuHLhmGBjw7bxuz1LCHOXQgmNIO3J56tlbOjuJcyJtd4aBCgnYIXNKLed3uRcQNHEO0mlg24I4iGxAV/UA==}
+    engines: {node: 10 || 12 || 14 || 16 || 18}
+    dependencies:
+      '@azure/msal-common': 7.4.1
+      jsonwebtoken: 8.5.1
+      uuid: 8.3.2
+    dev: false
+
+  /@azure/storage-blob/12.11.0:
+    resolution: {integrity: sha512-na+FisoARuaOWaHWpmdtk3FeuTWf2VWamdJ9/TJJzj5ZdXPLC3juoDgFs6XVuJIoK30yuBpyFBEDXVRK4pB7Tg==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-http': 1.2.6
-      '@azure/core-lro': 1.0.5
+      '@azure/core-http': 2.2.7
+      '@azure/core-lro': 2.3.1
       '@azure/core-paging': 1.3.0
-      '@azure/core-tracing': 1.0.0-preview.9
+      '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
-      '@opentelemetry/api': 0.10.2
       events: 3.3.0
       tslib: 2.3.1
     transitivePeerDependencies:
@@ -4187,7 +4243,7 @@ packages:
       '@emotion/weak-memoize': 0.2.5
     dev: true
 
-  /@emotion/core/10.3.1_826d7eb3d694b3b5b43bedeca16df9f4:
+  /@emotion/core/10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q:
     resolution: {integrity: sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==}
     peerDependencies:
       '@types/react': '>=16'
@@ -4253,7 +4309,7 @@ packages:
     resolution: {integrity: sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==}
     dev: true
 
-  /@emotion/styled-base/10.3.0_9bd9ddaee939da964d3eb192fdcf6fba:
+  /@emotion/styled-base/10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi:
     resolution: {integrity: sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==}
     peerDependencies:
       '@emotion/core': ^10.0.28
@@ -4261,7 +4317,7 @@ packages:
       react: '>=16.3.0'
     dependencies:
       '@babel/runtime': 7.18.3
-      '@emotion/core': 10.3.1_826d7eb3d694b3b5b43bedeca16df9f4
+      '@emotion/core': 10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
@@ -4269,15 +4325,15 @@ packages:
       react: 16.13.1
     dev: true
 
-  /@emotion/styled/10.3.0_9bd9ddaee939da964d3eb192fdcf6fba:
+  /@emotion/styled/10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi:
     resolution: {integrity: sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==}
     peerDependencies:
       '@emotion/core': ^10.0.27
       '@types/react': '>=16'
       react: '>=16.3.0'
     dependencies:
-      '@emotion/core': 10.3.1_826d7eb3d694b3b5b43bedeca16df9f4
-      '@emotion/styled-base': 10.3.0_9bd9ddaee939da964d3eb192fdcf6fba
+      '@emotion/core': 10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q
+      '@emotion/styled-base': 10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi
       '@types/react': 16.14.23
       babel-plugin-emotion: 10.2.2
       react: 16.13.1
@@ -4978,35 +5034,12 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /@opencensus/web-types/0.0.7:
-    resolution: {integrity: sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g==}
-    engines: {node: '>=6.0'}
-    dev: false
-
-  /@opentelemetry/api/0.10.2:
-    resolution: {integrity: sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@opentelemetry/context-base': 0.10.2
-    dev: false
-
-  /@opentelemetry/api/1.0.0-rc.0:
-    resolution: {integrity: sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==}
+  /@opentelemetry/api/1.2.0:
+    resolution: {integrity: sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==}
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@opentelemetry/context-base/0.10.2:
-    resolution: {integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==}
-    engines: {node: '>=8.0.0'}
-    dev: false
-
-  /@opentelemetry/types/0.2.0:
-    resolution: {integrity: sha512-GtwNB6BNDdsIPAYEdpp3JnOGO/3AJxjPvny53s3HERBdXSJTGQw8IRhiaTEX0b3w9P8+FwFZde4k+qkjn67aVw==}
-    engines: {node: '>=8.0.0'}
-    deprecated: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
-    dev: false
-
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.7_c08940c9891f92cdd9ce1094f8112d3e:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.7_yceubsmjd6jm3woocckpqejnhy:
     resolution: {integrity: sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -5144,19 +5177,19 @@ packages:
     resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: true
 
-  /@rushstack/eslint-config/3.0.0_eslint@7.30.0+typescript@4.7.4:
+  /@rushstack/eslint-config/3.0.0_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-9vkSsu7QnoCyujiJMB1uegfGF9LXe5Q+s08836H0PzHQ3lptsw4iqy1EQuuEPasjws6WR8b5oTT8SsrYVp9dcQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.1.4
-      '@rushstack/eslint-plugin': 0.10.0_eslint@7.30.0+typescript@4.7.4
-      '@rushstack/eslint-plugin-packlets': 0.5.0_eslint@7.30.0+typescript@4.7.4
-      '@rushstack/eslint-plugin-security': 0.4.0_eslint@7.30.0+typescript@4.7.4
-      '@typescript-eslint/eslint-plugin': 5.30.3_b370f103994699ac2a96d77c4e2a1ff3
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
-      '@typescript-eslint/parser': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@rushstack/eslint-plugin': 0.10.0_dqcs7jp2455ottgzcolweyyngu
+      '@rushstack/eslint-plugin-packlets': 0.5.0_dqcs7jp2455ottgzcolweyyngu
+      '@rushstack/eslint-plugin-security': 0.4.0_dqcs7jp2455ottgzcolweyyngu
+      '@typescript-eslint/eslint-plugin': 5.30.3_wnypca4zi2m2ykuw256e4kq76m
+      '@typescript-eslint/experimental-utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
+      '@typescript-eslint/parser': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
       eslint: 7.30.0
       eslint-plugin-promise: 6.0.0_eslint@7.30.0
@@ -5171,39 +5204,39 @@ packages:
     resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets/0.5.0_eslint@7.30.0+typescript@4.7.4:
+  /@rushstack/eslint-plugin-packlets/0.5.0_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-I160nHeAGzA0q4g3cR7kiHNgiU1HqrYto52+lEmxLAdbBllqc6IOyiWQfCDb5ug0f+Y8bTwMQHiUrI7XclZB/Q==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.4.0_eslint@7.30.0+typescript@4.7.4:
+  /@rushstack/eslint-plugin-security/0.4.0_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-jRFtrOnZZcuJ2MRA9RtoeyKiFQ60iKu7SDF1wkc7M9nHL5C1HkFApX6nTlAjY7C5B7UlV+9BP9fDmOJJmB4FSw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin/0.10.0_eslint@7.30.0+typescript@4.7.4:
+  /@rushstack/eslint-plugin/0.10.0_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-39DCBD6s7Y5XQxvcMmitXfupkReGcg0lmtil9mrGHkDoyiUln90sOWtpkSl6LqUrSL3lx7N2wRvJiJlwGIPYFQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
@@ -5219,7 +5252,7 @@ packages:
       jsonpath-plus: 4.0.0
     dev: true
 
-  /@rushstack/heft-jest-plugin/0.3.23_543eb31fd84e3d67bf9c6b7a75a24e65:
+  /@rushstack/heft-jest-plugin/0.3.23_kq7lgh6yjy6wpp44nn5hlisomu:
     resolution: {integrity: sha512-2SEHIbnqeAqwlClcGf8clc3K++Mh6uUc7rIfrWT/uPUPBCjvFeT7GyE/774bul9exN+kgVjw7gy78pGCbylhBg==}
     peerDependencies:
       '@rushstack/heft': ^0.47.0
@@ -5244,14 +5277,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@rushstack/heft-node-rig/1.10.0_543eb31fd84e3d67bf9c6b7a75a24e65:
+  /@rushstack/heft-node-rig/1.10.0_kq7lgh6yjy6wpp44nn5hlisomu:
     resolution: {integrity: sha512-1EISgMGx3+iBkJsNryR5Nu9GLedH0H3mvp5dEoXfCWaYubbEtxyNOyq9Urh3fUa/R1O0KeVk+n/8GNhAXwhFWg==}
     peerDependencies:
       '@rushstack/heft': ^0.47.0
     dependencies:
       '@microsoft/api-extractor': 7.29.0
       '@rushstack/heft': 0.47.0
-      '@rushstack/heft-jest-plugin': 0.3.23_543eb31fd84e3d67bf9c6b7a75a24e65
+      '@rushstack/heft-jest-plugin': 0.3.23_kq7lgh6yjy6wpp44nn5hlisomu
       eslint: 8.7.0
       jest-environment-node: 27.4.6
       typescript: 4.7.4
@@ -5334,7 +5367,7 @@ packages:
     resolution: {integrity: sha512-QVpFHqbVezHVHQP2wvVlomcOQ1CliEUq08vG2FcLX7tyAKi0EXlVNGOTx9AcA51jBPATtQFy8J1jeUXQeJ7ZbA==}
     hasBin: true
     dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32
+      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi
       '@serverless-stack/aws-lambda-ric': 2.0.13
       '@serverless-stack/core': 0.67.2
       '@serverless-stack/resources': 0.67.0
@@ -5399,10 +5432,10 @@ packages:
   /@serverless-stack/resources/0.67.0:
     resolution: {integrity: sha512-9ySIlDBvbQ5jko+HhwCzjAWPwwj0NRnzs6SdOfU8IqK/FTBnQW/4FdeKwr/0dffnVdua2eymyfzOx4sL81l/Tw==}
     dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32
-      '@aws-cdk/aws-apigatewayv2-authorizers-alpha': 2.7.0-alpha.0_59c765b7c3e0b1d8c04b0737d28976c7
-      '@aws-cdk/aws-apigatewayv2-integrations-alpha': 2.7.0-alpha.0_59c765b7c3e0b1d8c04b0737d28976c7
-      '@aws-cdk/aws-appsync-alpha': 2.7.0-alpha.0_e2bf53f15dadcceaf55b4d3d46e52a32
+      '@aws-cdk/aws-apigatewayv2-alpha': 2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi
+      '@aws-cdk/aws-apigatewayv2-authorizers-alpha': 2.7.0-alpha.0_lhdwln6d4cy5rqcla435fclwy4
+      '@aws-cdk/aws-apigatewayv2-integrations-alpha': 2.7.0-alpha.0_lhdwln6d4cy5rqcla435fclwy4
+      '@aws-cdk/aws-appsync-alpha': 2.7.0-alpha.0_4k7vh4k5vxgov5k3ju6unzjkgi
       '@graphql-tools/load-files': 6.5.4_graphql@15.8.0
       '@graphql-tools/merge': 6.2.17_graphql@15.8.0
       '@serverless-stack/core': 0.67.2
@@ -5435,7 +5468,7 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.3
 
-  /@storybook/addon-actions/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-actions/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-t2w3iLXFul+R/1ekYxIEzUOZZmvEa7EzUAVAuCHP4i6x0jBnTTZ7sAIUVRaxVREPguH5IqI/2OklYhKanty2Yw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5446,12 +5479,12 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       core-js: 3.23.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -5470,7 +5503,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-backgrounds/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-backgrounds/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-xQIV1SsjjRXP7P5tUoGKv+pul1EY8lsV7iBXQb5eGbp4AffBj3qoYBSZbX4uiazl21o0MQiQoeIhhaPVaFIIGg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5481,13 +5514,13 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       core-js: 3.23.1
       global: 4.4.0
       memoizerific: 1.11.3
@@ -5500,7 +5533,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-controls/6.4.22_95a3cfc640b025af813d9921abf1a7ab:
+  /@storybook/addon-controls/6.4.22_swr47rsawas27aj5teq2x4nhvm:
     resolution: {integrity: sha512-f/M/W+7UTEUnr/L6scBMvksq+ZA8GTfh3bomE5FtWyOyaFppq9k8daKAvdYNlzXAOrUUsoZVJDgpb20Z2VBiSQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5511,15 +5544,15 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.22
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       core-js: 3.23.1
       lodash: 4.17.21
       react: 16.13.1
@@ -5535,7 +5568,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.4.22_7e2b9031a1d337a771d2bc9c04254f3c:
+  /@storybook/addon-docs/6.4.22_pyvzamnb2m32o4osxsoaijkphq:
     resolution: {integrity: sha512-9j+i+W+BGHJuRe4jUrqk6ubCzP4fc1xgFS2o8pakRiZgPn5kUQPdkticmsyh1XeEJifwhqjKJvkEDrcsleytDA==}
     peerDependencies:
       '@storybook/angular': 6.4.22
@@ -5591,22 +5624,22 @@ packages:
       '@mdx-js/loader': 1.6.22_react@16.13.1
       '@mdx-js/mdx': 1.6.22
       '@mdx-js/react': 1.6.22_react@16.13.1
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/builder-webpack4': 6.4.22_95a3cfc640b025af813d9921abf1a7ab
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/builder-webpack4': 6.4.22_swr47rsawas27aj5teq2x4nhvm
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/core': 6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/core': 6.4.22_cei32ylenopc43cphy7qp7jolu
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.22
       '@storybook/node-logger': 6.4.22
       '@storybook/postinstall': 6.4.22
-      '@storybook/preview-web': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/react': 6.4.22_279426ed692d8796c508f05ab6d378ec
-      '@storybook/source-loader': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/preview-web': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/react': 6.4.22_e6kcn3ljfwdznrii6bnlnu3y5q
+      '@storybook/source-loader': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       acorn: 7.4.1
       acorn-jsx: 5.3.2_acorn@7.4.1
       acorn-walk: 7.2.0
@@ -5625,7 +5658,7 @@ packages:
       prop-types: 15.8.1
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      react-element-to-jsx-string: 14.3.4_react-dom@16.13.1+react@16.13.1
+      react-element-to-jsx-string: 14.3.4_5owmthsvj5ictknaj3ev736ofq
       regenerator-runtime: 0.13.9
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
@@ -5647,7 +5680,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.4.22_080f81680065a93ec6d94c5585c6099f:
+  /@storybook/addon-essentials/6.4.22_bahyc2aamwut5rwzjrkylrqjt4:
     resolution: {integrity: sha512-GTv291fqvWq2wzm7MruBvCGuWaCUiuf7Ca3kzbQ/WqWtve7Y/1PDsqRNQLGZrQxkXU0clXCqY1XtkTrtA3WGFQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -5673,18 +5706,18 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.17.12
-      '@storybook/addon-actions': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-backgrounds': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-controls': 6.4.22_95a3cfc640b025af813d9921abf1a7ab
-      '@storybook/addon-docs': 6.4.22_7e2b9031a1d337a771d2bc9c04254f3c
-      '@storybook/addon-measure': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-outline': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-toolbars': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addon-viewport': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addon-actions': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-backgrounds': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-controls': 6.4.22_swr47rsawas27aj5teq2x4nhvm
+      '@storybook/addon-docs': 6.4.22_pyvzamnb2m32o4osxsoaijkphq
+      '@storybook/addon-measure': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-outline': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-toolbars': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addon-viewport': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/node-logger': 6.4.22
-      babel-loader: 8.2.5_e04bbe8bd1c2fc6b62228a758534df6e
+      babel-loader: 8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny
       core-js: 3.23.1
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -5714,7 +5747,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-links/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-links/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-OSOyDnTXnmcplJHlXTYUTMkrfpLqxtHp2R69IXfAyI1e8WNDb79mXflrEXDA/RSNEliLkqYwCyYby7gDMGds5Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5725,11 +5758,11 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/router': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/qs': 6.9.7
       core-js: 3.23.1
       global: 4.4.0
@@ -5743,7 +5776,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-measure/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-measure/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-CjDXoCNIXxNfXfgyJXPc0McjCcwN1scVNtHa9Ckr+zMjiQ8pPHY7wDZCQsG69KTqcWHiVfxKilI82456bcHYhQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5754,10 +5787,10 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.23.1
@@ -5768,7 +5801,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-outline/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-outline/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-VIMEzvBBRbNnupGU7NV0ahpFFb6nKVRGYWGREjtABdFn2fdKr1YicOHFe/3U7hRGjb5gd+VazSvyUvhaKX9T7Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5779,10 +5812,10 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.23.1
@@ -5795,7 +5828,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-toolbars/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-toolbars/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-FFyj6XDYpBBjcUu6Eyng7R805LUbVclEfydZjNiByAoDVyCde9Hb4sngFxn/T4fKAfBz/32HKVXd5iq4AHYtLg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5806,10 +5839,10 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       core-js: 3.23.1
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -5818,7 +5851,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-viewport/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addon-viewport/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-6jk0z49LemeTblez5u2bYXYr6U+xIdLbywe3G283+PZCBbEDE6eNYy2d2HDL+LbCLbezJBLYPHPalElphjJIcw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5829,12 +5862,12 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       core-js: 3.23.1
       global: 4.4.0
       memoizerific: 1.11.3
@@ -5846,20 +5879,20 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addons/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/addons/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-P/R+Jsxh7pawKLYo8MtE3QU/ilRFKbtCewV/T1o5U/gm8v7hKQdFz3YdRMAra4QuCY8bQIp7MKd2HrB5aH5a1A==}
     peerDependencies:
       '@types/react': '>=16'
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channels': 6.4.22
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/router': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/react': 16.14.23
       '@types/webpack-env': 1.17.0
       core-js: 3.23.1
@@ -5869,7 +5902,7 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/api/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/api/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-lAVI3o2hKupYHXFTt+1nqFct942up5dHH6YD7SZZJGyW21dwKC3HK1IzCsTawq3fZAKkgWFgmOO649hKk60yKg==}
     peerDependencies:
       '@types/react': '>=16'
@@ -5880,9 +5913,9 @@ packages:
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/router': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/react': 16.14.23
       core-js: 3.23.1
       fast-deep-equal: 3.1.3
@@ -5898,7 +5931,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.4.22_95a3cfc640b025af813d9921abf1a7ab:
+  /@storybook/builder-webpack4/6.4.22_swr47rsawas27aj5teq2x4nhvm:
     resolution: {integrity: sha512-A+GgGtKGnBneRFSFkDarUIgUTI8pYFdLmUVKEAGdh2hL+vLXAz9A46sEY7C8LQ85XWa8TKy3OTDxqR4+4iWj3A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -5929,26 +5962,26 @@ packages:
       '@babel/preset-env': 7.18.2_@babel+core@7.17.12
       '@babel/preset-react': 7.17.12_@babel+core@7.17.12
       '@babel/preset-typescript': 7.17.12_@babel+core@7.17.12
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channel-postmessage': 6.4.22
       '@storybook/channels': 6.4.22
-      '@storybook/client-api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/client-api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/core-events': 6.4.22
       '@storybook/node-logger': 6.4.22
-      '@storybook/preview-web': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/router': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/preview-web': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/router': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/ui': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/ui': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/node': 14.18.21
       '@types/webpack': 4.41.32
       autoprefixer: 9.8.8
-      babel-loader: 8.2.5_e04bbe8bd1c2fc6b62228a758534df6e
+      babel-loader: 8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny
       babel-plugin-macros: 2.8.0
       babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.12
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -5964,7 +5997,7 @@ packages:
       pnp-webpack-plugin: 1.6.4_typescript@4.7.4
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.44.2
+      postcss-loader: 4.3.0_4a2i7aa2i6hzz4ngguaxzo4tzi
       raw-loader: 4.0.2_webpack@4.44.2
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -5973,10 +6006,10 @@ packages:
       terser-webpack-plugin: 4.2.3_webpack@4.44.2
       ts-dedent: 2.2.0
       typescript: 4.7.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.44.2
+      url-loader: 4.1.1_zmzwotvrfu62vdeozbyveyswza
       util-deprecate: 1.0.2
       webpack: 4.44.2
-      webpack-dev-middleware: 3.7.3_d24edb78ae5618d495d4654f5525d84c
+      webpack-dev-middleware: 3.7.3_2jhnw6fokymnjfoumvhvkjoyjq
       webpack-filter-warnings-plugin: 1.2.1_webpack@4.44.2
       webpack-hot-middleware: 2.25.1
       webpack-virtual-modules: 0.2.2
@@ -6019,7 +6052,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/cli/6.4.22_ac692b7e1502ac73c0200bf6b3bf5bd4:
+  /@storybook/cli/6.4.22_vrusw7qvakwhhqbabp3lhp232q:
     resolution: {integrity: sha512-Paj5JtiYG6HjYYEiLm0SGg6GJ+ebJSvfbbYx5W+MNiojyMwrzkof+G2VEGk5AbE2JSkXvDQJ/9B8/SuS94yqvA==}
     hasBin: true
     peerDependencies:
@@ -6028,7 +6061,7 @@ packages:
       '@babel/core': 7.17.12
       '@babel/preset-env': 7.18.2_@babel+core@7.17.12
       '@storybook/codemod': 6.4.22_@babel+preset-env@7.18.2
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/csf-tools': 6.4.22
       '@storybook/node-logger': 6.4.22
       '@storybook/semver': 7.3.2
@@ -6065,19 +6098,19 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/client-api/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/client-api/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-sO6HJNtrrdit7dNXQcZMdlmmZG1k6TswH3gAyP/DoYajycrTwSJ6ovkarzkO+0QcJ+etgra4TEdTIXiGHBMe/A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channel-postmessage': 6.4.22
       '@storybook/channels': 6.4.22
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.17.0
       core-js: 3.23.1
@@ -6125,7 +6158,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/components/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/components/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-dCbXIJF9orMvH72VtAfCQsYbe57OP7fAADtR6YTwfCw9Sm1jFuZr8JbblQ1HcrXEoJG21nOyad3Hm5EYVb/sBw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6134,7 +6167,7 @@ packages:
       '@popperjs/core': 2.11.5
       '@storybook/client-logger': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/color-convert': 2.0.0
       '@types/overlayscrollbars': 1.12.1
       '@types/react-syntax-highlighter': 11.0.5
@@ -6149,11 +6182,11 @@ packages:
       polished: 4.2.2
       prop-types: 15.8.1
       react: 16.13.1
-      react-colorful: 5.5.1_react-dom@16.13.1+react@16.13.1
+      react-colorful: 5.5.1_5owmthsvj5ictknaj3ev736ofq
       react-dom: 16.13.1_react@16.13.1
-      react-popper-tooltip: 3.1.1_react-dom@16.13.1+react@16.13.1
+      react-popper-tooltip: 3.1.1_5owmthsvj5ictknaj3ev736ofq
       react-syntax-highlighter: 13.5.3_react@16.13.1
-      react-textarea-autosize: 8.3.4_826d7eb3d694b3b5b43bedeca16df9f4
+      react-textarea-autosize: 8.3.4_qjwx5m6wssz3lnb35xwkc3pz6q
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -6161,7 +6194,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-client/6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d:
+  /@storybook/core-client/6.4.22_cei32ylenopc43cphy7qp7jolu:
     resolution: {integrity: sha512-uHg4yfCBeM6eASSVxStWRVTZrAnb4FT6X6v/xDqr4uXCpCttZLlBzrSDwPBLNNLtCa7ntRicHM8eGKIOD5lMYQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6172,16 +6205,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channel-postmessage': 6.4.22
       '@storybook/channel-websocket': 6.4.22
-      '@storybook/client-api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/client-api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/preview-web': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/ui': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/preview-web': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/ui': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.23.1
@@ -6200,7 +6233,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common/6.4.22_d953cfd1a8be5d7952b019292ff78182:
+  /@storybook/core-common/6.4.22_3fj47unixzoxsuvqdeus754bqi:
     resolution: {integrity: sha512-PD3N/FJXPNRHeQS2zdgzYFtqPLdi3MLwAicbnw+U3SokcsspfsAuyYHZOYZgwO8IAEKy6iCc7TpBdiSJZ/vAKQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6235,7 +6268,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@types/node': 14.18.21
       '@types/pretty-hrtime': 1.0.1
-      babel-loader: 8.2.5_e04bbe8bd1c2fc6b62228a758534df6e
+      babel-loader: 8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny
       babel-plugin-macros: 3.1.0
       babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.12
       chalk: 4.1.2
@@ -6243,7 +6276,7 @@ packages:
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_typescript@4.7.4+webpack@4.44.2
+      fork-ts-checker-webpack-plugin: 6.5.2_7db7cfvs5qrp3bnhg77xjtpjse
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -6276,7 +6309,7 @@ packages:
       core-js: 3.23.1
     dev: true
 
-  /@storybook/core-server/6.4.22_95a3cfc640b025af813d9921abf1a7ab:
+  /@storybook/core-server/6.4.22_swr47rsawas27aj5teq2x4nhvm:
     resolution: {integrity: sha512-wFh3e2fa0un1d4+BJP+nd3FVWUO7uHTqv3OGBfOmzQMKp4NU1zaBNdSQG7Hz6mw0fYPBPZgBjPfsJRwIYLLZyw==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -6293,16 +6326,16 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.4.22_95a3cfc640b025af813d9921abf1a7ab
-      '@storybook/core-client': 6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@storybook/builder-webpack4': 6.4.22_swr47rsawas27aj5teq2x4nhvm
+      '@storybook/core-client': 6.4.22_cei32ylenopc43cphy7qp7jolu
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.22
-      '@storybook/manager-webpack4': 6.4.22_95a3cfc640b025af813d9921abf1a7ab
+      '@storybook/manager-webpack4': 6.4.22_swr47rsawas27aj5teq2x4nhvm
       '@storybook/node-logger': 6.4.22
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/node': 14.18.21
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -6349,7 +6382,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d:
+  /@storybook/core/6.4.22_cei32ylenopc43cphy7qp7jolu:
     resolution: {integrity: sha512-KZYJt7GM5NgKFXbPRZZZPEONZ5u/tE/cRbMdkn/zWN3He8+VP+65/tz8hbriI/6m91AWVWkBKrODSkeq59NgRA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -6363,8 +6396,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d
-      '@storybook/core-server': 6.4.22_95a3cfc640b025af813d9921abf1a7ab
+      '@storybook/core-client': 6.4.22_cei32ylenopc43cphy7qp7jolu
+      '@storybook/core-server': 6.4.22_swr47rsawas27aj5teq2x4nhvm
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
       typescript: 4.7.4
@@ -6412,7 +6445,7 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/manager-webpack4/6.4.22_95a3cfc640b025af813d9921abf1a7ab:
+  /@storybook/manager-webpack4/6.4.22_swr47rsawas27aj5teq2x4nhvm:
     resolution: {integrity: sha512-nzhDMJYg0vXdcG0ctwE6YFZBX71+5NYaTGkxg3xT7gbgnP1YFXn9gVODvgq3tPb3gcRapjyOIxUa20rV+r8edA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6425,15 +6458,15 @@ packages:
       '@babel/core': 7.17.12
       '@babel/plugin-transform-template-literals': 7.18.2_@babel+core@7.17.12
       '@babel/preset-react': 7.17.12_@babel+core@7.17.12
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/core-client': 6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/core-client': 6.4.22_cei32ylenopc43cphy7qp7jolu
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/node-logger': 6.4.22
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/ui': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/ui': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/node': 14.18.21
       '@types/webpack': 4.41.32
-      babel-loader: 8.2.5_e04bbe8bd1c2fc6b62228a758534df6e
+      babel-loader: 8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
       core-js: 3.23.1
@@ -6456,10 +6489,10 @@ packages:
       terser-webpack-plugin: 4.2.3_webpack@4.44.2
       ts-dedent: 2.2.0
       typescript: 4.7.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.44.2
+      url-loader: 4.1.1_zmzwotvrfu62vdeozbyveyswza
       util-deprecate: 1.0.2
       webpack: 4.44.2
-      webpack-dev-middleware: 3.7.3_d24edb78ae5618d495d4654f5525d84c
+      webpack-dev-middleware: 3.7.3_2jhnw6fokymnjfoumvhvkjoyjq
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
@@ -6487,18 +6520,18 @@ packages:
       core-js: 3.23.1
     dev: true
 
-  /@storybook/preview-web/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/preview-web/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-sWS+sgvwSvcNY83hDtWUUL75O2l2LY/GTAS0Zp2dh3WkObhtuJ/UehftzPZlZmmv7PCwhb4Q3+tZDKzMlFxnKQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channel-postmessage': 6.4.22
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       ansi-to-html: 0.6.15
       core-js: 3.23.1
       global: 4.4.0
@@ -6515,7 +6548,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_typescript@4.7.4+webpack@4.44.2:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.253f8c1.0_7db7cfvs5qrp3bnhg77xjtpjse:
     resolution: {integrity: sha512-mmoRG/rNzAiTbh+vGP8d57dfcR2aP+5/Ll03KKFyfy5FqWFm/Gh7u27ikx1I3LmVMI8n6jh5SdWMkMKon7/tDw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -6534,7 +6567,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react/6.4.22_279426ed692d8796c508f05ab6d378ec:
+  /@storybook/react/6.4.22_e6kcn3ljfwdznrii6bnlnu3y5q:
     resolution: {integrity: sha512-5BFxtiguOcePS5Ty/UoH7C6odmvBYIZutfiy4R3Ua6FYmtxac5vP9r5KjCz1IzZKT8mCf4X+PuK1YvDrPPROgQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -6554,15 +6587,15 @@ packages:
       '@babel/core': 7.17.12
       '@babel/preset-flow': 7.17.12_@babel+core@7.17.12
       '@babel/preset-react': 7.17.12_@babel+core@7.17.12
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_c08940c9891f92cdd9ce1094f8112d3e
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/core': 6.4.22_1111bd61646b9e2e6c4f3e3f07fd2e5d
-      '@storybook/core-common': 6.4.22_d953cfd1a8be5d7952b019292ff78182
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_yceubsmjd6jm3woocckpqejnhy
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/core': 6.4.22_cei32ylenopc43cphy7qp7jolu
+      '@storybook/core-common': 6.4.22_3fj47unixzoxsuvqdeus754bqi
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.22
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_typescript@4.7.4+webpack@4.44.2
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0_7db7cfvs5qrp3bnhg77xjtpjse
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/store': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@types/node': 12.20.24
       '@types/react': 16.14.23
       '@types/webpack-env': 1.17.0
@@ -6600,7 +6633,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/router/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/router/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-zeuE8ZgFhNerQX8sICQYNYL65QEi3okyzw7ynF58Ud6nRw4fMxSOHcj2T+nZCIU5ufozRL4QWD/Rg9P2s/HtLw==}
     peerDependencies:
       '@types/react': '>=16'
@@ -6618,8 +6651,8 @@ packages:
       qs: 6.10.5
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      react-router: 6.3.0_826d7eb3d694b3b5b43bedeca16df9f4
-      react-router-dom: 6.3.0_271fd541efbf4d33e9098eae3aab5c60
+      react-router: 6.3.0_qjwx5m6wssz3lnb35xwkc3pz6q
+      react-router-dom: 6.3.0_e4p5kqppx5gth2ijr2xdvk24ma
       ts-dedent: 2.2.0
     dev: true
 
@@ -6632,13 +6665,13 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /@storybook/source-loader/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/source-loader/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-O4RxqPgRyOgAhssS6q1Rtc8LiOvPBpC1EqhCYWRV3K+D2EjFarfQMpjgPj18hC+QzpUSfzoBZYqsMECewEuLNw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.23.1
@@ -6654,13 +6687,13 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/store/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/store/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-lrmcZtYJLc2emO+1l6AG4Txm9445K6Pyv9cGAuhOJ9Kks0aYe0YtvMkZVVry0RNNAIv6Ypz72zyKc/QK+tZLAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/client-logger': 6.4.22
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
@@ -6681,21 +6714,21 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/theming/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/theming/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-NVMKH/jxSPtnMTO4VCN1k47uztq+u9fWv4GSnzq/eezxdGg9ceGL4/lCrNGoNajht9xbrsZ4QvsJ/V2sVGM8wA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@emotion/core': 10.3.1_826d7eb3d694b3b5b43bedeca16df9f4
+      '@emotion/core': 10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/serialize': 1.0.4
-      '@emotion/styled': 10.3.0_9bd9ddaee939da964d3eb192fdcf6fba
+      '@emotion/styled': 10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi
       '@emotion/utils': 1.1.0
       '@storybook/client-logger': 6.4.22
       core-js: 3.23.1
       deep-object-diff: 1.1.7
-      emotion-theming: 10.3.0_9bd9ddaee939da964d3eb192fdcf6fba
+      emotion-theming: 10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 4.2.2
@@ -6707,27 +6740,27 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/ui/6.4.22_271fd541efbf4d33e9098eae3aab5c60:
+  /@storybook/ui/6.4.22_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-UVjMoyVsqPr+mkS1L7m30O/xrdIEgZ5SCWsvqhmyMUok3F3tRB+6M+OA5Yy+cIVfvObpA7MhxirUT1elCGXsWQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@emotion/core': 10.3.1_826d7eb3d694b3b5b43bedeca16df9f4
-      '@storybook/addons': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
-      '@storybook/api': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@emotion/core': 10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q
+      '@storybook/addons': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
+      '@storybook/api': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/channels': 6.4.22
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/components': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/core-events': 6.4.22
-      '@storybook/router': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/router': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.4.22_271fd541efbf4d33e9098eae3aab5c60
+      '@storybook/theming': 6.4.22_e4p5kqppx5gth2ijr2xdvk24ma
       copy-to-clipboard: 3.3.1
       core-js: 3.23.1
       core-js-pure: 3.23.1
       downshift: 6.1.7_react@16.13.1
-      emotion-theming: 10.3.0_9bd9ddaee939da964d3eb192fdcf6fba
+      emotion-theming: 10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi
       fuse.js: 3.6.1
       global: 4.4.0
       lodash: 4.17.21
@@ -6737,8 +6770,8 @@ packages:
       qs: 6.10.5
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      react-draggable: 4.4.5_react-dom@16.13.1+react@16.13.1
-      react-helmet-async: 1.3.0_react-dom@16.13.1+react@16.13.1
+      react-draggable: 4.4.5_5owmthsvj5ictknaj3ev736ofq
+      react-helmet-async: 1.3.0_5owmthsvj5ictknaj3ev736ofq
       react-sizeme: 3.0.2
       regenerator-runtime: 0.13.9
       resolve-from: 5.0.0
@@ -6757,6 +6790,11 @@ packages:
   /@tootallnate/once/1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+
+  /@tootallnate/once/2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+    dev: false
 
   /@trpc/server/9.25.2:
     resolution: {integrity: sha512-E5ibK5jLgWremiPs2pO+Y/YktRH7+CqmMwp97mTp9ymYZn3od4C9TuFg6bxEK1bQKnUezpzHJyGRADVKCWrjsw==}
@@ -7177,8 +7215,8 @@ packages:
       '@types/node': 12.20.24
     dev: true
 
-  /@types/tunnel/0.0.1:
-    resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
+  /@types/tunnel/0.0.3:
+    resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
       '@types/node': 12.20.24
     dev: false
@@ -7243,7 +7281,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/5.30.3_25d6ff0ef0a03b2bd4ba63c6e16211db:
+  /@typescript-eslint/eslint-plugin/5.30.3_exlp6dxqua5sxvf2mpdocyqr3m:
     resolution: {integrity: sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7254,10 +7292,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       '@typescript-eslint/scope-manager': 5.30.3_typescript@4.7.4
-      '@typescript-eslint/type-utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
-      '@typescript-eslint/utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/type-utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
+      '@typescript-eslint/utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       debug: 4.3.4
       eslint: 8.7.0
       functional-red-black-tree: 1.0.1
@@ -7270,7 +7308,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.30.3_b370f103994699ac2a96d77c4e2a1ff3:
+  /@typescript-eslint/eslint-plugin/5.30.3_wnypca4zi2m2ykuw256e4kq76m:
     resolution: {integrity: sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7281,10 +7319,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       '@typescript-eslint/scope-manager': 5.30.3_typescript@4.7.4
-      '@typescript-eslint/type-utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
-      '@typescript-eslint/utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/type-utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
+      '@typescript-eslint/utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       debug: 4.3.4
       eslint: 7.30.0
       functional-red-black-tree: 1.0.1
@@ -7297,33 +7335,33 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.30.3_eslint@7.30.0+typescript@4.7.4:
+  /@typescript-eslint/experimental-utils/5.30.3_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-8UUoWqSJrutESTypS+J70qxuE4D9eZS/cvYbBTdVsZKLpmyqa/haIaL2USWCwcbMzFOJTaQkKWS++TPsoHIs2Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.30.3_eslint@8.7.0+typescript@4.7.4:
+  /@typescript-eslint/experimental-utils/5.30.3_valmiib6gbzc7jhcbpocdsabay:
     resolution: {integrity: sha512-8UUoWqSJrutESTypS+J70qxuE4D9eZS/cvYbBTdVsZKLpmyqa/haIaL2USWCwcbMzFOJTaQkKWS++TPsoHIs2Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       eslint: 8.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.30.3_eslint@7.30.0+typescript@4.7.4:
+  /@typescript-eslint/parser/5.30.3_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7343,7 +7381,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.30.3_eslint@8.7.0+typescript@4.7.4:
+  /@typescript-eslint/parser/5.30.3_valmiib6gbzc7jhcbpocdsabay:
     resolution: {integrity: sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7371,7 +7409,7 @@ packages:
     transitivePeerDependencies:
       - typescript
 
-  /@typescript-eslint/type-utils/5.30.3_eslint@7.30.0+typescript@4.7.4:
+  /@typescript-eslint/type-utils/5.30.3_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7381,7 +7419,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.30.3_eslint@7.30.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.30.3_dqcs7jp2455ottgzcolweyyngu
       debug: 4.3.4
       eslint: 7.30.0
       tsutils: 3.21.0_typescript@4.7.4
@@ -7390,7 +7428,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.30.3_eslint@8.7.0+typescript@4.7.4:
+  /@typescript-eslint/type-utils/5.30.3_valmiib6gbzc7jhcbpocdsabay:
     resolution: {integrity: sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7400,7 +7438,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.30.3_eslint@8.7.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.30.3_valmiib6gbzc7jhcbpocdsabay
       debug: 4.3.4
       eslint: 8.7.0
       tsutils: 3.21.0_typescript@4.7.4
@@ -7437,7 +7475,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.30.3_eslint@7.30.0+typescript@4.7.4:
+  /@typescript-eslint/utils/5.30.3_dqcs7jp2455ottgzcolweyyngu:
     resolution: {integrity: sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7455,7 +7493,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.30.3_eslint@8.7.0+typescript@4.7.4:
+  /@typescript-eslint/utils/5.30.3_valmiib6gbzc7jhcbpocdsabay:
     resolution: {integrity: sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8385,7 +8423,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-loader/8.2.5_e04bbe8bd1c2fc6b62228a758534df6e:
+  /babel-loader/8.2.5_4bf35c6ryl6gwyrcrj2ykng7ny:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -8819,7 +8857,7 @@ packages:
     dev: true
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
     dev: false
 
   /buffer-from/1.1.2:
@@ -10405,7 +10443,7 @@ packages:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
 
-  /emotion-theming/10.3.0_9bd9ddaee939da964d3eb192fdcf6fba:
+  /emotion-theming/10.3.0_tpm53lxjhhnjmtj6wgjp3t3pxi:
     resolution: {integrity: sha512-mXiD2Oj7N9b6+h/dC6oLf9hwxbtKHQjoIqtodEyL8CpkN4F3V4IK/BT4D0C7zSs4BBFOu4UlPJbvvBLa88SGEA==}
     peerDependencies:
       '@emotion/core': ^10.0.27
@@ -10413,7 +10451,7 @@ packages:
       react: '>=16.3.0'
     dependencies:
       '@babel/runtime': 7.18.3
-      '@emotion/core': 10.3.1_826d7eb3d694b3b5b43bedeca16df9f4
+      '@emotion/core': 10.3.1_qjwx5m6wssz3lnb35xwkc3pz6q
       '@emotion/weak-memoize': 0.2.5
       '@types/react': 16.14.23
       hoist-non-react-statics: 3.3.2
@@ -11727,7 +11765,7 @@ packages:
       worker-rpc: 0.1.1
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.2_typescript@4.7.4+webpack@4.44.2:
+  /fork-ts-checker-webpack-plugin/6.5.2_7db7cfvs5qrp3bnhg77xjtpjse:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11774,6 +11812,15 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /format/0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -12653,6 +12700,17 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+
+  /http-proxy-agent/5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /http-proxy-middleware/2.0.6:
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
@@ -14194,6 +14252,22 @@ packages:
     resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
     dev: true
 
+  /jsonwebtoken/8.5.1:
+    resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
+    engines: {node: '>=4', npm: '>=1.4.28'}
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 5.7.1
+    dev: false
+
   /jsprim/1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -14239,10 +14313,25 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
+  /jwa/2.0.0:
+    resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
   /jws/3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
     dependencies:
       jwa: 1.4.1
+      safe-buffer: 5.2.1
+    dev: false
+
+  /jws/4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+    dependencies:
+      jwa: 2.0.0
       safe-buffer: 5.2.1
     dev: false
 
@@ -14442,12 +14531,31 @@ packages:
   /lodash.get/4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
 
+  /lodash.includes/4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+    dev: false
+
+  /lodash.isboolean/3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+    dev: false
+
   /lodash.isequal/4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
 
+  /lodash.isinteger/4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+    dev: false
+
+  /lodash.isnumber/3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+    dev: false
+
   /lodash.isplainobject/4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-    dev: true
+
+  /lodash.isstring/4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+    dev: false
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -14455,6 +14563,10 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  /lodash.once/4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+    dev: false
 
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -14966,13 +15078,6 @@ packages:
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  /msal/1.4.16:
-    resolution: {integrity: sha512-Q6jIV5RG6mD9O0bzZrR/f8v5QikrVWU0sccwOyqWE1xlBkKYVKRa/L8Gxt1X58M+J/N9V0JskhvO4KIfRHlE8g==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
 
   /multicast-dns/7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
@@ -15930,7 +16035,7 @@ packages:
       postcss: 7.0.39
     dev: true
 
-  /postcss-loader/4.1.0_postcss@8.4.14+webpack@4.44.2:
+  /postcss-loader/4.1.0_5acfmy7ci7uo46t3nkxjtzzdua:
     resolution: {integrity: sha512-vbCkP70F3Q9PIk6d47aBwjqAMI4LfkXCoyxj+7NPNuVIwfTGdzv2KVQes59/RuxMniIgsYQCFSY42P3+ykJfaw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -15946,7 +16051,7 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /postcss-loader/4.3.0_postcss@7.0.39+webpack@4.44.2:
+  /postcss-loader/4.3.0_4a2i7aa2i6hzz4ngguaxzo4tzi:
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -15962,7 +16067,7 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /postcss-loader/6.2.1_postcss@8.4.14+webpack@5.68.0:
+  /postcss-loader/6.2.1_yo2uikd3tnzhibf7mpy6pnymra:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16586,6 +16691,7 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: true
 
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
@@ -16672,7 +16778,7 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-colorful/5.5.1_react-dom@16.13.1+react@16.13.1:
+  /react-colorful/5.5.1_5owmthsvj5ictknaj3ev736ofq:
     resolution: {integrity: sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -16720,7 +16826,7 @@ packages:
       react: 16.13.1
       scheduler: 0.19.1
 
-  /react-draggable/4.4.5_react-dom@16.13.1+react@16.13.1:
+  /react-draggable/4.4.5_5owmthsvj5ictknaj3ev736ofq:
     resolution: {integrity: sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==}
     peerDependencies:
       react: '>= 16.3.0'
@@ -16732,7 +16838,7 @@ packages:
       react-dom: 16.13.1_react@16.13.1
     dev: true
 
-  /react-element-to-jsx-string/14.3.4_react-dom@16.13.1+react@16.13.1:
+  /react-element-to-jsx-string/14.3.4_5owmthsvj5ictknaj3ev736ofq:
     resolution: {integrity: sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
@@ -16749,7 +16855,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: true
 
-  /react-helmet-async/1.3.0_react-dom@16.13.1+react@16.13.1:
+  /react-helmet-async/1.3.0_5owmthsvj5ictknaj3ev736ofq:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
@@ -16781,7 +16887,7 @@ packages:
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  /react-popper-tooltip/3.1.1_react-dom@16.13.1+react@16.13.1:
+  /react-popper-tooltip/3.1.1_5owmthsvj5ictknaj3ev736ofq:
     resolution: {integrity: sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0
@@ -16791,10 +16897,10 @@ packages:
       '@popperjs/core': 2.11.5
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      react-popper: 2.3.0_2afaff854aa75bfc466eabafd7978aa0
+      react-popper: 2.3.0_fl5p7bkku5n7yrtovox5pf4kua
     dev: true
 
-  /react-popper/2.3.0_2afaff854aa75bfc466eabafd7978aa0:
+  /react-popper/2.3.0_fl5p7bkku5n7yrtovox5pf4kua:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
@@ -16813,7 +16919,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.3.0_271fd541efbf4d33e9098eae3aab5c60:
+  /react-router-dom/6.3.0_e4p5kqppx5gth2ijr2xdvk24ma:
     resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
     peerDependencies:
       '@types/react': '>=16'
@@ -16824,10 +16930,10 @@ packages:
       history: 5.3.0
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      react-router: 6.3.0_826d7eb3d694b3b5b43bedeca16df9f4
+      react-router: 6.3.0_qjwx5m6wssz3lnb35xwkc3pz6q
     dev: true
 
-  /react-router/6.3.0_826d7eb3d694b3b5b43bedeca16df9f4:
+  /react-router/6.3.0_qjwx5m6wssz3lnb35xwkc3pz6q:
     resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
     peerDependencies:
       '@types/react': '>=16'
@@ -16860,7 +16966,7 @@ packages:
       refractor: 3.6.0
     dev: true
 
-  /react-textarea-autosize/8.3.4_826d7eb3d694b3b5b43bedeca16df9f4:
+  /react-textarea-autosize/8.3.4_qjwx5m6wssz3lnb35xwkc3pz6q:
     resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -16869,7 +16975,7 @@ packages:
       '@babel/runtime': 7.18.3
       react: 16.13.1
       use-composed-ref: 1.3.0_react@16.13.1
-      use-latest: 1.2.1_826d7eb3d694b3b5b43bedeca16df9f4
+      use-latest: 1.2.1_qjwx5m6wssz3lnb35xwkc3pz6q
     transitivePeerDependencies:
       - '@types/react'
     dev: true
@@ -17493,7 +17599,7 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /sass-loader/12.4.0_sass@1.49.11+webpack@5.68.0:
+  /sass-loader/12.4.0_ldtenuersk6xjw5tkzwiywgimy:
     resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -18103,6 +18209,11 @@ packages:
     resolution: {integrity: sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==}
     dependencies:
       readable-stream: 2.3.7
+    dev: false
+
+  /stoppable/1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
     dev: false
 
   /store2/2.13.2:
@@ -18832,7 +18943,7 @@ packages:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
     dev: true
 
-  /tslint-microsoft-contrib/6.2.0_tslint@5.20.1+typescript@4.7.4:
+  /tslint-microsoft-contrib/6.2.0_wpgmeabxiyvgmqrq46pditq7ku:
     resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
     peerDependencies:
       tslint: ^5.1.0
@@ -19179,23 +19290,6 @@ packages:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
 
-  /url-loader/4.1.1_file-loader@6.2.0+webpack@4.44.2:
-    resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      file-loader:
-        optional: true
-    dependencies:
-      file-loader: 6.2.0_webpack@4.44.2
-      loader-utils: 2.0.2
-      mime-types: 2.1.35
-      schema-utils: 3.1.1
-      webpack: 4.44.2
-    dev: true
-
   /url-loader/4.1.1_webpack@5.68.0:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
@@ -19211,6 +19305,23 @@ packages:
       schema-utils: 3.1.1
       webpack: 5.68.0
     dev: false
+
+  /url-loader/4.1.1_zmzwotvrfu62vdeozbyveyswza:
+    resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      file-loader: '*'
+      webpack: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      file-loader:
+        optional: true
+    dependencies:
+      file-loader: 6.2.0_webpack@4.44.2
+      loader-utils: 2.0.2
+      mime-types: 2.1.35
+      schema-utils: 3.1.1
+      webpack: 4.44.2
+    dev: true
 
   /url-parse-lax/3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
@@ -19240,7 +19351,7 @@ packages:
       react: 16.13.1
     dev: true
 
-  /use-isomorphic-layout-effect/1.1.2_826d7eb3d694b3b5b43bedeca16df9f4:
+  /use-isomorphic-layout-effect/1.1.2_qjwx5m6wssz3lnb35xwkc3pz6q:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -19253,7 +19364,7 @@ packages:
       react: 16.13.1
     dev: true
 
-  /use-latest/1.2.1_826d7eb3d694b3b5b43bedeca16df9f4:
+  /use-latest/1.2.1_qjwx5m6wssz3lnb35xwkc3pz6q:
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
     peerDependencies:
       '@types/react': '*'
@@ -19264,7 +19375,7 @@ packages:
     dependencies:
       '@types/react': 16.14.23
       react: 16.13.1
-      use-isomorphic-layout-effect: 1.1.2_826d7eb3d694b3b5b43bedeca16df9f4
+      use-isomorphic-layout-effect: 1.1.2_qjwx5m6wssz3lnb35xwkc3pz6q
     dev: true
 
   /use/3.1.1:
@@ -19505,7 +19616,7 @@ packages:
       yargs: 13.3.2
     dev: false
 
-  /webpack-dev-middleware/3.7.3_d24edb78ae5618d495d4654f5525d84c:
+  /webpack-dev-middleware/3.7.3_2jhnw6fokymnjfoumvhvkjoyjq:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -19524,7 +19635,7 @@ packages:
       webpack-log: 2.0.0
     dev: true
 
-  /webpack-dev-middleware/5.3.3_d24edb78ae5618d495d4654f5525d84c:
+  /webpack-dev-middleware/5.3.3_2jhnw6fokymnjfoumvhvkjoyjq:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -19578,7 +19689,61 @@ packages:
       schema-utils: 4.0.0
       webpack: 5.68.0
 
-  /webpack-dev-server/4.9.3_93ca2875a658e9d1552850624e6b91c7:
+  /webpack-dev-server/4.9.3_2jhnw6fokymnjfoumvhvkjoyjq:
+    resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
+    engines: {node: '>= 12.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@types/webpack': ^4
+      webpack: ^4.37.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      '@types/webpack':
+        optional: true
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/bonjour': 3.5.10
+      '@types/connect-history-api-fallback': 1.3.5
+      '@types/express': 4.17.13
+      '@types/express-serve-static-core': 4.17.29
+      '@types/serve-index': 1.9.1
+      '@types/serve-static': 1.13.10
+      '@types/sockjs': 0.3.33
+      '@types/webpack': 4.41.32
+      '@types/ws': 8.5.3
+      ansi-html-community: 0.0.8
+      anymatch: 3.1.2
+      bonjour-service: 1.0.13
+      chokidar: 3.5.3
+      colorette: 2.0.19
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.18.1
+      graceful-fs: 4.2.10
+      html-entities: 2.3.3
+      http-proxy-middleware: 2.0.6
+      ipaddr.js: 2.0.1
+      open: 8.4.0
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.0.0
+      selfsigned: 2.0.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack: 4.44.2
+      webpack-dev-middleware: 5.3.3_2jhnw6fokymnjfoumvhvkjoyjq
+      ws: 8.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /webpack-dev-server/4.9.3_spfcq5ngldu5cvjikbre424ry4:
     resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -19624,60 +19789,6 @@ packages:
       webpack: 4.44.2_webpack-cli@3.3.12
       webpack-cli: 3.3.12_webpack@4.44.2
       webpack-dev-middleware: 5.3.3_webpack@4.44.2
-      ws: 8.8.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /webpack-dev-server/4.9.3_d24edb78ae5618d495d4654f5525d84c:
-    resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@types/webpack': ^4
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      '@types/webpack':
-        optional: true
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.13
-      '@types/express-serve-static-core': 4.17.29
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.13.10
-      '@types/sockjs': 0.3.33
-      '@types/webpack': 4.41.32
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      anymatch: 3.1.2
-      bonjour-service: 1.0.13
-      chokidar: 3.5.3
-      colorette: 2.0.19
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.1
-      graceful-fs: 4.2.10
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.6
-      ipaddr.js: 2.0.1
-      open: 8.4.0
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.0.0
-      selfsigned: 2.0.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack: 4.44.2
-      webpack-dev-middleware: 5.3.3_d24edb78ae5618d495d4654f5525d84c
       ws: 8.8.0
     transitivePeerDependencies:
       - bufferutil
@@ -19824,7 +19935,6 @@ packages:
       terser-webpack-plugin: 1.4.5_webpack@4.44.2
       watchpack: 1.7.5
       webpack-sources: 1.4.3
-    dev: true
 
   /webpack/4.44.2_webpack-cli@3.3.12:
     resolution: {integrity: sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "4d6e5e67bed9cdd954bad49e75c121160092f083",
+  "pnpmShrinkwrapHash": "1efadc66b47fd7d03b3c2b33c94f9de84d9599b6",
   "preferredVersionsHash": "d15f901c51f5b82ae0cc4cc0a2cdc9a5e451367c"
 }

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -4,31 +4,20 @@
 
 ```ts
 
+import { AzureAuthorityHosts } from '@azure/identity';
 import type { IRushPlugin } from '@rushstack/rush-sdk';
 import type { ITerminal } from '@rushstack/node-core-library';
 import type { RushConfiguration } from '@rushstack/rush-sdk';
 import type { RushSession } from '@rushstack/rush-sdk';
 
 // @public (undocumented)
-export enum AzureAuthorityHosts {
-    // (undocumented)
-    AzureChina = "https://login.chinacloudapi.cn",
-    // (undocumented)
-    AzureGermany = "https://login.microsoftonline.de",
-    // (undocumented)
-    AzureGovernment = "https://login.microsoftonline.us",
-    // (undocumented)
-    AzurePublicCloud = "https://login.microsoftonline.com"
-}
-
-// @public (undocumented)
-export type AzureEnvironmentNames = keyof typeof AzureAuthorityHosts;
+export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
 
 // @public (undocumented)
 export class AzureStorageAuthentication {
     constructor(options: IAzureStorageAuthenticationOptions);
     // (undocumented)
-    protected readonly _azureEnvironment: AzureEnvironmentNames;
+    protected readonly _azureEnvironment: AzureEnvironmentName;
     // (undocumented)
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
     // (undocumented)
@@ -49,7 +38,7 @@ export class AzureStorageAuthentication {
 // @public (undocumented)
 export interface IAzureStorageAuthenticationOptions {
     // (undocumented)
-    azureEnvironment?: AzureEnvironmentNames;
+    azureEnvironment?: AzureEnvironmentName;
     // (undocumented)
     isCacheWriteAllowed: boolean;
     // (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
@@ -18,8 +18,8 @@
     "_phase:test": "heft test --no-build"
   },
   "dependencies": {
-    "@azure/identity": "~1.0.0",
-    "@azure/storage-blob": "~12.3.0",
+    "@azure/identity": "~2.1.0",
+    "@azure/storage-blob": "~12.11.0",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rush-sdk": "workspace:*",
     "@rushstack/terminal": "workspace:*"

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { DeviceCodeCredential, DeviceCodeInfo } from '@azure/identity';
+import { DeviceCodeCredential, DeviceCodeInfo, AzureAuthorityHosts } from '@azure/identity';
 import {
   BlobServiceClient,
   ContainerSASPermissions,
@@ -12,20 +12,6 @@ import {
 import type { ITerminal } from '@rushstack/node-core-library';
 import { CredentialCache, ICredentialCacheEntry, RushConstants } from '@rushstack/rush-sdk';
 import { PrintUtilities } from '@rushstack/terminal';
-
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-// TODO: This is a temporary workaround; it should be reverted when we upgrade to "@azure/identity" version 2.x
-// import { AzureAuthorityHosts } from '@azure/identity';
-/**
- * @public
- */
-export enum AzureAuthorityHosts {
-  AzureChina = 'https://login.chinacloudapi.cn',
-  AzureGermany = 'https://login.microsoftonline.de',
-  AzureGovernment = 'https://login.microsoftonline.us',
-  AzurePublicCloud = 'https://login.microsoftonline.com'
-}
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 /**
  * @public

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -16,7 +16,7 @@ import { PrintUtilities } from '@rushstack/terminal';
 /**
  * @public
  */
-export type AzureEnvironmentNames = keyof typeof AzureAuthorityHosts;
+export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
 
 /**
  * @public
@@ -24,7 +24,7 @@ export type AzureEnvironmentNames = keyof typeof AzureAuthorityHosts;
 export interface IAzureStorageAuthenticationOptions {
   storageContainerName: string;
   storageAccountName: string;
-  azureEnvironment?: AzureEnvironmentNames;
+  azureEnvironment?: AzureEnvironmentName;
   isCacheWriteAllowed: boolean;
 }
 
@@ -34,7 +34,7 @@ const SAS_TTL_MILLISECONDS: number = 7 * 24 * 60 * 60 * 1000; // Seven days
  * @public
  */
 export class AzureStorageAuthentication {
-  protected readonly _azureEnvironment: AzureEnvironmentNames;
+  protected readonly _azureEnvironment: AzureEnvironmentName;
   protected readonly _storageAccountName: string;
   protected readonly _storageContainerName: string;
   protected readonly _isCacheWriteAllowedByConfiguration: boolean;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -173,15 +173,12 @@ export class AzureStorageAuthentication {
       throw new Error(`Unexpected Azure environment: ${this._azureEnvironment}`);
     }
 
-    const DeveloperSignOnClientId: string = '04b07795-8ddb-461a-bbee-02f9e1bf7b46';
-    const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential(
-      'organizations',
-      DeveloperSignOnClientId,
-      (deviceCodeInfo: DeviceCodeInfo) => {
+    const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential({
+      authorityHost: authorityHost,
+      userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
         PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
-      },
-      { authorityHost: authorityHost }
-    );
+      }
+    });
     const blobServiceClient: BlobServiceClient = new BlobServiceClient(
       this._storageAccountUrl,
       deviceCodeCredential

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
@@ -9,12 +9,9 @@ import {
   EnvironmentConfiguration
 } from '@rushstack/rush-sdk';
 import { BlobClient, BlobServiceClient, BlockBlobClient, ContainerClient } from '@azure/storage-blob';
+import { AzureAuthorityHosts } from '@azure/identity';
 
-import {
-  AzureAuthorityHosts,
-  AzureStorageAuthentication,
-  IAzureStorageAuthenticationOptions
-} from './AzureStorageAuthentication';
+import { AzureStorageAuthentication, IAzureStorageAuthenticationOptions } from './AzureStorageAuthentication';
 
 export interface IAzureStorageBuildCacheProviderOptions extends IAzureStorageAuthenticationOptions {
   blobPrefix?: string;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IRushPlugin, RushSession, RushConfiguration, ILogger } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentNames } from './AzureStorageAuthentication';
+import type { AzureEnvironmentName } from './AzureStorageAuthentication';
 
 const PLUGIN_NAME: 'AzureInteractiveAuthPlugin' = 'AzureInteractiveAuthPlugin';
 
@@ -23,7 +23,7 @@ export interface IAzureInteractiveAuthOptions {
   /**
    * The Azure environment the storage account exists in. Defaults to AzureCloud.
    */
-  readonly azureEnvironment?: AzureEnvironmentNames;
+  readonly azureEnvironment?: AzureEnvironmentName;
 
   /**
    * If specified and a credential exists that will be valid for at least this many minutes from the time

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
@@ -3,7 +3,7 @@
 
 import { Import } from '@rushstack/node-core-library';
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentNames } from './AzureStorageAuthentication';
+import type { AzureEnvironmentName } from './AzureStorageAuthentication';
 
 const AzureStorageBuildCacheProviderModule: typeof import('./AzureStorageBuildCacheProvider') = Import.lazy(
   './AzureStorageBuildCacheProvider',
@@ -29,7 +29,7 @@ interface IAzureBlobStorageConfigurationJson {
   /**
    * The Azure environment the storage account exists in. Defaults to AzureCloud.
    */
-  azureEnvironment?: AzureEnvironmentNames;
+  azureEnvironment?: AzureEnvironmentName;
 
   /**
    * An optional prefix for cache item blob names.

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
@@ -5,8 +5,7 @@ import { RushAzureStorageBuildCachePlugin } from './RushAzureStorageBuildCachePl
 export {
   AzureStorageAuthentication,
   IAzureStorageAuthenticationOptions,
-  AzureEnvironmentNames,
-  AzureAuthorityHosts
+  AzureEnvironmentName
 } from './AzureStorageAuthentication';
 
 export default RushAzureStorageBuildCachePlugin;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/test/AzureStorageBuildCacheProvider.test.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/test/AzureStorageBuildCacheProvider.test.ts
@@ -5,7 +5,7 @@ import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-lib
 import { CredentialCache, EnvironmentConfiguration, RushUserConfiguration } from '@rushstack/rush-sdk';
 
 import { AzureStorageBuildCacheProvider } from '../AzureStorageBuildCacheProvider';
-import type { AzureEnvironmentNames } from '../AzureStorageAuthentication';
+import type { AzureEnvironmentName } from '../AzureStorageAuthentication';
 
 describe(AzureStorageBuildCacheProvider.name, () => {
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe(AzureStorageBuildCacheProvider.name, () => {
         new AzureStorageBuildCacheProvider({
           storageAccountName: 'storage-account',
           storageContainerName: 'container-name',
-          azureEnvironment: 'INCORRECT_AZURE_ENVIRONMENT' as AzureEnvironmentNames,
+          azureEnvironment: 'INCORRECT_AZURE_ENVIRONMENT' as AzureEnvironmentName,
           isCacheWriteAllowed: false
         })
     ).toThrowErrorMatchingSnapshot();


### PR DESCRIPTION
## Summary

This PR updates the `@azure/` packages in `rush-azure-storage-build-cache-plugin` to remove a hardcoded GUID.

[Version `1.2.0`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/CHANGELOG.md#changes-since-the-latest-12-beta) of the `@azure/identity` changed the constructor for the `DeviceCodeCredential` class to make the Client ID optional. Previously, it was required.

https://github.com/microsoft/rushstack/pull/2647 introduced this GUID when we downgraded to version `1.0.0` of `@azure/identity` to remove a dependency on `keytar`. Now that version `2.0.0` has been released, we can upgrade and remove hardcoded data.

## How it was tested

Tested in a Rush repo that uses authenticated Azure Storage.