### PR TITLE
[rush] Convert most enums to constants.

### DIFF
--- a/common/changes/@microsoft/rush/replace-enums_2022-11-06-01-05.json
+++ b/common/changes/@microsoft/rush/replace-enums_2022-11-06-01-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Convert enums in the API to consts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -128,7 +128,7 @@ export class CredentialCache {
 export const DependencyType: Record<string, DependencyType>;
 
 // @public (undocumented)
-export type DependencyType = 'dependencies' | 'devDependencies' | 'optionalDependencies' | 'peerDependencies' | 'resolutions';
+export type DependencyType = 'regularDependency' | 'devDependency' | 'optionalDependency' | 'peerDependency' | 'yarnResolutions';
 
 // @beta
 export class EnvironmentConfiguration {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -124,17 +124,11 @@ export class CredentialCache {
     static usingAsync(options: ICredentialCacheOptions, doActionAsync: (credentialCache: CredentialCache) => Promise<void> | void): Promise<void>;
 }
 
-// @public (undocumented)
-export const DependencyType: {
-    readonly Regular: "dependencies";
-    readonly Dev: "devDependencies";
-    readonly Optional: "optionalDependencies";
-    readonly Peer: "peerDependencies";
-    readonly YarnResolutions: "resolutions";
-};
+// @public @deprecated (undocumented)
+export const DependencyType: Record<string, DependencyType>;
 
 // @public (undocumented)
-export type DependencyType = typeof DependencyType[keyof typeof DependencyType];
+export type DependencyType = 'dependencies' | 'devDependencies' | 'optionalDependencies' | 'peerDependencies' | 'resolutions';
 
 // @beta
 export class EnvironmentConfiguration {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -70,20 +70,17 @@ export class BuildCacheConfiguration {
 }
 
 // @public
-export enum BumpType {
-    // (undocumented)
-    'major' = 5,
-    // (undocumented)
-    'minor' = 4,
-    // (undocumented)
-    'none' = 0,
-    // (undocumented)
-    'patch' = 2,
-    // (undocumented)
-    'preminor' = 3,
-    // (undocumented)
-    'prerelease' = 1
-}
+export const BumpType: {
+    readonly none: "none";
+    readonly prerelease: "prerelease";
+    readonly patch: "patch";
+    readonly preminor: "preminor";
+    readonly minor: "minor";
+    readonly major: "major";
+};
+
+// @public (undocumented)
+export type BumpType = typeof BumpType[keyof typeof BumpType];
 
 // @public
 export class ChangeManager {
@@ -128,18 +125,16 @@ export class CredentialCache {
 }
 
 // @public (undocumented)
-export enum DependencyType {
-    // (undocumented)
-    Dev = "devDependencies",
-    // (undocumented)
-    Optional = "optionalDependencies",
-    // (undocumented)
-    Peer = "peerDependencies",
-    // (undocumented)
-    Regular = "dependencies",
-    // (undocumented)
-    YarnResolutions = "resolutions"
-}
+export const DependencyType: {
+    readonly Regular: "dependencies";
+    readonly Dev: "devDependencies";
+    readonly Optional: "optionalDependencies";
+    readonly Peer: "peerDependencies";
+    readonly YarnResolutions: "resolutions";
+};
+
+// @public (undocumented)
+export type DependencyType = typeof DependencyType[keyof typeof DependencyType];
 
 // @beta
 export class EnvironmentConfiguration {
@@ -166,33 +161,39 @@ export class EnvironmentConfiguration {
 }
 
 // @beta
-export enum EnvironmentVariableNames {
-    RUSH_ABSOLUTE_SYMLINKS = "RUSH_ABSOLUTE_SYMLINKS",
-    RUSH_ALLOW_UNSUPPORTED_NODEJS = "RUSH_ALLOW_UNSUPPORTED_NODEJS",
-    RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD = "RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD",
-    RUSH_BUILD_CACHE_CREDENTIAL = "RUSH_BUILD_CACHE_CREDENTIAL",
-    RUSH_BUILD_CACHE_ENABLED = "RUSH_BUILD_CACHE_ENABLED",
-    RUSH_BUILD_CACHE_WRITE_ALLOWED = "RUSH_BUILD_CACHE_WRITE_ALLOWED",
-    RUSH_DEPLOY_TARGET_FOLDER = "RUSH_DEPLOY_TARGET_FOLDER",
-    RUSH_GIT_BINARY_PATH = "RUSH_GIT_BINARY_PATH",
-    RUSH_GLOBAL_FOLDER = "RUSH_GLOBAL_FOLDER",
-    RUSH_INVOKED_FOLDER = "RUSH_INVOKED_FOLDER",
-    RUSH_PARALLELISM = "RUSH_PARALLELISM",
-    RUSH_PNPM_STORE_PATH = "RUSH_PNPM_STORE_PATH",
-    RUSH_PNPM_VERIFY_STORE_INTEGRITY = "RUSH_PNPM_VERIFY_STORE_INTEGRITY",
-    RUSH_PREVIEW_VERSION = "RUSH_PREVIEW_VERSION",
-    RUSH_TAR_BINARY_PATH = "RUSH_TAR_BINARY_PATH",
-    RUSH_TEMP_FOLDER = "RUSH_TEMP_FOLDER",
-    RUSH_VARIANT = "RUSH_VARIANT"
-}
+export const EnvironmentVariableNames: {
+    readonly RUSH_TEMP_FOLDER: "RUSH_TEMP_FOLDER";
+    readonly RUSH_PREVIEW_VERSION: "RUSH_PREVIEW_VERSION";
+    readonly RUSH_ALLOW_UNSUPPORTED_NODEJS: "RUSH_ALLOW_UNSUPPORTED_NODEJS";
+    readonly RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD: "RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD";
+    readonly RUSH_VARIANT: "RUSH_VARIANT";
+    readonly RUSH_PARALLELISM: "RUSH_PARALLELISM";
+    readonly RUSH_ABSOLUTE_SYMLINKS: "RUSH_ABSOLUTE_SYMLINKS";
+    readonly RUSH_PNPM_STORE_PATH: "RUSH_PNPM_STORE_PATH";
+    readonly RUSH_PNPM_VERIFY_STORE_INTEGRITY: "RUSH_PNPM_VERIFY_STORE_INTEGRITY";
+    readonly RUSH_DEPLOY_TARGET_FOLDER: "RUSH_DEPLOY_TARGET_FOLDER";
+    readonly RUSH_GLOBAL_FOLDER: "RUSH_GLOBAL_FOLDER";
+    readonly RUSH_BUILD_CACHE_CREDENTIAL: "RUSH_BUILD_CACHE_CREDENTIAL";
+    readonly RUSH_BUILD_CACHE_ENABLED: "RUSH_BUILD_CACHE_ENABLED";
+    readonly RUSH_BUILD_CACHE_WRITE_ALLOWED: "RUSH_BUILD_CACHE_WRITE_ALLOWED";
+    readonly RUSH_GIT_BINARY_PATH: "RUSH_GIT_BINARY_PATH";
+    readonly RUSH_TAR_BINARY_PATH: "RUSH_TAR_BINARY_PATH";
+    readonly RUSH_INVOKED_FOLDER: "RUSH_INVOKED_FOLDER";
+};
+
+// @public (undocumented)
+export type EnvironmentVariableNames = typeof EnvironmentVariableNames[keyof typeof EnvironmentVariableNames];
 
 // @beta
-export enum Event {
-    postRushBuild = 4,
-    postRushInstall = 2,
-    preRushBuild = 3,
-    preRushInstall = 1
-}
+export const Event: {
+    readonly preRushInstall: "preRushInstall";
+    readonly postRushInstall: "postRushInstall";
+    readonly preRushBuild: "preRushBuild";
+    readonly postRushBuild: "postRushBuild";
+};
+
+// @public (undocumented)
+export type Event = typeof Event[keyof typeof Event];
 
 // @beta
 export class EventHooks {
@@ -615,17 +616,20 @@ export class _OperationStateFile {
 }
 
 // @beta
-export enum OperationStatus {
-    Blocked = "BLOCKED",
-    Executing = "EXECUTING",
-    Failure = "FAILURE",
-    FromCache = "FROM CACHE",
-    NoOp = "NO OP",
-    Ready = "READY",
-    Skipped = "SKIPPED",
-    Success = "SUCCESS",
-    SuccessWithWarning = "SUCCESS WITH WARNINGS"
-}
+export const OperationStatus: {
+    readonly Ready: "READY";
+    readonly Executing: "EXECUTING";
+    readonly Success: "SUCCESS";
+    readonly SuccessWithWarning: "SUCCESS WITH WARNINGS";
+    readonly Skipped: "SKIPPED";
+    readonly FromCache: "FROM CACHE";
+    readonly Failure: "FAILURE";
+    readonly Blocked: "BLOCKED";
+    readonly NoOp: "NO OP";
+};
+
+// @public (undocumented)
+export type OperationStatus = typeof OperationStatus[keyof typeof OperationStatus];
 
 // @public (undocumented)
 export class PackageJsonDependency {
@@ -1012,12 +1016,13 @@ export class VersionPolicyConfiguration {
 }
 
 // @public
-export enum VersionPolicyDefinitionName {
-    // (undocumented)
-    'individualVersion' = 1,
-    // (undocumented)
-    'lockStepVersion' = 0
-}
+export const VersionPolicyDefinitionName: {
+    readonly lockStepVersion: "lockStepVersion";
+    readonly individualVersion: "individualVersion";
+};
+
+// @public (undocumented)
+export type VersionPolicyDefinitionName = typeof VersionPolicyDefinitionName[keyof typeof VersionPolicyDefinitionName];
 
 // @public
 export class YarnOptionsConfiguration extends PackageManagerOptionsConfigurationBase {

--- a/libraries/rush-lib/src/api/ChangeManagement.ts
+++ b/libraries/rush-lib/src/api/ChangeManagement.ts
@@ -12,6 +12,8 @@ export interface IChangeFile {
 
 /**
  * Represents all of the types of change requests.
+ *
+ * todo: Replace enum
  */
 export enum ChangeType {
   none = 0,

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -18,7 +18,8 @@ export interface IEnvironmentConfigurationInitializeOptions {
  * Names of environment variables used by Rush.
  * @beta
  */
-export enum EnvironmentVariableNames {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const EnvironmentVariableNames = {
   /**
    * This variable overrides the temporary folder used by Rush.
    * The default value is "common/temp" under the repository root.
@@ -26,28 +27,28 @@ export enum EnvironmentVariableNames {
    * @remarks This environment variable is not compatible with workspace installs. If attempting
    * to move the PNPM store path, see the `RUSH_PNPM_STORE_PATH` environment variable.
    */
-  RUSH_TEMP_FOLDER = 'RUSH_TEMP_FOLDER',
+  RUSH_TEMP_FOLDER: 'RUSH_TEMP_FOLDER',
 
   /**
    * This variable overrides the version of Rush that will be installed by
    * the version selector.  The default value is determined by the "rushVersion"
    * field from rush.json.
    */
-  RUSH_PREVIEW_VERSION = 'RUSH_PREVIEW_VERSION',
+  RUSH_PREVIEW_VERSION: 'RUSH_PREVIEW_VERSION',
 
   /**
    * If this variable is set to "1", Rush will not fail the build when running a version
    * of Node that does not match the criteria specified in the "nodeSupportedVersionRange"
    * field from rush.json.
    */
-  RUSH_ALLOW_UNSUPPORTED_NODEJS = 'RUSH_ALLOW_UNSUPPORTED_NODEJS',
+  RUSH_ALLOW_UNSUPPORTED_NODEJS: 'RUSH_ALLOW_UNSUPPORTED_NODEJS',
 
   /**
    * Setting this environment variable overrides the value of `allowWarningsInSuccessfulBuild`
    * in the `command-line.json` configuration file. Specify `1` to allow warnings in a successful build,
    * or `0` to disallow them. (See the comments in the command-line.json file for more information).
    */
-  RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD = 'RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD',
+  RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD: 'RUSH_ALLOW_WARNINGS_IN_SUCCESSFUL_BUILD',
 
   /**
    * This variable selects a specific installation variant for Rush to use when installing
@@ -55,20 +56,20 @@ export enum EnvironmentVariableNames {
    * For more information, see the command-line help for the `--variant` parameter
    * and this article:  https://rushjs.io/pages/advanced/installation_variants/
    */
-  RUSH_VARIANT = 'RUSH_VARIANT',
+  RUSH_VARIANT: 'RUSH_VARIANT',
 
   /**
    * Specifies the maximum number of concurrent processes to launch during a build.
    * For more information, see the command-line help for the `--parallelism` parameter for "rush build".
    */
-  RUSH_PARALLELISM = 'RUSH_PARALLELISM',
+  RUSH_PARALLELISM: 'RUSH_PARALLELISM',
 
   /**
    * If this variable is set to "1", Rush will create symlinks with absolute paths instead
    * of relative paths. This can be necessary when a repository is moved during a build or
    * if parts of a repository are moved into a sandbox.
    */
-  RUSH_ABSOLUTE_SYMLINKS = 'RUSH_ABSOLUTE_SYMLINKS',
+  RUSH_ABSOLUTE_SYMLINKS: 'RUSH_ABSOLUTE_SYMLINKS',
 
   /**
    * When using PNPM as the package manager, this variable can be used to configure the path that
@@ -77,20 +78,20 @@ export enum EnvironmentVariableNames {
    * If a relative path is used, then the store path will be resolved relative to the process's
    * current working directory.  An absolute path is recommended.
    */
-  RUSH_PNPM_STORE_PATH = 'RUSH_PNPM_STORE_PATH',
+  RUSH_PNPM_STORE_PATH: 'RUSH_PNPM_STORE_PATH',
 
   /**
    * When using PNPM as the package manager, this variable can be used to control whether or not PNPM
    * validates the integrity of the PNPM store during installation. The value of this environment variable must be
    * `1` (for true) or `0` (for false). If not specified, defaults to the value in .npmrc.
    */
-  RUSH_PNPM_VERIFY_STORE_INTEGRITY = 'RUSH_PNPM_VERIFY_STORE_INTEGRITY',
+  RUSH_PNPM_VERIFY_STORE_INTEGRITY: 'RUSH_PNPM_VERIFY_STORE_INTEGRITY',
 
   /**
    * This environment variable can be used to specify the `--target-folder` parameter
    * for the "rush deploy" command.
    */
-  RUSH_DEPLOY_TARGET_FOLDER = 'RUSH_DEPLOY_TARGET_FOLDER',
+  RUSH_DEPLOY_TARGET_FOLDER: 'RUSH_DEPLOY_TARGET_FOLDER',
 
   /**
    * Overrides the location of the `~/.rush` global folder where Rush stores temporary files.
@@ -108,7 +109,7 @@ export enum EnvironmentVariableNames {
    *
    * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
    */
-  RUSH_GLOBAL_FOLDER = 'RUSH_GLOBAL_FOLDER',
+  RUSH_GLOBAL_FOLDER: 'RUSH_GLOBAL_FOLDER',
 
   /**
    * Provides a credential for a remote build cache, if configured.  This credential overrides any cached credentials.
@@ -123,7 +124,7 @@ export enum EnvironmentVariableNames {
    *
    * For information on SAS tokens, see here: https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview
    */
-  RUSH_BUILD_CACHE_CREDENTIAL = 'RUSH_BUILD_CACHE_CREDENTIAL',
+  RUSH_BUILD_CACHE_CREDENTIAL: 'RUSH_BUILD_CACHE_CREDENTIAL',
 
   /**
    * Setting this environment variable overrides the value of `buildCacheEnabled` in the `build-cache.json`
@@ -136,24 +137,24 @@ export enum EnvironmentVariableNames {
    *
    * If there is no build cache configured, then this environment variable is ignored.
    */
-  RUSH_BUILD_CACHE_ENABLED = 'RUSH_BUILD_CACHE_ENABLED',
+  RUSH_BUILD_CACHE_ENABLED: 'RUSH_BUILD_CACHE_ENABLED',
 
   /**
    * Overrides the value of `isCacheWriteAllowed` in the `build-cache.json` configuration file. The value of this
    * environment variable must be `1` (for true) or `0` (for false). If there is no build cache configured, then
    * this environment variable is ignored.
    */
-  RUSH_BUILD_CACHE_WRITE_ALLOWED = 'RUSH_BUILD_CACHE_WRITE_ALLOWED',
+  RUSH_BUILD_CACHE_WRITE_ALLOWED: 'RUSH_BUILD_CACHE_WRITE_ALLOWED',
 
   /**
    * Explicitly specifies the path for the Git binary that is invoked by certain Rush operations.
    */
-  RUSH_GIT_BINARY_PATH = 'RUSH_GIT_BINARY_PATH',
+  RUSH_GIT_BINARY_PATH: 'RUSH_GIT_BINARY_PATH',
 
   /**
    * Explicitly specifies the path for the `tar` binary that is invoked by certain Rush operations.
    */
-  RUSH_TAR_BINARY_PATH = 'RUSH_TAR_BINARY_PATH',
+  RUSH_TAR_BINARY_PATH: 'RUSH_TAR_BINARY_PATH',
 
   /**
    * When Rush executes shell scripts, it sometimes changes the working directory to be a project folder or
@@ -164,8 +165,9 @@ export enum EnvironmentVariableNames {
    * The `RUSH_INVOKED_FOLDER` variable is the same idea as the `INIT_CWD` variable that package managers
    * assign when they execute lifecycle scripts.
    */
-  RUSH_INVOKED_FOLDER = 'RUSH_INVOKED_FOLDER'
-}
+  RUSH_INVOKED_FOLDER: 'RUSH_INVOKED_FOLDER'
+} as const;
+export type EnvironmentVariableNames = typeof EnvironmentVariableNames[keyof typeof EnvironmentVariableNames];
 
 /**
  * Provides Rush-specific environment variable data. All Rush environment variables must start with "RUSH_". This class
@@ -212,7 +214,7 @@ export class EnvironmentConfiguration {
 
   /**
    * If "1", create symlinks with absolute paths instead of relative paths.
-   * See {@link EnvironmentVariableNames.RUSH_ABSOLUTE_SYMLINKS}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_ABSOLUTE_SYMLINKS}
    */
   public static get absoluteSymlinks(): boolean {
     EnvironmentConfiguration._ensureValidated();
@@ -224,7 +226,7 @@ export class EnvironmentConfiguration {
    * instead of causing a hard error if the environment's Node.js version doesn't match the
    * version specifier in `rush.json`'s "nodeSupportedVersionRange" property.
    *
-   * See {@link EnvironmentVariableNames.RUSH_ALLOW_UNSUPPORTED_NODEJS}.
+   * See {@link (EnvironmentVariableNames:variable).RUSH_ALLOW_UNSUPPORTED_NODEJS}.
    */
   public static get allowUnsupportedNodeVersion(): boolean {
     EnvironmentConfiguration._ensureValidated();
@@ -243,7 +245,7 @@ export class EnvironmentConfiguration {
 
   /**
    * An override for the PNPM store path, if `pnpmStore` configuration is set to 'path'
-   * See {@link EnvironmentVariableNames.RUSH_PNPM_STORE_PATH}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_PNPM_STORE_PATH}
    */
   public static get pnpmStorePathOverride(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -252,7 +254,7 @@ export class EnvironmentConfiguration {
 
   /**
    * If specified, enables or disables integrity verification of the pnpm store during install.
-   * See {@link EnvironmentVariableNames.RUSH_PNPM_VERIFY_STORE_INTEGRITY}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_PNPM_VERIFY_STORE_INTEGRITY}
    */
   public static get pnpmVerifyStoreIntegrity(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -261,7 +263,7 @@ export class EnvironmentConfiguration {
 
   /**
    * Overrides the location of the `~/.rush` global folder where Rush stores temporary files.
-   * See {@link EnvironmentVariableNames.RUSH_GLOBAL_FOLDER}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_GLOBAL_FOLDER}
    */
   public static get rushGlobalFolderOverride(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -270,7 +272,7 @@ export class EnvironmentConfiguration {
 
   /**
    * Provides a credential for reading from and writing to a remote build cache, if configured.
-   * See {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_CREDENTIAL}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_BUILD_CACHE_CREDENTIAL}
    */
   public static get buildCacheCredential(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -279,7 +281,7 @@ export class EnvironmentConfiguration {
 
   /**
    * If set, enables or disables the cloud build cache feature.
-   * See {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_ENABLED}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_BUILD_CACHE_ENABLED}
    */
   public static get buildCacheEnabled(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -288,7 +290,7 @@ export class EnvironmentConfiguration {
 
   /**
    * If set, enables or disables writing to the cloud build cache.
-   * See {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_WRITE_ALLOWED}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_BUILD_CACHE_WRITE_ALLOWED}
    */
   public static get buildCacheWriteAllowed(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -297,7 +299,7 @@ export class EnvironmentConfiguration {
 
   /**
    * Allows the git binary path to be explicitly provided.
-   * See {@link EnvironmentVariableNames.RUSH_GIT_BINARY_PATH}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_GIT_BINARY_PATH}
    */
   public static get gitBinaryPath(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
@@ -306,7 +308,7 @@ export class EnvironmentConfiguration {
 
   /**
    * Allows the tar binary path to be explicitly provided.
-   * See {@link EnvironmentVariableNames.RUSH_TAR_BINARY_PATH}
+   * See {@link (EnvironmentVariableNames:variable).RUSH_TAR_BINARY_PATH}
    */
   public static get tarBinaryPath(): string | undefined {
     EnvironmentConfiguration._ensureValidated();

--- a/libraries/rush-lib/src/api/EventHooks.ts
+++ b/libraries/rush-lib/src/api/EventHooks.ts
@@ -8,24 +8,26 @@ import { Enum } from '@rushstack/node-core-library';
  * Events happen during Rush runs.
  * @beta
  */
-export enum Event {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const Event = {
   /**
    * Pre Rush install event
    */
-  preRushInstall = 1,
+  preRushInstall: 'preRushInstall',
   /**
    * Post Rush install event
    */
-  postRushInstall = 2,
+  postRushInstall: 'postRushInstall',
   /**
    * Pre Rush build event
    */
-  preRushBuild = 3,
+  preRushBuild: 'preRushBuild',
   /**
    * Post Rush build event
    */
-  postRushBuild = 4
-}
+  postRushBuild: 'postRushBuild'
+} as const;
+export type Event = typeof Event[keyof typeof Event];
 
 /**
  * This class represents Rush event hooks configured for this repo.

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -9,13 +9,15 @@ const lodash: typeof import('lodash') = Import.lazy('lodash', require);
 /**
  * @public
  */
-export enum DependencyType {
-  Regular = 'dependencies',
-  Dev = 'devDependencies',
-  Optional = 'optionalDependencies',
-  Peer = 'peerDependencies',
-  YarnResolutions = 'resolutions'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const DependencyType = {
+  Regular: 'dependencies',
+  Dev: 'devDependencies',
+  Optional: 'optionalDependencies',
+  Peer: 'peerDependencies',
+  YarnResolutions: 'resolutions'
+} as const;
+export type DependencyType = typeof DependencyType[keyof typeof DependencyType];
 
 /**
  * @public

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -8,26 +8,26 @@ const lodash: typeof import('lodash') = Import.lazy('lodash', require);
 
 /**
  * @deprecated
- * Use a string literal instead of an enum.
+ * Use a string literal instead.
  *
  * @public
  */
 export const DependencyType: Record<string, DependencyType> = {
-  Regular: 'dependencies',
-  Dev: 'devDependencies',
-  Optional: 'optionalDependencies',
-  Peer: 'peerDependencies',
-  YarnResolutions: 'resolutions'
+  Regular: 'regularDependency',
+  Dev: 'devDependency',
+  Optional: 'optionalDependency',
+  Peer: 'peerDependency',
+  YarnResolutions: 'yarnResolutions'
 } as const;
 /**
  * @public
  */
 export type DependencyType =
-  | 'dependencies'
-  | 'devDependencies'
-  | 'optionalDependencies'
-  | 'peerDependencies'
-  | 'resolutions';
+  | 'regularDependency'
+  | 'devDependency'
+  | 'optionalDependency'
+  | 'peerDependency'
+  | 'yarnResolutions';
 
 /**
  * @public
@@ -118,7 +118,7 @@ export class PackageJsonEditor {
 
         this._dependencies.set(
           packageName,
-          new PackageJsonDependency(packageName, dependencies[packageName], 'dependencies', _onChange)
+          new PackageJsonDependency(packageName, dependencies[packageName], 'regularDependency', _onChange)
         );
       });
 
@@ -134,7 +134,7 @@ export class PackageJsonEditor {
           new PackageJsonDependency(
             packageName,
             optionalDependencies[packageName],
-            'optionalDependencies',
+            'optionalDependency',
             _onChange
           )
         );
@@ -143,21 +143,21 @@ export class PackageJsonEditor {
       Object.keys(peerDependencies || {}).forEach((packageName: string) => {
         this._dependencies.set(
           packageName,
-          new PackageJsonDependency(packageName, peerDependencies[packageName], 'peerDependencies', _onChange)
+          new PackageJsonDependency(packageName, peerDependencies[packageName], 'peerDependency', _onChange)
         );
       });
 
       Object.keys(devDependencies || {}).forEach((packageName: string) => {
         this._devDependencies.set(
           packageName,
-          new PackageJsonDependency(packageName, devDependencies[packageName], 'devDependencies', _onChange)
+          new PackageJsonDependency(packageName, devDependencies[packageName], 'devDependency', _onChange)
         );
       });
 
       Object.keys(resolutions || {}).forEach((packageName: string) => {
         this._resolutions.set(
           packageName,
-          new PackageJsonDependency(packageName, resolutions[packageName], 'resolutions', _onChange)
+          new PackageJsonDependency(packageName, resolutions[packageName], 'yarnResolutions', _onChange)
         );
       });
 
@@ -190,14 +190,14 @@ export class PackageJsonEditor {
   }
 
   /**
-   * The list of dependencies of type 'dependencies', 'optionalDependencies', or 'peerDependencies'.
+   * The list of dependencies of type 'regularDependency', 'optionalDependency', or 'peerDependency'.
    */
   public get dependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._dependencies.values()];
   }
 
   /**
-   * The list of dependencies of type 'devDependencies'.
+   * The list of dependencies of type 'devDependency'.
    */
   public get devDependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._devDependencies.values()];
@@ -237,15 +237,15 @@ export class PackageJsonEditor {
     // Rush collapses everything that isn't a devDependency into the dependencies
     // field, so we need to set the value depending on dependency type
     switch (dependencyType) {
-      case 'dependencies':
-      case 'optionalDependencies':
-      case 'peerDependencies':
+      case 'regularDependency':
+      case 'optionalDependency':
+      case 'peerDependency':
         this._dependencies.set(packageName, dependency);
         break;
-      case 'devDependencies':
+      case 'devDependency':
         this._devDependencies.set(packageName, dependency);
         break;
-      case 'resolutions':
+      case 'yarnResolutions':
         this._resolutions.set(packageName, dependency);
         break;
       default:
@@ -257,15 +257,15 @@ export class PackageJsonEditor {
 
   public removeDependency(packageName: string, dependencyType: DependencyType): void {
     switch (dependencyType) {
-      case 'dependencies':
-      case 'optionalDependencies':
-      case 'peerDependencies':
+      case 'regularDependency':
+      case 'optionalDependency':
+      case 'peerDependency':
         this._dependencies.delete(packageName);
         break;
-      case 'devDependencies':
+      case 'devDependency':
         this._devDependencies.delete(packageName);
         break;
-      case 'resolutions':
+      case 'yarnResolutions':
         this._resolutions.delete(packageName);
         break;
       default:
@@ -322,26 +322,26 @@ export class PackageJsonEditor {
       const dependency: PackageJsonDependency = this._dependencies.get(packageName)!;
 
       switch (dependency.dependencyType) {
-        case 'dependencies':
+        case 'regularDependency':
           if (!normalizedData.dependencies) {
             normalizedData.dependencies = {};
           }
           normalizedData.dependencies[dependency.name] = dependency.version;
           break;
-        case 'optionalDependencies':
+        case 'optionalDependency':
           if (!normalizedData.optionalDependencies) {
             normalizedData.optionalDependencies = {};
           }
           normalizedData.optionalDependencies[dependency.name] = dependency.version;
           break;
-        case 'peerDependencies':
+        case 'peerDependency':
           if (!normalizedData.peerDependencies) {
             normalizedData.peerDependencies = {};
           }
           normalizedData.peerDependencies[dependency.name] = dependency.version;
           break;
-        case 'devDependencies': // uses this._devDependencies instead
-        case 'resolutions': // uses this._resolutions instead
+        case 'devDependency': // uses this._devDependencies instead
+        case 'yarnResolutions': // uses this._resolutions instead
         default:
           throw new InternalError('Unsupported DependencyType');
       }

--- a/libraries/rush-lib/src/api/RushGlobalFolder.ts
+++ b/libraries/rush-lib/src/api/RushGlobalFolder.ts
@@ -25,7 +25,7 @@ export class RushGlobalFolder {
    * in a global folder to speed up installations.  The default location is `~/.rush` on POSIX-like
    * operating systems or `C:\Users\YourName` on Windows.
    *
-   * You can use the {@link EnvironmentVariableNames.RUSH_GLOBAL_FOLDER} environment  variable to specify
+   * You can use the {@link (EnvironmentVariableNames:variable).RUSH_GLOBAL_FOLDER} environment  variable to specify
    * a different folder path.  This is useful for example if a Windows group policy forbids executing scripts
    * installed in a user's home directory.
    *

--- a/libraries/rush-lib/src/api/VersionPolicy.ts
+++ b/libraries/rush-lib/src/api/VersionPolicy.ts
@@ -22,29 +22,46 @@ const lodash: typeof import('lodash') = Import.lazy('lodash', require);
  * Type of version bumps
  * @public
  */
-export enum BumpType {
-  // No version bump
-  'none',
-  // Prerelease version bump
-  'prerelease',
-  // Patch version bump
-  'patch',
-  // Preminor version bump
-  'preminor',
-  // Minor version bump
-  'minor',
-  // Major version bump
-  'major'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const BumpType = {
+  /**
+   * No version bump
+   */
+  none: 'none',
+  /**
+   * Prerelease version bump
+   */
+  prerelease: 'prerelease',
+  /**
+   * Patch version bump
+   */
+  patch: 'patch',
+  /**
+   * Preminor version bump
+   */
+  preminor: 'preminor',
+  /**
+   * Minor version bump
+   */
+  minor: 'minor',
+  /**
+   * Major version bump
+   */
+  major: 'major'
+} as const;
+export type BumpType = typeof BumpType[keyof typeof BumpType];
 
 /**
  * Version policy base type names
  * @public
  */
-export enum VersionPolicyDefinitionName {
-  'lockStepVersion',
-  'individualVersion'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const VersionPolicyDefinitionName = {
+  lockStepVersion: 'lockStepVersion',
+  individualVersion: 'individualVersion'
+} as const;
+export type VersionPolicyDefinitionName =
+  typeof VersionPolicyDefinitionName[keyof typeof VersionPolicyDefinitionName];
 
 /**
  * This is the base class for version policy which controls how versions get bumped.

--- a/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
+++ b/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
@@ -26,15 +26,19 @@ export interface IIndividualVersionJson extends IVersionPolicyJson {
   lockedMajor?: number;
 }
 
-export enum VersionFormatForPublish {
-  original = 'original',
-  exact = 'exact'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const VersionFormatForPublish = {
+  original: 'original',
+  exact: 'exact'
+} as const;
+export type VersionFormatForPublish = typeof VersionFormatForPublish[keyof typeof VersionFormatForPublish];
 
-export enum VersionFormatForCommit {
-  wildcard = 'wildcard',
-  original = 'original'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const VersionFormatForCommit = {
+  wildcard: 'wildcard',
+  original: 'original'
+} as const;
+export type VersionFormatForCommit = typeof VersionFormatForCommit[keyof typeof VersionFormatForCommit];
 
 export interface IVersionPolicyDependencyJson {
   versionFormatForPublish?: VersionFormatForPublish;

--- a/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
@@ -54,9 +54,9 @@ describe(RemoveAction.name, () => {
         const packageName: string = removeDependencyMock.mock.calls[0][0];
         expect(packageName).toEqual('assert');
         const dependencyType1: DependencyType = removeDependencyMock.mock.calls[0][1];
-        expect(dependencyType1).toEqual(DependencyType.Regular);
+        expect(dependencyType1).toEqual('dependencies');
         const dependencyType2: DependencyType = removeDependencyMock.mock.calls[1][1];
-        expect(dependencyType2).toEqual(DependencyType.Dev);
+        expect(dependencyType2).toEqual('devDependencies');
       });
       it(`remove a dependency to just one repo in the workspace`, async () => {
         const startPath: string = `${__dirname}/removeRepo`;

--- a/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
@@ -54,9 +54,9 @@ describe(RemoveAction.name, () => {
         const packageName: string = removeDependencyMock.mock.calls[0][0];
         expect(packageName).toEqual('assert');
         const dependencyType1: DependencyType = removeDependencyMock.mock.calls[0][1];
-        expect(dependencyType1).toEqual('dependencies');
+        expect(dependencyType1).toEqual('regularDependency');
         const dependencyType2: DependencyType = removeDependencyMock.mock.calls[1][1];
-        expect(dependencyType2).toEqual('devDependencies');
+        expect(dependencyType2).toEqual('devDependency');
       });
       it(`remove a dependency to just one repo in the workspace`, async () => {
         const startPath: string = `${__dirname}/removeRepo`;

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -87,7 +87,7 @@ export class DependencyAnalyzer {
         ...project.packageJsonEditor.devDependencyList
       ];
       for (const { name: dependencyName, version: dependencyVersion, dependencyType } of dependencies) {
-        if (dependencyType === 'peerDependencies') {
+        if (dependencyType === 'peerDependency') {
           // If this is a peer dependency, it isn't a real dependency in this context, so it shouldn't
           // be included in the list of dependency versions.
           continue;

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -3,7 +3,7 @@
 
 import * as semver from 'semver';
 import { CommonVersionsConfiguration } from '../api/CommonVersionsConfiguration';
-import { DependencyType, PackageJsonDependency } from '../api/PackageJsonEditor';
+import { PackageJsonDependency } from '../api/PackageJsonEditor';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 
@@ -87,7 +87,7 @@ export class DependencyAnalyzer {
         ...project.packageJsonEditor.devDependencyList
       ];
       for (const { name: dependencyName, version: dependencyVersion, dependencyType } of dependencies) {
-        if (dependencyType === DependencyType.Peer) {
+        if (dependencyType === 'peerDependencies') {
           // If this is a peer dependency, it isn't a real dependency in this context, so it shouldn't
           // be included in the list of dependency versions.
           continue;

--- a/libraries/rush-lib/src/logic/DependencySpecifier.ts
+++ b/libraries/rush-lib/src/logic/DependencySpecifier.ts
@@ -7,52 +7,54 @@ import { InternalError } from '@rushstack/node-core-library';
 /**
  * The parsed format of a provided version specifier.
  */
-export enum DependencySpecifierType {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const DependencySpecifierType = {
   /**
    * A git repository
    */
-  Git = 'Git',
+  Git: 'Git',
 
   /**
    * A tagged version, e.g. "example@latest"
    */
-  Tag = 'Tag',
+  Tag: 'Tag',
 
   /**
    * A specific version number, e.g. "example@1.2.3"
    */
-  Version = 'Version',
+  Version: 'Version',
 
   /**
    * A version range, e.g. "example@2.x"
    */
-  Range = 'Range',
+  Range: 'Range',
 
   /**
    * A local .tar.gz, .tar or .tgz file
    */
-  File = 'File',
+  File: 'File',
 
   /**
    * A local directory
    */
-  Directory = 'Directory',
+  Directory: 'Directory',
 
   /**
    * An HTTP url to a .tar.gz, .tar or .tgz file
    */
-  Remote = 'Remote',
+  Remote: 'Remote',
 
   /**
    * A package alias, e.g. "npm:other-package@^1.2.3"
    */
-  Alias = 'Alias',
+  Alias: 'Alias',
 
   /**
    * A package specified using workspace protocol, e.g. "workspace:^1.2.3"
    */
-  Workspace = 'Workspace'
-}
+  Workspace: 'Workspace'
+} as const;
+export type DependencySpecifierType = typeof DependencySpecifierType[keyof typeof DependencySpecifierType];
 
 /**
  * An NPM "version specifier" is a string that can appear as a package.json "dependencies" value.

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -261,13 +261,13 @@ export class PackageJsonUpdater {
       const currentProjectDepUpdate: IUpdateProjectOptions = {
         project: mismatchFinderProject,
         dependenciesToAddOrUpdateOrRemove: dependenciesToUpdate,
-        dependencyType: 'dependencies'
+        dependencyType: 'regularDependency'
       };
 
       const currentProjectDevDepUpdate: IUpdateProjectOptions = {
         project: mismatchFinderProject,
         dependenciesToAddOrUpdateOrRemove: devDependenciesToUpdate,
-        dependencyType: 'devDependencies'
+        dependencyType: 'devDependency'
       };
 
       allPackageUpdates.set(mismatchFinderProject.filePath, mismatchFinderProject);
@@ -450,7 +450,7 @@ export class PackageJsonUpdater {
       const currentProjectUpdate: IUpdateProjectOptions = {
         project: new VersionMismatchFinderProject(project),
         dependenciesToAddOrUpdateOrRemove: dependenciesToAddOrUpdate,
-        dependencyType: devDependency ? 'devDependencies' : undefined
+        dependencyType: devDependency ? 'devDependency' : undefined
       };
       this.updateProject(currentProjectUpdate);
 
@@ -559,7 +559,7 @@ export class PackageJsonUpdater {
         ? oldDependency.dependencyType
         : undefined;
 
-      dependencyType = dependencyType || oldDependencyType || 'dependencies';
+      dependencyType = dependencyType || oldDependencyType || 'regularDependency';
 
       project.addOrUpdateDependency(packageName, newVersion, dependencyType!);
     }

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -261,13 +261,13 @@ export class PackageJsonUpdater {
       const currentProjectDepUpdate: IUpdateProjectOptions = {
         project: mismatchFinderProject,
         dependenciesToAddOrUpdateOrRemove: dependenciesToUpdate,
-        dependencyType: DependencyType.Regular
+        dependencyType: 'dependencies'
       };
 
       const currentProjectDevDepUpdate: IUpdateProjectOptions = {
         project: mismatchFinderProject,
         dependenciesToAddOrUpdateOrRemove: devDependenciesToUpdate,
-        dependencyType: DependencyType.Dev
+        dependencyType: 'devDependencies'
       };
 
       allPackageUpdates.set(mismatchFinderProject.filePath, mismatchFinderProject);
@@ -450,7 +450,7 @@ export class PackageJsonUpdater {
       const currentProjectUpdate: IUpdateProjectOptions = {
         project: new VersionMismatchFinderProject(project),
         dependenciesToAddOrUpdateOrRemove: dependenciesToAddOrUpdate,
-        dependencyType: devDependency ? DependencyType.Dev : undefined
+        dependencyType: devDependency ? 'devDependencies' : undefined
       };
       this.updateProject(currentProjectUpdate);
 
@@ -559,7 +559,7 @@ export class PackageJsonUpdater {
         ? oldDependency.dependencyType
         : undefined;
 
-      dependencyType = dependencyType || oldDependencyType || DependencyType.Regular;
+      dependencyType = dependencyType || oldDependencyType || 'dependencies';
 
       project.addOrUpdateDependency(packageName, newVersion, dependencyType!);
     }

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -23,12 +23,14 @@ import type { DependencyAnalyzer, IDependencyAnalysis } from './DependencyAnalyz
 /**
  * The type of SemVer range specifier that is prepended to the version
  */
-export const enum SemVerStyle {
-  Exact = 'exact',
-  Caret = 'caret',
-  Tilde = 'tilde',
-  Passthrough = 'passthrough'
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const SemVerStyle = {
+  Exact: 'exact',
+  Caret: 'caret',
+  Tilde: 'tilde',
+  Passthrough: 'passthrough'
+} as const;
+export type SemVerStyle = typeof SemVerStyle[keyof typeof SemVerStyle];
 
 export interface IPackageForRushUpdate {
   packageName: string;

--- a/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -19,10 +19,12 @@ import { BasePackage } from './BasePackage';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { LastLinkFlagFactory } from '../../api/LastLinkFlag';
 
-export enum SymlinkKind {
-  File,
-  Directory
-}
+// eslint-disable-next-line @typescript-eslint/typedef
+export const SymlinkKind = {
+  File: 'File',
+  Directory: 'Directory'
+} as const;
+export type SymlinkKind = typeof SymlinkKind[keyof typeof SymlinkKind];
 
 export interface IBaseLinkManagerCreateSymlinkOptions extends IFileSystemCreateLinkOptions {
   symlinkKind: SymlinkKind;

--- a/libraries/rush-lib/src/logic/base/BasePackage.ts
+++ b/libraries/rush-lib/src/logic/base/BasePackage.ts
@@ -6,18 +6,20 @@ import { JsonFile, IPackageJson } from '@rushstack/node-core-library';
 /**
  * The type of dependency; used by IPackageDependency.
  */
-export enum PackageDependencyKind {
-  Normal,
+// eslint-disable-next-line @typescript-eslint/typedef
+export const PackageDependencyKind = {
+  Normal: 'Normal',
   /**
    * The dependency was listed in the optionalDependencies section of package.json.
    */
-  Optional,
+  Optional: 'Optional',
 
   /**
    * The dependency should be a symlink to a project that is locally built by Rush..
    */
-  LocalLink
-}
+  LocalLink: 'LocalLink'
+} as const;
+export type PackageDependencyKind = typeof PackageDependencyKind[keyof typeof PackageDependencyKind];
 
 export interface IPackageDependency {
   /**

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -26,7 +26,7 @@ import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushConstants } from '../../logic/RushConstants';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { Utilities } from '../../utilities/Utilities';
-import { PackageJsonEditor, DependencyType, PackageJsonDependency } from '../../api/PackageJsonEditor';
+import { PackageJsonEditor, PackageJsonDependency } from '../../api/PackageJsonEditor';
 import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
 import { InstallHelpers } from './InstallHelpers';
 import { TempProjectHelper } from '../TempProjectHelper';
@@ -193,7 +193,7 @@ export class RushInstallManager extends BaseInstallManager {
         }
 
         // If there are any optional dependencies, copy directly into the optionalDependencies field.
-        if (dependency.dependencyType === DependencyType.Optional) {
+        if (dependency.dependencyType === 'optionalDependencies') {
           if (!tempPackageJson.optionalDependencies) {
             tempPackageJson.optionalDependencies = {};
           }

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -193,7 +193,7 @@ export class RushInstallManager extends BaseInstallManager {
         }
 
         // If there are any optional dependencies, copy directly into the optionalDependencies field.
-        if (dependency.dependencyType === 'optionalDependencies') {
+        if (dependency.dependencyType === 'optionalDependency') {
           if (!tempPackageJson.optionalDependencies) {
             tempPackageJson.optionalDependencies = {};
           }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -10,7 +10,7 @@ import { FileSystem, FileConstants, AlreadyReportedError, Async } from '@rushsta
 import { BaseInstallManager, IInstallManagerOptions } from '../base/BaseInstallManager';
 import { BaseShrinkwrapFile } from '../../logic/base/BaseShrinkwrapFile';
 import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
-import { PackageJsonEditor, DependencyType } from '../../api/PackageJsonEditor';
+import { PackageJsonEditor } from '../../api/PackageJsonEditor';
 import { PnpmWorkspaceFile } from '../pnpm/PnpmWorkspaceFile';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { RushConstants } from '../../logic/RushConstants';
@@ -141,7 +141,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         // Allow the package manager to handle peer dependency resolution, since this is simply a constraint
         // enforced by the package manager. Additionally, peer dependencies are simply a version constraint
         // and do not need to be converted to workspaces protocol.
-        if (dependencyType === DependencyType.Peer) {
+        if (dependencyType === 'peerDependencies') {
           continue;
         }
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -141,7 +141,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         // Allow the package manager to handle peer dependency resolution, since this is simply a constraint
         // enforced by the package manager. Additionally, peer dependencies are simply a version constraint
         // and do not need to be converted to workspaces protocol.
-        if (dependencyType === 'peerDependencies') {
+        if (dependencyType === 'peerDependency') {
           continue;
         }
 

--- a/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -12,9 +12,10 @@ import { FileSystem, FileConstants, LegacyAdapters } from '@rushstack/node-core-
 import { RushConstants } from '../../logic/RushConstants';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { Utilities } from '../../utilities/Utilities';
-import { NpmPackage, IResolveOrCreateResult, PackageDependencyKind } from './NpmPackage';
+import { NpmPackage, IResolveOrCreateResult } from './NpmPackage';
 import { PackageLookup } from '../PackageLookup';
 import { BaseLinkManager, SymlinkKind } from '../base/BaseLinkManager';
+import { PackageDependencyKind } from '../base/BasePackage';
 
 interface IQueueItem {
   // A project from somewhere under "common/temp/node_modules"

--- a/libraries/rush-lib/src/logic/npm/NpmPackage.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmPackage.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import readPackageTree = require('read-package-tree');
 import { JsonFile, IPackageJson } from '@rushstack/node-core-library';
 
-import { BasePackage, IRushTempPackageJson } from '../base/BasePackage';
+import { BasePackage, IRushTempPackageJson, PackageDependencyKind } from '../base/BasePackage';
 
 /**
  * Used by the linking algorithm when doing NPM package resolution.
@@ -13,22 +13,6 @@ import { BasePackage, IRushTempPackageJson } from '../base/BasePackage';
 export interface IResolveOrCreateResult {
   found: BasePackage | undefined;
   parentForCreate: BasePackage | undefined;
-}
-
-/**
- * The type of dependency; used by IPackageDependency.
- */
-export enum PackageDependencyKind {
-  Normal,
-  /**
-   * The dependency was listed in the optionalDependencies section of package.json.
-   */
-  Optional,
-
-  /**
-   * The dependency should be a symlink to a project that is locally built by Rush..
-   */
-  LocalLink
 }
 
 export interface IPackageDependency {

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -5,41 +5,43 @@
  * Enumeration defining potential states of an operation
  * @beta
  */
-export enum OperationStatus {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const OperationStatus = {
   /**
    * The Operation is on the queue, ready to execute (but may be waiting for dependencies)
    */
-  Ready = 'READY',
+  Ready: 'READY',
   /**
    * The Operation is currently executing
    */
-  Executing = 'EXECUTING',
+  Executing: 'EXECUTING',
   /**
    * The Operation completed successfully and did not write to standard output
    */
-  Success = 'SUCCESS',
+  Success: 'SUCCESS',
   /**
    * The Operation completed successfully, but wrote to standard output
    */
-  SuccessWithWarning = 'SUCCESS WITH WARNINGS',
+  SuccessWithWarning: 'SUCCESS WITH WARNINGS',
   /**
    * The Operation was skipped via the legacy incremental build logic
    */
-  Skipped = 'SKIPPED',
+  Skipped: 'SKIPPED',
   /**
    * The Operation had its outputs restored from the build cache
    */
-  FromCache = 'FROM CACHE',
+  FromCache: 'FROM CACHE',
   /**
    * The Operation failed
    */
-  Failure = 'FAILURE',
+  Failure: 'FAILURE',
   /**
    * The Operation could not be executed because one or more of its dependencies failed
    */
-  Blocked = 'BLOCKED',
+  Blocked: 'BLOCKED',
   /**
    * The Operation was a no-op (for example, it had an empty script)
    */
-  NoOp = 'NO OP'
-}
+  NoOp: 'NO OP'
+} as const;
+export type OperationStatus = typeof OperationStatus[keyof typeof OperationStatus];

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -15,7 +15,7 @@ import { IShrinkwrapFilePolicyValidatorOptions } from '../policy/ShrinkwrapFileP
 import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';
 import { RushConstants } from '../RushConstants';
 import { IExperimentsJson } from '../../api/ExperimentsConfiguration';
-import { DependencyType, PackageJsonDependency, PackageJsonEditor } from '../../api/PackageJsonEditor';
+import { PackageJsonDependency, PackageJsonEditor } from '../../api/PackageJsonEditor';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { PnpmfileConfiguration } from './PnpmfileConfiguration';
 import { PnpmProjectShrinkwrapFile } from './PnpmProjectShrinkwrapFile';
@@ -575,7 +575,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const dependencyVersions: Map<string, PackageJsonDependency> = new Map();
     for (const packageDependency of [...dependencyList, ...devDependencyList]) {
       // We will also filter out peer dependencies since these are not installed at development time.
-      if (packageDependency.dependencyType === DependencyType.Peer) {
+      if (packageDependency.dependencyType === 'peerDependencies') {
         continue;
       }
 
@@ -589,14 +589,14 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         // the least prioritized. We will only keep the most prioritized option.
         // See: https://github.com/pnpm/pnpm/blob/main/packages/lockfile-utils/src/satisfiesPackageManifest.ts
         switch (foundDependency.dependencyType) {
-          case DependencyType.Optional:
+          case 'optionalDependencies':
             break;
-          case DependencyType.Regular:
-            if (packageDependency.dependencyType === DependencyType.Optional) {
+          case 'dependencies':
+            if (packageDependency.dependencyType === 'optionalDependencies') {
               dependencyVersions.set(packageDependency.name, packageDependency);
             }
             break;
-          case DependencyType.Dev:
+          case 'devDependencies':
             dependencyVersions.set(packageDependency.name, packageDependency);
             break;
         }
@@ -607,14 +607,14 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // when moving a package from one field to the other.
     for (const dependencyVersion of dependencyVersions.values()) {
       switch (dependencyVersion.dependencyType) {
-        case DependencyType.Optional:
+        case 'optionalDependencies':
           if (!importer.optionalDependencies || !importer.optionalDependencies[dependencyVersion.name])
             return true;
           break;
-        case DependencyType.Regular:
+        case 'dependencies':
           if (!importer.dependencies || !importer.dependencies[dependencyVersion.name]) return true;
           break;
-        case DependencyType.Dev:
+        case 'devDependencies':
           if (!importer.devDependencies || !importer.devDependencies[dependencyVersion.name]) return true;
           break;
       }

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -15,7 +15,7 @@ import { IShrinkwrapFilePolicyValidatorOptions } from '../policy/ShrinkwrapFileP
 import { PNPM_SHRINKWRAP_YAML_FORMAT } from './PnpmYamlCommon';
 import { RushConstants } from '../RushConstants';
 import { IExperimentsJson } from '../../api/ExperimentsConfiguration';
-import { PackageJsonDependency, PackageJsonEditor } from '../../api/PackageJsonEditor';
+import { DependencyType, PackageJsonDependency, PackageJsonEditor } from '../../api/PackageJsonEditor';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { PnpmfileConfiguration } from './PnpmfileConfiguration';
 import { PnpmProjectShrinkwrapFile } from './PnpmProjectShrinkwrapFile';
@@ -575,7 +575,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const dependencyVersions: Map<string, PackageJsonDependency> = new Map();
     for (const packageDependency of [...dependencyList, ...devDependencyList]) {
       // We will also filter out peer dependencies since these are not installed at development time.
-      if (packageDependency.dependencyType === 'peerDependencies') {
+      if (packageDependency.dependencyType === 'peerDependency') {
         continue;
       }
 
@@ -589,14 +589,14 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         // the least prioritized. We will only keep the most prioritized option.
         // See: https://github.com/pnpm/pnpm/blob/main/packages/lockfile-utils/src/satisfiesPackageManifest.ts
         switch (foundDependency.dependencyType) {
-          case 'optionalDependencies':
+          case 'optionalDependency':
             break;
-          case 'dependencies':
-            if (packageDependency.dependencyType === 'optionalDependencies') {
+          case 'regularDependency':
+            if (packageDependency.dependencyType === 'optionalDependency') {
               dependencyVersions.set(packageDependency.name, packageDependency);
             }
             break;
-          case 'devDependencies':
+          case 'devDependency':
             dependencyVersions.set(packageDependency.name, packageDependency);
             break;
         }
@@ -607,14 +607,14 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // when moving a package from one field to the other.
     for (const dependencyVersion of dependencyVersions.values()) {
       switch (dependencyVersion.dependencyType) {
-        case 'optionalDependencies':
+        case 'optionalDependency':
           if (!importer.optionalDependencies || !importer.optionalDependencies[dependencyVersion.name])
             return true;
           break;
-        case 'dependencies':
+        case 'regularDependency':
           if (!importer.dependencies || !importer.dependencies[dependencyVersion.name]) return true;
           break;
-        case 'devDependencies':
+        case 'devDependency':
           if (!importer.devDependencies || !importer.devDependencies[dependencyVersion.name]) return true;
           break;
       }

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -250,7 +250,7 @@ export class VersionMismatchFinder {
         // levels of compatibility -- we should wait for someone to actually request this feature
         // before we get into that.)
         project.allDependencies.forEach((dependency: PackageJsonDependency) => {
-          if (dependency.dependencyType !== 'peerDependencies') {
+          if (dependency.dependencyType !== 'peerDependency') {
             const version: string = dependency.version!;
 
             const isCyclic: boolean = project.decoupledLocalDependencies.has(dependency.name);

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -5,7 +5,7 @@ import colors from 'colors/safe';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
-import { PackageJsonDependency, DependencyType } from '../../api/PackageJsonEditor';
+import { PackageJsonDependency } from '../../api/PackageJsonEditor';
 import { CommonVersionsConfiguration } from '../../api/CommonVersionsConfiguration';
 import { VersionMismatchFinderEntity } from './VersionMismatchFinderEntity';
 import { VersionMismatchFinderProject } from './VersionMismatchFinderProject';
@@ -250,7 +250,7 @@ export class VersionMismatchFinder {
         // levels of compatibility -- we should wait for someone to actually request this feature
         // before we get into that.)
         project.allDependencies.forEach((dependency: PackageJsonDependency) => {
-          if (dependency.dependencyType !== DependencyType.Peer) {
+          if (dependency.dependencyType !== 'peerDependencies') {
             const version: string = dependency.version!;
 
             const isCyclic: boolean = project.decoupledLocalDependencies.has(dependency.name);

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
@@ -50,8 +50,10 @@ export class VersionMismatchFinderCommonVersions extends VersionMismatchFinderEn
     newVersion: string,
     dependencyType: DependencyType
   ): void {
-    if (dependencyType !== 'dependencies') {
-      throw new Error(`${RushConstants.commonVersionsFilename} only accepts "dependencies" dependencies`);
+    if (dependencyType !== 'regularDependency') {
+      throw new Error(
+        `${RushConstants.commonVersionsFilename} only accepts "regularDependency" dependencies`
+      );
     }
 
     this._fileManager.preferredVersions.set(packageName, newVersion);
@@ -66,8 +68,8 @@ export class VersionMismatchFinderCommonVersions extends VersionMismatchFinderEn
   }
 
   private _getPackageJsonDependency(dependencyName: string, version: string): PackageJsonDependency {
-    return new PackageJsonDependency(dependencyName, version, 'dependencies', () =>
-      this.addOrUpdateDependency(dependencyName, version, 'dependencies')
+    return new PackageJsonDependency(dependencyName, version, 'regularDependency', () =>
+      this.addOrUpdateDependency(dependencyName, version, 'regularDependency')
     );
   }
 }

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinderCommonVersions.ts
@@ -50,10 +50,8 @@ export class VersionMismatchFinderCommonVersions extends VersionMismatchFinderEn
     newVersion: string,
     dependencyType: DependencyType
   ): void {
-    if (dependencyType !== DependencyType.Regular) {
-      throw new Error(
-        `${RushConstants.commonVersionsFilename} only accepts "${DependencyType.Regular}" dependencies`
-      );
+    if (dependencyType !== 'dependencies') {
+      throw new Error(`${RushConstants.commonVersionsFilename} only accepts "dependencies" dependencies`);
     }
 
     this._fileManager.preferredVersions.set(packageName, newVersion);
@@ -68,8 +66,8 @@ export class VersionMismatchFinderCommonVersions extends VersionMismatchFinderEn
   }
 
   private _getPackageJsonDependency(dependencyName: string, version: string): PackageJsonDependency {
-    return new PackageJsonDependency(dependencyName, version, DependencyType.Regular, () =>
-      this.addOrUpdateDependency(dependencyName, version, DependencyType.Regular)
+    return new PackageJsonDependency(dependencyName, version, 'dependencies', () =>
+      this.addOrUpdateDependency(dependencyName, version, 'dependencies')
     );
   }
 }


### PR DESCRIPTION
@elliot-nelson 

## Summary

This PR converts most enums in the `rush-lib` project to object constants with a merged type. This improves typesafety. For example:

```TypeScript
import { BumpType } from '@microsoft/rush-lib';

const x: BumpType = BumpType.minor; // Works the same
const y: BumpType = 1234; // Used to be allowed, now errors
```

## Issues

@octogonz  - API Extractor isn't happy with the merged declarations. It has the following errors:

```
  [api-extractor] src\api\EnvironmentConfiguration.ts:22:14 - (ae-different-release-tags) This symbol has another declaration with a different release tag
  [api-extractor] src\api\EnvironmentConfiguration.ts:22:14 - (ae-missing-release-tag) "EnvironmentVariableNames" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
  [api-extractor] src\api\EventHooks.ts:12:14 - (ae-different-release-tags) This symbol has another declaration with a different release tag
  [api-extractor] src\api\EventHooks.ts:12:14 - (ae-missing-release-tag) "Event" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
  [api-extractor] src\api\PackageJsonEditor.ts:13:14 - (ae-missing-release-tag) "DependencyType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
  [api-extractor] src\api\VersionPolicy.ts:26:14 - (ae-missing-release-tag) "BumpType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
  [api-extractor] src\api\VersionPolicy.ts:59:14 - (ae-missing-release-tag) "VersionPolicyDefinitionName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
  [api-extractor] src\logic\operations\OperationStatus.ts:9:14 - (ae-different-release-tags) This symbol has another declaration with a different release tag
  [api-extractor] src\logic\operations\OperationStatus.ts:9:14 - (ae-missing-release-tag) "OperationStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

## How it was tested

This PR still needs to be tested.