### PR TITLE
[rush] "rush setup" should work even if plugins can't be loaded

### DIFF
--- a/common/changes/@microsoft/rush/enelson-setupaction_2022-11-09-19-52.json
+++ b/common/changes/@microsoft/rush/enelson-setupaction_2022-11-09-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Rush \"setup\" command works even if plugins cannot be installed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -150,8 +150,12 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
     //   "rush init-autoinstaller"
     //   "rush update-autoinstaller"
     //
+    // In addition, the "rush setup" command is designed to help new users configure their access
+    // to a private NPM registry, which means it can't rely on plugins that might live in that
+    // registry.
+    //
     // Thus we do not report plugin errors when invoking these commands.
-    if (!['update', 'init-autoinstaller', 'update-autoinstaller'].includes(this.actionName)) {
+    if (!['update', 'init-autoinstaller', 'update-autoinstaller', 'setup'].includes(this.actionName)) {
       const pluginError: Error | undefined = this.parser.pluginManager.error;
       if (pluginError) {
         throw pluginError;


### PR DESCRIPTION
## Summary

If you publish rush plugins to a private NPM registry, then use them, you need to download them in an autoinstaller.

But, if a new user doesn't have credentials for the private NPM registry yet, they need to use `rush setup` (if configured), which blows up because the plugins can't be downloaded.

This PR adds `setup` to the list of magic actions that do not fail on plugin errors.

## Details

 - Add `setup` to the pre-existing list of actions.

## How it was tested

 - Tested locally in our repo -- with this change, the error message is still printed above, but it then continues on and asks to setup the credentials interactively.
