### PR TITLE
[rush] Rush setup can use "_authToken" instead of "_password"

### DIFF
--- a/common/changes/@microsoft/rush/enelson-credentialtype_2022-11-10-03-49.json
+++ b/common/changes/@microsoft/rush/enelson-credentialtype_2022-11-10-03-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add credentialType option for rush setup command",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
@@ -47,6 +47,14 @@
     "artifactoryWebsiteUrl": "",
 
     /**
+     * Uncomment this line to specify the type of credential to save in the user's ~/.npmrc file.
+     * The default is "password", which means the user's API token will be traded in for an
+     * npm password specific to that registry. Optionally you can specify "authToken", which
+     * will save the user's API token as credentials instead.
+     */
+    // "credentialType": "password",
+
+    /**
      * These settings allow the "rush setup" interactive prompts to be customized, for
      * example with messages specific to your team or configuration.  Specify an empty string
      * to suppress that message entirely.

--- a/libraries/rush-lib/src/logic/setup/ArtifactoryConfiguration.ts
+++ b/libraries/rush-lib/src/logic/setup/ArtifactoryConfiguration.ts
@@ -11,6 +11,8 @@ export interface IArtifactoryPackageRegistryJson {
   registryUrl: string;
   artifactoryWebsiteUrl: string;
 
+  credentialType?: 'password' | 'authToken';
+
   messageOverrides?: {
     introduction?: string;
     obtainAnAccount?: string;
@@ -56,6 +58,9 @@ export class ArtifactoryConfiguration {
 
     if (FileSystem.exists(this._jsonFileName)) {
       this._setupJson = JsonFile.loadAndValidate(this._jsonFileName, ArtifactoryConfiguration._jsonSchema);
+      if (!this._setupJson.packageRegistry.credentialType) {
+        this._setupJson.packageRegistry.credentialType = 'password';
+      }
     }
   }
 

--- a/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -326,6 +326,15 @@ export class SetupPackageRegistry {
     }
     responseLines.shift(); // Remove the @.npm line
 
+    // If we are configured to use authToken for authentication, we still go through the above process
+    // (both to ensure the user's credentials are valid, and to let Artifactory format the standard
+    // npmrc boilerplate for us), but we'll discard the generated password and use the authToken instead.
+    if (packageRegistry.credentialType === 'authToken') {
+      for (let i: number = 0; i < responseLines.length; i++) {
+        responseLines[i] = responseLines[i].replace(/_password=.+/, '_authToken=' + artifactoryKey);
+      }
+    }
+
     // These are the lines to be injected in ~/.npmrc
     const linesToAdd: string[] = [];
 

--- a/libraries/rush-lib/src/schemas/artifactory.schema.json
+++ b/libraries/rush-lib/src/schemas/artifactory.schema.json
@@ -32,6 +32,11 @@
           "description": "Specifies the URL of the Artifactory control panel where the user can generate an API key.  This URL is printed after the \"visitWebsite\" message.  It should look something like this example: https://your-company.jfrog.io/  Specify an empty string to suppress this line entirely.",
           "type": "string"
         },
+        "credentialType": {
+          "description": "Specifies the type of credential to save in the user's ~/.npmrc file. The default is \"password\", which means the user's entered API token will be passed to the Artifactory website URL specified and traded in for an npm registry password, which is saved. Specify \"authToken\" to save the authToken directly into the ~/.npmrc file and use that for credentials instead.",
+          "type": "string",
+          "enum": ["password", "authToken"]
+        },
 
         "messageOverrides": {
           "description": "These settings allow the \"rush setup\" interactive prompts to be customized, for example with messages specific to your team or configuration.  Specify an empty string to suppress that message entirely.",


### PR DESCRIPTION
## Summary

Add a new option, `credentialType`, to the artifactory setup schema for the `rush setup` command.

## Details

Today, the default behavior of `rush setup` is to ask for the jFrog user's API token, and then trade it in for an NPM password. This is a good default, as the API token can have all kinds of unrelated scopes and privileges on many different jFrog registries, whereas the password that we get after "trading it in" is scoped just to the NPM registry we are talking with.

However, in some cases, a monorepo maintainer might prefer that all users use their _API tokens_ instead of their NPM password (especially if the developers are also using that token for access to other jFrog registries as well).

## How it was tested

 - Tested new option locally with both the `password`, `authToken`, and missing (not defined) options.
