### PR TITLE
[rush] Handle ProjectWatcher edge case

### DIFF
--- a/common/changes/@microsoft/rush/project-watcher-undefined_2022-10-10-18-23.json
+++ b/common/changes/@microsoft/rush/project-watcher-undefined_2022-10-10-18-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Handle case in ProjectWatcher where a project contains no git tracked files or status information is or was unavailable.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -262,7 +262,7 @@ export class ProjectWatcher {
         state._tryGetProjectDependenciesAsync(project, this._terminal)
       ]);
 
-      if (ProjectWatcher._haveProjectDepsChanged(previous!, current!)) {
+      if (ProjectWatcher._haveProjectDepsChanged(previous, current)) {
         // May need to detect if the nature of the change will break the process, e.g. changes to package.json
         changedProjects.add(project);
       }
@@ -286,7 +286,18 @@ export class ProjectWatcher {
    *
    * @returns `true` if the maps are different, `false` otherwise
    */
-  private static _haveProjectDepsChanged(prev: Map<string, string>, next: Map<string, string>): boolean {
+  private static _haveProjectDepsChanged(
+    prev: Map<string, string> | undefined,
+    next: Map<string, string> | undefined
+  ): boolean {
+    if (!prev && !next) {
+      return false;
+    }
+
+    if (!prev || !next) {
+      return true;
+    }
+
     if (prev.size !== next.size) {
       return true;
     }


### PR DESCRIPTION
## Summary
Gracefully handle the scenario when a project contains no Git tracked files in the ProjectWatcher or Git information is not available.

Fixes #3686 

## Details
Removes the non-null assertions and replaces with explicit handling of either old or new project tracked files being `undefined`.

## How it was tested
