### PR TITLE
Rush: allow customFields in change files and change logs

### DIFF
--- a/common/changes/@microsoft/rush/enelson-customfields_2022-10-24-00-56.json
+++ b/common/changes/@microsoft/rush/enelson-customfields_2022-10-24-00-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Change files and change logs can store custom fields.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/ChangeManagement.ts
+++ b/libraries/rush-lib/src/api/ChangeManagement.ts
@@ -61,6 +61,11 @@ export interface IChangeInfo {
   comment?: string;
 
   /**
+   * An optional dictionary of custom string fields.
+   */
+  customFields?: Record<string, string>;
+
+  /**
    * The email of the user who provided the comment. Pulled from the Git log.
    */
   author?: string;

--- a/libraries/rush-lib/src/api/Changelog.ts
+++ b/libraries/rush-lib/src/api/Changelog.ts
@@ -78,4 +78,9 @@ export interface IChangeLogComment {
    * The commit, if applicable, including the change request.
    */
   commit?: string;
+
+  /**
+   * An optional dictionary of custom string fields.
+   */
+  customFields?: Record<string, string>;
 }

--- a/libraries/rush-lib/src/logic/ChangelogGenerator.ts
+++ b/libraries/rush-lib/src/logic/ChangelogGenerator.ts
@@ -135,6 +135,9 @@ export class ChangelogGenerator {
           if (individualChange.commit) {
             changeLogComment.commit = individualChange.commit;
           }
+          if (individualChange.customFields) {
+            changeLogComment.customFields = individualChange.customFields;
+          }
           comments.push(changeLogComment);
         }
       });

--- a/libraries/rush-lib/src/logic/test/ChangelogGenerator.test.ts
+++ b/libraries/rush-lib/src/logic/test/ChangelogGenerator.test.ts
@@ -120,6 +120,72 @@ describe(ChangelogGenerator.updateIndividualChangelog.name, () => {
     expect(actualResult).toEqual(expectedResult);
   });
 
+  it('translates custom fields from change files to change log', () => {
+    const actualResult: IChangelog = ChangelogGenerator.updateIndividualChangelog(
+      {
+        packageName: 'a',
+        newVersion: '1.0.0',
+        changeType: ChangeType.major,
+        changes: [
+          {
+            packageName: 'a',
+            type: 'major',
+            changeType: ChangeType.major,
+            comment: 'Patching a',
+            customFields: {
+              issueTicket: 'A-1053',
+              vendorTag: 'AAAAA'
+            }
+          }
+        ]
+      },
+      `${__dirname}/exampleChangelog`,
+      false,
+      rushConfiguration
+    )!;
+
+    const expectedResult: IChangelog = {
+      name: 'a',
+      entries: [
+        {
+          version: '1.0.0',
+          tag: 'a_v1.0.0',
+          date: '',
+          comments: {
+            major: [
+              {
+                author: undefined,
+                comment: 'Patching a',
+                commit: undefined,
+                customFields: {
+                  issueTicket: 'A-1053',
+                  vendorTag: 'AAAAA'
+                }
+              }
+            ]
+          }
+        },
+        {
+          version: '0.0.1',
+          tag: 'a_v0.0.1',
+          date: 'Wed, 30 Nov 2016 18:37:45 GMT',
+          comments: {
+            patch: [
+              {
+                comment: 'Patching a'
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    // Ignore comparing date.
+    expectedResult.entries[0].date = actualResult.entries[0].date;
+
+    expect(actualResult).toEqual(expectedResult);
+  });
+
   it('can avoid adding duplicate entries', () => {
     const actualResult: IChangelog = ChangelogGenerator.updateIndividualChangelog(
       {

--- a/libraries/rush-lib/src/schemas/change-file.schema.json
+++ b/libraries/rush-lib/src/schemas/change-file.schema.json
@@ -28,6 +28,15 @@
             "type": "string",
             "description": "The change type associated with the change.",
             "enum": ["none", "dependency", "hotfix", "patch", "minor", "major"]
+          },
+          "customFields": {
+            "type": "object",
+            "description": "An optional dictionary of custom string fields.",
+            "patternProperties": {
+              "^.*$": {
+                "type": "string"
+              }
+            }
           }
         }
       }

--- a/libraries/rush-lib/src/schemas/changelog.schema.json
+++ b/libraries/rush-lib/src/schemas/changelog.schema.json
@@ -37,6 +37,15 @@
         "commit": {
           "description": "The commit, if applicable, including the change request.",
           "type": "string"
+        },
+        "customFields": {
+          "type": "object",
+          "description": "An optional dictionary of custom string fields.",
+          "patternProperties": {
+            "^.*$": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

This is my suggested implementation of "custom field support" (related to https://github.com/microsoft/rushstack/issues/3707).

In this PR, base Rush allows custom fields in change files, and copies them over into generated changelogs. There's no way in base Rush to end up having these fields added _to_ your change files, but different programs could add them directly into the file, or a Rush plugin (not yet implemented) could inject them during `rush change`.

## Details

Pretty straightforward - schema updates, a couple new fields, and a line in the changelog generator. No changes needed to the `rush change` action as part of this PR.

## How it was tested

 - New unit test for changelog behavior
 - Ensured rush change still works properly (new customFields property is optional)

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
