### PR TITLE
[ts-command-line] Make the `onDefineParameters` function optional.

### DIFF
--- a/apps/api-documenter/src/cli/ApiDocumenterCommandLine.ts
+++ b/apps/api-documenter/src/cli/ApiDocumenterCommandLine.ts
@@ -17,11 +17,6 @@ export class ApiDocumenterCommandLine extends CommandLineParser {
     this._populateActions();
   }
 
-  protected onDefineParameters(): void {
-    // override
-    // No parameters
-  }
-
   private _populateActions(): void {
     this.addAction(new MarkdownAction(this));
     this.addAction(new YamlAction(this));

--- a/apps/api-documenter/src/cli/BaseAction.ts
+++ b/apps/api-documenter/src/cli/BaseAction.ts
@@ -3,9 +3,13 @@
 
 import * as path from 'path';
 import * as tsdoc from '@microsoft/tsdoc';
-import colors from 'colors';
+import colors from 'colors/safe';
 
-import { CommandLineAction, CommandLineStringParameter } from '@rushstack/ts-command-line';
+import {
+  CommandLineAction,
+  CommandLineStringParameter,
+  type ICommandLineActionOptions
+} from '@rushstack/ts-command-line';
 import { FileSystem } from '@rushstack/node-core-library';
 import {
   ApiModel,
@@ -22,10 +26,12 @@ export interface IBuildApiModelResult {
 }
 
 export abstract class BaseAction extends CommandLineAction {
-  private _inputFolderParameter!: CommandLineStringParameter;
-  private _outputFolderParameter!: CommandLineStringParameter;
+  private readonly _inputFolderParameter: CommandLineStringParameter;
+  private readonly _outputFolderParameter: CommandLineStringParameter;
 
-  protected onDefineParameters(): void {
+  protected constructor(options: ICommandLineActionOptions) {
+    super(options);
+
     // override
     this._inputFolderParameter = this.defineStringParameter({
       parameterLongName: '--input-folder',

--- a/apps/api-documenter/src/cli/YamlAction.ts
+++ b/apps/api-documenter/src/cli/YamlAction.ts
@@ -10,9 +10,9 @@ import { YamlDocumenter } from '../documenters/YamlDocumenter';
 import { OfficeYamlDocumenter } from '../documenters/OfficeYamlDocumenter';
 
 export class YamlAction extends BaseAction {
-  private _officeParameter!: CommandLineFlagParameter;
-  private _newDocfxNamespacesParameter!: CommandLineFlagParameter;
-  private _yamlFormatParameter!: CommandLineChoiceParameter;
+  private readonly _officeParameter: CommandLineFlagParameter;
+  private readonly _newDocfxNamespacesParameter: CommandLineFlagParameter;
+  private readonly _yamlFormatParameter: CommandLineChoiceParameter;
 
   public constructor(parser: ApiDocumenterCommandLine) {
     super({
@@ -23,11 +23,6 @@ export class YamlAction extends BaseAction {
         ' to the universal reference YAML format, which is used by the docs.microsoft.com' +
         ' pipeline.'
     });
-  }
-
-  protected onDefineParameters(): void {
-    // override
-    super.onDefineParameters();
 
     this._officeParameter = this.defineFlagParameter({
       parameterLongName: '--office',

--- a/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
+++ b/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
@@ -11,7 +11,7 @@ import { RunAction } from './RunAction';
 import { InitAction } from './InitAction';
 
 export class ApiExtractorCommandLine extends CommandLineParser {
-  private _debugParameter!: CommandLineFlagParameter;
+  private readonly _debugParameter: CommandLineFlagParameter;
 
   public constructor() {
     super({
@@ -24,10 +24,7 @@ export class ApiExtractorCommandLine extends CommandLineParser {
         ' tool such as api-documenter.  For details, please visit the web site.'
     });
     this._populateActions();
-  }
 
-  protected onDefineParameters(): void {
-    // override
     this._debugParameter = this.defineFlagParameter({
       parameterLongName: '--debug',
       parameterShortName: '-d',

--- a/apps/api-extractor/src/cli/InitAction.ts
+++ b/apps/api-extractor/src/cli/InitAction.ts
@@ -21,11 +21,6 @@ export class InitAction extends CommandLineAction {
     });
   }
 
-  protected onDefineParameters(): void {
-    // override
-    // No parameters yet
-  }
-
   protected async onExecute(): Promise<void> {
     // override
     const inputFilePath: string = path.resolve(__dirname, '../schemas/api-extractor-template.json');

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -18,11 +18,11 @@ import { ApiExtractorCommandLine } from './ApiExtractorCommandLine';
 import { ExtractorConfig, IExtractorConfigPrepareOptions } from '../api/ExtractorConfig';
 
 export class RunAction extends CommandLineAction {
-  private _configFileParameter!: CommandLineStringParameter;
-  private _localParameter!: CommandLineFlagParameter;
-  private _verboseParameter!: CommandLineFlagParameter;
-  private _diagnosticsParameter!: CommandLineFlagParameter;
-  private _typescriptCompilerFolder!: CommandLineStringParameter;
+  private readonly _configFileParameter: CommandLineStringParameter;
+  private readonly _localParameter: CommandLineFlagParameter;
+  private readonly _verboseParameter: CommandLineFlagParameter;
+  private readonly _diagnosticsParameter: CommandLineFlagParameter;
+  private readonly _typescriptCompilerFolder: CommandLineStringParameter;
 
   public constructor(parser: ApiExtractorCommandLine) {
     super({
@@ -30,10 +30,7 @@ export class RunAction extends CommandLineAction {
       summary: 'Invoke API Extractor on a project',
       documentation: 'Invoke API Extractor on a project'
     });
-  }
 
-  protected onDefineParameters(): void {
-    // override
     this._configFileParameter = this.defineStringParameter({
       parameterLongName: '--config',
       parameterShortName: '-c',

--- a/apps/heft/src/cli/HeftCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftCommandLineParser.ts
@@ -57,9 +57,9 @@ export class HeftCommandLineParser extends CommandLineParser {
 
   private _preInitializationArgumentValues: IPreInitializationArgumentValues;
 
-  private _unmanagedFlag!: CommandLineFlagParameter;
-  private _debugFlag!: CommandLineFlagParameter;
-  private _pluginsParameter!: CommandLineStringListParameter;
+  private readonly _unmanagedFlag: CommandLineFlagParameter;
+  private readonly _debugFlag: CommandLineFlagParameter;
+  private readonly _pluginsParameter: CommandLineStringListParameter;
 
   public get isDebug(): boolean {
     return !!this._preInitializationArgumentValues.debug;
@@ -73,6 +73,26 @@ export class HeftCommandLineParser extends CommandLineParser {
     super({
       toolFilename: 'heft',
       toolDescription: 'Heft is a pluggable build system designed for web projects.'
+    });
+
+    this._unmanagedFlag = this.defineFlagParameter({
+      parameterLongName: '--unmanaged',
+      description:
+        'Disables the Heft version selector: When Heft is invoked via the shell path, normally it' +
+        " will examine the project's package.json dependencies and try to use the locally installed version" +
+        ' of Heft. Specify "--unmanaged" to force the invoked version of Heft to be used. This is useful for' +
+        ' example if you want to test a different version of Heft.'
+    });
+
+    this._debugFlag = this.defineFlagParameter({
+      parameterLongName: Constants.debugParameterLongName,
+      description: 'Show the full call stack if an error occurs while executing the tool'
+    });
+
+    this._pluginsParameter = this.defineStringListParameter({
+      parameterLongName: Constants.pluginParameterLongName,
+      argumentName: 'PATH',
+      description: 'Used to specify Heft plugins.'
     });
 
     this._preInitializationArgumentValues = this._getPreInitializationArgumentValues();
@@ -137,28 +157,6 @@ export class HeftCommandLineParser extends CommandLineParser {
     this.addAction(buildAction);
     this.addAction(startAction);
     this.addAction(testAction);
-  }
-
-  protected onDefineParameters(): void {
-    this._unmanagedFlag = this.defineFlagParameter({
-      parameterLongName: '--unmanaged',
-      description:
-        'Disables the Heft version selector: When Heft is invoked via the shell path, normally it' +
-        " will examine the project's package.json dependencies and try to use the locally installed version" +
-        ' of Heft. Specify "--unmanaged" to force the invoked version of Heft to be used. This is useful for' +
-        ' example if you want to test a different version of Heft.'
-    });
-
-    this._debugFlag = this.defineFlagParameter({
-      parameterLongName: Constants.debugParameterLongName,
-      description: 'Show the full call stack if an error occurs while executing the tool'
-    });
-
-    this._pluginsParameter = this.defineStringListParameter({
-      parameterLongName: Constants.pluginParameterLongName,
-      argumentName: 'PATH',
-      description: 'Used to specify Heft plugins.'
-    });
   }
 
   public async execute(args?: string[]): Promise<boolean> {

--- a/apps/heft/src/cli/actions/BuildAction.ts
+++ b/apps/heft/src/cli/actions/BuildAction.ts
@@ -9,11 +9,11 @@ import { Logging } from '../../utilities/Logging';
 import { BuildStage, IBuildStageOptions, IBuildStageStandardParameters } from '../../stages/BuildStage';
 
 export class BuildAction extends HeftActionBase {
-  protected _watchFlag!: CommandLineFlagParameter;
-  protected _productionFlag!: CommandLineFlagParameter;
-  protected _liteFlag!: CommandLineFlagParameter;
-  private _buildStandardParameters!: IBuildStageStandardParameters;
-  private _cleanFlag!: CommandLineFlagParameter;
+  protected readonly _watchFlag: CommandLineFlagParameter;
+  protected readonly _productionFlag: CommandLineFlagParameter;
+  protected readonly _liteFlag: CommandLineFlagParameter;
+  private readonly _buildStandardParameters: IBuildStageStandardParameters;
+  private readonly _cleanFlag: CommandLineFlagParameter;
 
   public constructor(
     heftActionOptions: IHeftActionBaseOptions,
@@ -24,10 +24,6 @@ export class BuildAction extends HeftActionBase {
     }
   ) {
     super(commandLineActionOptions, heftActionOptions);
-  }
-
-  public onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._buildStandardParameters = BuildStage.defineStageStandardParameters(this);
     this._productionFlag = this._buildStandardParameters.productionFlag;

--- a/apps/heft/src/cli/actions/CleanAction.ts
+++ b/apps/heft/src/cli/actions/CleanAction.ts
@@ -7,7 +7,7 @@ import { HeftActionBase, IHeftActionBaseOptions } from './HeftActionBase';
 import { CleanStage, ICleanStageOptions } from '../../stages/CleanStage';
 
 export class CleanAction extends HeftActionBase {
-  private _deleteCacheFlag!: CommandLineFlagParameter;
+  private readonly _deleteCacheFlag: CommandLineFlagParameter;
 
   public constructor(options: IHeftActionBaseOptions) {
     super(
@@ -18,10 +18,6 @@ export class CleanAction extends HeftActionBase {
       },
       options
     );
-  }
-
-  public onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._deleteCacheFlag = this.defineFlagParameter({
       parameterLongName: '--clear-cache',

--- a/apps/heft/src/cli/actions/CustomAction.ts
+++ b/apps/heft/src/cli/actions/CustomAction.ts
@@ -65,8 +65,8 @@ export interface ICustomActionOptions<TParameters> {
 }
 
 export class CustomAction<TParameters> extends HeftActionBase {
-  private _customActionOptions: ICustomActionOptions<TParameters>;
-  private _parameterValues!: Map<string, () => CustomActionParameterType>;
+  private readonly _customActionOptions: ICustomActionOptions<TParameters>;
+  private readonly _parameterValues: Map<string, () => CustomActionParameterType>;
 
   public constructor(
     customActionOptions: ICustomActionOptions<TParameters>,
@@ -82,10 +82,6 @@ export class CustomAction<TParameters> extends HeftActionBase {
     );
 
     this._customActionOptions = customActionOptions;
-  }
-
-  public onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._parameterValues = new Map<string, () => CustomActionParameterType>();
     for (const [callbackValueName, untypedParameterOption] of Object.entries(

--- a/apps/heft/src/cli/actions/HeftActionBase.ts
+++ b/apps/heft/src/cli/actions/HeftActionBase.ts
@@ -53,7 +53,7 @@ export abstract class HeftActionBase extends CommandLineAction {
   protected readonly metricsCollector: MetricsCollector;
   protected readonly heftConfiguration: HeftConfiguration;
   protected readonly stages: IStages;
-  protected verboseFlag!: CommandLineFlagParameter;
+  protected readonly verboseFlag: CommandLineFlagParameter;
 
   public constructor(
     commandLineOptions: ICommandLineActionOptions,
@@ -66,9 +66,7 @@ export abstract class HeftActionBase extends CommandLineAction {
     this.heftConfiguration = heftActionOptions.heftConfiguration;
     this.stages = heftActionOptions.stages;
     this.setStartTime();
-  }
 
-  public onDefineParameters(): void {
     this.verboseFlag = this.defineFlagParameter({
       parameterLongName: '--verbose',
       parameterShortName: '-v',

--- a/apps/heft/src/cli/actions/StartAction.ts
+++ b/apps/heft/src/cli/actions/StartAction.ts
@@ -8,8 +8,8 @@ import { ICleanStageOptions, CleanStage } from '../../stages/CleanStage';
 import { Logging } from '../../utilities/Logging';
 
 export class StartAction extends HeftActionBase {
-  private _buildStandardParameters!: IBuildStageStandardParameters;
-  private _cleanFlag!: CommandLineFlagParameter;
+  private readonly _buildStandardParameters: IBuildStageStandardParameters;
+  private readonly _cleanFlag: CommandLineFlagParameter;
   private _storybookFlag!: CommandLineFlagParameter;
 
   public constructor(heftActionOptions: IHeftActionBaseOptions) {
@@ -21,10 +21,6 @@ export class StartAction extends HeftActionBase {
       },
       heftActionOptions
     );
-  }
-
-  public onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._buildStandardParameters = BuildStage.defineStageStandardParameters(this);
 

--- a/apps/heft/src/cli/actions/TestAction.ts
+++ b/apps/heft/src/cli/actions/TestAction.ts
@@ -9,11 +9,11 @@ import { TestStage, ITestStageOptions } from '../../stages/TestStage';
 import { Logging } from '../../utilities/Logging';
 
 export class TestAction extends BuildAction {
-  private _noTestFlag!: CommandLineFlagParameter;
-  private _noBuildFlag!: CommandLineFlagParameter;
+  private readonly _noTestFlag: CommandLineFlagParameter;
+  private readonly _noBuildFlag: CommandLineFlagParameter;
   /*
   // Temporary workaround for https://github.com/microsoft/rushstack/issues/2759
-  private _passWithNoTests!: CommandLineFlagParameter;
+  private readonly _passWithNoTests: CommandLineFlagParameter;
   */
 
   public constructor(heftActionOptions: IHeftActionBaseOptions) {
@@ -22,10 +22,6 @@ export class TestAction extends BuildAction {
       summary: 'Build the project and run tests.',
       documentation: ''
     });
-  }
-
-  public onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._noTestFlag = this.defineFlagParameter({
       parameterLongName: '--no-test',

--- a/apps/rundown/src/cli/BaseReportAction.ts
+++ b/apps/rundown/src/cli/BaseReportAction.ts
@@ -12,17 +12,14 @@ import {
 } from '@rushstack/ts-command-line';
 
 export abstract class BaseReportAction extends CommandLineAction {
-  protected scriptParameter!: CommandLineStringParameter;
-  protected argsParameter!: CommandLineStringParameter;
-  protected quietParameter!: CommandLineFlagParameter;
-  protected ignoreExitCodeParameter!: CommandLineFlagParameter;
+  protected readonly scriptParameter: CommandLineStringParameter;
+  protected readonly argsParameter: CommandLineStringParameter;
+  protected readonly quietParameter: CommandLineFlagParameter;
+  protected readonly ignoreExitCodeParameter: CommandLineFlagParameter;
 
   public constructor(options: ICommandLineActionOptions) {
     super(options);
-  }
 
-  // abstract
-  protected onDefineParameters(): void {
     this.scriptParameter = this.defineStringParameter({
       parameterLongName: '--script',
       parameterShortName: '-s',

--- a/apps/rundown/src/cli/InspectAction.ts
+++ b/apps/rundown/src/cli/InspectAction.ts
@@ -7,7 +7,7 @@ import { BaseReportAction } from './BaseReportAction';
 import { Rundown } from '../Rundown';
 
 export class InspectAction extends BaseReportAction {
-  private _traceParameter!: CommandLineFlagParameter;
+  private readonly _traceParameter: CommandLineFlagParameter;
 
   public constructor() {
     super({
@@ -17,10 +17,6 @@ export class InspectAction extends BaseReportAction {
         'Invoke a Node.js script and generate detailed diagnostic output.  This command is used' +
         ' to inspect performance regressions.'
     });
-  }
-
-  protected onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._traceParameter = this.defineFlagParameter({
       parameterLongName: '--trace-imports',

--- a/apps/rundown/src/cli/RundownCommandLine.ts
+++ b/apps/rundown/src/cli/RundownCommandLine.ts
@@ -18,6 +18,4 @@ export class RundownCommandLine extends CommandLineParser {
     this.addAction(new SnapshotAction());
     this.addAction(new InspectAction());
   }
-
-  protected onDefineParameters(): void {}
 }

--- a/apps/rundown/src/cli/SnapshotAction.ts
+++ b/apps/rundown/src/cli/SnapshotAction.ts
@@ -16,10 +16,6 @@ export class SnapshotAction extends BaseReportAction {
     });
   }
 
-  protected onDefineParameters(): void {
-    super.onDefineParameters();
-  }
-
   protected async onExecute(): Promise<void> {
     const rundown: Rundown = new Rundown();
     await rundown.invokeAsync(

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.48.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.1.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.5.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.48.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.1.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.5.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -460,7 +460,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
   /cross-spawn/7.0.3:
@@ -1799,15 +1799,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.48.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.48.1.tgz}
+  file:../temp/tarballs/rushstack-heft-0.48.5.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.48.5.tgz}
     name: '@rushstack/heft'
-    version: 0.48.1
+    version: 0.48.5
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.2.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.1.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.12.5.tgz
       '@types/tapable': 1.0.6
@@ -1822,21 +1822,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.2.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.11.2
+    version: 0.11.3
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.1.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.53.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.53.1.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.53.1
+    version: 3.53.2
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5

--- a/common/changes/@microsoft/api-documenter/ts-command-line-cleanup_2022-10-17-19-14.json
+++ b/common/changes/@microsoft/api-documenter/ts-command-line-cleanup_2022-10-17-19-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor/ts-command-line-cleanup_2022-10-17-19-14.json
+++ b/common/changes/@microsoft/api-extractor/ts-command-line-cleanup_2022-10-17-19-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/rush/ts-command-line-cleanup_2022-10-17-19-14.json
+++ b/common/changes/@microsoft/rush/ts-command-line-cleanup_2022-10-17-19-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft/ts-command-line-cleanup_2022-10-17-19-14.json
+++ b/common/changes/@rushstack/heft/ts-command-line-cleanup_2022-10-17-19-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/rundown/ts-command-line-cleanup_2022-10-17-19-14.json
+++ b/common/changes/@rushstack/rundown/ts-command-line-cleanup_2022-10-17-19-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown"
+}

--- a/common/changes/@rushstack/ts-command-line/ts-command-line-cleanup_2022-10-17-19-12.json
+++ b/common/changes/@rushstack/ts-command-line/ts-command-line-cleanup_2022-10-17-19-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Make the onDefineParameters function optional for `CommandLineAction`s and `CommandLineParser`s that either don't have parameters or that define their parameters in their constructor.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -17,7 +17,6 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
     _execute(): Promise<void>;
     // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
-    protected abstract onDefineParameters(): void;
     protected abstract onExecute(): Promise<void>;
     // @internal
     _processParsedData(parserOptions: ICommandLineParserOptions, data: _ICommandLineParserData): void;
@@ -165,7 +164,7 @@ export abstract class CommandLineParameterProvider {
     getParameterStringMap(): Record<string, string>;
     getStringListParameter(parameterLongName: string, parameterScope?: string): CommandLineStringListParameter;
     getStringParameter(parameterLongName: string, parameterScope?: string): CommandLineStringParameter;
-    protected abstract onDefineParameters(): void;
+    protected onDefineParameters?(): void;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     get parametersProcessed(): boolean;
     parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult;
@@ -247,15 +246,11 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
 // @public (undocumented)
 export class DynamicCommandLineAction extends CommandLineAction {
     // (undocumented)
-    protected onDefineParameters(): void;
-    // (undocumented)
     protected onExecute(): Promise<void>;
 }
 
 // @public (undocumented)
 export class DynamicCommandLineParser extends CommandLineParser {
-    // (undocumented)
-    protected onDefineParameters(): void;
 }
 
 // @public

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -71,9 +71,9 @@ export class RushCommandLineParser extends CommandLineParser {
   public readonly rushSession: RushSession;
   public readonly pluginManager: PluginManager;
 
-  private _debugParameter!: CommandLineFlagParameter;
-  private _quietParameter!: CommandLineFlagParameter;
-  private _restrictConsoleOutput: boolean = RushCommandLineParser.shouldRestrictConsoleOutput();
+  private readonly _debugParameter: CommandLineFlagParameter;
+  private readonly _quietParameter: CommandLineFlagParameter;
+  private readonly _restrictConsoleOutput: boolean = RushCommandLineParser.shouldRestrictConsoleOutput();
   private readonly _rushOptions: IRushCommandLineParserOptions;
   private readonly _terminalProvider: ConsoleTerminalProvider;
   private readonly _terminal: Terminal;
@@ -91,6 +91,18 @@ export class RushCommandLineParser extends CommandLineParser {
         ' automation tools.  If you are looking for a proven turnkey solution for monorepo management,' +
         ' Rush is for you.',
       enableTabCompletionAction: true
+    });
+
+    this._debugParameter = this.defineFlagParameter({
+      parameterLongName: '--debug',
+      parameterShortName: '-d',
+      description: 'Show the full call stack if an error occurs while executing the tool'
+    });
+
+    this._quietParameter = this.defineFlagParameter({
+      parameterLongName: '--quiet',
+      parameterShortName: '-q',
+      description: 'Hide rush startup information'
     });
 
     this._terminalProvider = new ConsoleTerminalProvider();
@@ -180,20 +192,6 @@ export class RushCommandLineParser extends CommandLineParser {
     await this.pluginManager.tryInitializeUnassociatedPluginsAsync();
 
     return await super.execute(args);
-  }
-
-  protected onDefineParameters(): void {
-    this._debugParameter = this.defineFlagParameter({
-      parameterLongName: '--debug',
-      parameterShortName: '-d',
-      description: 'Show the full call stack if an error occurs while executing the tool'
-    });
-
-    this._quietParameter = this.defineFlagParameter({
-      parameterLongName: '--quiet',
-      parameterShortName: '-q',
-      description: 'Hide rush startup information'
-    });
   }
 
   protected async onExecute(): Promise<void> {

--- a/libraries/rush-lib/src/cli/actions/AddAction.ts
+++ b/libraries/rush-lib/src/cli/actions/AddAction.ts
@@ -3,7 +3,7 @@
 
 import * as os from 'os';
 import * as semver from 'semver';
-import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import type { CommandLineFlagParameter, CommandLineStringListParameter } from '@rushstack/ts-command-line';
 
 import { BaseAddAndRemoveAction } from './BaseAddAndRemoveAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
@@ -14,10 +14,12 @@ import { SemVerStyle } from '../../logic/PackageJsonUpdater';
 import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
 
 export class AddAction extends BaseAddAndRemoveAction {
-  private _exactFlag!: CommandLineFlagParameter;
-  private _caretFlag!: CommandLineFlagParameter;
-  private _devDependencyFlag!: CommandLineFlagParameter;
-  private _makeConsistentFlag!: CommandLineFlagParameter;
+  protected readonly _allFlag: CommandLineFlagParameter;
+  protected readonly _packageNameList: CommandLineStringListParameter;
+  private readonly _exactFlag: CommandLineFlagParameter;
+  private readonly _caretFlag: CommandLineFlagParameter;
+  private readonly _devDependencyFlag: CommandLineFlagParameter;
+  private readonly _makeConsistentFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     const documentation: string[] = [
@@ -35,9 +37,7 @@ export class AddAction extends BaseAddAndRemoveAction {
       safeForSimultaneousRushProcesses: false,
       parser
     });
-  }
 
-  public onDefineParameters(): void {
     this._packageNameList = this.defineStringListParameter({
       parameterLongName: '--package',
       parameterShortName: '-p',
@@ -78,7 +78,6 @@ export class AddAction extends BaseAddAndRemoveAction {
       parameterLongName: '--all',
       description: 'If specified, the dependency will be added to all projects.'
     });
-    super.onDefineParameters();
   }
 
   public getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushAddOptions {

--- a/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { CommandLineFlagParameter, CommandLineStringListParameter } from '@rushstack/ts-command-line';
+import type { CommandLineFlagParameter, CommandLineStringListParameter } from '@rushstack/ts-command-line';
 
-import { BaseRushAction } from './BaseRushAction';
+import { BaseRushAction, type IBaseRushActionOptions } from './BaseRushAction';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
 
@@ -30,17 +30,17 @@ export interface IBasePackageJsonUpdaterRushOptions {
  * This is the common base class for AddAction and RemoveAction.
  */
 export abstract class BaseAddAndRemoveAction extends BaseRushAction {
-  protected _allFlag!: CommandLineFlagParameter;
-  protected _skipUpdateFlag!: CommandLineFlagParameter;
-  protected _packageNameList!: CommandLineStringListParameter;
+  protected abstract readonly _allFlag: CommandLineFlagParameter;
+  protected readonly _skipUpdateFlag!: CommandLineFlagParameter;
+  protected abstract readonly _packageNameList: CommandLineStringListParameter;
 
   protected get specifiedPackageNameList(): readonly string[] {
     return this._packageNameList.values!;
   }
 
-  protected abstract getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushBaseUpdateOptions;
+  public constructor(options: IBaseRushActionOptions) {
+    super(options);
 
-  protected onDefineParameters(): void {
     this._skipUpdateFlag = this.defineFlagParameter({
       parameterLongName: '--skip-update',
       parameterShortName: '-s',
@@ -48,6 +48,8 @@ export abstract class BaseAddAndRemoveAction extends BaseRushAction {
         'If specified, the "rush update" command will not be run after updating the package.json files.'
     });
   }
+
+  protected abstract getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushBaseUpdateOptions;
 
   protected getProjects(): RushConfigurationProject[] {
     if (this._allFlag.value) {

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -5,13 +5,13 @@ import colors from 'colors/safe';
 import * as os from 'os';
 
 import { Import } from '@rushstack/node-core-library';
-import {
+import type {
   CommandLineFlagParameter,
   CommandLineIntegerParameter,
   CommandLineStringParameter
 } from '@rushstack/ts-command-line';
 
-import { BaseRushAction } from './BaseRushAction';
+import { BaseRushAction, IBaseRushActionOptions } from './BaseRushAction';
 import { Event } from '../../api/EventHooks';
 import { BaseInstallManager, IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
 import { PurgeManager } from '../../logic/PurgeManager';
@@ -32,21 +32,23 @@ const installManagerFactoryModule: typeof import('../../logic/InstallManagerFact
  * This is the common base class for InstallAction and UpdateAction.
  */
 export abstract class BaseInstallAction extends BaseRushAction {
-  protected _variant!: CommandLineStringParameter;
-  protected _purgeParameter!: CommandLineFlagParameter;
-  protected _bypassPolicyParameter!: CommandLineFlagParameter;
-  protected _noLinkParameter!: CommandLineFlagParameter;
-  protected _networkConcurrencyParameter!: CommandLineIntegerParameter;
-  protected _debugPackageManagerParameter!: CommandLineFlagParameter;
-  protected _maxInstallAttempts!: CommandLineIntegerParameter;
-  protected _ignoreHooksParameter!: CommandLineFlagParameter;
+  protected readonly _variant: CommandLineStringParameter;
+  protected readonly _purgeParameter: CommandLineFlagParameter;
+  protected readonly _bypassPolicyParameter: CommandLineFlagParameter;
+  protected readonly _noLinkParameter: CommandLineFlagParameter;
+  protected readonly _networkConcurrencyParameter: CommandLineIntegerParameter;
+  protected readonly _debugPackageManagerParameter: CommandLineFlagParameter;
+  protected readonly _maxInstallAttempts: CommandLineIntegerParameter;
+  protected readonly _ignoreHooksParameter: CommandLineFlagParameter;
   /*
    * Subclasses can initialize the _selectionParameters property in order for
    * the parameters to be written to the telemetry file
    */
   protected _selectionParameters?: SelectionParameterSet;
 
-  protected onDefineParameters(): void {
+  public constructor(options: IBaseRushActionOptions) {
+    super(options);
+
     this._purgeParameter = this.defineFlagParameter({
       parameterLongName: '--purge',
       parameterShortName: '-p',

--- a/libraries/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ChangeAction.ts
@@ -40,19 +40,23 @@ import type * as inquirerTypes from 'inquirer';
 import { Utilities } from '../../utilities/Utilities';
 const inquirer: typeof inquirerTypes = Import.lazy('inquirer', require);
 
+const BULK_LONG_NAME: string = '--bulk';
+const BULK_MESSAGE_LONG_NAME: string = '--message';
+const BULK_BUMP_TYPE_LONG_NAME: string = '--bump-type';
+
 export class ChangeAction extends BaseRushAction {
   private readonly _git: Git;
   private readonly _terminal: ITerminal;
-  private _verifyParameter!: CommandLineFlagParameter;
-  private _noFetchParameter!: CommandLineFlagParameter;
-  private _targetBranchParameter!: CommandLineStringParameter;
-  private _changeEmailParameter!: CommandLineStringParameter;
-  private _bulkChangeParameter!: CommandLineFlagParameter;
-  private _bulkChangeMessageParameter!: CommandLineStringParameter;
-  private _bulkChangeBumpTypeParameter!: CommandLineChoiceParameter;
-  private _overwriteFlagParameter!: CommandLineFlagParameter;
-  private _commitChangesFlagParameter!: CommandLineFlagParameter;
-  private _commitChangesMessageStringParameter!: CommandLineStringParameter;
+  private readonly _verifyParameter: CommandLineFlagParameter;
+  private readonly _noFetchParameter: CommandLineFlagParameter;
+  private readonly _targetBranchParameter: CommandLineStringParameter;
+  private readonly _changeEmailParameter: CommandLineStringParameter;
+  private readonly _bulkChangeParameter: CommandLineFlagParameter;
+  private readonly _bulkChangeMessageParameter: CommandLineStringParameter;
+  private readonly _bulkChangeBumpTypeParameter: CommandLineChoiceParameter;
+  private readonly _overwriteFlagParameter: CommandLineFlagParameter;
+  private readonly _commitChangesFlagParameter: CommandLineFlagParameter;
+  private readonly _commitChangesMessageStringParameter: CommandLineStringParameter;
 
   private _targetBranchName: string | undefined;
 
@@ -98,12 +102,6 @@ export class ChangeAction extends BaseRushAction {
 
     this._git = new Git(this.rushConfiguration);
     this._terminal = new Terminal(new ConsoleTerminalProvider({ verboseEnabled: parser.isDebug }));
-  }
-
-  public onDefineParameters(): void {
-    const BULK_LONG_NAME: string = '--bulk';
-    const BULK_MESSAGE_LONG_NAME: string = '--message';
-    const BULK_BUMP_TYPE_LONG_NAME: string = '--bump-type';
 
     this._verifyParameter = this.defineFlagParameter({
       parameterLongName: '--verify',

--- a/libraries/rush-lib/src/cli/actions/CheckAction.ts
+++ b/libraries/rush-lib/src/cli/actions/CheckAction.ts
@@ -10,9 +10,9 @@ import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismat
 import { Variants } from '../../api/Variants';
 
 export class CheckAction extends BaseRushAction {
-  private _variant!: CommandLineStringParameter;
-  private _jsonFlag!: CommandLineFlagParameter;
-  private _verboseFlag!: CommandLineFlagParameter;
+  private readonly _variant: CommandLineStringParameter;
+  private readonly _jsonFlag: CommandLineFlagParameter;
+  private readonly _verboseFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -26,9 +26,7 @@ export class CheckAction extends BaseRushAction {
       safeForSimultaneousRushProcesses: true,
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
     this._jsonFlag = this.defineFlagParameter({
       parameterLongName: '--json',

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -14,11 +14,11 @@ const deployManagerModule: typeof deployManagerTypes = Import.lazy(
 );
 
 export class DeployAction extends BaseRushAction {
-  private _scenario!: CommandLineStringParameter;
-  private _project!: CommandLineStringParameter;
-  private _overwrite!: CommandLineFlagParameter;
-  private _targetFolder!: CommandLineStringParameter;
-  private _createArchivePath!: CommandLineStringParameter;
+  private readonly _scenario: CommandLineStringParameter;
+  private readonly _project: CommandLineStringParameter;
+  private readonly _overwrite: CommandLineFlagParameter;
+  private readonly _targetFolder: CommandLineStringParameter;
+  private readonly _createArchivePath: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -37,9 +37,7 @@ export class DeployAction extends BaseRushAction {
       // to different target folders.
       safeForSimultaneousRushProcesses: true
     });
-  }
 
-  protected onDefineParameters(): void {
     this._project = this.defineStringParameter({
       parameterLongName: '--project',
       parameterShortName: '-p',

--- a/libraries/rush-lib/src/cli/actions/InitAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitAction.ts
@@ -18,40 +18,40 @@ import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 import { Rush } from '../../api/Rush';
 
+// Matches a well-formed BEGIN macro starting a block section.
+// Example:  /*[BEGIN "DEMO"]*/
+//
+// Group #1 is the indentation spaces before the macro
+// Group #2 is the section name
+const BEGIN_MARCO_REGEXP: RegExp = /^(\s*)\/\*\[BEGIN "([A-Z]+)"\]\s*\*\/\s*$/;
+
+// Matches a well-formed END macro ending a block section.
+// Example:  /*[END "DEMO"]*/
+//
+// Group #1 is the indentation spaces before the macro
+// Group #2 is the section name
+const END_MACRO_REGEXP: RegExp = /^(\s*)\/\*\[END "([A-Z]+)"\]\s*\*\/\s*$/;
+
+// Matches a well-formed single-line section, including the space character after it
+// if present.
+// Example:  /*[LINE "HYPOTHETICAL"]*/
+//
+// Group #1 is the section name
+const LINE_MACRO_REGEXP: RegExp = /\/\*\[LINE "([A-Z]+)"\]\s*\*\/\s?/;
+
+// Matches a variable expansion.
+// Example:  [%RUSH_VERSION%]
+//
+// Group #1 is the variable name including the dollar sign
+const VARIABLE_MACRO_REGEXP: RegExp = /\[(%[A-Z0-9_]+%)\]/;
+
+// Matches anything that starts with "/*[" and ends with "]*/"
+// Used to catch malformed macro expressions
+const ANY_MACRO_REGEXP: RegExp = /\/\*\s*\[.*\]\s*\*\//;
+
 export class InitAction extends BaseConfiglessRushAction {
-  // Matches a well-formed BEGIN macro starting a block section.
-  // Example:  /*[BEGIN "DEMO"]*/
-  //
-  // Group #1 is the indentation spaces before the macro
-  // Group #2 is the section name
-  private static _beginMacroRegExp: RegExp = /^(\s*)\/\*\[BEGIN "([A-Z]+)"\]\s*\*\/\s*$/;
-
-  // Matches a well-formed END macro ending a block section.
-  // Example:  /*[END "DEMO"]*/
-  //
-  // Group #1 is the indentation spaces before the macro
-  // Group #2 is the section name
-  private static _endMacroRegExp: RegExp = /^(\s*)\/\*\[END "([A-Z]+)"\]\s*\*\/\s*$/;
-
-  // Matches a well-formed single-line section, including the space character after it
-  // if present.
-  // Example:  /*[LINE "HYPOTHETICAL"]*/
-  //
-  // Group #1 is the section name
-  private static _lineMacroRegExp: RegExp = /\/\*\[LINE "([A-Z]+)"\]\s*\*\/\s?/;
-
-  // Matches a variable expansion.
-  // Example:  [%RUSH_VERSION%]
-  //
-  // Group #1 is the variable name including the dollar sign
-  private static _variableMacroRegExp: RegExp = /\[(%[A-Z0-9_]+%)\]/;
-
-  // Matches anything that starts with "/*[" and ends with "]*/"
-  // Used to catch malformed macro expressions
-  private static _anyMacroRegExp: RegExp = /\/\*\s*\[.*\]\s*\*\//;
-
-  private _overwriteParameter!: CommandLineFlagParameter;
-  private _rushExampleParameter!: CommandLineFlagParameter;
+  private readonly _overwriteParameter: CommandLineFlagParameter;
+  private readonly _rushExampleParameter: CommandLineFlagParameter;
 
   // template section name --> whether it should be commented out
   private _commentedBySectionName: Map<string, boolean> = new Map<string, boolean>();
@@ -65,10 +65,7 @@ export class InitAction extends BaseConfiglessRushAction {
         ' set of config file templates to start managing projects using Rush.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
-    // abstract
     this._overwriteParameter = this.defineFlagParameter({
       parameterLongName: '--overwrite-existing',
       description:
@@ -253,7 +250,7 @@ export class InitAction extends BaseConfiglessRushAction {
 
       // Check for a block section start
       // Example:  /*[BEGIN "DEMO"]*/
-      match = line.match(InitAction._beginMacroRegExp);
+      match = line.match(BEGIN_MARCO_REGEXP);
       if (match) {
         if (activeBlockSectionName) {
           // If this happens, please report a Rush bug
@@ -270,7 +267,7 @@ export class InitAction extends BaseConfiglessRushAction {
 
       // Check for a block section end
       // Example:  /*[END "DEMO"]*/
-      match = line.match(InitAction._endMacroRegExp);
+      match = line.match(END_MACRO_REGEXP);
       if (match) {
         if (activeBlockSectionName === undefined) {
           // If this happens, please report a Rush bug
@@ -303,23 +300,23 @@ export class InitAction extends BaseConfiglessRushAction {
 
       // Check for a single-line section
       // Example:  /*[LINE "HYPOTHETICAL"]*/
-      match = transformedLine.match(InitAction._lineMacroRegExp);
+      match = transformedLine.match(LINE_MACRO_REGEXP);
       if (match) {
         const sectionName: string = match[1];
         const replacement: string = this._isSectionCommented(sectionName) ? '// ' : '';
-        transformedLine = transformedLine.replace(InitAction._lineMacroRegExp, replacement);
+        transformedLine = transformedLine.replace(LINE_MACRO_REGEXP, replacement);
       }
 
       // Check for variable expansions
       // Example:  [%RUSH_VERSION%]
-      while ((match = transformedLine.match(InitAction._variableMacroRegExp))) {
+      while ((match = transformedLine.match(VARIABLE_MACRO_REGEXP))) {
         const variableName: string = match[1];
         const replacement: string = this._expandMacroVariable(variableName);
-        transformedLine = transformedLine.replace(InitAction._variableMacroRegExp, replacement);
+        transformedLine = transformedLine.replace(VARIABLE_MACRO_REGEXP, replacement);
       }
 
       // Verify that all macros were handled
-      match = transformedLine.match(InitAction._anyMacroRegExp);
+      match = transformedLine.match(ANY_MACRO_REGEXP);
       if (match) {
         // If this happens, please report a Rush bug
         throw new InternalError(

--- a/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -11,7 +11,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class InitAutoinstallerAction extends BaseRushAction {
-  private _name!: CommandLineStringParameter;
+  private readonly _name: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -23,9 +23,7 @@ export class InitAutoinstallerAction extends BaseRushAction {
         ' "rush install" context.  See the command-line.json documentation for an example.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._name = this.defineStringParameter({
       parameterLongName: '--name',
       argumentName: 'AUTOINSTALLER_NAME',

--- a/libraries/rush-lib/src/cli/actions/InitDeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitDeployAction.ts
@@ -10,13 +10,14 @@ import { FileSystem, NewlineKind } from '@rushstack/node-core-library';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { DeployScenarioConfiguration } from '../../logic/deploy/DeployScenarioConfiguration';
 
+const CONFIG_TEMPLATE_PATH: string = path.join(
+  __dirname,
+  '../../../assets/rush-init-deploy/scenario-template.json'
+);
+
 export class InitDeployAction extends BaseRushAction {
-  private static _CONFIG_TEMPLATE_PATH: string = path.join(
-    __dirname,
-    '../../../assets/rush-init-deploy/scenario-template.json'
-  );
-  private _project!: CommandLineStringParameter;
-  private _scenario!: CommandLineStringParameter;
+  private readonly _project: CommandLineStringParameter;
+  private readonly _scenario: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -28,9 +29,7 @@ export class InitDeployAction extends BaseRushAction {
         ' deployments with different settings, you can use use "--scenario" to create additional config files.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._project = this.defineStringParameter({
       parameterLongName: '--project',
       parameterShortName: '-p',
@@ -75,7 +74,7 @@ export class InitDeployAction extends BaseRushAction {
       throw new Error(`The specified project was not found in rush.json: "${shortProjectName}"`);
     }
 
-    const templateContent: string = FileSystem.readFile(InitDeployAction._CONFIG_TEMPLATE_PATH);
+    const templateContent: string = FileSystem.readFile(CONFIG_TEMPLATE_PATH);
     const expandedContent: string = templateContent.replace(
       '[%PROJECT_NAME_TO_DEPLOY%]',
       rushProject.packageName

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -10,7 +10,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 
 export class InstallAction extends BaseInstallAction {
-  private _checkOnlyParameter!: CommandLineFlagParameter;
+  private readonly _checkOnlyParameter: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -29,13 +29,6 @@ export class InstallAction extends BaseInstallAction {
         ' accidentally updating their shrinkwrap file.',
       parser
     });
-  }
-
-  /**
-   * @override
-   */
-  protected onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._selectionParameters = new SelectionParameterSet(this.rushConfiguration, this, {
       // Include lockfile processing since this expands the selection, and we need to select

--- a/libraries/rush-lib/src/cli/actions/LinkAction.ts
+++ b/libraries/rush-lib/src/cli/actions/LinkAction.ts
@@ -16,7 +16,7 @@ const linkManagerFactoryModule: typeof LinkManagerFactoryTypes = Import.lazy(
 );
 
 export class LinkAction extends BaseRushAction {
-  private _force!: CommandLineFlagParameter;
+  private readonly _force: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -29,9 +29,7 @@ export class LinkAction extends BaseRushAction {
         ' for "rush install" or "rush update".',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._force = this.defineFlagParameter({
       parameterLongName: '--force',
       parameterShortName: '-f',

--- a/libraries/rush-lib/src/cli/actions/ListAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ListAction.ts
@@ -51,12 +51,12 @@ export interface IJsonOutput {
 }
 
 export class ListAction extends BaseRushAction {
-  private _version!: CommandLineFlagParameter;
-  private _path!: CommandLineFlagParameter;
-  private _fullPath!: CommandLineFlagParameter;
-  private _jsonFlag!: CommandLineFlagParameter;
-  private _detailedFlag!: CommandLineFlagParameter;
-  private _selectionParameters!: SelectionParameterSet;
+  private readonly _version: CommandLineFlagParameter;
+  private readonly _path: CommandLineFlagParameter;
+  private readonly _fullPath: CommandLineFlagParameter;
+  private readonly _jsonFlag: CommandLineFlagParameter;
+  private readonly _detailedFlag: CommandLineFlagParameter;
+  private readonly _selectionParameters: SelectionParameterSet;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -69,9 +69,7 @@ export class ListAction extends BaseRushAction {
       parser,
       safeForSimultaneousRushProcesses: true
     });
-  }
 
-  protected onDefineParameters(): void {
     this._version = this.defineFlagParameter({
       parameterLongName: '--version',
       parameterShortName: '-v',

--- a/libraries/rush-lib/src/cli/actions/PublishAction.ts
+++ b/libraries/rush-lib/src/cli/actions/PublishAction.ts
@@ -29,26 +29,26 @@ import { Utilities } from '../../utilities/Utilities';
 import { Git } from '../../logic/Git';
 
 export class PublishAction extends BaseRushAction {
-  private _addCommitDetails!: CommandLineFlagParameter;
-  private _apply!: CommandLineFlagParameter;
-  private _includeAll!: CommandLineFlagParameter;
-  private _npmAuthToken!: CommandLineStringParameter;
-  private _npmTag!: CommandLineStringParameter;
-  private _npmAccessLevel!: CommandLineChoiceParameter;
-  private _publish!: CommandLineFlagParameter;
-  private _regenerateChangelogs!: CommandLineFlagParameter;
-  private _registryUrl!: CommandLineStringParameter;
-  private _targetBranch!: CommandLineStringParameter;
-  private _prereleaseName!: CommandLineStringParameter;
-  private _partialPrerelease!: CommandLineFlagParameter;
-  private _suffix!: CommandLineStringParameter;
-  private _force!: CommandLineFlagParameter;
-  private _versionPolicy!: CommandLineStringParameter;
-  private _applyGitTagsOnPack!: CommandLineFlagParameter;
-  private _commitId!: CommandLineStringParameter;
-  private _releaseFolder!: CommandLineStringParameter;
-  private _pack!: CommandLineFlagParameter;
-  private _ignoreGitHooksParameter!: CommandLineFlagParameter;
+  private readonly _addCommitDetails: CommandLineFlagParameter;
+  private readonly _apply: CommandLineFlagParameter;
+  private readonly _includeAll: CommandLineFlagParameter;
+  private readonly _npmAuthToken: CommandLineStringParameter;
+  private readonly _npmTag: CommandLineStringParameter;
+  private readonly _npmAccessLevel: CommandLineChoiceParameter;
+  private readonly _publish: CommandLineFlagParameter;
+  private readonly _regenerateChangelogs: CommandLineFlagParameter;
+  private readonly _registryUrl: CommandLineStringParameter;
+  private readonly _targetBranch: CommandLineStringParameter;
+  private readonly _prereleaseName: CommandLineStringParameter;
+  private readonly _partialPrerelease: CommandLineFlagParameter;
+  private readonly _suffix: CommandLineStringParameter;
+  private readonly _force: CommandLineFlagParameter;
+  private readonly _versionPolicy: CommandLineStringParameter;
+  private readonly _applyGitTagsOnPack: CommandLineFlagParameter;
+  private readonly _commitId: CommandLineStringParameter;
+  private readonly _releaseFolder: CommandLineStringParameter;
+  private readonly _pack: CommandLineFlagParameter;
+  private readonly _ignoreGitHooksParameter: CommandLineFlagParameter;
 
   private _prereleaseToken!: PrereleaseToken;
   private _hotfixTagOverride!: string;
@@ -65,9 +65,7 @@ export class PublishAction extends BaseRushAction {
         'changes and publish packages, you must use the --commit flag and/or the --publish flag.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._apply = this.defineFlagParameter({
       parameterLongName: '--apply',
       parameterShortName: '-a',

--- a/libraries/rush-lib/src/cli/actions/PurgeAction.ts
+++ b/libraries/rush-lib/src/cli/actions/PurgeAction.ts
@@ -13,7 +13,7 @@ import { PurgeManager } from '../../logic/PurgeManager';
 import { UnlinkManager } from '../../logic/UnlinkManager';
 
 export class PurgeAction extends BaseRushAction {
-  private _unsafeParameter!: CommandLineFlagParameter;
+  private readonly _unsafeParameter: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -25,9 +25,7 @@ export class PurgeAction extends BaseRushAction {
         ' useful if you are having problems and suspect that cache files may be corrupt.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._unsafeParameter = this.defineFlagParameter({
       parameterLongName: '--unsafe',
       description:

--- a/libraries/rush-lib/src/cli/actions/RemoveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/RemoveAction.ts
@@ -3,6 +3,7 @@
 
 import * as os from 'os';
 import { ConsoleTerminalProvider, Terminal, ITerminal } from '@rushstack/node-core-library';
+import type { CommandLineFlagParameter, CommandLineStringListParameter } from '@rushstack/ts-command-line';
 
 import { BaseAddAndRemoveAction } from './BaseAddAndRemoveAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
@@ -11,6 +12,8 @@ import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
 
 export class RemoveAction extends BaseAddAndRemoveAction {
+  protected readonly _allFlag: CommandLineFlagParameter;
+  protected readonly _packageNameList: CommandLineStringListParameter;
   private _terminalProvider: ConsoleTerminalProvider;
   private _terminal: ITerminal;
 
@@ -28,9 +31,7 @@ export class RemoveAction extends BaseAddAndRemoveAction {
     });
     this._terminalProvider = new ConsoleTerminalProvider();
     this._terminal = new Terminal(this._terminalProvider);
-  }
 
-  public onDefineParameters(): void {
     this._packageNameList = this.defineStringListParameter({
       parameterLongName: '--package',
       parameterShortName: '-p',
@@ -44,7 +45,6 @@ export class RemoveAction extends BaseAddAndRemoveAction {
       parameterLongName: '--all',
       description: 'If specified, the dependency will be removed from all projects that declare it.'
     });
-    super.onDefineParameters();
   }
 
   public getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushRemoveOptions {

--- a/libraries/rush-lib/src/cli/actions/ScanAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ScanAction.ts
@@ -28,8 +28,8 @@ export interface IJsonOutput {
 }
 
 export class ScanAction extends BaseConfiglessRushAction {
-  private _jsonFlag!: CommandLineFlagParameter;
-  private _allFlag!: CommandLineFlagParameter;
+  private readonly _jsonFlag: CommandLineFlagParameter;
+  private readonly _allFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -49,9 +49,7 @@ export class ScanAction extends BaseConfiglessRushAction {
       safeForSimultaneousRushProcesses: true,
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._jsonFlag = this.defineFlagParameter({
       parameterLongName: '--json',
       description: 'If this flag is specified, output will be in JSON format.'

--- a/libraries/rush-lib/src/cli/actions/SetupAction.ts
+++ b/libraries/rush-lib/src/cli/actions/SetupAction.ts
@@ -20,10 +20,6 @@ export class SetupAction extends BaseRushAction {
     });
   }
 
-  protected onDefineParameters(): void {
-    // abstract
-  }
-
   protected async runAsync(): Promise<void> {
     const setupPackageRegistry: SetupPackageRegistry = new SetupPackageRegistry({
       rushConfiguration: this.rushConfiguration,

--- a/libraries/rush-lib/src/cli/actions/UnlinkAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UnlinkAction.ts
@@ -20,10 +20,6 @@ export class UnlinkAction extends BaseRushAction {
     });
   }
 
-  protected onDefineParameters(): void {
-    // No parameters
-  }
-
   protected async runAsync(): Promise<void> {
     const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
 

--- a/libraries/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAction.ts
@@ -8,8 +8,8 @@ import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 
 export class UpdateAction extends BaseInstallAction {
-  private _fullParameter!: CommandLineFlagParameter;
-  private _recheckParameter!: CommandLineFlagParameter;
+  private readonly _fullParameter: CommandLineFlagParameter;
+  private readonly _recheckParameter: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -30,10 +30,6 @@ export class UpdateAction extends BaseInstallAction {
         ' -- for details, see the command help for "rush install".',
       parser
     });
-  }
-
-  protected onDefineParameters(): void {
-    super.onDefineParameters();
 
     this._fullParameter = this.defineFlagParameter({
       parameterLongName: '--full',

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -8,7 +8,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class UpdateAutoinstallerAction extends BaseRushAction {
-  private _name!: CommandLineStringParameter;
+  private readonly _name: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -17,9 +17,7 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
       documentation: 'Use this command to regenerate the shrinkwrap file for an autoinstaller folder.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._name = this.defineStringParameter({
       parameterLongName: '--name',
       argumentName: 'AUTOINSTALLER_NAME',

--- a/libraries/rush-lib/src/cli/actions/UpdateCloudCredentialsAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateCloudCredentialsAction.ts
@@ -10,9 +10,9 @@ import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { RushConstants } from '../../logic/RushConstants';
 
 export class UpdateCloudCredentialsAction extends BaseRushAction {
-  private _interactiveModeFlag!: CommandLineFlagParameter;
-  private _credentialParameter!: CommandLineStringParameter;
-  private _deleteFlag!: CommandLineFlagParameter;
+  private readonly _interactiveModeFlag: CommandLineFlagParameter;
+  private readonly _credentialParameter: CommandLineStringParameter;
+  private readonly _deleteFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -24,9 +24,7 @@ export class UpdateCloudCredentialsAction extends BaseRushAction {
       safeForSimultaneousRushProcesses: false,
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._interactiveModeFlag = this.defineFlagParameter({
       parameterLongName: '--interactive',
       parameterShortName: '-i',

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -22,15 +22,15 @@ export const DEFAULT_PACKAGE_UPDATE_MESSAGE: string = 'Bump versions [skip ci]';
 export const DEFAULT_CHANGELOG_UPDATE_MESSAGE: string = 'Update changelogs [skip ci]';
 
 export class VersionAction extends BaseRushAction {
-  private _ensureVersionPolicy!: CommandLineFlagParameter;
-  private _overrideVersion!: CommandLineStringParameter;
-  private _bumpVersion!: CommandLineFlagParameter;
-  private _versionPolicy!: CommandLineStringParameter;
-  private _bypassPolicy!: CommandLineFlagParameter;
-  private _targetBranch!: CommandLineStringParameter;
-  private _overwriteBump!: CommandLineStringParameter;
-  private _prereleaseIdentifier!: CommandLineStringParameter;
-  private _ignoreGitHooksParameter!: CommandLineFlagParameter;
+  private readonly _ensureVersionPolicy: CommandLineFlagParameter;
+  private readonly _overrideVersion: CommandLineStringParameter;
+  private readonly _bumpVersion: CommandLineFlagParameter;
+  private readonly _versionPolicy: CommandLineStringParameter;
+  private readonly _bypassPolicy: CommandLineFlagParameter;
+  private readonly _targetBranch: CommandLineStringParameter;
+  private readonly _overwriteBump: CommandLineStringParameter;
+  private readonly _prereleaseIdentifier: CommandLineStringParameter;
+  private readonly _ignoreGitHooksParameter: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -39,9 +39,7 @@ export class VersionAction extends BaseRushAction {
       documentation: 'use this "rush version" command to ensure version policies and bump versions.',
       parser
     });
-  }
 
-  protected onDefineParameters(): void {
     this._targetBranch = this.defineStringParameter({
       parameterLongName: '--target-branch',
       parameterShortName: '-b',

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -81,6 +81,8 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
     } else {
       this._autoinstallerFullPath = '';
     }
+
+    this.defineScriptParameters();
   }
 
   private async _prepareAutoinstallerName(): Promise<void> {
@@ -162,10 +164,6 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
       console.log(os.EOL + colors.red(`The script failed with exit code ${exitCode}`));
       throw new AlreadyReportedError();
     }
-  }
-
-  protected onDefineParameters(): void {
-    this.defineScriptParameters();
   }
 
   private _expandShellCommandWithTokens(

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -479,10 +479,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
   }
 
-  protected onDefineParameters(): void {
-    // Handled in constructor
-  }
-
   /**
    * Runs a set of operations and reports the results.
    */

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -74,7 +74,7 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: add 1`] = `
-"usage: rush add [-h] -p PACKAGE [--exact] [--caret] [--dev] [-m] [--all] [-s]
+"usage: rush add [-h] [-s] -p PACKAGE [--exact] [--caret] [--dev] [-m] [--all]
 
 Adds specified package(s) to the dependencies of the current project (as 
 determined by the current working directory) and then runs \\"rush update\\". If 
@@ -88,6 +88,8 @@ packages with the dependency.
 
 Optional arguments:
   -h, --help            Show this help message and exit.
+  -s, --skip-update     If specified, the \\"rush update\\" command will not be 
+                        run after updating the package.json files.
   -p PACKAGE, --package PACKAGE
                         The name of the package which should be added as a 
                         dependency. A SemVer version specifier can be 
@@ -112,8 +114,6 @@ Optional arguments:
                         same version of the dependency.
   --all                 If specified, the dependency will be added to all 
                         projects.
-  -s, --skip-update     If specified, the \\"rush update\\" command will not be 
-                        run after updating the package.json files.
 "
 `;
 
@@ -1044,21 +1044,21 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: remove 1`] = `
-"usage: rush remove [-h] -p PACKAGE [--all] [-s]
+"usage: rush remove [-h] [-s] -p PACKAGE [--all]
 
 Removes specified package(s) from the dependencies of the current project (as 
 determined by the current working directory) and then runs \\"rush update\\".
 
 Optional arguments:
   -h, --help            Show this help message and exit.
+  -s, --skip-update     If specified, the \\"rush update\\" command will not be 
+                        run after updating the package.json files.
   -p PACKAGE, --package PACKAGE
                         The name of the package which should be removed. To 
                         remove multiple packages, run \\"rush remove --package 
                         foo --package bar\\".
   --all                 If specified, the dependency will be removed from all 
                         projects that declare it.
-  -s, --skip-update     If specified, the \\"rush update\\" command will not be 
-                        run after updating the package.json files.
 "
 `;
 

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -26,28 +26,36 @@ export enum CommandLineParameterKind {
 }
 
 /**
+ * Matches kebab-case formatted strings prefixed with double dashes.
+ * Example: "--do-something"
+ */
+const LONG_NAME_REGEXP: RegExp = /^-(-[a-z0-9]+)+$/;
+
+/**
+ * Matches a single upper-case or lower-case letter prefixed with a dash.
+ * Example: "-d"
+ */
+const SHORT_NAME_REGEXP: RegExp = /^-[a-zA-Z]$/;
+
+/**
+ * Matches kebab-case formatted strings
+ * Example: "my-scope"
+ */
+const SCOPE_REGEXP: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/**
+ * "Environment variable names used by the utilities in the Shell and Utilities volume of
+ * IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore)
+ * from the characters defined in Portable Character Set and do not begin with a digit."
+ * Example: "THE_SETTING"
+ */
+const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
+
+/**
  * The base class for the various command-line parameter types.
  * @public
  */
 export abstract class CommandLineParameter {
-  // Matches kebab-case formatted strings prefixed with double dashes.
-  // Example: "--do-something"
-  private static _longNameRegExp: RegExp = /^-(-[a-z0-9]+)+$/;
-
-  // Matches a single upper-case or lower-case letter prefixed with a dash.
-  // Example: "-d"
-  private static _shortNameRegExp: RegExp = /^-[a-zA-Z]$/;
-
-  // Matches kebab-case formatted strings
-  // Example: "my-scope"
-  private static _scopeRegExp: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-  // "Environment variable names used by the utilities in the Shell and Utilities volume of
-  // IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore)
-  // from the characters defined in Portable Character Set and do not begin with a digit."
-  // Example: "THE_SETTING"
-  private static _environmentVariableRegExp: RegExp = /^[A-Z_][A-Z0-9_]*$/;
-
   /**
    * A unique internal key used to retrieve the value from the parser's dictionary.
    * @internal
@@ -95,7 +103,7 @@ export abstract class CommandLineParameter {
     this.environmentVariable = definition.environmentVariable;
     this.undocumentedSynonyms = definition.undocumentedSynonyms;
 
-    if (!CommandLineParameter._longNameRegExp.test(this.longName)) {
+    if (!LONG_NAME_REGEXP.test(this.longName)) {
       throw new Error(
         `Invalid name: "${this.longName}". The parameter long name must be` +
           ` lower-case and use dash delimiters (e.g. "--do-a-thing")`
@@ -103,7 +111,7 @@ export abstract class CommandLineParameter {
     }
 
     if (this.shortName) {
-      if (!CommandLineParameter._shortNameRegExp.test(this.shortName)) {
+      if (!SHORT_NAME_REGEXP.test(this.shortName)) {
         throw new Error(
           `Invalid name: "${this.shortName}". The parameter short name must be` +
             ` a dash followed by a single upper-case or lower-case letter (e.g. "-a")`
@@ -112,13 +120,13 @@ export abstract class CommandLineParameter {
     }
 
     if (this.parameterScope) {
-      if (!CommandLineParameter._scopeRegExp.test(this.parameterScope)) {
+      if (!SCOPE_REGEXP.test(this.parameterScope)) {
         throw new Error(
           `Invalid scope: "${this.parameterScope}". The parameter scope name must be` +
             ` lower-case and use dash delimiters (e.g. "my-scope")`
         );
       }
-      // Parameter long name is guranteed to start with '--' since this is validated above
+      // Parameter long name is guaranteed to start with '--' since this is validated above
       const unprefixedLongName: string = this.longName.slice(2);
       this.scopedLongName = `--${this.parameterScope}:${unprefixedLongName}`;
     }
@@ -133,7 +141,7 @@ export abstract class CommandLineParameter {
         );
       }
 
-      if (!CommandLineParameter._environmentVariableRegExp.test(this.environmentVariable)) {
+      if (!ENVIRONMENT_VARIABLE_NAME_REGEXP.test(this.environmentVariable)) {
         throw new Error(
           `Invalid environment variable name: "${this.environmentVariable}". The name must` +
             ` consist only of upper-case letters, numbers, and underscores. It may not start with a number.`
@@ -148,7 +156,7 @@ export abstract class CommandLineParameter {
             `Invalid name: "${undocumentedSynonym}". Undocumented synonyms must not be the same` +
               ` as the the long name.`
           );
-        } else if (!CommandLineParameter._longNameRegExp.test(undocumentedSynonym)) {
+        } else if (!LONG_NAME_REGEXP.test(undocumentedSynonym)) {
           throw new Error(
             `Invalid name: "${undocumentedSynonym}". All undocumented synonyms name must be lower-case and ` +
               'use dash delimiters (e.g. "--do-a-thing")'

--- a/libraries/ts-command-line/src/providers/CommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineAction.ts
@@ -31,6 +31,11 @@ export interface ICommandLineActionOptions {
 }
 
 /**
+ * Example: "do-something"
+ */
+const ACTION_NAME_REGEXP: RegExp = /^[a-z][a-z0-9]*([-:][a-z0-9]+)*$/;
+
+/**
  * Represents a sub-command that is part of the CommandLineParser command line.
  * Applications should create subclasses of CommandLineAction corresponding to
  * each action that they want to expose.
@@ -44,9 +49,6 @@ export interface ICommandLineActionOptions {
  * @public
  */
 export abstract class CommandLineAction extends CommandLineParameterProvider {
-  // Example: "do-something"
-  private static _actionNameRegExp: RegExp = /^[a-z][a-z0-9]*([-:][a-z0-9]+)*$/;
-
   /** {@inheritDoc ICommandLineActionOptions.actionName} */
   public readonly actionName: string;
 
@@ -61,7 +63,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
   public constructor(options: ICommandLineActionOptions) {
     super();
 
-    if (!CommandLineAction._actionNameRegExp.test(options.actionName)) {
+    if (!ACTION_NAME_REGEXP.test(options.actionName)) {
       throw new Error(
         `Invalid action name "${options.actionName}". ` +
           `The name must be comprised of lower-case words optionally separated by hyphens or colons.`
@@ -85,7 +87,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
       description: this.documentation
     });
 
-    this.onDefineParameters();
+    this.onDefineParameters?.();
   }
 
   /**
@@ -117,11 +119,6 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 
     return this._argumentParser;
   }
-
-  /**
-   * {@inheritDoc CommandLineParameterProvider.onDefineParameters}
-   */
-  protected abstract onDefineParameters(): void;
 
   /**
    * Your subclass should implement this hook to perform the operation.

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -57,6 +57,11 @@ export interface ICommandLineParserData {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
+const SCOPE_GROUP_NAME: string = 'scope';
+const LONG_NAME_GROUP_NAME: string = 'longName';
+const POSSIBLY_SCOPED_LONG_NAME_REGEXP: RegExp =
+  /^--((?<scope>[a-z0-9]+(-[a-z0-9]+)*):)?(?<longName>[a-z0-9]+((-[a-z0-9]+)+)?)$/;
+
 /**
  * This is the common base class for CommandLineAction and CommandLineParser
  * that provides functionality for defining command-line parameters.
@@ -64,15 +69,14 @@ export interface ICommandLineParserData {
  * @public
  */
 export abstract class CommandLineParameterProvider {
-  private static readonly _scopeGroupName: string = 'scope';
-  private static readonly _longNameGroupName: string = 'longName';
-  private static readonly _possiblyScopedLongNameRegex: RegExp =
-    /^--((?<scope>[a-z0-9]+(-[a-z0-9]+)*):)?(?<longName>[a-z0-9]+((-[a-z0-9]+)+)?)$/;
   private static _keyCounter: number = 0;
 
-  private _parameters: CommandLineParameter[];
-  private _parametersByLongName: Map<string, CommandLineParameter[]>;
-  private _parameterGroupsByName: Map<string | typeof SCOPING_PARAMETER_GROUP, argparse.ArgumentGroup>;
+  private readonly _parameters: CommandLineParameter[];
+  private readonly _parametersByLongName: Map<string, CommandLineParameter[]>;
+  private readonly _parameterGroupsByName: Map<
+    string | typeof SCOPING_PARAMETER_GROUP,
+    argparse.ArgumentGroup
+  >;
   private _parametersRegistered: boolean;
   private _parametersProcessed: boolean;
   private _remainder: CommandLineRemainder | undefined;
@@ -384,14 +388,13 @@ export abstract class CommandLineParameterProvider {
    * Returns an object with the parsed scope (if present) and the long name of the parameter.
    */
   public parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult {
-    const result: RegExpExecArray | null =
-      CommandLineParameterProvider._possiblyScopedLongNameRegex.exec(scopedLongName);
+    const result: RegExpExecArray | null = POSSIBLY_SCOPED_LONG_NAME_REGEXP.exec(scopedLongName);
     if (!result || !result.groups) {
       throw new Error(`The parameter long name "${scopedLongName}" is not valid.`);
     }
     return {
-      longName: `--${result.groups[CommandLineParameterProvider._longNameGroupName]}`,
-      scope: result.groups[CommandLineParameterProvider._scopeGroupName]
+      longName: `--${result.groups[LONG_NAME_GROUP_NAME]}`,
+      scope: result.groups[SCOPE_GROUP_NAME]
     };
   }
 
@@ -433,7 +436,7 @@ export abstract class CommandLineParameterProvider {
    * The child class should implement this hook to define its command-line parameters,
    * e.g. by calling defineFlagParameter().
    */
-  protected abstract onDefineParameters(): void;
+  protected onDefineParameters?(): void;
 
   /**
    * Retrieves the argparse object.

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -54,11 +54,11 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
    */
   public selectedAction: CommandLineAction | undefined;
 
-  private _argumentParser: argparse.ArgumentParser;
+  private readonly _argumentParser: argparse.ArgumentParser;
   private _actionsSubParser: argparse.SubParser | undefined;
-  private _options: ICommandLineParserOptions;
-  private _actions: CommandLineAction[];
-  private _actionsByName: Map<string, CommandLineAction>;
+  private readonly _options: ICommandLineParserOptions;
+  private readonly _actions: CommandLineAction[];
+  private readonly _actionsByName: Map<string, CommandLineAction>;
   private _executed: boolean = false;
   private _tabCompleteActionWasAdded: boolean = false;
 
@@ -79,7 +79,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
       )
     });
 
-    this.onDefineParameters();
+    this.onDefineParameters?.();
   }
 
   /**

--- a/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
@@ -7,11 +7,6 @@ import { CommandLineAction } from './CommandLineAction';
  * @public
  */
 export class DynamicCommandLineAction extends CommandLineAction {
-  protected onDefineParameters(): void {
-    // abstract
-    // (handled by the external code)
-  }
-
   protected async onExecute(): Promise<void> {
     // abstract
     // (handled by the external code)

--- a/libraries/ts-command-line/src/providers/DynamicCommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/DynamicCommandLineParser.ts
@@ -6,8 +6,4 @@ import { CommandLineParser } from './CommandLineParser';
 /**
  * @public
  */
-export class DynamicCommandLineParser extends CommandLineParser {
-  protected onDefineParameters(): void {
-    // abstract
-  }
-}
+export class DynamicCommandLineParser extends CommandLineParser {}

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -20,7 +20,7 @@ interface IInternalScopedCommandLineParserOptions extends ICommandLineParserOpti
  */
 class InternalScopedCommandLineParser extends CommandLineParser {
   private _canExecute: boolean;
-  private _internalOptions: IInternalScopedCommandLineParserOptions;
+  private readonly _internalOptions: IInternalScopedCommandLineParserOptions;
 
   public get canExecute(): boolean {
     return this._canExecute;
@@ -45,10 +45,6 @@ class InternalScopedCommandLineParser extends CommandLineParser {
     this._canExecute = false;
     this._internalOptions = options;
     this._internalOptions.onDefineScopedParameters(this);
-  }
-
-  protected onDefineParameters(): void {
-    // No-op. Parameters are manually defined in the constructor.
   }
 
   protected async onExecute(): Promise<void> {

--- a/libraries/ts-command-line/src/providers/TabCompletionAction.ts
+++ b/libraries/ts-command-line/src/providers/TabCompletionAction.ts
@@ -18,8 +18,8 @@ const DEFAULT_WORD_TO_AUTOCOMPLETE: string = '';
 const DEFAULT_POSITION: number = 0;
 
 export class TabCompleteAction extends CommandLineAction {
-  private _wordToCompleteParameter!: CommandLineStringParameter;
-  private _positionParameter!: CommandLineIntegerParameter;
+  private readonly _wordToCompleteParameter: CommandLineStringParameter;
+  private readonly _positionParameter: CommandLineIntegerParameter;
   private readonly _actions: Map<string, Map<string, CommandLineParameter>>;
   private readonly _globalParameters: Map<string, CommandLineParameter>;
 
@@ -55,9 +55,7 @@ export class TabCompleteAction extends CommandLineAction {
         this._globalParameters.set(parameter.shortName, parameter);
       }
     }
-  }
 
-  protected onDefineParameters(): void {
     this._wordToCompleteParameter = this.defineStringParameter({
       parameterLongName: '--word',
       argumentName: 'WORD',

--- a/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
@@ -107,10 +107,6 @@ class BrokenTestCommandLine extends CommandLineParser {
 
     this.addAction(new BrokenTestAction());
   }
-
-  protected onDefineParameters(): void {
-    // no parameters
-  }
 }
 
 describe(`Conflicting ${CommandLineParser.name}`, () => {

--- a/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
@@ -66,10 +66,6 @@ class TestCommandLine extends CommandLineParser {
 
     this.addAction(new TestScopedAction());
   }
-
-  protected onDefineParameters(): void {
-    // no parameters
-  }
 }
 
 describe(CommandLineParser.name, () => {

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -15,8 +15,6 @@ export class BumpCyclicsAction extends CommandLineAction {
     });
   }
 
-  protected onDefineParameters(): void {}
-
   protected async onExecute(): Promise<void> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromDefaultLocation({

--- a/repo-scripts/repo-toolbox/src/ReadmeAction.ts
+++ b/repo-scripts/repo-toolbox/src/ReadmeAction.ts
@@ -21,13 +21,19 @@ const GENERATED_PROJECT_SUMMARY_START_COMMENT_TEXT: string = '<!-- GENERATED PRO
 const GENERATED_PROJECT_SUMMARY_END_COMMENT_TEXT: string = '<!-- GENERATED PROJECT SUMMARY END -->';
 
 export class ReadmeAction extends CommandLineAction {
-  private _verifyParameter!: CommandLineFlagParameter;
+  private readonly _verifyParameter: CommandLineFlagParameter;
 
   public constructor() {
     super({
       actionName: 'readme',
       summary: 'Generates README.md project table based on rush.json inventory',
       documentation: "Use this to update the repo's README.md"
+    });
+
+    this._verifyParameter = this.defineFlagParameter({
+      parameterLongName: '--verify',
+      parameterShortName: '-v',
+      description: 'Verify that the README.md file is up-to-date.'
     });
   }
 
@@ -190,13 +196,5 @@ export class ReadmeAction extends CommandLineAction {
     } else {
       console.log(`The README.md is up to date.`);
     }
-  }
-
-  protected onDefineParameters(): void {
-    this._verifyParameter = this.defineFlagParameter({
-      parameterLongName: '--verify',
-      parameterShortName: '-v',
-      description: 'Verify that the README.md file is up-to-date.'
-    });
   }
 }

--- a/repo-scripts/repo-toolbox/src/RecordVersionsAction.ts
+++ b/repo-scripts/repo-toolbox/src/RecordVersionsAction.ts
@@ -7,7 +7,7 @@ import { RushConfiguration } from '@microsoft/rush-lib';
 import { CommandLineAction, CommandLineStringParameter } from '@rushstack/ts-command-line';
 
 export class RecordVersionsAction extends CommandLineAction {
-  private _outFilePath!: CommandLineStringParameter;
+  private readonly _outFilePath: CommandLineStringParameter;
 
   public constructor() {
     super({
@@ -15,9 +15,7 @@ export class RecordVersionsAction extends CommandLineAction {
       summary: 'Generates a JSON file recording the version numbers of all published packages.',
       documentation: ''
     });
-  }
 
-  protected onDefineParameters(): void {
     this._outFilePath = this.defineStringParameter({
       parameterLongName: '--out-file',
       parameterShortName: '-o',

--- a/repo-scripts/repo-toolbox/src/ToolboxCommandLine.ts
+++ b/repo-scripts/repo-toolbox/src/ToolboxCommandLine.ts
@@ -18,13 +18,4 @@ export class ToolboxCommandLine extends CommandLineParser {
     this.addAction(new RecordVersionsAction());
     this.addAction(new BumpCyclicsAction());
   }
-
-  protected onDefineParameters(): void {
-    // abstract
-  }
-
-  protected onExecute(): Promise<void> {
-    // override
-    return super.onExecute();
-  }
 }


### PR DESCRIPTION
## Summary

This PR makes the `onDefineParameters` function in `CommandLineAction` and `CommandLineParser`. That function is called by the base classes' constructors, which means that parameters can be defined in subclasses' constructors. Defining parameters in subclasses constructors is beneficial because it eliminates the need for non-null assertions on the parameter properties.

In the future, I think we should deprecate and then remove `onDefineParameters` in favor of always defining parameters in constructors.

This PR also moves parameter definition to the constructors in our 1st-party tools. Most test projects still use the old design.

## How it was tested

Building the repo tests this functionality.