### PR TITLE
[loader-load-themed-styles] Remove the namedExport option.

### DIFF
--- a/common/changes/@microsoft/loader-load-themed-styles/remove-namedExport_2022-09-28-01-13.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/remove-namedExport_2022-09-28-01-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Remove the namedExport option.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles"
+}

--- a/webpack/loader-load-themed-styles/README.md
+++ b/webpack/loader-load-themed-styles/README.md
@@ -28,7 +28,6 @@ var css = require("@microsoft/loader-load-themed-styles!css!./file.css");
           {
             loader: "@microsoft/loader-load-themed-styles",  // creates style nodes from JS strings
             options: {
-              namedExport: 'default',
               async: false
             }
           },
@@ -59,22 +58,6 @@ var css = require("@microsoft/loader-load-themed-styles!css!./file.css");
 ```
 
 ## Options
-
-### `namedExport` (string, defaults to `undefined`)
-
-By default, css modules will be exported as a commonjs export:
-
-```js
-module.exports = { ... };
-```
-
-To override this, you may provide a named export to export to a specifically named thing. This
-is useful in exporting as the default in es6 module import scenarios. For example, providing
-"default" for the named export will output this:
-
-```js
-module.exports.default = { ... };
-```
 
 ### `async` (boolean, defaults to `false`)
 

--- a/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
+++ b/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
@@ -19,12 +19,6 @@ const loadedThemedStylesPath: string = require.resolve('@microsoft/load-themed-s
  */
 export interface ILoadThemedStylesLoaderOptions {
   /**
-   * If this parameter is specified, override the name of the value exported from this loader. This is useful in
-   *  exporting as the default in es6 module import scenarios. See the README for more information.
-   */
-  namedExport?: string;
-
-  /**
    * If this parameter is set to "true," the "loadAsync" parameter is set to true in the call to loadStyles.
    * Defaults to false.
    */
@@ -63,12 +57,12 @@ export class LoadThemedStylesLoader {
   }
 
   public static pitch(this: loader.LoaderContext, remainingRequest: string): string {
-    const { namedExport, async = false }: ILoadThemedStylesLoaderOptions = loaderUtils.getOptions(this) || {};
-
-    let exportName: string = 'module.exports';
-    if (namedExport) {
-      exportName += `.${namedExport}`;
+    const options: ILoadThemedStylesLoaderOptions = loaderUtils.getOptions(this) || {};
+    if ((options as Record<string, unknown>).namedExport) {
+      throw new Error('The "namedExport" option has been removed.');
     }
+
+    const { async = false } = options;
 
     return [
       `var content = require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)});`,
@@ -79,7 +73,7 @@ export class LoadThemedStylesLoader {
       '// add the styles to the DOM',
       `for (var i = 0; i < content.length; i++) loader.loadStyles(content[i][1], ${async === true});`,
       '',
-      `if(content.locals) ${exportName} = content.locals;`
+      'if(content.locals) module.exports = content.locals;'
     ].join('\n');
   }
 }

--- a/webpack/loader-load-themed-styles/src/test/LoadThemedStylesLoader.test.ts
+++ b/webpack/loader-load-themed-styles/src/test/LoadThemedStylesLoader.test.ts
@@ -90,28 +90,6 @@ describe(LoadThemedStylesLoader.name, () => {
     expect(returnedModule.exports).toEqual({});
   });
 
-  it('correctly handles the namedExport option', () => {
-    LoadThemedStylesLoader.loadedThemedStylesPath = './testData/LoadThemedStylesMock';
-
-    const query: {} = { namedExport: 'default' };
-    let loaderResult: string = LoadThemedStylesLoader.pitch.call(
-      { query } as webpack.loader.LoaderContext,
-      './testData/MockStyle1'
-    );
-    loaderResult = loaderResult.replace(/require\(\"!!/, 'require("');
-    loaderResult = wrapResult(loaderResult);
-
-    const returnedModule: { exports: string } = eval(loaderResult); // eslint-disable-line no-eval
-
-    expect(LoadThemedStylesMock.loadedData.indexOf('STYLE 1') !== -1).toEqual(true);
-    expect(LoadThemedStylesMock.loadedData.indexOf('STYLE 2') !== -1).toEqual(true);
-    expect(LoadThemedStylesMock.loadedData).toHaveLength(2);
-    expect(LoadThemedStylesMock.calledWithAsync[0]).toEqual(false);
-    expect(LoadThemedStylesMock.calledWithAsync[1]).toEqual(false);
-    expect(LoadThemedStylesMock.calledWithAsync).toHaveLength(2);
-    expect(returnedModule.exports).toEqual({ default: 'locals' });
-  });
-
   it('correctly handles the async option set to "true"', () => {
     LoadThemedStylesLoader.loadedThemedStylesPath = './testData/LoadThemedStylesMock';
 


### PR DESCRIPTION
This option isn't used and will be superseded by ES6 support soon.