### PR TITLE
[api-extractor] Fix an issue with the 'fileUrlPath' on Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,9 @@ jobs:
         with:
           fetch-depth: 2
       - name: Git config user
-        uses: snow-actions/git-config-user@v1.0.0
-        with:
-          name: Rushbot
-          email: rushbot@users.noreply.github.com
+        run: |
+          git config --local user.name "Rushbot"
+          git config --local user.email "rushbot@users.noreply.github.com"
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.NodeVersion }}

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -34,6 +34,7 @@ import {
   IApiTypeParameterOptions,
   EnumMemberOrder
 } from '@microsoft/api-extractor-model';
+import { Path } from '@rushstack/node-core-library';
 
 import { Collector } from '../collector/Collector';
 import { ISourceLocation } from '../collector/SourceMapper';
@@ -1138,6 +1139,11 @@ export class ApiModelGenerator {
       pos: declaration.pos
     });
 
-    return path.posix.relative(this._collector.extractorConfig.projectFolder, sourceLocation.sourceFilePath);
+    let result: string = path.relative(
+      this._collector.extractorConfig.projectFolder,
+      sourceLocation.sourceFilePath
+    );
+    result = Path.convertToSlashes(result);
+    return result;
   }
 }

--- a/build-tests/api-extractor-scenarios/etc/referenceTokens/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/referenceTokens/api-extractor-scenarios.api.json
@@ -907,6 +907,7 @@
               "text": "unique symbol"
             }
           ],
+          "fileUrlPath": "src/referenceTokens/index.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "SomeSymbol1",
@@ -929,6 +930,7 @@
               "text": "\"ThisIsSomeVar1\""
             }
           ],
+          "fileUrlPath": "src/referenceTokens/index.ts",
           "initializerTokenRange": {
             "startIndex": 1,
             "endIndex": 2

--- a/common/changes/@microsoft/api-extractor/fix-path-regression_2022-10-17-02-48.json
+++ b/common/changes/@microsoft/api-extractor/fix-path-regression_2022-10-17-02-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix a regression where the \"fileUrlPath\" property would contain a malformed path when API Extractor is run on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Summary

There is currently an issue where the `fileUrlPath` gets populated with something that looks like `../E:\\code\\rushstack\\build-tests\\api-extractor-scenarios\\src\\apiItemKinds\\classes.ts` on Windows. This is probably due to a recent change in the TypeScript compiler's behavior.

## Details

This PR fixes this using the platform default `path.relative` behavior and then explicitly converting slashes in the path.

## How it was tested

Built and made sure that the `*.api.json` files produed by `api-extractor-scenarios` matched the old behavior.