### PR TITLE
[rush] Fix an issue where a "Current PNPM store path does not match the last one used." error will erroneously get thrown on Windows with an unchanged path, but with a forward slash instead of a backslash.

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-bug_2022-09-28-20-55.json
+++ b/common/changes/@microsoft/rush/fix-rush-bug_2022-09-28-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an error message that always says to run \"rush update --purge\" even if the user only needs to run \"rush install --purge.\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/main_2022-09-28-20-46.json
+++ b/common/changes/@microsoft/rush/main_2022-09-28-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where a \"Current PNPM store path does not match the last one used.\" error will erroneously get thrown on Windows with an unchanged path, but with a forward slash instead of a backslash.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/main_2022-09-28-20-46.json
+++ b/common/changes/@rushstack/node-core-library/main_2022-09-28-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a Path.convertToPlatformDefault API to convert a path to use the platform-default slashes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -781,6 +781,7 @@ export class PackageNameParser {
 // @public
 export class Path {
     static convertToBackslashes(inputPath: string): string;
+    static convertToPlatformDefault(inputPath: string): string;
     static convertToSlashes(inputPath: string): string;
     static formatConcisely(options: IPathFormatConciselyOptions): string;
     static formatFileLocation(options: IPathFormatFileLocationOptions): string;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -526,7 +526,7 @@ export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
 // @internal
 export class _LastInstallFlag {
     constructor(folderPath: string, state?: JsonObject);
-    checkValidAndReportStoreIssues(): boolean;
+    checkValidAndReportStoreIssues(rushVerb: string): boolean;
     clear(): void;
     create(): void;
     protected get flagName(): string;

--- a/libraries/node-core-library/src/Path.ts
+++ b/libraries/node-core-library/src/Path.ts
@@ -229,6 +229,12 @@ export class Path {
   public static convertToBackslashes(inputPath: string): string {
     return inputPath.replace(/\//g, '\\');
   }
+  /**
+   * Replaces slashes or backslashes with the appropriate slash for the current operating system.
+   */
+  public static convertToPlatformDefault(inputPath: string): string {
+    return path.sep === '/' ? Path.convertToSlashes(inputPath) : Path.convertToBackslashes(inputPath);
+  }
 
   /**
    * Returns true if the specified path is a relative path and does not use `..` to walk upwards.

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -46,11 +46,13 @@ export class LastInstallFlag {
    *
    * @internal
    */
-  public checkValidAndReportStoreIssues(): boolean {
-    return this._isValid(true);
+  public checkValidAndReportStoreIssues(rushVerb: string): boolean {
+    return this._isValid(true, rushVerb);
   }
 
-  private _isValid(checkValidAndReportStoreIssues: boolean): boolean {
+  private _isValid(checkValidAndReportStoreIssues: false, rushVerb?: string): boolean;
+  private _isValid(checkValidAndReportStoreIssues: true, rushVerb: string): boolean;
+  private _isValid(checkValidAndReportStoreIssues: boolean, rushVerb: string = 'update'): boolean {
     let oldState: JsonObject;
     try {
       oldState = JsonFile.load(this._path);
@@ -80,7 +82,7 @@ export class LastInstallFlag {
             ) {
               throw new Error(
                 'Current PNPM store path does not match the last one used. This may cause inconsistency in your builds.\n\n' +
-                  'If you wish to install with the new store path, please run "rush update --purge"\n\n' +
+                  `If you wish to install with the new store path, please run "rush ${rushVerb} --purge"\n\n` +
                   `Old Path: ${normalizedOldStorePath}\n` +
                   `New Path: ${normalizedNewStorePath}`
               );

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 
-import { FileSystem, JsonFile, JsonObject, Import } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile, JsonObject, Import, Path } from '@rushstack/node-core-library';
 
 import { PackageManagerName } from './packageManager/PackageManager';
 import { RushConfiguration } from './RushConfiguration';
@@ -66,19 +66,25 @@ export class LastInstallFlag {
         if (pkgManager === 'pnpm') {
           if (
             // Only throw an error if the package manager hasn't changed from PNPM
-            oldState.packageManager === pkgManager &&
-            // Throw if the store path changed
-            oldState.storePath !== newState.storePath
+            oldState.packageManager === pkgManager
           ) {
-            const oldStorePath: string = oldState.storePath || '<global>';
-            const newStorePath: string = newState.storePath || '<global>';
-
-            throw new Error(
-              'Current PNPM store path does not match the last one used. This may cause inconsistency in your builds.\n\n' +
-                'If you wish to install with the new store path, please run "rush update --purge"\n\n' +
-                `Old Path: ${oldStorePath}\n` +
-                `New Path: ${newStorePath}`
-            );
+            const normalizedOldStorePath: string = oldState.storePath
+              ? Path.convertToPlatformDefault(oldState.storePath)
+              : '<global>';
+            const normalizedNewStorePath: string = newState.storePath
+              ? Path.convertToPlatformDefault(newState.storePath)
+              : '<global>';
+            if (
+              // Throw if the store path changed
+              normalizedOldStorePath !== normalizedNewStorePath
+            ) {
+              throw new Error(
+                'Current PNPM store path does not match the last one used. This may cause inconsistency in your builds.\n\n' +
+                  'If you wish to install with the new store path, please run "rush update --purge"\n\n' +
+                  `Old Path: ${normalizedOldStorePath}\n` +
+                  `New Path: ${normalizedNewStorePath}`
+              );
+            }
           }
         }
       }

--- a/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
+++ b/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
@@ -82,7 +82,7 @@ describe(LastInstallFlag.name, () => {
 
     flag1.create();
     expect(() => {
-      flag2.checkValidAndReportStoreIssues();
+      flag2.checkValidAndReportStoreIssues('install');
     }).toThrowError(/PNPM store path/);
   });
 
@@ -97,8 +97,8 @@ describe(LastInstallFlag.name, () => {
 
     flag1.create();
     expect(() => {
-      flag2.checkValidAndReportStoreIssues();
+      flag2.checkValidAndReportStoreIssues('install');
     }).not.toThrow();
-    expect(flag2.checkValidAndReportStoreIssues()).toEqual(false);
+    expect(flag2.checkValidAndReportStoreIssues('install')).toEqual(false);
   });
 });

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -217,7 +217,10 @@ export abstract class BaseInstallManager {
     // "--purge" was specified, or if the last install was interrupted, then we will
     // need to perform a clean install.  Otherwise, we can do an incremental install.
     const cleanInstall: boolean =
-      isFilteredInstall || !this._commonTempInstallFlag.checkValidAndReportStoreIssues();
+      isFilteredInstall ||
+      !this._commonTempInstallFlag.checkValidAndReportStoreIssues(
+        this.options.allowShrinkwrapUpdates ? 'update' : 'install'
+      );
 
     // Allow us to defer the file read until we need it
     const canSkipInstall: () => boolean = () => {


### PR DESCRIPTION
## Summary

Fixes an issue where a "Current PNPM store path does not match the last one used." error will erroneously get thrown on Windows with an unchanged path, but with a forward slash instead of a backslash.

## Details

This change normalizes the path to always be the platform default.

## How it was tested

Tested in a repo experiencing this error.