### PR TITLE
[chore] Migrate to pnpm-config.json

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -28,27 +28,6 @@ module.exports = {
  */
 function readPackage(packageJson, context) {
   switch (packageJson.name) {
-    case '@emotion/core':
-    case '@emotion/styled':
-    case '@emotion/styled-base':
-    case '@emotion/theming':
-    case '@storybook/addons':
-    case '@storybook/api':
-    case '@storybook/router':
-    case 'emotion-theming':
-    case 'react-router-dom':
-    case 'react-router': {
-      // This package reexports types from `react`
-      packageJson.peerDependencies['@types/react'] = '>=16';
-      break;
-    }
-
-    case '@jest/reporters': {
-      // The `@jest/reporters` package reexports types from `istanbul-lib-coverage`
-      packageJson.dependencies['@types/istanbul-lib-coverage'] = '2.0.4';
-      break;
-    }
-
     case '@jest/test-result': {
       // The `@jest/test-result` package takes undeclared dependencies on `jest-haste-map`
       // and `jest-resolve`
@@ -63,73 +42,10 @@ function readPackage(packageJson, context) {
       break;
     }
 
-    case '@serverless-stack/resources': {
-      packageJson.dependencies.esbuild = '*';
-      break;
-    }
-
-    case '@storybook/react': {
-      // This package reexports types from `react`
-      packageJson.peerDependencies['@types/node'] = '>=12';
-      packageJson.peerDependencies['@types/react'] = '>=16';
-      break;
-    }
-
-    case '@storybook/theming': {
-      packageJson.dependencies['@emotion/serialize'] = '*';
-      packageJson.dependencies['@emotion/utils'] = '*';
-      break;
-    }
-
-    case '@types/webpack': {
-      packageJson.dependencies.anymatch = '^3';
-      break;
-    }
-
-    case '@typescript-eslint/types': {
-      // `@typescript-eslint/types` reexports types from `typescript`
-      packageJson.peerDependencies = { typescript: '*' };
-      break;
-    }
-
-    case 'collect-v8-coverage': {
-      // The `collect-v8-coverage` package references `node` in its typings
-      packageJson.peerDependencies = {
-        '@types/node': '>=12'
-      };
-      break;
-    }
-
-    case 'http-proxy-middleware': {
-      packageJson.dependencies['@types/express'] = '*';
-      break;
-    }
-
     case 'tslint-microsoft-contrib': {
       // The `tslint-microsoft-contrib` repo is archived so it can't be updated to TS 4.4+.
       // unmet peer typescript@"^2.1.0 || ^3.0.0": found 4.5.5
       packageJson.peerDependencies['typescript'] = '*';
-      break;
-    }
-
-    case 'webpack-dev-server': {
-      packageJson.dependencies.anymatch = '^3';
-      packageJson.dependencies['@types/express-serve-static-core'] = '*';
-      packageJson.dependencies['@types/serve-static'] = '*';
-      // If using webpack 4, need peer dependency on the typings
-      packageJson.peerDependencies['@types/webpack'] = '^4';
-      (packageJson.peerDependenciesMeta || (packageJson.peerDependenciesMeta = {}))['@types/webpack'] = {
-        optional: true
-      };
-      break;
-    }
-
-    case 'webpack-dev-middleware': {
-      // If using webpack 4, need peer dependency on the typings
-      packageJson.peerDependencies['@types/webpack'] = '^4';
-      (packageJson.peerDependenciesMeta || (packageJson.peerDependenciesMeta = {}))['@types/webpack'] = {
-        optional: true
-      };
       break;
     }
   }

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/rushstack/main/libraries/rush-lib/src/schemas/pnpm-config.schema.json",
+
+  "strictPeerDependencies": true,
+
+  "useWorkspaces": true,
+
+  "preventManualShrinkwrapChanges": true,
+
+  "globalPackageExtensions": {
+    "@emotion/core": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@emotion/styled": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@emotion/styled-base": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@emotion/theming": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@storybook/addons": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@storybook/api": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@storybook/router": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "emotion-theming": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "react-router": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "react-router-dom": {
+      "peerDependencies": {
+        "@types/react": ">=16"
+      }
+    },
+
+    "@jest/reporters": {
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "2.0.4"
+      }
+    },
+
+    "@serverless-stack/resources": {
+      "dependencies": {
+        "esbuild": "*"
+      }
+    },
+
+    "@storybook/react": {
+      "peerDependencies": {
+        "@types/node": ">=12",
+        "@types/react": ">=16"
+      }
+    },
+
+    "@storybook/theming": {
+      "dependencies": {
+        "@emotion/serialize": "*",
+        "@emotion/utils": "*"
+      }
+    },
+
+    "@types/webpack": {
+      "dependencies": {
+        "anymatch": "^3"
+      }
+    },
+
+    "@typescript-eslint/types": {
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+
+    "collect-v8-coverage": {
+      "peerDependencies": {
+        "@types/node": ">=12"
+      }
+    },
+
+    "http-proxy-middleware": {
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+
+    "webpack-dev-middleware": {
+      "peerDependencies": {
+        "@types/webpack": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        }
+      }
+    },
+
+    "webpack-dev-server": {
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*",
+        "anymatch": "^3"
+      },
+      "peerDependencies": {
+        "@types/webpack": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,7 @@
 lockfileVersion: 5.4
 
+packageExtensionsChecksum: 4cee63805d63bd8991d4c7a30da2ca02
+
 importers:
 
   .:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "719c3fbf604cb77b4bafd03bc5f95579e3c937b5",
+  "pnpmShrinkwrapHash": "73458f691cb466263769c9c9c40b4ce141e7c1ad",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/rush.json
+++ b/rush.json
@@ -26,92 +26,10 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "7.9.5",
+  "pnpmVersion": "7.13.0",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",
-
-  /**
-   * Options that are only used when the PNPM package manager is selected
-   */
-  "pnpmOptions": {
-    /**
-     * Specifies the location of the PNPM store.  There are two possible values:
-     *
-     * - "local" - use the "pnpm-store" folder in the current configured temp folder:
-     *   "common/temp/pnpm-store" by default.
-     * - "global" - use PNPM's global store, which has the benefit of being shared
-     *    across multiple repo folders, but the disadvantage of less isolation for builds
-     *    (e.g. bugs or incompatibilities when two repos use different releases of PNPM)
-     *
-     * RUSH_PNPM_STORE_PATH will override the directory that will be used as the store
-     *
-     * In all cases, the store path will be overridden by the environment variable RUSH_PNPM_STORE_PATH.
-     *
-     * The default value is "local".
-     */
-    // "pnpmStore": "local",
-
-    /**
-     * If true, then Rush will add the "--strict-peer-dependencies" option when invoking PNPM.
-     * This causes "rush install" to fail if there are unsatisfied peer dependencies, which is
-     * an invalid state that can cause build failures or incompatible dependency versions.
-     * (For historical reasons, JavaScript package managers generally do not treat this invalid
-     * state as an error.)
-     *
-     * The default value is false to avoid legacy compatibility issues.
-     * It is strongly recommended to set strictPeerDependencies=true.
-     */
-    "strictPeerDependencies": true,
-
-    /**
-     * Configures the strategy used to select versions during installation.
-     *
-     * This feature requires PNPM version 3.1 or newer.  It corresponds to the "--resolution-strategy" command-line
-     * option for PNPM.  Possible values are "fast" and "fewer-dependencies".  PNPM's default is "fast", but this may
-     * be incompatible with certain packages, for example the "@types" packages from DefinitelyTyped.  Rush's default
-     * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
-     * can be reused; this is more similar to NPM's algorithm.
-     *
-     * After modifying this field, it's recommended to run "rush update --full" so that the package manager
-     * will recalculate all version selections.
-     */
-    // "resolutionStrategy": "fast",
-
-    /**
-     * If true, then `rush install` will report an error if manual modifications
-     * were made to the PNPM shrinkwrap file without running "rush update" afterwards.
-     *
-     * This feature protects against accidental inconsistencies that may be introduced
-     * if the PNPM shrinkwrap file ("pnpm-lock.yaml") is manually edited.  When this
-     * feature is enabled, "rush update" will append a hash to the file as a YAML comment,
-     * and then "rush update" and "rush install" will validate the hash.  Note that this does not prohibit
-     * manual modifications, but merely requires "rush update" be run
-     * afterwards, ensuring that PNPM can report or repair any potential inconsistencies.
-     *
-     * To temporarily disable this validation when invoking "rush install", use the
-     * "--bypass-policy" command-line parameter.
-     *
-     * The default value is false.
-     */
-    "preventManualShrinkwrapChanges": true,
-
-    /**
-     * If true, then `rush install` will use the PNPM workspaces feature to perform the
-     * install.
-     *
-     * This feature uses PNPM to perform the entire monorepo install. When using workspaces, Rush will
-     * generate a "pnpm-workspace.yaml" file referencing all local projects to install. Rush will
-     * also generate a "pnpmfile.js" which is used to provide preferred versions support. When install
-     * is run, this pnpmfile will be used to replace dependency version ranges with a smaller subset
-     * of the original range. If the preferred version is not fully a subset of the original version
-     * range, it will be left as-is. After this, the pnpmfile.js provided in the repository (if one
-     * exists) will be called to further modify package dependencies.
-     *
-     * This option is experimental. The default value is false.
-     */
-    "useWorkspaces": true
-  },
 
   /**
    * Older releases of the Node.js engine may be missing features required by your system.


### PR DESCRIPTION
## Summary
Convert the rushstack repository to leverage the new `pnpm-config.json` file to replace most of the configuration in `.pnpmfile.cjs`.

## Details
Leverages `packageExtensions` primarily. Other modifications have been left in `.pnpmfile.cjs` due to being dynamic or otherwise not possible to do via `packageExtensions`.

## How it was tested
Installation and retest.