### PR TITLE
[heft-sass-plugin] Support non-module SCSS files via "nonModuleFileExtensions"

### DIFF
--- a/build-tests/heft-sass-test/src/ExampleApp.tsx
+++ b/build-tests/heft-sass-test/src/ExampleApp.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import styles from './styles.sass';
 import oldStyles from './stylesCSS.css';
 import altSyntaxStyles from './stylesAltSyntax.scss';
+import './stylesAltSyntax.global.scss';
 
 /**
  * This React component renders the application page.

--- a/build-tests/heft-sass-test/src/stylesAltSyntax.global.scss
+++ b/build-tests/heft-sass-test/src/stylesAltSyntax.global.scss
@@ -1,0 +1,11 @@
+/**
+ * This file gets transpiled by the heft-sass-plugin and output to the lib/ folder.
+ * Then Webpack uses css-loader to embed, and finally style-loader to apply it to the DOM.
+ */
+
+// Testing SCSS syntax
+$marginValue: 20px;
+
+.ms-label {
+  margin-bottom: $marginValue;
+}

--- a/common/changes/@rushstack/heft-sass-plugin/sass-non-module_2022-10-11-22-35.json
+++ b/common/changes/@rushstack/heft-sass-plugin/sass-non-module_2022-10-11-22-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Add `nonModuleFileExtensions` property to support generating typings for non-module CSS files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/node-core-library/sass-non-module_2022-10-11-22-24.json
+++ b/common/changes/@rushstack/node-core-library/sass-non-module_2022-10-11-22-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix a bug where `Sort.isSorted` and `Sort.isSortedBy` unexpectedly compared the first element against `undefined`. Optimize `Sort.sortMapKeys` to run the check for already being sorted against the original Map instead of a derived array.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
@@ -51,7 +51,16 @@
 
     "fileExtensions": {
       "type": "array",
-      "description": "Files with these extensions will pass through the Sass transpiler for typings generation.",
+      "description": "Files with these extensions will be treated as SCSS modules and pass through the Sass transpiler for typings generation.",
+      "items": {
+        "type": "string",
+        "pattern": "^\\.[A-z0-9-_.]*[A-z0-9-_]+$"
+      }
+    },
+
+    "nonModuleFileExtensions": {
+      "type": "array",
+      "description": "Files with these extensions will be treated as non-module SCSS and pass through the Sass transpiler for typings generation.",
       "items": {
         "type": "string",
         "pattern": "^\\.[A-z0-9-_.]*[A-z0-9-_]+$"

--- a/libraries/node-core-library/src/Sort.ts
+++ b/libraries/node-core-library/src/Sort.ts
@@ -87,9 +87,13 @@ export class Sort {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     comparer: (x: any, y: any) => number = Sort.compareByValue
   ): boolean {
+    let isFirst: boolean = true;
     let previous: T | undefined = undefined;
     for (const element of collection) {
-      if (comparer(previous, element) > 0) {
+      if (isFirst) {
+        // Don't start by comparing against undefined.
+        isFirst = false;
+      } else if (comparer(previous, element) > 0) {
         return false;
       }
       previous = element;
@@ -114,10 +118,14 @@ export class Sort {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     comparer: (x: any, y: any) => number = Sort.compareByValue
   ): boolean {
+    let isFirst: boolean = true;
     let previousKey: T | undefined = undefined;
     for (const element of collection) {
       const key: T = keySelector(element);
-      if (comparer(previousKey, key) > 0) {
+      if (isFirst) {
+        // Don't start by comparing against undefined.
+        isFirst = false;
+      } else if (comparer(previousKey, key) > 0) {
         return false;
       }
       previousKey = key;
@@ -145,12 +153,12 @@ export class Sort {
     map: Map<K, V>,
     keyComparer: (x: K, y: K) => number = Sort.compareByValue
   ): void {
-    const pairs: [K, V][] = Array.from(map.entries());
-
     // Sorting a map is expensive, so first check whether it's already sorted.
-    if (Sort.isSortedBy(pairs, (x) => x[0], keyComparer)) {
+    if (Sort.isSorted(map.keys(), keyComparer)) {
       return;
     }
+
+    const pairs: [K, V][] = Array.from(map.entries());
 
     Sort.sortBy(pairs, (x) => x[0], keyComparer);
     map.clear();


### PR DESCRIPTION
## Summary
Adds a new property to the `heft-sass-plugin` configuration called `nonModuleFileExtensions`. Input files that end in these extensions (and do not match a more specific extension from `fileExtensions`, which are the file extensions for SCSS modules) will be treated as non-module SCSS files: the CSS modules transform will be skipped and the typings will not contain any names.

## Details
Also fixed a bug encountered in `Sort.sortMapKeys` wherein the comparer was run between the first element of the collection and `undefined`.

## How it was tested
Added test case to `heft-sass-test` for a file with `.global.scss` as the file extension. Validated that the typings for it don't have any names.