### PR TITLE
[rush] Validate the change type in changefiles during publishing.

### DIFF
--- a/common/autoinstallers/rush-prettier/package.json
+++ b/common/autoinstallers/rush-prettier/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "pretty-quick": "3.1.0",
-    "prettier": "2.3.1"
+    "pretty-quick": "3.1.3",
+    "prettier": "2.7.1"
   }
 }

--- a/common/autoinstallers/rush-prettier/pnpm-lock.yaml
+++ b/common/autoinstallers/rush-prettier/pnpm-lock.yaml
@@ -1,12 +1,12 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
-  prettier: 2.3.1
-  pretty-quick: 3.1.0
+  prettier: 2.7.1
+  pretty-quick: 3.1.3
 
 dependencies:
-  prettier: 2.3.1
-  pretty-quick: 3.1.0_prettier@2.3.1
+  prettier: 2.7.1
+  pretty-quick: 3.1.3_prettier@2.7.1
 
 packages:
 
@@ -37,7 +37,7 @@ packages:
     dev: false
 
   /balanced-match/1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion/1.1.11:
@@ -136,7 +136,7 @@ packages:
     dev: false
 
   /isexe/2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: false
 
   /locate-path/5.0.0:
@@ -185,7 +185,7 @@ packages:
     dev: false
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
@@ -226,14 +226,14 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /prettier/2.3.1:
-    resolution: {integrity: sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==}
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: false
 
-  /pretty-quick/3.1.0_prettier@2.3.1:
-    resolution: {integrity: sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==}
+  /pretty-quick/3.1.3_prettier@2.7.1:
+    resolution: {integrity: sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==}
     engines: {node: '>=10.13'}
     hasBin: true
     peerDependencies:
@@ -245,7 +245,7 @@ packages:
       ignore: 5.1.8
       mri: 1.1.5
       multimatch: 4.0.0
-      prettier: 2.3.1
+      prettier: 2.7.1
     dev: false
 
   /pump/3.0.0:
@@ -292,5 +292,5 @@ packages:
     dev: false
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/common/changes/@microsoft/rush/validate-change-type_2022-10-09-02-51.json
+++ b/common/changes/@microsoft/rush/validate-change-type_2022-10-09-02-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Validate the change type in changefiles during publishing.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/validate-change-type_2022-10-09-21-55.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/validate-change-type_2022-10-09-21-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -124,7 +124,7 @@ export class ProjectBuildCache {
     if (inputOutputFiles.length > 0) {
       terminal.writeWarningLine(
         'Unable to use build cache. The following files are used to calculate project state ' +
-        `and are considered project output: ${inputOutputFiles.join(', ')}`
+          `and are considered project output: ${inputOutputFiles.join(', ')}`
       );
       return false;
     } else {
@@ -259,14 +259,14 @@ export class ProjectBuildCache {
       } else {
         terminal.writeWarningLine(
           `"tar" exited with code ${tarExitCode} while attempting to create the cache entry. ` +
-          `See "${logFilePath}" for logs from the tar process.`
+            `See "${logFilePath}" for logs from the tar process.`
         );
         return false;
       }
     } else {
       terminal.writeWarningLine(
         `Unable to locate "tar". Please ensure that "tar" is on your PATH environment variable, or set the ` +
-        `${EnvironmentVariableNames.RUSH_TAR_BINARY_PATH} environment variable to the full path to the "tar" binary.`
+          `${EnvironmentVariableNames.RUSH_TAR_BINARY_PATH} environment variable to the full path to the "tar" binary.`
       );
       return false;
     }

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -276,7 +276,10 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
   }
 
   /** @internal */
-  public static loadFromJsonObject(json: IPnpmOptionsJson, commonTempFolder: string): PnpmOptionsConfiguration {
+  public static loadFromJsonObject(
+    json: IPnpmOptionsJson,
+    commonTempFolder: string
+  ): PnpmOptionsConfiguration {
     return new PnpmOptionsConfiguration(json, commonTempFolder);
   }
 }

--- a/webpack/webpack4-module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/webpack4-module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -246,9 +246,11 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
         const getRealId: (id: number | string) => number | string | undefined = (id: number | string) =>
           this.hooks.finalModuleId.call(id, compilation);
 
-        const postProcessCode: (code: ReplaceSource, context: IPostProcessFragmentContext) => ReplaceSource =
-          (code: ReplaceSource, context: IPostProcessFragmentContext) =>
-            this.hooks.postProcessCodeFragment.call(code, context);
+        const postProcessCode: (
+          code: ReplaceSource,
+          context: IPostProcessFragmentContext
+        ) => ReplaceSource = (code: ReplaceSource, context: IPostProcessFragmentContext) =>
+          this.hooks.postProcessCodeFragment.call(code, context);
 
         /**
          * Callback to invoke when a file has finished minifying.


### PR DESCRIPTION
## Summary

We recently discovered an issue in Rush where a changefile with a missing or malformed "type" property would cause `rush version` to produce an invalid `changelog.json`, which will fail to parse.

Adding schema validation to the step that loads the changefiles proved difficult because `rush version` writes and then reads and deletes a changefile that does not conform to the schema. This is a stopgap measure until version bumping and publishing is redesigned.

## How it was tested

Tested by running `rush version --bump --version-policy rush` on this repo on branches both with and without malformed changefiles.