### PR TITLE
[rush][package-deps-hash] Fix Git operations when cwd is in the Rush repo

### DIFF
--- a/common/changes/@microsoft/rush/fix-repo-state_2022-09-23-01-42.json
+++ b/common/changes/@microsoft/rush/fix-repo-state_2022-09-23-01-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix Git detection when the current working directory is unrelated to the Rush workspace.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/fix-repo-state_2022-09-23-01-39.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-repo-state_2022-09-23-01-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Fix getRepoState when the current working directory is not in the Git repository.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -215,7 +215,7 @@ export function applyWorkingTreeState(
     const hashObjectResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
       gitPath || 'git',
       ['hash-object', '--stdin-paths'],
-      { input: filesToHash.join('\n') }
+      { currentWorkingDirectory: rootDirectory, input: filesToHash.join('\n') }
     );
 
     if (hashObjectResult.status !== 0) {

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -204,14 +204,14 @@ export class Git {
 
   /**
    * Get information about the current Git working tree.
-   * Returns undefined if the current path is not under a Git working tree.
+   * Returns undefined if rush.json is not under a Git working tree.
    */
   public getGitInfo(): Readonly<gitInfo.GitRepoInfo> | undefined {
     if (!this._checkedGitInfo) {
       let repoInfo: gitInfo.GitRepoInfo | undefined;
       try {
         // gitInfo() shouldn't usually throw, but wrapping in a try/catch just in case
-        repoInfo = gitInfo();
+        repoInfo = gitInfo(this._rushConfiguration.rushJsonFolder);
       } catch (ex) {
         // if there's an error, assume we're not in a Git working tree
       }


### PR DESCRIPTION
## Summary
Fixes detection of a Git repository in `@microsoft/rush-lib` when the current working directory is not in the Rush workspace.
Fixes `getRepoState` when the current working directory is not in the Git working tree.

## Details
Modifies the call in `Git.ts` to pass in `rushConfiguration.rushJsonFolder` as the starting directory for locating the Git repository.
Modifies `getRepoState` to correctly set the working directory when invoking `git hash-object`. 

## How it was tested
Invoked `PackageChangeAnalyzer` against a Rush repository when the current working directory was outside the repository.