### PR TITLE
[rush] environmentVariables in pnpm-config schema

### DIFF
--- a/common/changes/@microsoft/rush/pnpm-config-environment_2022-10-06-21-55.json
+++ b/common/changes/@microsoft/rush/pnpm-config-environment_2022-10-06-21-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add missing \"environmentVariables\" property to \"pnpm-config.json\" schema to restore feature parity with \"rush.json\" \"pnpmOptions\" field.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -37,6 +37,13 @@ describe(PnpmOptionsConfiguration.name, () => {
       'bar@^2.1.0': '3.0.0',
       'qar@1>zoo': '2'
     });
+
+    expect(pnpmConfiguration.environmentVariables).toEqual({
+      NODE_OPTIONS: {
+        value: '--max-old-space-size=4096',
+        override: false
+      }
+    });
   });
 
   it('loads packageExtensions', () => {

--- a/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-overrides.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-overrides.json
@@ -4,5 +4,12 @@
     "quux": "npm:@myorg/quux@^1.0.0",
     "bar@^2.1.0": "3.0.0",
     "qar@1>zoo": "2"
+  },
+
+  "environmentVariables": {
+    "NODE_OPTIONS": {
+      "value": "--max-old-space-size=4096",
+      "override": false
+    }
   }
 }

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -26,6 +26,23 @@
       "enum": ["local", "global"]
     },
 
+    "environmentVariables": {
+      "description": "Environment variables for PNPM invocation",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "override": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+
     "preventManualShrinkwrapChanges": {
       "description": "If true, then \"rush install\" will report an error if manual modifications were made to the PNPM shrinkwrap file without running `rush update` afterwards. To temporarily disable this validation when invoking \"rush install\", use the \"--bypassPolicy\" command-line parameter. The default value is false.",
       "type": "boolean"


### PR DESCRIPTION
## Summary
Adds the missing `environmentVariables` entry to the schema for `pnpm-config.json`, so that it can be used when transcribing from an existing `rush.json` `pnpmOptions` field.

## Details
The code path to use the field already exists, it was simply missing from the schema and therefore failing schema validation.

## How it was tested
Added unit test coverage of extracting the value from `pnpm-config.json`.