### PR TITLE
[rush] Support passing a lockfile to install-run

### DIFF
--- a/common/changes/@microsoft/rush/install-run-lockfile_2022-10-04-00-27.json
+++ b/common/changes/@microsoft/rush/install-run-lockfile_2022-10-04-00-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support passing a lockfile to \"install-run.js\" and \"install-run-rush.js\" to ensure stable installation on CI.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -25,6 +25,8 @@ import {
 
 const PACKAGE_NAME: string = '@microsoft/rush';
 const RUSH_PREVIEW_VERSION: string = 'RUSH_PREVIEW_VERSION';
+const INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE: 'INSTALL_RUN_RUSH_LOCKFILE_PATH' =
+  'INSTALL_RUN_RUSH_LOCKFILE_PATH';
 
 function _getRushVersion(logger: ILogger): string {
   const rushPreviewVersion: string | undefined = process.env[RUSH_PREVIEW_VERSION];
@@ -103,7 +105,14 @@ function _run(): void {
     const version: string = _getRushVersion(logger);
     logger.info(`The rush.json configuration requests Rush version ${version}`);
 
-    return installAndRun(logger, PACKAGE_NAME, version, bin, packageBinArgs);
+    const lockFilePath: string | undefined = process.env[INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE];
+    if (lockFilePath) {
+      logger.info(
+        `Found ${INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE}="${lockFilePath}", installing with lockfile.`
+      );
+    }
+
+    return installAndRun(logger, PACKAGE_NAME, version, bin, packageBinArgs, lockFilePath);
   });
 }
 


### PR DESCRIPTION
## Summary
Provides the ability to invoke `install-run.js` and `install-run-rush.js` with a lockfile for stable CI installation.

## Details
Set `INSTALL_RUN_LOCKFILE_PATH` for the general `install-run.js` script, or `INSTALL_RUN_RUSH_LOCKFILE_PATH` to scope specifically to `install-run-rush.js`.

## How it was tested
Code was used previously to pin a known good version of `node-fetch`.