### PR TITLE
[rush] restore the duration of the same operation without cache hit as telemetry data

### DIFF
--- a/common/changes/@microsoft/rush/feat-operation-metadata_2022-09-26-12-16.json
+++ b/common/changes/@microsoft/rush/feat-operation-metadata_2022-09-26-12-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "restore the duration of the same operation without cache hit as telemetry data",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/feat-operation-metadata_2022-09-26-12-16.json
+++ b/common/changes/@microsoft/rush/feat-operation-metadata_2022-09-26-12-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "restore the duration of the same operation without cache hit as telemetry data",
+      "comment": "Include the operation duration in the telemetry data that was recorded during the non-cached run when a cache hit occurs.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -400,12 +400,25 @@ export interface IOperationRunner {
 export interface IOperationRunnerContext {
     collatedWriter: CollatedWriter;
     debugMode: boolean;
-    // Warning: (ae-forgotten-export) The symbol "OperationStateFile" needs to be exported by the entry point index.d.ts
-    operationStateFile?: OperationStateFile;
+    // @internal
+    _operationStateFile?: _OperationStateFile;
     quietMode: boolean;
     stdioSummarizer: StdioSummarizer;
-    // Warning: (ae-forgotten-export) The symbol "Stopwatch" needs to be exported by the entry point index.d.ts
-    stopwatch: Stopwatch;
+    stopwatch: IStopwatchResult;
+}
+
+// @internal (undocumented)
+export interface _IOperationStateFileOptions {
+    // (undocumented)
+    phase: IPhase;
+    // (undocumented)
+    rushProject: RushConfigurationProject;
+}
+
+// @internal (undocumented)
+export interface _IOperationStateJson {
+    // (undocumented)
+    nonCachedDurationMs: number;
 }
 
 // @public
@@ -476,7 +489,7 @@ export interface IRushSessionOptions {
     terminalProvider: ITerminalProvider;
 }
 
