### PR TITLE
[rush] Add a more useful error message in cases when a merge base for rush change cannot be determined.

### DIFF
--- a/common/changes/@microsoft/rush/shallow-clone-error-message_2022-10-03-19-56.json
+++ b/common/changes/@microsoft/rush/shallow-clone-error-message_2022-10-03-19-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a more useful error message in cases when a merge base for `rush change` cannot be determined.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -230,16 +230,26 @@ export class Git {
     }
 
     const gitPath: string = this.getGitPathOrThrow();
-    const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
-      '--no-optional-locks',
-      'merge-base',
-      '--',
-      'HEAD',
-      targetBranch
-    ]);
-    const result: string = output.trim();
+    try {
+      const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
+        '--no-optional-locks',
+        'merge-base',
+        '--',
+        'HEAD',
+        targetBranch
+      ]);
+      const result: string = output.trim();
 
-    return result;
+      return result;
+    } catch (e) {
+      terminal.writeErrorLine(
+        `Unable to determine merge base for branch "${targetBranch}". ` +
+          'This can occur if the current clone is a shallow clone. If this clone is running in a CI ' +
+          'pipeline, check your pipeline settings to ensure that the clone depth includes ' +
+          'the expected merge base. If this clone is running locally, consider running "git fetch --deepen".'
+      );
+      throw new AlreadyReportedError();
+    }
   }
 
   public getBlobContent({ blobSpec, repositoryRoot }: IGetBlobOptions): string {

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -246,7 +246,7 @@ export class Git {
         `Unable to determine merge base for branch "${targetBranch}". ` +
           'This can occur if the current clone is a shallow clone. If this clone is running in a CI ' +
           'pipeline, check your pipeline settings to ensure that the clone depth includes ' +
-          'the expected merge base. If this clone is running locally, consider running "git fetch --deepen".'
+          'the expected merge base. If this clone is running locally, consider running "git fetch --deepen=<depth>".'
       );
       throw new AlreadyReportedError();
     }


### PR DESCRIPTION
Addresses https://github.com/microsoft/rushstack/issues/3663.

## Summary

This change adds an error message when Rush tries to find the merge base during an operation like `rush change` and can't find the merge base. Currently, Rush gives the cryptic

```
ERROR: The command failed with exit code 1
```

message. With this change, the error message will read

```
Unable to determine merge base for branch "<BRANCH NAME>". This can occur if the current clone is a shallow clone. If this clone is running in a CI pipeline, check your pipeline settings to ensure that the clone depth includes the expected merge base. If this clone is running locally, consider running "git fetch --deepen".
```

## How it was tested

Tested on a shallow clone.