### PR TITLE
[rush] Remove node tar fallback

### DIFF
--- a/common/changes/@microsoft/rush/node-tar-cleanup_2022-09-26-20-33.json
+++ b/common/changes/@microsoft/rush/node-tar-cleanup_2022-09-26-20-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove fallback from tar binary to npm 'tar' package. The npm 'tar' package would sometimes produce invalid output if the cache entry was corrupt.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fallback to the node implementation of `tar` in practice seems to only occur when the tarball is invalid, unless the `tar` is not on `PATH`. This results in restoring from corrupt cache entries and producing an invalid build result.

This PR removes the fallback to node `tar`.

Fixes #3454
Fixes #2827

## Details
Completely disables fallback path to node implementation of `tar`. Updates logged warning to suggest ensuring that `tar` is on `PATH` or setting `RUSH_TAR_EXECUTABLE_PATH` to point to `tar` in the event that the binary cannot be found.

## How it was tested
This is the normal state for most builds.