-// @alpha
+// @beta
 export interface IStopwatchResult {
     get duration(): number;
     get endTime(): number | undefined;
@@ -586,6 +599,19 @@ export class Operation {
     get name(): string | undefined;
     runner: IOperationRunner | undefined;
     weight: number;
+}
+
+// @internal
+export class _OperationStateFile {
+    constructor(options: _IOperationStateFileOptions);
+    get filename(): string;
+    static getFilenameRelativeToProjectRoot(phase: IPhase): string;
+    // (undocumented)
+    get state(): _IOperationStateJson | undefined;
+    // (undocumented)
+    tryRestoreAsync(): Promise<_IOperationStateJson | undefined>;
+    // (undocumented)
+    writeAsync(json: _IOperationStateJson): Promise<void>;
 }
 
 // @beta

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -371,8 +371,8 @@ export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
 
 // @alpha
 export interface IOperationExecutionResult {
-    readonly durationInSecondsWithoutCache: number | undefined;
     readonly error: Error | undefined;
+    readonly nonCachedDurationMs: number | undefined;
     readonly status: OperationStatus;
     readonly stdioSummarizer: StdioSummarizer;
     readonly stopwatch: IStopwatchResult;
@@ -400,8 +400,12 @@ export interface IOperationRunner {
 export interface IOperationRunnerContext {
     collatedWriter: CollatedWriter;
     debugMode: boolean;
+    // Warning: (ae-forgotten-export) The symbol "OperationStateFile" needs to be exported by the entry point index.d.ts
+    operationStateFile?: OperationStateFile;
     quietMode: boolean;
     stdioSummarizer: StdioSummarizer;
+    // Warning: (ae-forgotten-export) The symbol "Stopwatch" needs to be exported by the entry point index.d.ts
+    stopwatch: Stopwatch;
 }
 
 // @public
@@ -508,8 +512,8 @@ export interface ITelemetryMachineInfo {
 // @beta (undocumented)
 export interface ITelemetryOperationResult {
     dependencies: string[];
-    durationInSecondsWithoutCache?: number;
     endTimestampMs?: number;
+    nonCachedDurationMs?: number;
     result: string;
     startTimestampMs?: number;
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -371,6 +371,7 @@ export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
 
 // @alpha
 export interface IOperationExecutionResult {
+    readonly durationInSecondsWithoutCache: number | undefined;
     readonly error: Error | undefined;
     readonly status: OperationStatus;
     readonly stdioSummarizer: StdioSummarizer;
@@ -507,6 +508,7 @@ export interface ITelemetryMachineInfo {
 // @beta (undocumented)
 export interface ITelemetryOperationResult {
     dependencies: string[];
+    durationInSecondsWithoutCache?: number;
     endTimestampMs?: number;
     result: string;
     startTimestampMs?: number;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -578,6 +578,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           operationResults[operation.name!] = {
             startTimestampMs: startTime,
             endTimestampMs: endTime,
+            durationInSecondsWithoutCache: operationResult.durationInSecondsWithoutCache,
             result: operationResult.status,
             dependencies: Array.from(getNonSilentDependencies(operation)).sort()
           };

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -578,7 +578,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           operationResults[operation.name!] = {
             startTimestampMs: startTime,
             endTimestampMs: endTime,
-            durationInSecondsWithoutCache: operationResult.durationInSecondsWithoutCache,
+            nonCachedDurationMs: operationResult.nonCachedDurationMs,
             result: operationResult.status,
             dependencies: Array.from(getNonSilentDependencies(operation)).sort()
           };

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -118,3 +118,8 @@ export { ICredentialCacheOptions, ICredentialCacheEntry, CredentialCache } from 
 export type { ITelemetryData, ITelemetryMachineInfo, ITelemetryOperationResult } from './logic/Telemetry';
 
 export { IStopwatchResult } from './utilities/Stopwatch';
+export {
+  OperationStateFile as _OperationStateFile,
+  IOperationStateFileOptions as _IOperationStateFileOptions,
+  IOperationStateJson as _IOperationStateJson
+} from './logic/operations/OperationStateFile';

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -68,7 +68,7 @@ export interface ITelemetryOperationResult {
   endTimestampMs?: number;
 
   /**
-   * Duration in seconds when the operation does not hit cache
+   * Duration in milliseconds when the operation does not hit cache
    */
   nonCachedDurationMs?: number;
 }

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -66,6 +66,11 @@ export interface ITelemetryOperationResult {
    * If the operation was blocked, will be `undefined`.
    */
   endTimestampMs?: number;
+
+  /**
+   * Duration in seconds when the operation does not hit cache
+   */
+  durationInSecondsWithoutCache?: number;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -70,7 +70,7 @@ export interface ITelemetryOperationResult {
   /**
    * Duration in seconds when the operation does not hit cache
    */
-  durationInSecondsWithoutCache?: number;
+  nonCachedDurationMs?: number;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -44,6 +44,7 @@ export class ProjectBuildCache {
   private readonly _buildCacheEnabled: boolean;
   private readonly _cacheWriteEnabled: boolean;
   private readonly _projectOutputFolderNames: ReadonlyArray<string>;
+  private _additionalOutputFilePaths: string[];
   private _cacheId: string | undefined;
 
   private constructor(cacheId: string | undefined, options: IProjectBuildCacheOptions) {
@@ -54,6 +55,7 @@ export class ProjectBuildCache {
     this._buildCacheEnabled = buildCacheConfiguration.buildCacheEnabled;
     this._cacheWriteEnabled = buildCacheConfiguration.cacheWriteEnabled;
     this._projectOutputFolderNames = projectOutputFolderNames || [];
+    this._additionalOutputFilePaths = [];
     this._cacheId = cacheId;
   }
 
@@ -122,6 +124,14 @@ export class ProjectBuildCache {
     } else {
       return true;
     }
+  }
+
+  public get additionalOutputFilePaths(): string[] {
+    return this._additionalOutputFilePaths;
+  }
+
+  public addAdditionalOutputFilePaths(outputFilePath: string): void {
+    this._additionalOutputFilePaths.push(outputFilePath);
   }
 
   public async tryRestoreFromCacheAsync(terminal: ITerminal): Promise<boolean> {
@@ -357,6 +367,14 @@ export class ProjectBuildCache {
     if (hasSymbolicLinks) {
       // Symbolic links do not round-trip safely.
       return undefined;
+    }
+
+    // Add additional output file paths
+    for (const addAdditionalOutputFilePath of this._additionalOutputFilePaths) {
+      const fullPath: string = `${projectFolderPath}/${addAdditionalOutputFilePath}`;
+      if (FileSystem.exists(fullPath)) {
+        outputFilePaths.push(addAdditionalOutputFilePath);
+      }
     }
 
     // Ensure stable output path order.

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { FileSystem, Path, ITerminal, FolderItem, InternalError } from '@rushstack/node-core-library';
+import { FileSystem, Path, ITerminal, FolderItem, InternalError, Async } from '@rushstack/node-core-library';
 
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
@@ -19,6 +19,7 @@ export interface IProjectBuildCacheOptions {
   buildCacheConfiguration: BuildCacheConfiguration;
   projectConfiguration: RushProjectConfiguration;
   projectOutputFolderNames: ReadonlyArray<string>;
+  additionalProjectOutputFilePaths?: ReadonlyArray<string>;
   command: string;
   trackedProjectFiles: string[] | undefined;
   projectChangeAnalyzer: ProjectChangeAnalyzer;
@@ -44,18 +45,23 @@ export class ProjectBuildCache {
   private readonly _buildCacheEnabled: boolean;
   private readonly _cacheWriteEnabled: boolean;
   private readonly _projectOutputFolderNames: ReadonlyArray<string>;
-  private readonly _additionalOutputFilePaths: string[];
+  private readonly _additionalProjectOutputFilePaths: ReadonlyArray<string>;
   private _cacheId: string | undefined;
 
   private constructor(cacheId: string | undefined, options: IProjectBuildCacheOptions) {
-    const { buildCacheConfiguration, projectConfiguration, projectOutputFolderNames } = options;
+    const {
+      buildCacheConfiguration,
+      projectConfiguration,
+      projectOutputFolderNames,
+      additionalProjectOutputFilePaths
+    } = options;
     this._project = projectConfiguration.project;
     this._localBuildCacheProvider = buildCacheConfiguration.localCacheProvider;
     this._cloudBuildCacheProvider = buildCacheConfiguration.cloudCacheProvider;
     this._buildCacheEnabled = buildCacheConfiguration.buildCacheEnabled;
     this._cacheWriteEnabled = buildCacheConfiguration.cacheWriteEnabled;
     this._projectOutputFolderNames = projectOutputFolderNames || [];
-    this._additionalOutputFilePaths = [];
+    this._additionalProjectOutputFilePaths = additionalProjectOutputFilePaths || [];
     this._cacheId = cacheId;
   }
 
@@ -118,20 +124,12 @@ export class ProjectBuildCache {
     if (inputOutputFiles.length > 0) {
       terminal.writeWarningLine(
         'Unable to use build cache. The following files are used to calculate project state ' +
-          `and are considered project output: ${inputOutputFiles.join(', ')}`
+        `and are considered project output: ${inputOutputFiles.join(', ')}`
       );
       return false;
     } else {
       return true;
     }
-  }
-
-  public get additionalOutputFilePaths(): string[] {
-    return this._additionalOutputFilePaths;
-  }
-
-  public addAdditionalOutputFilePaths(outputFilePath: string): void {
-    this._additionalOutputFilePaths.push(outputFilePath);
   }
 
   public async tryRestoreFromCacheAsync(terminal: ITerminal): Promise<boolean> {
@@ -261,14 +259,14 @@ export class ProjectBuildCache {
       } else {
         terminal.writeWarningLine(
           `"tar" exited with code ${tarExitCode} while attempting to create the cache entry. ` +
-            `See "${logFilePath}" for logs from the tar process.`
+          `See "${logFilePath}" for logs from the tar process.`
         );
         return false;
       }
     } else {
       terminal.writeWarningLine(
         `Unable to locate "tar". Please ensure that "tar" is on your PATH environment variable, or set the ` +
-          `${EnvironmentVariableNames.RUSH_TAR_BINARY_PATH} environment variable to the full path to the "tar" binary.`
+        `${EnvironmentVariableNames.RUSH_TAR_BINARY_PATH} environment variable to the full path to the "tar" binary.`
       );
       return false;
     }
@@ -370,13 +368,17 @@ export class ProjectBuildCache {
     }
 
     // Add additional output file paths
-    await Async.foreEachAsync(this._additionalOutputFilePaths, async (additionalOutputFilePath) => {
-      const fullPath: string = `${projectFolderPath}/${addAdditionalOutputFilePath}`;
-      const pathExists: boolean = await FileSystem.existsAsync(fullPath);
-      if (pathExists) {
-        outputFilePaths.push(addAdditionalOutputFilePath);
-      }
-    }, { concurrency: 10 });
+    await Async.forEachAsync(
+      this._additionalProjectOutputFilePaths,
+      async (additionalProjectOutputFilePath) => {
+        const fullPath: string = `${projectFolderPath}/${additionalProjectOutputFilePath}`;
+        const pathExists: boolean = await FileSystem.existsAsync(fullPath);
+        if (pathExists) {
+          outputFilePaths.push(additionalProjectOutputFilePath);
+        }
+      },
+      { concurrency: 10 }
+    );
 
     // Ensure stable output path order.
     outputFilePaths.sort();

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -44,7 +44,7 @@ export class ProjectBuildCache {
   private readonly _buildCacheEnabled: boolean;
   private readonly _cacheWriteEnabled: boolean;
   private readonly _projectOutputFolderNames: ReadonlyArray<string>;
-  private _additionalOutputFilePaths: string[];
+  private readonly _additionalOutputFilePaths: string[];
   private _cacheId: string | undefined;
 
   private constructor(cacheId: string | undefined, options: IProjectBuildCacheOptions) {
@@ -370,12 +370,13 @@ export class ProjectBuildCache {
     }
 
     // Add additional output file paths
-    for (const addAdditionalOutputFilePath of this._additionalOutputFilePaths) {
+    await Async.foreEachAsync(this._additionalOutputFilePaths, async (additionalOutputFilePath) => {
       const fullPath: string = `${projectFolderPath}/${addAdditionalOutputFilePath}`;
-      if (FileSystem.exists(fullPath)) {
+      const pathExists: boolean = await FileSystem.existsAsync(fullPath);
+      if (pathExists) {
         outputFilePaths.push(addAdditionalOutputFilePath);
       }
-    }
+    }, { concurrency: 10 });
 
     // Ensure stable output path order.
     outputFilePaths.sort();

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -31,6 +31,11 @@ export interface IOperationExecutionResult {
    * Object used to report a summary at the end of the Rush invocation.
    */
   readonly stdioSummarizer: StdioSummarizer;
+  /**
+   * The value indicates the duration of the same operation without cache hit.
+   * It is specified if current operation hits cache
+   */
+  readonly durationInSecondsWithoutCache: number | undefined;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -33,7 +33,6 @@ export interface IOperationExecutionResult {
   readonly stdioSummarizer: StdioSummarizer;
   /**
    * The value indicates the duration of the same operation without cache hit.
-   * It is specified if current operation hits cache
    */
   readonly nonCachedDurationMs: number | undefined;
 }

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -35,7 +35,7 @@ export interface IOperationExecutionResult {
    * The value indicates the duration of the same operation without cache hit.
    * It is specified if current operation hits cache
    */
-  readonly durationInSecondsWithoutCache: number | undefined;
+  readonly nonCachedDurationMs: number | undefined;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -6,7 +6,7 @@ import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
 import type { OperationStateFile } from './OperationStateFile';
-import type { Stopwatch } from '../../utilities/Stopwatch';
+import type { IStopwatchResult } from '../../utilities/Stopwatch';
 
 /**
  * Information passed to the executing `IOperationRunner`
@@ -32,12 +32,14 @@ export interface IOperationRunnerContext {
   stdioSummarizer: StdioSummarizer;
   /**
    * Object used to record state of the operation.
+   *
+   * @internal
    */
-  operationStateFile?: OperationStateFile;
+  _operationStateFile?: OperationStateFile;
   /**
    * Object used to track elapsed time.
    */
-  stopwatch: Stopwatch;
+  stopwatch: IStopwatchResult;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -5,6 +5,8 @@ import type { StdioSummarizer } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
+import type { OperationStateFile } from './OperationStateFile';
+import type { Stopwatch } from '../../utilities/Stopwatch';
 
 /**
  * Information passed to the executing `IOperationRunner`
@@ -28,6 +30,14 @@ export interface IOperationRunnerContext {
    * Object used to report a summary at the end of the Rush invocation.
    */
   stdioSummarizer: StdioSummarizer;
+  /**
+   * Object used to record state of the operation.
+   */
+  operationStateFile?: OperationStateFile;
+  /**
+   * Object used to track elapsed time.
+   */
+  stopwatch: Stopwatch;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -87,8 +87,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   private _collatedWriter: CollatedWriter | undefined = undefined;
 
-  public nonCachedDurationMs: number | undefined = undefined;
-
   public constructor(operation: Operation, context: IOperationExecutionRecordContext) {
     const { runner } = operation;
 
@@ -127,6 +125,11 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
       this._collatedWriter = this._context.streamCollator.registerTask(this.name);
     }
     return this._collatedWriter;
+  }
+
+  public get nonCachedDurationMs(): number | undefined {
+    // Lazy calculated because the state file is created/restored later on
+    return this.operationStateFile?.state?.nonCachedDurationMs;
   }
 
   public async executeAsync(onResult: (record: OperationExecutionRecord) => void): Promise<void> {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -81,7 +81,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public readonly runner: IOperationRunner;
   public readonly weight: number;
-  public readonly operationStateFile: OperationStateFile | undefined;
+  public readonly _operationStateFile: OperationStateFile | undefined;
 
   private readonly _context: IOperationExecutionRecordContext;
 
@@ -99,7 +99,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
     this.runner = runner;
     this.weight = operation.weight;
     if (operation.associatedPhase && operation.associatedProject) {
-      this.operationStateFile = new OperationStateFile({
+      this._operationStateFile = new OperationStateFile({
         phase: operation.associatedPhase,
         rushProject: operation.associatedProject
       });
@@ -129,7 +129,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public get nonCachedDurationMs(): number | undefined {
     // Lazy calculated because the state file is created/restored later on
-    return this.operationStateFile?.state?.nonCachedDurationMs;
+    return this._operationStateFile?.state?.nonCachedDurationMs;
   }
 
   public async executeAsync(onResult: (record: OperationExecutionRecord) => void): Promise<void> {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -87,7 +87,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   private _collatedWriter: CollatedWriter | undefined = undefined;
 
-  private _durationInSecondsWithoutCache: number | undefined = undefined;
+  public nonCachedDurationMs: number | undefined = undefined;
 
   public constructor(operation: Operation, context: IOperationExecutionRecordContext) {
     const { runner } = operation;
@@ -127,14 +127,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
       this._collatedWriter = this._context.streamCollator.registerTask(this.name);
     }
     return this._collatedWriter;
-  }
-
-  public get durationInSecondsWithoutCache(): number | undefined {
-    return this._durationInSecondsWithoutCache;
-  }
-
-  public set durationInSecondsWithoutCache(value: number | undefined) {
-    this._durationInSecondsWithoutCache = value;
   }
 
   public async executeAsync(onResult: (record: OperationExecutionRecord) => void): Promise<void> {

--- a/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
@@ -49,7 +49,7 @@ export class OperationStateFile {
    * @internal
    */
   public static getFilenameRelativeToProjectRoot(phase: IPhase): string {
-    const identifier: string = `${phase.logFilenameIdentifier}`;
+    const identifier: string = phase.logFilenameIdentifier;
     return `${RushConstants.projectRushFolderName}/${RushConstants.rushTempFolderName}/operation/${identifier}/state.json`;
   }
 

--- a/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { FileSystem, InternalError, JsonFile } from '@rushstack/node-core-library';
+import { RushConstants } from '../RushConstants';
+
+import type { IPhase } from '../../api/CommandLineConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+
+export interface IOperationStateFileOptions {
+  rushProject: RushConfigurationProject;
+  phase: IPhase;
+}
+
+export interface IOperationStateJson {
+  durationInSecondsWithoutCache: number;
+}
+
+export class OperationStateFile {
+  private readonly _rushProject: RushConfigurationProject;
+  private _filename: string;
+
+  public constructor(options: IOperationStateFileOptions) {
+    const { rushProject, phase } = options;
+    this._rushProject = rushProject;
+    this._filename = OperationStateFile.getFilename(phase, rushProject);
+  }
+
+  public static getFilename(phase: IPhase, project: RushConfigurationProject): string {
+    const relativeFilename: string = OperationStateFile.getFilenameRelativeToProjectRoot(phase);
+    return path.join(project.projectFolder, relativeFilename);
+  }
+
+  public static getFilenameRelativeToProjectRoot(phase: IPhase): string {
+    const identifier: string = `${phase.logFilenameIdentifier}`;
+    return path.join(
+      RushConstants.projectRushFolderName,
+      RushConstants.rushTempFolderName,
+      'operation',
+      identifier,
+      'state.json'
+    );
+  }
+
+  /**
+   * Returns the filename of the metadata file.
+   */
+  public get filename(): string {
+    return this._filename;
+  }
+
+  public write(json: IOperationStateJson): void {
+    JsonFile.save(json, this._filename, { ensureFolderExists: true, updateExistingFile: true });
+  }
+
+  public tryRead(): IOperationStateJson | undefined {
+    let json: IOperationStateJson | undefined;
+    try {
+      json = JsonFile.load(this._filename);
+    } catch (error) {
+      if (FileSystem.isFileDoesNotExistError(error as Error)) {
+        json = undefined;
+      } else {
+        // This should not happen
+        throw new InternalError(error);
+      }
+    }
+    return json;
+  }
+}

--- a/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStateFile.ts
@@ -7,11 +7,17 @@ import { RushConstants } from '../RushConstants';
 import type { IPhase } from '../../api/CommandLineConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 
+/**
+ * @internal
+ */
 export interface IOperationStateFileOptions {
   rushProject: RushConfigurationProject;
   phase: IPhase;
 }
 
+/**
+ * @internal
+ */
 export interface IOperationStateJson {
   nonCachedDurationMs: number;
 }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -275,7 +275,7 @@ export class ShellOperationRunner implements IOperationRunner {
 
         if (restoreFromCacheSuccess) {
           // Restore the original state of the operation without cache
-          await context.operationStateFile?.tryRestoreAsync();
+          await context._operationStateFile?.tryRestoreAsync();
           return OperationStatus.FromCache;
         }
       }
@@ -375,7 +375,7 @@ export class ShellOperationRunner implements IOperationRunner {
 
         // If the operation without cache was successful, we can save the state to disk
         const { duration: durationInSeconds } = context.stopwatch;
-        await context.operationStateFile?.writeAsync({
+        await context._operationStateFile?.writeAsync({
           nonCachedDurationMs: durationInSeconds * 1000
         });
 

--- a/libraries/rush-lib/src/utilities/Stopwatch.ts
+++ b/libraries/rush-lib/src/utilities/Stopwatch.ts
@@ -13,7 +13,7 @@ export enum StopwatchState {
 
 /**
  * Represents a readonly view of a `Stopwatch`.
- * @alpha
+ * @beta
  */
 export interface IStopwatchResult {
   /**


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This PR makes Rush.js restores the duration of the same operation without cache hit and log `durationInSecondsWithoutCache` in operationResult

## Details

1. When operation doesn't hit cache, Rush.js creates a `.rush/temp/operation/<identifier>/state.json` which contains `durationInSecondsWithoutCache`.
2. Set the state.json in Step 1 as an additional output file when create project build cache tarball.
3. When operation hit cache, read the restored state.json and set `durationInSecondsWithoutCache` as one of the property of operationResult

## How it was tested

- [x] Tested it with local build cache in rushstack repo
- [x] Tested it with cloud build cache in private repo

Test with local build cache in rushstack repo steps:
1. Enable telemetry by setting up `"telemetryEnabled": true` in rush.json
2. Run `rm -rf common/temp/build-cache`
3. Run `node rush-lib/lib/start.js build -v --to tree-pattern`
  a.  `libraries/tree-pattern/.rush/temp/operation/_phase_build/state.json` created
  b. `libraries/tree-pattern/.rush/temp/rushstack+tree-pattern-_phase_build-<identifier>.log` shows `.rush/temp/operation/_phase_build/state.json` is included when creating build archive.
4. Remove the state.json by running `rm rf libraries/tree-pattern/.rush/temp/operation/_phase_build/state.json`
5. Run `node rush-lib/lib/start.js build -v --to tree-pattern` the second time
  a. `libraries/tree-pattern/.rush/temp/operation/_phase_build/state.json` restored
  b. `common/temp/telemetry/<...>.json` records `nonCachedDurationMs` in `operationResult` of `tree-pattern`

