### PR TITLE
[rush] Fix a rush-lib test on Windows.

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.0.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.47.9.tgz
+      '@rushstack/heft': file:rushstack-heft-0.47.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.7.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.0.1.tgz_valmiib6gbzc7jhcbpocdsabay
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.47.9.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.47.10.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.7.4
       typescript: 4.7.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.0.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.47.9.tgz
+      '@rushstack/heft': file:rushstack-heft-0.47.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.7.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.0.1.tgz_valmiib6gbzc7jhcbpocdsabay
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.47.9.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.47.10.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.7.4
       typescript: 4.7.4
@@ -1799,15 +1799,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.47.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.47.9.tgz}
+  file:../temp/tarballs/rushstack-heft-0.47.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.47.10.tgz}
     name: '@rushstack/heft'
-    version: 0.47.9
+    version: 0.47.10
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.9.6.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.51.2.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.10.0.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.52.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.15.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.12.3.tgz
       '@types/tapable': 1.0.6
@@ -1822,21 +1822,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.9.6.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.9.6.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.10.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.10.0.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.9.6
+    version: 0.10.0
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.51.2.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.52.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.15.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.51.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.51.2.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.52.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.52.0.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.51.2
+    version: 3.52.0
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5

--- a/common/changes/@microsoft/rush/fix-rush-test-on-windows_2022-09-27-21-44.json
+++ b/common/changes/@microsoft/rush/fix-rush-test-on-windows_2022-09-27-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 
-import { Text } from '@rushstack/node-core-library';
+import { Path, Text } from '@rushstack/node-core-library';
 import { RushConfiguration } from '../RushConfiguration';
 import { ApprovedPackagesPolicy } from '../ApprovedPackagesPolicy';
 import { RushConfigurationProject } from '../RushConfigurationProject';
@@ -250,7 +250,9 @@ describe(RushConfiguration.name, () => {
 
         expect(rushConfiguration.packageManager).toEqual('pnpm');
         expect(rushConfiguration.pnpmOptions.pnpmStore).toEqual('local');
-        expect(rushConfiguration.pnpmOptions.pnpmStorePath).toEqual(EXPECT_STORE_PATH);
+        expect(Path.convertToSlashes(rushConfiguration.pnpmOptions.pnpmStorePath)).toEqual(
+          Path.convertToSlashes(EXPECT_STORE_PATH)
+        );
         expect(path.isAbsolute(rushConfiguration.pnpmOptions.pnpmStorePath)).toEqual(true);
       });
 


### PR DESCRIPTION
There is a test in `rush-lib` that relies on the existence of a forward slash. This PR fixes that.