### PR TITLE
[rush] Refactor @rushstack/rush-azure-storage-build-cache-plugin to expose an API for generating and caching Azure credentials for other workloads, in addition to Storage.

### DIFF
--- a/common/changes/@microsoft/rush/rush-azure-storage-plugin-refactor_2022-10-17-21-12.json
+++ b/common/changes/@microsoft/rush/rush-azure-storage-plugin-refactor_2022-10-17-21-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Refactor @rushstack/rush-azure-storage-build-cache-plugin to expose an API for generating and caching Azure credentials for other workloads, in addition to Storage.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -5,46 +5,83 @@
 ```ts
 
 import { AzureAuthorityHosts } from '@azure/identity';
+import { DeviceCodeCredential } from '@azure/identity';
 import type { IRushPlugin } from '@rushstack/rush-sdk';
 import type { ITerminal } from '@rushstack/node-core-library';
 import type { RushConfiguration } from '@rushstack/rush-sdk';
 import type { RushSession } from '@rushstack/rush-sdk';
 
 // @public (undocumented)
-export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
-
-// @public (undocumented)
-export class AzureStorageAuthentication {
-    constructor(options: IAzureStorageAuthenticationOptions);
+export abstract class AzureAuthenticationBase {
+    constructor(options: IAzureAuthenticationBaseOptions);
     // (undocumented)
     protected readonly _azureEnvironment: AzureEnvironmentName;
     // (undocumented)
+    protected abstract readonly _credentialKindForLogging: string;
+    // (undocumented)
+    protected abstract readonly _credentialNameForCache: string;
+    // (undocumented)
+    protected abstract readonly _credentialUpdateCommandForLogging: string | undefined;
+    // (undocumented)
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
+    protected abstract _getCacheIdParts(): string[];
     // (undocumented)
-    protected readonly _isCacheWriteAllowedByConfiguration: boolean;
+    protected abstract _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
     // (undocumented)
-    protected readonly _storageAccountName: string;
-    // (undocumented)
-    protected get _storageAccountUrl(): string;
-    // (undocumented)
-    protected readonly _storageContainerName: string;
-    // (undocumented)
-    tryGetCachedCredentialAsync(): Promise<string | undefined>;
+    tryGetCachedCredentialAsync(doNotThrowIfExpired?: boolean): Promise<string | undefined>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
     updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresAfter?: Date): Promise<void>;
 }
 
 // @public (undocumented)
-export interface IAzureStorageAuthenticationOptions {
+export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
+
+// @public (undocumented)
+export class AzureStorageAuthentication extends AzureAuthenticationBase {
+    constructor(options: IAzureStorageAuthenticationOptions);
+    // (undocumented)
+    protected readonly _credentialKindForLogging: string;
+    // (undocumented)
+    protected readonly _credentialNameForCache: string;
+    // (undocumented)
+    protected readonly _credentialUpdateCommandForLogging: string;
+    // (undocumented)
+    protected _getCacheIdParts(): string[];
+    // (undocumented)
+    protected _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
+    // (undocumented)
+    protected readonly _isCacheWriteAllowedByConfiguration: boolean;
+    // (undocumented)
+    protected readonly _storageAccountName: string;
+    // (undocumented)
+    protected readonly _storageAccountUrl: string;
+    // (undocumented)
+    protected readonly _storageContainerName: string;
+}
+
+// @public (undocumented)
+export interface IAzureAuthenticationBaseOptions {
     // (undocumented)
     azureEnvironment?: AzureEnvironmentName;
+}
+
+// @public (undocumented)
+export interface IAzureStorageAuthenticationOptions extends IAzureAuthenticationBaseOptions {
     // (undocumented)
     isCacheWriteAllowed: boolean;
     // (undocumented)
     storageAccountName: string;
     // (undocumented)
     storageContainerName: string;
+}
+
+// @public (undocumented)
+export interface ICredentialResult {
+    // (undocumented)
+    credentialString: string;
+    // (undocumented)
+    expiresOn: Date | undefined;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { DeviceCodeCredential, type DeviceCodeInfo, AzureAuthorityHosts } from '@azure/identity';
+import type { ITerminal } from '@rushstack/node-core-library';
+import { CredentialCache, type ICredentialCacheEntry } from '@rushstack/rush-sdk';
+import { PrintUtilities } from '@rushstack/terminal';
+
+/**
+ * @public
+ */
+export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
+
+/**
+ * @public
+ */
+export interface IAzureAuthenticationBaseOptions {
+  azureEnvironment?: AzureEnvironmentName;
+}
+
+/**
+ * @public
+ */ export interface ICredentialResult {
+  credentialString: string;
+  expiresOn: Date | undefined;
+}
+
+/**
+ * @public
+ */
+export abstract class AzureAuthenticationBase {
+  protected abstract readonly _credentialNameForCache: string;
+  protected abstract readonly _credentialKindForLogging: string;
+  protected abstract readonly _credentialUpdateCommandForLogging: string | undefined;
+
+  protected readonly _azureEnvironment: AzureEnvironmentName;
+
+  private __credentialCacheId: string | undefined;
+  private get _credentialCacheId(): string {
+    if (!this.__credentialCacheId) {
+      const cacheIdParts: string[] = [
+        this._credentialNameForCache,
+        this._azureEnvironment,
+        ...this._getCacheIdParts()
+      ];
+
+      this.__credentialCacheId = cacheIdParts.join('|');
+    }
+
+    return this.__credentialCacheId;
+  }
+
+  public constructor(options: IAzureAuthenticationBaseOptions) {
+    this._azureEnvironment = options.azureEnvironment || 'AzurePublicCloud';
+  }
+
+  public async updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void> {
+    await CredentialCache.usingAsync(
+      {
+        supportEditing: true
+      },
+      async (credentialsCache: CredentialCache) => {
+        credentialsCache.setCacheEntry(this._credentialCacheId, credential);
+        await credentialsCache.saveIfModifiedAsync();
+      }
+    );
+  }
+
+  /**
+   * Launches an interactive flow to renew a cached credential.
+   *
+   * @param terminal - The terminal to log output to
+   * @param onlyIfExistingCredentialExpiresAfter - If specified, and a cached credential exists that is still valid
+   * after the date specified, no action will be taken.
+   */
+  public async updateCachedCredentialInteractiveAsync(
+    terminal: ITerminal,
+    onlyIfExistingCredentialExpiresAfter?: Date
+  ): Promise<void> {
+    await CredentialCache.usingAsync(
+      {
+        supportEditing: true
+      },
+      async (credentialsCache: CredentialCache) => {
+        if (onlyIfExistingCredentialExpiresAfter) {
+          const existingCredentialExpiration: Date | undefined = credentialsCache.tryGetCacheEntry(
+            this._credentialCacheId
+          )?.expires;
+          if (
+            existingCredentialExpiration &&
+            existingCredentialExpiration > onlyIfExistingCredentialExpiresAfter
+          ) {
+            return;
+          }
+        }
+
+        const credential: ICredentialResult = await this._getCredentialAsync(terminal);
+        credentialsCache.setCacheEntry(
+          this._credentialCacheId,
+          credential.credentialString,
+          credential.expiresOn
+        );
+        await credentialsCache.saveIfModifiedAsync();
+      }
+    );
+  }
+
+  public async deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void> {
+    await CredentialCache.usingAsync(
+      {
+        supportEditing: true
+      },
+      async (credentialsCache: CredentialCache) => {
+        credentialsCache.deleteCacheEntry(this._credentialCacheId);
+        await credentialsCache.saveIfModifiedAsync();
+      }
+    );
+  }
+
+  public async tryGetCachedCredentialAsync(doNotThrowIfExpired?: boolean): Promise<string | undefined> {
+    let cacheEntry: ICredentialCacheEntry | undefined;
+    await CredentialCache.usingAsync(
+      {
+        supportEditing: false
+      },
+      (credentialsCache: CredentialCache) => {
+        cacheEntry = credentialsCache.tryGetCacheEntry(this._credentialCacheId);
+      }
+    );
+
+    const expirationTime: number | undefined = cacheEntry?.expires?.getTime();
+    if (expirationTime && expirationTime < Date.now()) {
+      if (!doNotThrowIfExpired) {
+        let errorMessage: string = `Cached Azure ${this._credentialKindForLogging} credentials have expired.`;
+        if (this._credentialUpdateCommandForLogging) {
+          errorMessage += ` Update the credentials by running "${this._credentialUpdateCommandForLogging}".`;
+        }
+
+        throw new Error(errorMessage);
+      } else {
+        return undefined;
+      }
+    } else {
+      return cacheEntry?.credential;
+    }
+  }
+
+  /**
+   * Get parts of the cache ID that are specific to the credential type. Note that this should
+   * not contain the Azure environment or the {@link AzureAuthenticationBase._credentialNameForCache}
+   * value, as those are added automatically.
+   */
+  protected abstract _getCacheIdParts(): string[];
+
+  protected abstract _getCredentialFromDeviceCodeAsync(
+    terminal: ITerminal,
+    deviceCodeCredential: DeviceCodeCredential
+  ): Promise<ICredentialResult>;
+
+  private async _getCredentialAsync(terminal: ITerminal): Promise<ICredentialResult> {
+    const authorityHost: string | undefined = AzureAuthorityHosts[this._azureEnvironment];
+    if (!authorityHost) {
+      throw new Error(`Unexpected Azure environment: ${this._azureEnvironment}`);
+    }
+
+    const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential({
+      authorityHost: authorityHost,
+      userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
+        PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
+      }
+    });
+
+    return await this._getCredentialFromDeviceCodeAsync(terminal, deviceCodeCredential);
+  }
+}

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -1,30 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { DeviceCodeCredential, DeviceCodeInfo, AzureAuthorityHosts } from '@azure/identity';
+import type { DeviceCodeCredential } from '@azure/identity';
 import {
   BlobServiceClient,
   ContainerSASPermissions,
   generateBlobSASQueryParameters,
-  SASQueryParameters,
-  ServiceGetUserDelegationKeyResponse
+  type SASQueryParameters,
+  type ServiceGetUserDelegationKeyResponse
 } from '@azure/storage-blob';
 import type { ITerminal } from '@rushstack/node-core-library';
-import { CredentialCache, ICredentialCacheEntry, RushConstants } from '@rushstack/rush-sdk';
-import { PrintUtilities } from '@rushstack/terminal';
+import { RushConstants } from '@rushstack/rush-sdk';
+import {
+  AzureAuthenticationBase,
+  type ICredentialResult,
+  type IAzureAuthenticationBaseOptions
+} from './AzureAuthenticationBase';
 
 /**
  * @public
  */
-export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
-
-/**
- * @public
- */
-export interface IAzureStorageAuthenticationOptions {
+export interface IAzureStorageAuthenticationOptions extends IAzureAuthenticationBaseOptions {
   storageContainerName: string;
   storageAccountName: string;
-  azureEnvironment?: AzureEnvironmentName;
   isCacheWriteAllowed: boolean;
 }
 
@@ -33,138 +31,38 @@ const SAS_TTL_MILLISECONDS: number = 7 * 24 * 60 * 60 * 1000; // Seven days
 /**
  * @public
  */
-export class AzureStorageAuthentication {
-  protected readonly _azureEnvironment: AzureEnvironmentName;
+export class AzureStorageAuthentication extends AzureAuthenticationBase {
+  protected readonly _credentialNameForCache: string = 'azure-blob-storage';
+  protected readonly _credentialKindForLogging: string = 'Storage';
+  protected readonly _credentialUpdateCommandForLogging: string = `rush ${RushConstants.updateCloudCredentialsCommandName}`;
+
   protected readonly _storageAccountName: string;
   protected readonly _storageContainerName: string;
   protected readonly _isCacheWriteAllowedByConfiguration: boolean;
-
-  private __credentialCacheId: string | undefined;
-  private get _credentialCacheId(): string {
-    if (!this.__credentialCacheId) {
-      const cacheIdParts: string[] = [
-        'azure-blob-storage',
-        this._azureEnvironment,
-        this._storageAccountName,
-        this._storageContainerName
-      ];
-
-      if (this._isCacheWriteAllowedByConfiguration) {
-        cacheIdParts.push('cacheWriteAllowed');
-      }
-
-      this.__credentialCacheId = cacheIdParts.join('|');
-    }
-
-    return this.__credentialCacheId;
-  }
-
-  protected get _storageAccountUrl(): string {
-    return `https://${this._storageAccountName}.blob.core.windows.net/`;
-  }
+  protected readonly _storageAccountUrl: string;
 
   public constructor(options: IAzureStorageAuthenticationOptions) {
+    super(options);
     this._storageAccountName = options.storageAccountName;
     this._storageContainerName = options.storageContainerName;
-    this._azureEnvironment = options.azureEnvironment || 'AzurePublicCloud';
     this._isCacheWriteAllowedByConfiguration = options.isCacheWriteAllowed;
+    this._storageAccountUrl = `https://${this._storageAccountName}.blob.core.windows.net/`;
   }
 
