### PR TITLE
[certificate-manager] Revise self-signed TLS certificate generation and usage

### DIFF
--- a/build-tests/heft-webpack5-everything-test/webpack.dev.config.js
+++ b/build-tests/heft-webpack5-everything-test/webpack.dev.config.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  mode: 'none',
+  module: {
+    rules: [
+      {
+        test: /\.png$/i,
+        type: 'asset/resource'
+      }
+    ]
+  },
+  target: ['web', 'es2020'],
+  resolve: {
+    extensions: ['.js', '.jsx', '.json']
+  },
+  entry: {
+    'heft-test-A': path.join(__dirname, 'lib', 'indexA.js'),
+    'heft-test-B': path.join(__dirname, 'lib', 'indexB.js')
+  },
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: '[name]_[contenthash].js',
+    chunkFilename: '[id].[name]_[contenthash].js',
+    assetModuleFilename: '[name]_[contenthash][ext][query]'
+  },
+  devtool: 'source-map',
+  optimization: {
+    minimize: false,
+    minimizer: []
+  },
+  plugins: [new HtmlWebpackPlugin()]
+};

--- a/common/changes/@rushstack/debug-certificate-manager/serve-cert-subjects_2022-10-04-22-25.json
+++ b/common/changes/@rushstack/debug-certificate-manager/serve-cert-subjects_2022-10-04-22-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Support custom certificate subjects and validity period.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/debug-certificate-manager/serve-cert-subjects_2022-10-24-21-40.json
+++ b/common/changes/@rushstack/debug-certificate-manager/serve-cert-subjects_2022-10-24-21-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Generate and trust a separate CA certificate, use that to generate the TLS certificate, then destroy the private key for the CA certificate.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/serve-cert-subjects_2022-10-13-23-30.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/serve-cert-subjects_2022-10-13-23-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "Set allowedHosts from the subjectAltNames of the TLS certificate.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack4-plugin/serve-cert-subjects_2022-10-24-22-29.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/serve-cert-subjects_2022-10-24-22-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Set web socket port to match http port.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack4-plugin/serve-cert-subjects_2022-10-24-22-29.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/serve-cert-subjects_2022-10-24-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-webpack4-plugin",
-      "comment": "Set web socket port to match http port.",
+      "comment": "Set WebSocket port to match http port.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft-webpack5-plugin/serve-cert-subjects_2022-10-24-22-29.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/serve-cert-subjects_2022-10-24-22-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Set web socket port to match http port.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/serve-cert-subjects_2022-10-24-22-29.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/serve-cert-subjects_2022-10-24-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-webpack5-plugin",
-      "comment": "Set web socket port to match http port.",
+      "comment": "Set WebSocket port to match http port.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-serve-plugin/serve-cert-subjects_2022-10-13-23-30.json
+++ b/common/changes/@rushstack/rush-serve-plugin/serve-cert-subjects_2022-10-13-23-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "Extract host name from active TLS certificate.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/common/reviews/api/debug-certificate-manager.api.md
+++ b/common/reviews/api/debug-certificate-manager.api.md
@@ -16,6 +16,9 @@ export class CertificateManager {
 // @public
 export class CertificateStore {
     constructor();
+    get caCertificateData(): string | undefined;
+    set caCertificateData(certificate: string | undefined);
+    get caCertificatePath(): string;
     get certificateData(): string | undefined;
     set certificateData(certificate: string | undefined);
     get certificatePath(): string;
@@ -28,6 +31,7 @@ export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string>;
 
 // @public
 export interface ICertificate {
+    pemCaCertificate: string | undefined;
     pemCertificate: string | undefined;
     pemKey: string | undefined;
     subjectAltNames: readonly string[] | undefined;

--- a/common/reviews/api/debug-certificate-manager.api.md
+++ b/common/reviews/api/debug-certificate-manager.api.md
@@ -9,7 +9,7 @@ import { ITerminal } from '@rushstack/node-core-library';
 // @public
 export class CertificateManager {
     constructor();
-    ensureCertificateAsync(canGenerateNewCertificate: boolean, terminal: ITerminal): Promise<ICertificate>;
+    ensureCertificateAsync(canGenerateNewCertificate: boolean, terminal: ITerminal, generationOptions?: ICertificateGenerationOptions): Promise<ICertificate>;
     untrustCertificateAsync(terminal: ITerminal): Promise<boolean>;
 }
 
@@ -24,9 +24,19 @@ export class CertificateStore {
 }
 
 // @public
+export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string>;
+
+// @public
 export interface ICertificate {
     pemCertificate: string | undefined;
     pemKey: string | undefined;
+    subjectAltNames: readonly string[] | undefined;
+}
+
+// @public
+export interface ICertificateGenerationOptions {
+    subjectAltNames?: ReadonlyArray<string>;
+    validityInDays?: number;
 }
 
 ```

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
@@ -163,7 +163,10 @@ export class WebpackPlugin implements IHeftPlugin {
           }
         },
         client: {
-          logging: 'info'
+          logging: 'info',
+          webSocketURL: {
+            port: 8080
+          }
         },
         port: 8080
       };

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -168,7 +168,10 @@ export class WebpackPlugin implements IHeftPlugin {
           }
         },
         client: {
-          logging: 'info'
+          logging: 'info',
+          webSocketURL: {
+            port: 8080
+          }
         },
         port: 8080
       };

--- a/libraries/debug-certificate-manager/src/index.ts
+++ b/libraries/debug-certificate-manager/src/index.ts
@@ -16,5 +16,10 @@
  * @packageDocumentation
  */
 
-export { ICertificate, CertificateManager } from './CertificateManager';
+export {
+  ICertificate,
+  CertificateManager,
+  ICertificateGenerationOptions,
+  DEFAULT_CERTIFICATE_SUBJECT_NAMES
+} from './CertificateManager';
 export { CertificateStore } from './CertificateStore';


### PR DESCRIPTION
## Summary
Changes the certificate manager to generate two certificates: a trusted CA certificate, and a separate TLS certificate signed by that trusted CA certificate.

Adds critical constraints to both the CA certificate and the TLS end entity certificate to restrict their usage to only the intended purposes.

Modifies the tools that consume the TLS certificates to extract the `subjectAltNames` extension and use the values contained within to set the allowed host fields for TLS servers.

## Details
The private key for the CA certificate gets deleted immediately after being used to sign the TLS certificate, to prevent the CA from being used to sign other certificates.

## How it was tested
Used the `heft-webpack5-everything-test` build test in serve mode.