### PR TITLE
[@rushstack/rush-serve-plugin] Apply specific headers when serving web bundles

### DIFF
--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -91,9 +91,14 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
 
       const fileRoutingRules: Map<string, IRoutingRule> = new Map();
 
+      const wbnRegex = /\.wbn$/i;
       function setHeaders(response: express.Response, path?: string, stat?: unknown): void {
         response.set('Access-Control-Allow-Origin', '*');
         response.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        if (path && wbnRegex.test(path)) {
+          response.set('X-Content-Type-Options', 'nosniff');
+          response.set('Content-Type', 'application/webbundle');
+        }
       }
 
       for (const rule of routingRules) {


### PR DESCRIPTION
## Summary

In order to serve web bundles from `rush start`, we need to apply specific headers to the web bundle responses.

## Details

The two required headers in question are:

```
X-Content-Type-Options: nosniff
Content-Type: application/webbundle
```

You can see them defined in [the web bundles specification](https://www.ietf.org/archive/id/draft-yasskin-wpack-bundled-exchanges-04.html#name-serving-constraints).

This change applies the appropriate headers to any files with the `.wbn` extension, which is unlikely to clash with any other files. We could also consider a separate approach making this option configurable, but for now it is hard-coded since it is a very scoped requirement.

## How it was tested

TODO
