### PR TITLE
[rush-lib] Add project filtering to upgrade-interactive ui

### DIFF
--- a/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
+++ b/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Add project filtering to the upgrade-interactive UI prompt. Also increases the default page size for project lists in UI to 12.",
-      "type": "minor"
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
+++ b/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add project filtering to upgrade-interactive ui prompt. Also increase default page size for project lists in UI.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
+++ b/common/changes/@microsoft/rush/feature-ui-filter-prompt_2022-11-04-21-07.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add project filtering to upgrade-interactive ui prompt. Also increase default page size for project lists in UI.",
-      "type": "none"
+      "comment": "Add project filtering to the upgrade-interactive UI prompt. Also increases the default page size for project lists in UI to 12.",
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -43,6 +43,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "rxjs",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "tslib",
       "allowedCategories": [ "libraries", "tests" ]
     }

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -23,6 +23,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "figures",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "office-ui-fabric-core",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -23,10 +23,6 @@
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "figures",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
       "name": "office-ui-fabric-core",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -407,6 +407,10 @@
       "allowedCategories": [ "tests" ]
     },
     {
+      "name": "figures",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "file-loader",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1852,6 +1852,7 @@ importers:
       builtin-modules: ~3.1.0
       cli-table: ~0.3.1
       colors: ~1.2.1
+      figures: 3.0.0
       git-repo-info: ~2.1.0
       glob: ~7.0.5
       glob-escape: ~0.0.2
@@ -1887,6 +1888,7 @@ importers:
       builtin-modules: 3.1.0
       cli-table: 0.3.11
       colors: 1.2.5
+      figures: 3.0.0
       git-repo-info: 2.1.1
       glob: 7.0.6
       glob-escape: 0.0.2
@@ -12304,6 +12306,13 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
       object-assign: 4.1.1
+    dev: false
+
+  /figures/3.0.0:
+    resolution: {integrity: sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      escape-string-regexp: 1.0.5
     dev: false
 
   /figures/3.2.0:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1868,6 +1868,7 @@ importers:
       npm-packlist: ~2.1.2
       read-package-tree: ~5.1.5
       resolve: ~1.17.0
+      rxjs: ~6.6.7
       semver: ~7.3.0
       ssri: ~8.0.0
       strict-uri-encode: ~2.0.0
@@ -1904,6 +1905,7 @@ importers:
       npm-packlist: 2.1.5
       read-package-tree: 5.1.6
       resolve: 1.17.0
+      rxjs: 6.6.7
       semver: 7.3.8
       ssri: 8.0.1
       strict-uri-encode: 2.0.0
@@ -12315,13 +12317,6 @@ packages:
       escape-string-regexp: 1.0.5
     dev: false
 
-  /figures/3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
-    dependencies:
-      escape-string-regexp: 1.0.5
-    dev: false
-
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -13726,7 +13721,7 @@ packages:
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
-      figures: 3.2.0
+      figures: 3.0.0
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,9 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
+<<<<<<< HEAD
   "pnpmShrinkwrapHash": "f1b5560754a56b0869694a51e1c98b1885312bd3",
+=======
+  "pnpmShrinkwrapHash": "2d628979c967be8e071745e57d7292d38eee0c2c",
+>>>>>>> 4fba021fb5 (add missing figures dep)
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,9 +1,13 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
 <<<<<<< HEAD
+<<<<<<< HEAD
   "pnpmShrinkwrapHash": "f1b5560754a56b0869694a51e1c98b1885312bd3",
 =======
   "pnpmShrinkwrapHash": "2d628979c967be8e071745e57d7292d38eee0c2c",
 >>>>>>> 4fba021fb5 (add missing figures dep)
+=======
+  "pnpmShrinkwrapHash": "6db8bddc149abdab1fadf9bfda8c5a6bdd78216e",
+>>>>>>> d6c9692ad8 (rush update)
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,13 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  "pnpmShrinkwrapHash": "f1b5560754a56b0869694a51e1c98b1885312bd3",
-=======
-  "pnpmShrinkwrapHash": "2d628979c967be8e071745e57d7292d38eee0c2c",
->>>>>>> 4fba021fb5 (add missing figures dep)
-=======
-  "pnpmShrinkwrapHash": "6db8bddc149abdab1fadf9bfda8c5a6bdd78216e",
->>>>>>> d6c9692ad8 (rush update)
+  "pnpmShrinkwrapHash": "fe4b87f39994b33d3dc6e57f19829115e1956dd1",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -51,6 +51,7 @@
     "npm-packlist": "~2.1.2",
     "read-package-tree": "~5.1.5",
     "resolve": "~1.17.0",
+    "rxjs": "~6.6.7",
     "semver": "~7.3.0",
     "ssri": "~8.0.0",
     "strict-uri-encode": "~2.0.0",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -55,7 +55,8 @@
     "tapable": "2.2.1",
     "tar": "~6.1.11",
     "true-case-path": "~2.2.1",
-    "npm-check": "~5.9.2"
+    "npm-check": "~5.9.2",
+    "figures": "3.0.0"
   },
   "devDependencies": {
     "@pnpm/logger": "4.0.0",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -35,6 +35,7 @@
     "builtin-modules": "~3.1.0",
     "cli-table": "~0.3.1",
     "colors": "~1.2.1",
+    "figures": "3.0.0",
     "git-repo-info": "~2.1.0",
     "glob": "~7.0.5",
     "glob-escape": "~0.0.2",
@@ -45,6 +46,7 @@
     "jszip": "~3.7.1",
     "lodash": "~4.17.15",
     "node-fetch": "2.6.7",
+    "npm-check": "~5.9.2",
     "npm-package-arg": "~6.1.0",
     "npm-packlist": "~2.1.2",
     "read-package-tree": "~5.1.5",
@@ -54,9 +56,7 @@
     "strict-uri-encode": "~2.0.0",
     "tapable": "2.2.1",
     "tar": "~6.1.11",
-    "true-case-path": "~2.2.1",
-    "npm-check": "~5.9.2",
-    "figures": "3.0.0"
+    "true-case-path": "~2.2.1"
   },
   "devDependencies": {
     "@pnpm/logger": "4.0.0",

--- a/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';

--- a/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
+++ b/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
@@ -1,10 +1,12 @@
 import npmCheck from 'npm-check';
 import colors from 'colors/safe';
-import inquirer from 'inquirer';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { upgradeInteractive, IDepsToUpgradeAnswers } from '../utilities/InteractiveUpgradeUI';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
+import Prompt from 'inquirer/lib/ui/prompt';
+
+import { SearchListPrompt } from '../utilities/prompts/SearchListPrompt';
 
 interface IUpgradeInteractiveDeps {
   projects: RushConfigurationProject[];
@@ -39,18 +41,24 @@ export class InteractiveUpgrader {
 
   private async _getUserSelectedProjectForUpgrade(): Promise<RushConfigurationProject> {
     const projects: RushConfigurationProject[] | undefined = this._rushConfiguration.projects;
-
-    const { selectProject } = await inquirer.prompt({
-      name: 'selectProject',
-      message: 'Select a project you would like to upgrade',
-      type: 'list',
-      choices: projects.map((project) => {
-        return {
-          name: colors.green(project.packageName),
-          value: project
-        };
-      })
+    const ui: Prompt = new Prompt({
+      list: SearchListPrompt
     });
+
+    const { selectProject } = await ui.run([
+      {
+        name: 'selectProject',
+        message: 'Select a project you would like to upgrade',
+        type: 'list',
+        choices: projects.map((project) => {
+          return {
+            name: colors.green(project.packageName),
+            value: project
+          };
+        }),
+        pageSize: 12
+      }
+    ]);
 
     return selectProject;
   }

--- a/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
+++ b/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import npmCheck from 'npm-check';
 import colors from 'colors/safe';
 

--- a/libraries/rush-lib/src/utilities/InteractiveUpgradeUI.ts
+++ b/libraries/rush-lib/src/utilities/InteractiveUpgradeUI.ts
@@ -1,3 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// UI Code, Table creation, and choice layout leveraged from npm-check
+// https://github.com/dylang/npm-check/blob/master/lib/out/interactive-update.js
+// Extended to use one type of text table
+
 import inquirer from 'inquirer';
 import _ from 'lodash';
 import colors from 'colors/safe';

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -157,28 +157,35 @@ export class SearchListPrompt extends BasePrompt<ListQuestion> {
     this._adjustSelected(0);
   }
 
+  // Provide the delta in deplayed choices and change the selected
+  // index accordingly by the delta in real choices
   private _adjustSelected(delta: number): void {
     const { choices } = this.opt.choices;
     const pointer: number = this._selected;
     let lastValidIndex: number = pointer;
+
+    // if delta is greater than 0, we are moving down in list w/ selected index
     if (delta < 0) {
       for (let i: number = pointer - 1; i >= 0; i--) {
         const choice: Choice<Answers> = choices[i] as Choice<Answers>;
         if (isValidChoice(choice)) {
           ++delta;
           lastValidIndex = i;
+          // if delta is 0, we have found the next valid choice that has an index greater than the selected index
           if (delta === 0) {
             break;
           }
         }
       }
     } else {
+      // if delta is less than 0, we are moving up in list w/ selected index
       ++delta;
       for (let i: number = pointer, len: number = choices.length; i < len; i++) {
         const choice: Choice<Answers> = choices[i] as Choice<Answers>;
         if (isValidChoice(choice)) {
           --delta;
           lastValidIndex = i;
+          // if delta is 0, we have found the next valid choice that has an index greater than the selected index
           if (delta === 0) {
             break;
           }

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -1,7 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { Interface } from 'readline';
 import _ from 'lodash';
 import colors from 'colors/safe';
 
+// Modified from the choice list prompt in inquirer:
+// https://github.com/SBoudrias/Inquirer.js/blob/inquirer%407.3.3/packages/inquirer/lib/prompts/list.js
+// Extended to include text filtering for the list
 import type inquirer from 'inquirer';
 import type { Answers, ListQuestion, DistinctChoice } from 'inquirer';
 import BasePrompt from 'inquirer/lib/prompts/base';

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -1,0 +1,278 @@
+import type { Interface } from 'readline';
+import _ from 'lodash';
+import colors from 'colors/safe';
+
+import type inquirer from 'inquirer';
+import type { Answers, ListQuestion, DistinctChoice } from 'inquirer';
+import BasePrompt from 'inquirer/lib/prompts/base';
+import observe from 'inquirer/lib/utils/events';
+import Paginator from 'inquirer/lib/utils/paginator';
+import type Separator from 'inquirer/lib/objects/separator';
+import type Choice from 'inquirer/lib/objects/choice';
+import type Choices from 'inquirer/lib/objects/choices';
+
+import figures from 'figures';
+
+const { map, takeUntil } = require('rxjs/operators');
+
+interface IKeyPressEvent {
+  key: { name: string; ctrl: boolean; sequence?: string };
+}
+
+export class SearchListPrompt extends BasePrompt<ListQuestion> {
+  protected done!: (result: unknown) => void;
+
+  private readonly _paginator: Paginator;
+  private _selected: number = 0;
+  private _query: string = '';
+  private _firstRender: boolean = true;
+
+  public constructor(question: ListQuestion, readline: Interface, answers: Answers) {
+    super(question, readline, answers);
+
+    if (!this.opt.choices) {
+      this.throwParamError('choices');
+    }
+
+    if (
+      _.isNumber(this.opt.default) &&
+      this.opt.default >= 0 &&
+      this.opt.default < this.opt.choices.realLength
+    ) {
+      this._selected = this.opt.default;
+    } else if (!_.isNumber(this.opt.default) && this.opt.default !== null) {
+      const index: number = _.findIndex(
+        this.opt.choices.realChoices,
+        ({ value }) => value === this.opt.default
+      );
+      this._selected = Math.max(index, 0);
+    }
+
+    // Make sure no default is set (so it won't be printed)
+    this.opt.default = null;
+
+    this._paginator = new Paginator(this.screen);
+  }
+
+  protected _run(callback: (result: unknown) => void): this {
+    this.done = callback;
+
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const events = observe(this.rl);
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const validation = this.handleSubmitEvents(events.line.pipe(map(this._getCurrentValue.bind(this))));
+
+    //eslint-disable-next-line no-void
+    void validation.success.forEach(this._onSubmit.bind(this));
+    //eslint-disable-next-line no-void
+    void validation.error.forEach(this._onError.bind(this));
+
+    // eslint-disable-next-line no-void
+    void events.numberKey
+      .pipe(takeUntil(events.line))
+      .forEach(this._onNumberKey.bind(this) as (evt: unknown) => void);
+
+    // eslint-disable-next-line no-void
+    void events.keypress
+      .pipe(takeUntil(validation.success))
+      .forEach(this._onKeyPress.bind(this) as (evt: unknown) => void);
+
+    this.render();
+    return this;
+  }
+
+  private _onUpKey(): void {
+    return this._adjustSelected(-1);
+  }
+
+  private _onDownKey(): void {
+    return this._adjustSelected(1);
+  }
+
+  private _onNumberKey(input: number): void {
+    if (input <= this.opt.choices.realLength) {
+      this._selected = input - 1;
+    }
+
+    this.render();
+  }
+
+  /**
+   * When user press `enter` key
+   */
+  private _onSubmit(state: { value: unknown }): void {
+    this.status = 'answered';
+    // Rerender prompt (and clean subline error)
+    this.render();
+
+    this.screen.done();
+    this.done(state.value);
+  }
+
+  private _onError(state: inquirer.prompts.FailedPromptStateData): void {
+    this.render(state.isValid || undefined);
+  }
+
+  private _onKeyPress(event: IKeyPressEvent): void {
+    if (event.key.ctrl) {
+      switch (event.key.name) {
+        case 'backspace':
+          return this._setQuery('');
+      }
+    } else {
+      switch (event.key.name) {
+        case 'backspace':
+          return this._setQuery(this._query.slice(0, -1));
+        case 'up':
+          return this._onUpKey();
+        case 'down':
+          return this._onDownKey();
+
+        default:
+          if (event.key.sequence && event.key.sequence.length === 1) {
+            this._setQuery(this._query + event.key.sequence);
+          }
+      }
+    }
+  }
+
+  private _setQuery(query: string): void {
+    this._query = query;
+    const filter: string = query.toUpperCase();
+
+    const { choices } = this.opt.choices;
+    for (const choice of choices as Iterable<{ disabled?: boolean; type: string; short: string }>) {
+      if (choice.type !== 'separator') {
+        choice.disabled = !choice.short.toUpperCase().includes(filter);
+      }
+    }
+
+    // Select the first valid option
+    this._adjustSelected(0);
+  }
+
+  private _adjustSelected(delta: number): void {
+    const { choices } = this.opt.choices;
+    const pointer: number = this._selected;
+    let lastValidIndex: number = pointer;
+    if (delta < 0) {
+      for (let i: number = pointer - 1; i >= 0; i--) {
+        const choice: Choice<Answers> = choices[i] as Choice<Answers>;
+        if (isValidChoice(choice)) {
+          ++delta;
+          lastValidIndex = i;
+          if (delta === 0) {
+            break;
+          }
+        }
+      }
+    } else {
+      ++delta;
+      for (let i: number = pointer, len: number = choices.length; i < len; i++) {
+        const choice: Choice<Answers> = choices[i] as Choice<Answers>;
+        if (isValidChoice(choice)) {
+          --delta;
+          lastValidIndex = i;
+          if (delta === 0) {
+            break;
+          }
+        }
+      }
+    }
+
+    this._selected = lastValidIndex;
+    this.render();
+  }
+
+  private _getCurrentValue(): string {
+    return this.opt.choices.getChoice(this._selected).value;
+  }
+
+  public render(error?: string): void {
+    // Render the question
+    let message: string = this.getQuestion();
+    let bottomContent: string = '';
+
+    if (this._firstRender) {
+      message += colors.dim(' (Use arrow keys)');
+    }
+
+    // Render choices or answer depending on the state
+    if (this.status === 'answered') {
+      message += colors.cyan(this.opt.choices.getChoice(this._selected).short!);
+    } else {
+      const choicesStr: string = listRender(this.opt.choices, this._selected);
+      const indexPosition: number = this.opt.choices.indexOf(
+        this.opt.choices.getChoice(this._selected) as Choice<Answers>
+      );
+      let realIndexPosition: number = 0;
+      const { choices } = this.opt.choices;
+
+      for (let i: number = 0; i < indexPosition; i++) {
+        const value: DistinctChoice<Answers> = choices[i];
+
+        // Add line if it's a separator
+        if (value.type === 'separator') {
+          realIndexPosition++;
+          continue;
+        }
+
+        // Do not render choices which disabled property
+        // these represent choices that are filtered out
+        if ((value as { disabled?: unknown }).disabled) {
+          continue;
+        }
+
+        const line: string | undefined = value.name;
+        // Non-strings take up one line
+        if (typeof line !== 'string') {
+          realIndexPosition++;
+          continue;
+        }
+
+        // Calculate lines taken up by string
+        // eslint-disable-next-line no-bitwise
+        realIndexPosition += ((line.length / process.stdout.columns!) | 0) + 1;
+      }
+      message += `\n${colors.white(colors.bold('Start typing to filter:'))} ${colors.cyan(this._query)}`;
+      // @ts-expect-error Types are wrong
+      message += '\n' + this._paginator.paginate(choicesStr, realIndexPosition, this.opt.pageSize!);
+    }
+
+    if (error) {
+      bottomContent = colors.red('>> ') + error;
+    }
+
+    this.screen.render(message, bottomContent);
+  }
+}
+
+function listRender(choices: Choices, pointer: number): string {
+  let output: string = '';
+
+  choices.forEach((choice: Separator | Choice<Answers>, i: number) => {
+    if (choice.type === 'separator') {
+      output += ' ' + choice + '\n';
+      return;
+    }
+
+    if (!choice.disabled) {
+      const line: string = choice.name;
+      if (i === pointer) {
+        output += colors.cyan(figures.pointer + line);
+      } else {
+        output += ' ' + line;
+      }
+    }
+
+    if (i < choices.length - 1) {
+      output += '\n';
+    }
+  });
+
+  return output.replace(/\n$/, '');
+}
+
+function isValidChoice(choice: Choice<Answers>): boolean {
+  return !choice.disabled;
+}

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -8,8 +8,7 @@ import colors from 'colors/safe';
 // Modified from the choice list prompt in inquirer:
 // https://github.com/SBoudrias/Inquirer.js/blob/inquirer%407.3.3/packages/inquirer/lib/prompts/list.js
 // Extended to include text filtering for the list
-import type inquirer from 'inquirer';
-import type { Answers, ListQuestion, DistinctChoice } from 'inquirer';
+import type { default as inquirer, Answers, ListQuestion, DistinctChoice } from 'inquirer';
 import BasePrompt from 'inquirer/lib/prompts/base';
 import observe from 'inquirer/lib/utils/events';
 import Paginator from 'inquirer/lib/utils/paginator';
@@ -19,7 +18,7 @@ import type Choices from 'inquirer/lib/objects/choices';
 
 import figures from 'figures';
 
-const { map, takeUntil } = require('rxjs/operators');
+import { map, takeUntil } from 'rxjs/operators';
 
 interface IKeyPressEvent {
   key: { name: string; ctrl: boolean; sequence?: string };

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -47,10 +47,7 @@ export class SearchListPrompt extends BasePrompt<ListQuestion> {
     ) {
       this._selected = this.opt.default;
     } else if (!_.isNumber(this.opt.default) && this.opt.default !== null) {
-      const index: number = _.findIndex(
-        this.opt.choices.realChoices,
-        ({ value }) => value === this.opt.default
-      );
+      const index: number = this.opt.choices.realChoices.findIndex(({ value }) => value === this.opt.default);
       this._selected = Math.max(index, 0);
     }
 
@@ -127,6 +124,19 @@ export class SearchListPrompt extends BasePrompt<ListQuestion> {
       }
     } else {
       switch (event.key.name) {
+        // Go to beginning of list
+        case 'home':
+          return this._adjustSelected(-Infinity);
+        // Got to end of list
+        case 'end':
+          return this._adjustSelected(Infinity);
+        // Paginate up
+        case 'pageup':
+          return this._adjustSelected(-(this.opt.pageSize ?? 1));
+        // Paginate down
+        case 'pagedown':
+          return this._adjustSelected(this.opt.pageSize ?? 1);
+
         case 'backspace':
           return this._setQuery(this._query.slice(0, -1));
         case 'up':

--- a/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
+++ b/libraries/rush-lib/src/utilities/prompts/SearchListPrompt.ts
@@ -173,21 +173,23 @@ export class SearchListPrompt extends BasePrompt<ListQuestion> {
     const pointer: number = this._selected;
     let lastValidIndex: number = pointer;
 
-    // if delta is greater than 0, we are moving down in list w/ selected index
+    // if delta is less than 0, we are moving up in list w/ selected index
     if (delta < 0) {
       for (let i: number = pointer - 1; i >= 0; i--) {
         const choice: Choice<Answers> = choices[i] as Choice<Answers>;
         if (isValidChoice(choice)) {
           ++delta;
           lastValidIndex = i;
-          // if delta is 0, we have found the next valid choice that has an index greater than the selected index
+          // if delta is 0, we have found the next valid choice that has an index less than the selected index
           if (delta === 0) {
             break;
           }
         }
       }
     } else {
-      // if delta is less than 0, we are moving up in list w/ selected index
+      // if delta is greater than 0, we are moving down in list w/ selected index
+      // Also, if delta is exactly 0, the request is to adjust to the first
+      // displayed choice that has an index >= the current selected choice.
       ++delta;
       for (let i: number = pointer, len: number = choices.length; i < len; i++) {
         const choice: Choice<Answers> = choices[i] as Choice<Answers>;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This PR introduces project filtering feature as a part of the `upgrade-interactive` UI. 

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

By default a user will now be able to type after running `upgrade-interactive` to filter from the list of projects in their monorepo. 

![image](https://user-images.githubusercontent.com/3408176/200075378-ca1db0bb-8db4-4bd6-89a5-97640ad005fa.png)

![image](https://user-images.githubusercontent.com/3408176/200075412-d5786e68-09ee-4c83-960a-5040e5a4456f.png)

![image](https://user-images.githubusercontent.com/3408176/200075431-cea29523-10c0-4cd3-a3dc-a3cfb2809260.png)

In addition the PR also expands the default list height/pageSize to 12 for the prompt so you can see more projects before infinite scrolling begins.

The PR also adds missing licenses and attribution links.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
