### PR TITLE
[ts-command-line] Make `onDefineUnscopedParameters` non-abstract and optional, mirroring `onDefineParameters`

### DIFF
--- a/common/changes/@rushstack/ts-command-line/user-danade-OptionalOnDefineUnscopedParameters_2022-11-08-00-20.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-OptionalOnDefineUnscopedParameters_2022-11-08-00-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Make ScopedCommandLineAction.onDefineUnscopedParameters optional to match CommandLineAciton.onDefineParameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -351,7 +351,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
     protected _getScopedCommandLineParser(): CommandLineParser;
     protected onDefineParameters(): void;
     protected abstract onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void;
-    protected abstract onDefineUnscopedParameters(): void;
+    protected onDefineUnscopedParameters?(): void;
     protected abstract onExecute(): Promise<void>;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     // @internal

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -173,7 +173,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    * {@inheritdoc CommandLineParameterProvider.onDefineParameters}
    */
   protected onDefineParameters(): void {
-    this.onDefineUnscopedParameters();
+    this.onDefineUnscopedParameters?.();
 
     if (!this._scopingParameters.length) {
       throw new Error(
@@ -224,7 +224,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    * Scoping parameters are defined by setting the parameterGroupName to
    * ScopedCommandLineAction.ScopingParameterGroupName.
    */
-  protected abstract onDefineUnscopedParameters(): void;
+  protected onDefineUnscopedParameters?(): void;
 
   /**
    * The child class should implement this hook to define its scoped command-line


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

A recent change allowed for `CommandLineAction.onDefineParameters` to not be specified on the implementing class. This change implements the same change, but with the equivalent `ScopedCommandLineAction.onDefineUnscopedParameters` method.