### PR TITLE
[certificate-manager] Remove Import.lazy

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/debug-cert-remove-import-lazy_2022-11-02-23-51.json
+++ b/common/changes/@rushstack/debug-certificate-manager/debug-cert-remove-import-lazy_2022-11-02-23-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Remove usage of Import.lazy so that the tool can be bundled.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}


### PR DESCRIPTION
## Summary
Removes usage of `Import.lazy` in favor of a standard `await import()` call so that `@rushstack/debug-certificate-manager` may be bundled.

## Details


## How it was tested
Local builds using the tool.