### PR TITLE
[rush] Move parallelism parsing to cli

### DIFF
--- a/common/changes/@microsoft/rush/move-parallelism-parse_2022-09-30-22-57.json
+++ b/common/changes/@microsoft/rush/move-parallelism-parse_2022-09-30-22-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Move parsing of \"--parallelism\" out of execution logic.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/move-parallelism-parse_2022-09-30-22-57.json
+++ b/common/changes/@microsoft/rush/move-parallelism-parse_2022-09-30-22-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Move parsing of \"--parallelism\" out of execution logic.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -21,7 +21,7 @@ import { Stopwatch } from '../../utilities/Stopwatch';
 import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismatchFinder';
 import { Variants } from '../../api/Variants';
 import { RushConstants } from '../../logic/RushConstants';
-import { SelectionParameterSet } from '../SelectionParameterSet';
+import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 
 const installManagerFactoryModule: typeof import('../../logic/InstallManagerFactory') = Import.lazy(
   '../../logic/InstallManagerFactory',

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -7,7 +7,7 @@ import { ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library'
 import { BaseInstallAction } from './BaseInstallAction';
 import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
-import { SelectionParameterSet } from '../SelectionParameterSet';
+import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 
 export class InstallAction extends BaseInstallAction {
   private _checkOnlyParameter!: CommandLineFlagParameter;

--- a/libraries/rush-lib/src/cli/actions/ListAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ListAction.ts
@@ -8,7 +8,7 @@ import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { VersionPolicyDefinitionName } from '../../api/VersionPolicy';
-import { SelectionParameterSet } from '../SelectionParameterSet';
+import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 
 /**
  * Shape of "rush list --json" output.

--- a/libraries/rush-lib/src/cli/parsing/ParseParallelism.ts
+++ b/libraries/rush-lib/src/cli/parsing/ParseParallelism.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'os';
+
+/**
+ * Parses a command line specification for desired parallelism.
+ * Factored out to enable unit tests
+ */
+export function parseParallelism(
+  rawParallelism: string | undefined,
+  numberOfCores: number = os.cpus().length
+): number {
+  if (rawParallelism) {
+    if (rawParallelism === 'max') {
+      return numberOfCores;
+    } else {
+      const parallelismAsNumber: number = Number(rawParallelism);
+
+      if (typeof rawParallelism === 'string' && rawParallelism.trim().endsWith('%')) {
+        const parsedPercentage: number = Number(rawParallelism.trim().replace(/\%$/, ''));
+
+        if (parsedPercentage <= 0 || parsedPercentage > 100) {
+          throw new Error(
+            `Invalid percentage value of '${rawParallelism}', value cannot be less than '0%' or more than '100%'`
+          );
+        }
+
+        const workers: number = Math.floor((parsedPercentage / 100) * numberOfCores);
+        return Math.max(workers, 1);
+      } else if (!isNaN(parallelismAsNumber)) {
+        return Math.max(parallelismAsNumber, 1);
+      } else {
+        throw new Error(
+          `Invalid parallelism value of '${rawParallelism}', expected a number, a percentage, or 'max'`
+        );
+      }
+    }
+  } else {
+    // If an explicit parallelism number wasn't provided, then choose a sensible
+    // default.
+    if (os.platform() === 'win32') {
+      // On desktop Windows, some people have complained that their system becomes
+      // sluggish if Rush is using all the CPU cores.  Leave one thread for
+      // other operations. For CI environments, you can use the "max" argument to use all available cores.
+      return Math.max(numberOfCores - 1, 1);
+    } else {
+      // Unix-like operating systems have more balanced scheduling, so default
+      // to the number of CPU cores
+      return numberOfCores;
+    }
+  }
+}

--- a/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
+++ b/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
@@ -9,17 +9,17 @@ import {
 } from '@rushstack/node-core-library';
 import { CommandLineParameterProvider, CommandLineStringListParameter } from '@rushstack/ts-command-line';
 
-import { RushConfiguration } from '../api/RushConfiguration';
-import { RushConfigurationProject } from '../api/RushConfigurationProject';
-import { Selection } from '../logic/Selection';
-import type { ISelectorParser as ISelectorParser } from '../logic/selectors/ISelectorParser';
+import { RushConfiguration } from '../../api/RushConfiguration';
+import { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import { Selection } from '../../logic/Selection';
+import type { ISelectorParser as ISelectorParser } from '../../logic/selectors/ISelectorParser';
 import {
   GitChangedProjectSelectorParser,
   IGitSelectorParserOptions
-} from '../logic/selectors/GitChangedProjectSelectorParser';
-import { NamedProjectSelectorParser } from '../logic/selectors/NamedProjectSelectorParser';
-import { TagProjectSelectorParser } from '../logic/selectors/TagProjectSelectorParser';
-import { VersionPolicyProjectSelectorParser } from '../logic/selectors/VersionPolicyProjectSelectorParser';
+} from '../../logic/selectors/GitChangedProjectSelectorParser';
+import { NamedProjectSelectorParser } from '../../logic/selectors/NamedProjectSelectorParser';
+import { TagProjectSelectorParser } from '../../logic/selectors/TagProjectSelectorParser';
+import { VersionPolicyProjectSelectorParser } from '../../logic/selectors/VersionPolicyProjectSelectorParser';
 
 /**
  * This class is provides the set of command line parameters used to select projects

--- a/libraries/rush-lib/src/cli/parsing/test/ParseParallelism.test.ts
+++ b/libraries/rush-lib/src/cli/parsing/test/ParseParallelism.test.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { parseParallelism } from '../ParseParallelism';
+
+describe(parseParallelism.name, () => {
+  it('throwsErrorOnInvalidParallelism', () => {
+    expect(() => parseParallelism('tequila')).toThrowErrorMatchingSnapshot();
+  });
+
+  it('createsWithPercentageBasedParallelism', () => {
+    const value: number = parseParallelism('50%', 20);
+    expect(value).toEqual(10);
+  });
+
+  it('throwsErrorOnInvalidParallelismPercentage', () => {
+    expect(() => parseParallelism('200%')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/libraries/rush-lib/src/cli/parsing/test/__snapshots__/ParseParallelism.test.ts.snap
+++ b/libraries/rush-lib/src/cli/parsing/test/__snapshots__/ParseParallelism.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseParallelism throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number, a percentage, or 'max'"`;
+
+exports[`parseParallelism throwsErrorOnInvalidParallelismPercentage 1`] = `"Invalid percentage value of '200%', value cannot be less than '0%' or more than '100%'"`;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import colors from 'colors/safe';
 import type { AsyncSeriesHook } from 'tapable';
 
-import { AlreadyReportedError, InternalError, Terminal } from '@rushstack/node-core-library';
+import { AlreadyReportedError, InternalError, ITerminal, Terminal } from '@rushstack/node-core-library';
 import {
   CommandLineFlagParameter,
   CommandLineParameter,
@@ -26,7 +26,7 @@ import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
 import { LastLinkFlag, LastLinkFlagFactory } from '../../api/LastLinkFlag';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
-import { SelectionParameterSet } from '../SelectionParameterSet';
+import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 import type { IPhase, IPhasedCommandConfig } from '../../api/CommandLineConfiguration';
 import { Operation } from '../../logic/operations/Operation';
 import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlugin';
@@ -37,6 +37,7 @@ import { OperationStatus } from '../../logic/operations/OperationStatus';
 import { IExecutionResult } from '../../logic/operations/IOperationExecutionResult';
 import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
 import type { ITelemetryOperationResult } from '../../logic/Telemetry';
+import { parseParallelism } from '../parsing/ParseParallelism';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -60,7 +61,7 @@ interface IRunPhasesOptions {
   initialCreateOperationsContext: ICreateOperationsContext;
   executionManagerOptions: IOperationExecutionManagerOptions;
   stopwatch: Stopwatch;
-  terminal: Terminal;
+  terminal: ITerminal;
 }
 
 interface IExecutionOperationsOptions {
@@ -69,7 +70,7 @@ interface IExecutionOperationsOptions {
   ignoreHooks: boolean;
   operations: Set<Operation>;
   stopwatch: Stopwatch;
-  terminal: Terminal;
+  terminal: ITerminal;
 }
 
 interface IPhasedCommandTelemetry {
@@ -108,15 +109,16 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   private readonly _alwaysWatch: boolean;
   private readonly _alwaysInstall: boolean | undefined;
   private readonly _knownPhases: ReadonlyMap<string, IPhase>;
+  private readonly _terminal: ITerminal;
 
-  private _changedProjectsOnly!: CommandLineFlagParameter;
-  private _selectionParameters!: SelectionParameterSet;
-  private _verboseParameter!: CommandLineFlagParameter;
-  private _parallelismParameter: CommandLineStringParameter | undefined;
-  private _ignoreHooksParameter!: CommandLineFlagParameter;
-  private _watchParameter: CommandLineFlagParameter | undefined;
-  private _timelineParameter: CommandLineFlagParameter | undefined;
-  private _installParameter: CommandLineFlagParameter | undefined;
+  private readonly _changedProjectsOnly: CommandLineFlagParameter | undefined;
+  private readonly _selectionParameters: SelectionParameterSet;
+  private readonly _verboseParameter: CommandLineFlagParameter;
+  private readonly _parallelismParameter: CommandLineStringParameter | undefined;
+  private readonly _ignoreHooksParameter: CommandLineFlagParameter;
+  private readonly _watchParameter: CommandLineFlagParameter | undefined;
+  private readonly _timelineParameter: CommandLineFlagParameter | undefined;
+  private readonly _installParameter: CommandLineFlagParameter | undefined;
 
   public constructor(options: IPhasedScriptActionOptions) {
     super(options);
@@ -132,10 +134,101 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     this.hooks = new PhasedCommandHooks();
 
+    const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
+    this._terminal = terminal;
+
     // Generates the default operation graph
     new PhasedOperationPlugin().apply(this.hooks);
     // Applies the Shell Operation Runner to selected operations
     new ShellOperationRunnerPlugin().apply(this.hooks);
+
+    if (this._enableParallelism) {
+      this._parallelismParameter = this.defineStringParameter({
+        parameterLongName: '--parallelism',
+        parameterShortName: '-p',
+        argumentName: 'COUNT',
+        environmentVariable: EnvironmentVariableNames.RUSH_PARALLELISM,
+        description:
+          'Specifies the maximum number of concurrent processes to launch during a build.' +
+          ' The COUNT should be a positive integer, a percentage value (eg. "50%%") or the word "max"' +
+          ' to specify a count that is equal to the number of CPU cores. If this parameter is omitted,' +
+          ' then the default value depends on the operating system and number of CPU cores.'
+      });
+      this._timelineParameter = this.defineFlagParameter({
+        parameterLongName: '--timeline',
+        description:
+          'After the build is complete, print additional statistics and CPU usage information,' +
+          ' including an ASCII chart of the start and stop times for each operation.'
+      });
+    }
+
+    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
+      // Include lockfile processing since this expands the selection, and we need to select
+      // at least the same projects selected with the same query to "rush build"
+      includeExternalDependencies: true,
+      // Enable filtering to reduce evaluation cost
+      enableFiltering: true
+    });
+
+    this._verboseParameter = this.defineFlagParameter({
+      parameterLongName: '--verbose',
+      parameterShortName: '-v',
+      description: 'Display the logs during the build, rather than just displaying the build status summary'
+    });
+
+    if (this._isIncrementalBuildAllowed) {
+      this._changedProjectsOnly = this.defineFlagParameter({
+        parameterLongName: '--changed-projects-only',
+        parameterShortName: '-c',
+        description:
+          'Normally the incremental build logic will rebuild changed projects as well as' +
+          ' any projects that directly or indirectly depend on a changed project. Specify "--changed-projects-only"' +
+          ' to ignore dependent projects, only rebuilding those projects whose files were changed.' +
+          ' Note that this parameter is "unsafe"; it is up to the developer to ensure that the ignored projects' +
+          ' are okay to ignore.'
+      });
+    }
+
+    this._ignoreHooksParameter = this.defineFlagParameter({
+      parameterLongName: '--ignore-hooks',
+      description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
+    });
+
+    if (this._watchPhases.size > 0 && !this._alwaysWatch) {
+      // Only define the parameter if it has an effect.
+      this._watchParameter = this.defineFlagParameter({
+        parameterLongName: '--watch',
+        description: `Starts a file watcher after initial execution finishes. Will run the following phases on affected projects: ${Array.from(
+          this._watchPhases,
+          (phase: IPhase) => phase.name
+        ).join(', ')}`
+      });
+    }
+
+    // If `this._alwaysInstall === undefined`, Rush does not define the parameter
+    // but a repository may still define a custom parameter with the same name.
+    if (this._alwaysInstall === false) {
+      this._installParameter = this.defineFlagParameter({
+        parameterLongName: '--install',
+        description:
+          'Normally a phased command expects "rush install" to have been manually run first. If this flag is specified, ' +
+          'Rush will automatically perform an install before processing the current command.'
+      });
+    }
+
+    this.defineScriptParameters();
+
+    for (const [{ associatedPhases }, tsCommandLineParameter] of this.customParameters) {
+      if (associatedPhases) {
+        for (const phaseName of associatedPhases) {
+          const phase: IPhase | undefined = this._knownPhases.get(phaseName);
+          if (!phase) {
+            throw new InternalError(`Could not find a phase matching ${phaseName}.`);
+          }
+          phase.associatedParameters.add(tsCommandLineParameter);
+        }
+      }
+    }
   }
 
   public async runAsync(): Promise<void> {
@@ -163,9 +256,15 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     this._doBeforeTask();
 
-    const stopwatch: Stopwatch = Stopwatch.start();
+    // if this is parallelizable, then use the value from the flag (undefined or a number),
+    // if parallelism is not enabled, then restrict to 1 core
+    const parallelism: number = this._enableParallelism
+      ? parseParallelism(this._parallelismParameter?.value)
+      : 1;
 
-    const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
+    const terminal: ITerminal = this._terminal;
+
+    const stopwatch: Stopwatch = Stopwatch.start();
 
     const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
     if (showTimeline) {
@@ -192,11 +291,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const isQuietMode: boolean = !this._verboseParameter.value;
 
-    // if this is parallelizable, then use the value from the flag (undefined or a number),
-    // if parallelism is not enabled, then restrict to 1 core
-    const parallelism: string | undefined = this._enableParallelism ? this._parallelismParameter!.value : '1';
-
-    const changedProjectsOnly: boolean = this._isIncrementalBuildAllowed && this._changedProjectsOnly.value;
+    const changedProjectsOnly: boolean = !!this._changedProjectsOnly?.value;
 
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
     if (!this._disableBuildCache) {
@@ -385,93 +480,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   }
 
   protected onDefineParameters(): void {
-    if (this._enableParallelism) {
-      this._parallelismParameter = this.defineStringParameter({
-        parameterLongName: '--parallelism',
-        parameterShortName: '-p',
-        argumentName: 'COUNT',
-        environmentVariable: EnvironmentVariableNames.RUSH_PARALLELISM,
-        description:
-          'Specifies the maximum number of concurrent processes to launch during a build.' +
-          ' The COUNT should be a positive integer, a percentage value (eg. "50%%") or the word "max"' +
-          ' to specify a count that is equal to the number of CPU cores. If this parameter is omitted,' +
-          ' then the default value depends on the operating system and number of CPU cores.'
-      });
-      this._timelineParameter = this.defineFlagParameter({
-        parameterLongName: '--timeline',
-        description:
-          'After the build is complete, print additional statistics and CPU usage information,' +
-          ' including an ASCII chart of the start and stop times for each operation.'
-      });
-    }
-
-    this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
-      // Include lockfile processing since this expands the selection, and we need to select
-      // at least the same projects selected with the same query to "rush build"
-      includeExternalDependencies: true,
-      // Enable filtering to reduce evaluation cost
-      enableFiltering: true
-    });
-
-    this._verboseParameter = this.defineFlagParameter({
-      parameterLongName: '--verbose',
-      parameterShortName: '-v',
-      description: 'Display the logs during the build, rather than just displaying the build status summary'
-    });
-
-    if (this._isIncrementalBuildAllowed) {
-      this._changedProjectsOnly = this.defineFlagParameter({
-        parameterLongName: '--changed-projects-only',
-        parameterShortName: '-c',
-        description:
-          'Normally the incremental build logic will rebuild changed projects as well as' +
-          ' any projects that directly or indirectly depend on a changed project. Specify "--changed-projects-only"' +
-          ' to ignore dependent projects, only rebuilding those projects whose files were changed.' +
-          ' Note that this parameter is "unsafe"; it is up to the developer to ensure that the ignored projects' +
-          ' are okay to ignore.'
-      });
-    }
-
-    this._ignoreHooksParameter = this.defineFlagParameter({
-      parameterLongName: '--ignore-hooks',
-      description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
-    });
-
-    if (this._watchPhases.size > 0 && !this._alwaysWatch) {
-      // Only define the parameter if it has an effect.
-      this._watchParameter = this.defineFlagParameter({
-        parameterLongName: '--watch',
-        description: `Starts a file watcher after initial execution finishes. Will run the following phases on affected projects: ${Array.from(
-          this._watchPhases,
-          (phase: IPhase) => phase.name
-        ).join(', ')}`
-      });
-    }
-
-    // If `this._alwaysInstall === undefined`, Rush does not define the parameter
-    // but a repository may still define a custom parameter with the same name.
-    if (this._alwaysInstall === false) {
-      this._installParameter = this.defineFlagParameter({
-        parameterLongName: '--install',
-        description:
-          'Normally a phased command expects "rush install" to have been manually run first. If this flag is specified, ' +
-          'Rush will automatically perform an install before processing the current command.'
-      });
-    }
-
-    this.defineScriptParameters();
-
-    for (const [{ associatedPhases }, tsCommandLineParameter] of this.customParameters) {
-      if (associatedPhases) {
-        for (const phaseName of associatedPhases) {
-          const phase: IPhase | undefined = this._knownPhases.get(phaseName);
-          if (!phase) {
-            throw new InternalError(`Could not find a phase matching ${phaseName}.`);
-          }
-          phase.associatedParameters.add(tsCommandLineParameter);
-        }
-      }
-    }
+    // Handled in constructor
   }
 
   /**

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -68,53 +68,12 @@ describe(OperationExecutionManager.name, () => {
     mockWritable.reset();
   });
 
-  describe('Constructor', () => {
-    it('throwsErrorOnInvalidParallelism', () => {
-      expect(
-        () =>
-          new OperationExecutionManager(new Set(), {
-            quietMode: false,
-            debugMode: false,
-            parallelism: 'tequila',
-            changedProjectsOnly: false,
-            destination: mockWritable
-          })
-      ).toThrowErrorMatchingSnapshot();
-    });
-
-    it('createsWithPercentageBasedParallelism', () => {
-      expect(
-        () =>
-          new OperationExecutionManager(new Set(), {
-            quietMode: false,
-            debugMode: false,
-            parallelism: '50%',
-            changedProjectsOnly: false,
-            destination: mockWritable
-          })
-      ).toBeInstanceOf(Function);
-    });
-
-    it('throwsErrorOnInvalidParallelismPercentage', () => {
-      expect(
-        () =>
-          new OperationExecutionManager(new Set(), {
-            quietMode: false,
-            debugMode: false,
-            parallelism: '200%',
-            changedProjectsOnly: false,
-            destination: mockWritable
-          })
-      ).toThrowErrorMatchingSnapshot();
-    });
-  });
-
   describe('Error logging', () => {
     beforeEach(() => {
       executionManagerOptions = {
         quietMode: false,
         debugMode: false,
-        parallelism: '1',
+        parallelism: 1,
         changedProjectsOnly: false,
         destination: mockWritable
       };
@@ -172,7 +131,7 @@ describe(OperationExecutionManager.name, () => {
         executionManagerOptions = {
           quietMode: false,
           debugMode: false,
-          parallelism: '1',
+          parallelism: 1,
           changedProjectsOnly: false,
           destination: mockWritable
         };
@@ -207,7 +166,7 @@ describe(OperationExecutionManager.name, () => {
         executionManagerOptions = {
           quietMode: false,
           debugMode: false,
-          parallelism: '1',
+          parallelism: 1,
           changedProjectsOnly: false,
           destination: mockWritable
         };


### PR DESCRIPTION
## Summary
Move the parsing of the `parallelism` parameter out of `OperationExecutionManager` and into a dedicated parsing function. Moves responsibility for invoking the parsing function to `PhasedScriptAction`, since CLI parsing is not the responsibility of the execution engine.

## Details
General cleanup.

## How it was tested
Moved unit tests.
Manual invocation of `rush build` with parallelism parameter values.