### PR TITLE
[rush] Turn on build cache for heft-jest-plugin

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/enelson-heft-jest-cache_2022-10-30-12-13.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-heft-jest-cache_2022-10-30-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Enable build caching for heft-jest-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/enelson-heft-jest-cache_2022-10-30-12-13.json
+++ b/common/changes/@rushstack/heft-jest-plugin/enelson-heft-jest-cache_2022-10-30-12-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "Enable build caching for heft-jest-plugin",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/heft-plugins/heft-jest-plugin/config/rush-project.json
+++ b/heft-plugins/heft-jest-plugin/config/rush-project.json
@@ -1,8 +1,16 @@
+// Copied from heft-node-rig
+//
+// heft-jest-plugin cannot use heft-node-rig because it would cause a circular
+// dependency, but we can still use the same build cache outputs.
 {
   "operationSettings": [
     {
+      "operationName": "_phase:build",
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
+    },
+    {
       "operationName": "build",
-      "outputFolderNames": ["lib", "dist"]
+      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enable build caching for heft-jest-plugin (via rush-project).

## Details

This project wasn't using the rig, because it would cause a circular dependency, but we can still use the same build cache settings.

## How it was tested

 - Tested locally for build & test.