-  public async updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void> {
-    await CredentialCache.usingAsync(
-      {
-        supportEditing: true
-      },
-      async (credentialsCache: CredentialCache) => {
-        credentialsCache.setCacheEntry(this._credentialCacheId, credential);
-        await credentialsCache.saveIfModifiedAsync();
-      }
-    );
+  protected _getCacheIdParts(): string[] {
+    const cacheIdParts: string[] = [this._storageAccountName, this._storageContainerName];
+
+    if (this._isCacheWriteAllowedByConfiguration) {
+      cacheIdParts.push('cacheWriteAllowed');
+    }
+
+    return cacheIdParts;
   }
 
-  /**
-   * Launches an interactive flow to renew a cached credential.
-   *
-   * @param terminal - The terminal to log output to
-   * @param onlyIfExistingCredentialExpiresAfter - If specified, and a cached credential exists that is still valid
-   * after the date specified, no action will be taken.
-   */
-  public async updateCachedCredentialInteractiveAsync(
+  protected async _getCredentialFromDeviceCodeAsync(
     terminal: ITerminal,
-    onlyIfExistingCredentialExpiresAfter?: Date
-  ): Promise<void> {
-    await CredentialCache.usingAsync(
-      {
-        supportEditing: true
-      },
-      async (credentialsCache: CredentialCache) => {
-        if (onlyIfExistingCredentialExpiresAfter) {
-          const existingCredentialExpiration: Date | undefined = credentialsCache.tryGetCacheEntry(
-            this._credentialCacheId
-          )?.expires;
-          if (
-            existingCredentialExpiration &&
-            existingCredentialExpiration > onlyIfExistingCredentialExpiresAfter
-          ) {
-            return;
-          }
-        }
-
-        const sasQueryParameters: SASQueryParameters = await this._getSasQueryParametersAsync(terminal);
-        const sasString: string = sasQueryParameters.toString();
-
-        credentialsCache.setCacheEntry(this._credentialCacheId, sasString, sasQueryParameters.expiresOn);
-        await credentialsCache.saveIfModifiedAsync();
-      }
-    );
-  }
-
-  public async deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void> {
-    await CredentialCache.usingAsync(
-      {
-        supportEditing: true
-      },
-      async (credentialsCache: CredentialCache) => {
-        credentialsCache.deleteCacheEntry(this._credentialCacheId);
-        await credentialsCache.saveIfModifiedAsync();
-      }
-    );
-  }
-
-  public async tryGetCachedCredentialAsync(): Promise<string | undefined> {
-    let cacheEntry: ICredentialCacheEntry | undefined;
-    await CredentialCache.usingAsync(
-      {
-        supportEditing: false
-      },
-      (credentialsCache: CredentialCache) => {
-        cacheEntry = credentialsCache.tryGetCacheEntry(this._credentialCacheId);
-      }
-    );
-
-    const expirationTime: number | undefined = cacheEntry?.expires?.getTime();
-    if (expirationTime && expirationTime < Date.now()) {
-      throw new Error(
-        'Cached Azure Storage credentials have expired. ' +
-          `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}".`
-      );
-    } else {
-      return cacheEntry?.credential;
-    }
-  }
-
-  private async _getSasQueryParametersAsync(terminal: ITerminal): Promise<SASQueryParameters> {
-    const authorityHost: string | undefined = AzureAuthorityHosts[this._azureEnvironment];
-    if (!authorityHost) {
-      throw new Error(`Unexpected Azure environment: ${this._azureEnvironment}`);
-    }
-
-    const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential({
-      authorityHost: authorityHost,
-      userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
-        PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
-      }
-    });
+    deviceCodeCredential: DeviceCodeCredential
+  ): Promise<ICredentialResult> {
     const blobServiceClient: BlobServiceClient = new BlobServiceClient(
       this._storageAccountUrl,
       deviceCodeCredential
@@ -192,6 +90,9 @@ export class AzureStorageAuthentication {
       this._storageAccountName
     );
 
-    return queryParameters;
+    return {
+      credentialString: queryParameters.toString(),
+      expiresOn: queryParameters.expiresOn
+    };
   }
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IRushPlugin, RushSession, RushConfiguration, ILogger } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentName } from './AzureStorageAuthentication';
+import type { AzureEnvironmentName } from './AzureAuthenticationBase';
 
 const PLUGIN_NAME: 'AzureInteractiveAuthPlugin' = 'AzureInteractiveAuthPlugin';
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
@@ -3,7 +3,7 @@
 
 import { Import } from '@rushstack/node-core-library';
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentName } from './AzureStorageAuthentication';
+import type { AzureEnvironmentName } from './AzureAuthenticationBase';
 
 const AzureStorageBuildCacheProviderModule: typeof import('./AzureStorageBuildCacheProvider') = Import.lazy(
   './AzureStorageBuildCacheProvider',

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
@@ -3,9 +3,14 @@
 
 import { RushAzureStorageBuildCachePlugin } from './RushAzureStorageBuildCachePlugin';
 export {
+  AzureAuthenticationBase,
+  type IAzureAuthenticationBaseOptions,
+  type ICredentialResult,
+  type AzureEnvironmentName
+} from './AzureAuthenticationBase';
+export {
   AzureStorageAuthentication,
-  IAzureStorageAuthenticationOptions,
-  AzureEnvironmentName
+  type IAzureStorageAuthenticationOptions
 } from './AzureStorageAuthentication';
 
 export default RushAzureStorageBuildCachePlugin;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/test/AzureStorageBuildCacheProvider.test.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/test/AzureStorageBuildCacheProvider.test.ts
@@ -5,7 +5,7 @@ import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-lib
 import { CredentialCache, EnvironmentConfiguration, RushUserConfiguration } from '@rushstack/rush-sdk';
 
 import { AzureStorageBuildCacheProvider } from '../AzureStorageBuildCacheProvider';
-import type { AzureEnvironmentName } from '../AzureStorageAuthentication';
+import type { AzureEnvironmentName } from '../AzureAuthenticationBase';
 
 describe(AzureStorageBuildCacheProvider.name, () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

This PR exposes a class called `AzureAuthenticationBase` from `@rushstack/rush-azure-storage-build-cache-plugin` that moves the non-Storage-specific code into its own base class, to allow a consumer to interact with the Rush credential cache for a different Azure workload.

## How it was tested

- [x] `rush build` in a project with a non-authenticated read-only Azure cache.
- [x] `rush build` in a project with an authenticated read/write Azure cache.
- [x] `rush build` in a project with an authenticated read-only Azure cache.