### PR TITLE
[heft-config-file] Allow a schema object to be passed to the ConfigurationFile constructor instead of the path to a schema file.

### DIFF
--- a/common/changes/@rushstack/heft-config-file/heft-config-file-schema-object_2022-09-27-21-34.json
+++ b/common/changes/@rushstack/heft-config-file/heft-config-file-schema-object_2022-09-27-21-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Allow a schema object to be passed to the ConfigurationFile constructor instead of the path to a schema file.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -20,12 +20,28 @@ export class ConfigurationFile<TConfigurationFile> {
 }
 
 // @beta (undocumented)
-export interface IConfigurationFileOptions<TConfigurationFile> {
+export type IConfigurationFileOptions<TConfigurationFile> = IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile> | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile>;
+
+// @beta (undocumented)
+export interface IConfigurationFileOptionsBase<TConfigurationFile> {
     jsonPathMetadata?: IJsonPathsMetadata;
-    jsonSchemaPath: string;
     projectRelativeFilePath: string;
     propertyInheritance?: IPropertiesInheritance<TConfigurationFile>;
     propertyInheritanceDefaults?: IPropertyInheritanceDefaults;
+}
+
+// @beta (undocumented)
+export interface IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile> extends IConfigurationFileOptionsBase<TConfigurationFile> {
+    // (undocumented)
+    jsonSchemaObject?: never;
+    jsonSchemaPath: string;
+}
+
+// @beta (undocumented)
+export interface IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile> extends IConfigurationFileOptionsBase<TConfigurationFile> {
+    jsonSchemaObject: object;
+    // (undocumented)
+    jsonSchemaPath?: never;
 }
 
 // @beta

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -3,6 +3,9 @@
 
 export {
   ConfigurationFile,
+  IConfigurationFileOptionsBase,
+  IConfigurationFileOptionsWithJsonSchemaFilePath,
+  IConfigurationFileOptionsWithJsonSchemaObject,
   IConfigurationFileOptions,
   ICustomJsonPathMetadata,
   ICustomPropertyInheritance,

--- a/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
+++ b/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
@@ -180,6 +180,66 @@ Object {
 }
 `;
 
+exports[`ConfigurationFile A simple config file with a JSON schema object Correctly loads the config file 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema object Correctly resolves paths relative to the config file 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema object Correctly resolves paths relative to the project root 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema path Correctly loads the config file 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema path Correctly resolves paths relative to the config file 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema path Correctly resolves paths relative to the project root 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
 exports[`ConfigurationFile a complex file with inheritance type annotations Correctly loads a complex config file with a single inheritance type annotation 1`] = `
 Object {
   "debug": "",


### PR DESCRIPTION
## Summary

Adds a constructor option to the `ConfigurationFile` object to allow a schema object instead of the path to a schema file to be passed in. This allows a project that uses `ConfigurationFile` to be webpacked.

## How it was tested

Added a unit test.