### PR TITLE
[@microsoft/loader-load-themed-styles][@rushstack/loader-raw-script][@rushstack/webpack4-localization-plugin] Resolving critical GitHub advisory with webpack/loader-utils

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.5.tgz
+      '@rushstack/heft': file:rushstack-heft-0.48.8.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.5.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.8.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.5.tgz
+      '@rushstack/heft': file:rushstack-heft-0.48.8.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.5.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.8.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -460,7 +460,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /cross-spawn/7.0.3:
@@ -1799,17 +1799,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.48.5.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.48.5.tgz}
+  file:../temp/tarballs/rushstack-heft-0.48.8.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.48.8.tgz}
     name: '@rushstack/heft'
-    version: 0.48.5
+    version: 0.48.8
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.12.5.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -1863,10 +1863,10 @@ packages:
     version: 0.2.4
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.12.5.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.12.5.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.12.5
+    version: 4.13.1
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/common/changes/@microsoft/loader-load-themed-styles/bugfix-audit-loader-utils_2022-11-11-18-34.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/bugfix-audit-loader-utils_2022-11-11-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Updating webpack/loader-utils to resolve github advisory CVE-2022-37601. https://github.com/advisories/GHSA-76p3-8jx3-jpfq",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles"
+}

--- a/common/changes/@rushstack/loader-raw-script/bugfix-audit-loader-utils_2022-11-11-18-34.json
+++ b/common/changes/@rushstack/loader-raw-script/bugfix-audit-loader-utils_2022-11-11-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/loader-raw-script",
+      "comment": "Updating webpack/loader-utils to resolve github advisory CVE-2022-37601. https://github.com/advisories/GHSA-76p3-8jx3-jpfq",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/loader-raw-script"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/bugfix-audit-loader-utils_2022-11-11-18-34.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/bugfix-audit-loader-utils_2022-11-11-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-localization-plugin",
+      "comment": "Updating webpack/loader-utils to resolve github advisory CVE-2022-37601. https://github.com/advisories/GHSA-76p3-8jx3-jpfq",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2369,9 +2369,9 @@ importers:
       '@types/loader-utils': 1.1.3
       '@types/node': 12.20.24
       '@types/webpack': 4.41.32
-      loader-utils: ~1.1.0
+      loader-utils: 1.4.2
     dependencies:
-      loader-utils: 1.1.0
+      loader-utils: 1.4.2
     devDependencies:
       '@microsoft/load-themed-styles': link:../../libraries/load-themed-styles
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -2389,9 +2389,9 @@ importers:
       '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 12.20.24
-      loader-utils: ~1.1.0
+      loader-utils: 1.4.2
     dependencies:
-      loader-utils: 1.1.0
+      loader-utils: 1.4.2
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -2470,7 +2470,7 @@ importers:
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.32
-      loader-utils: ~1.1.0
+      loader-utils: 1.4.2
       lodash: ~4.17.15
       minimatch: ~3.0.3
       webpack: ~4.44.2
@@ -2479,7 +2479,7 @@ importers:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/node': 12.20.24
       '@types/tapable': 1.0.6
-      loader-utils: 1.1.0
+      loader-utils: 1.4.2
       lodash: 4.17.21
       minimatch: 3.0.8
     devDependencies:
@@ -10218,7 +10218,7 @@ packages:
       camelcase: 5.3.1
       cssesc: 3.0.0
       icss-utils: 4.1.1
-      loader-utils: 1.4.0
+      loader-utils: 1.4.2
       normalize-path: 3.0.0
       postcss: 7.0.39
       postcss-modules-extract-imports: 2.0.0
@@ -13377,7 +13377,7 @@ packages:
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.32
       html-minifier-terser: 5.1.1
-      loader-utils: 1.4.0
+      loader-utils: 1.4.2
       lodash: 4.17.21
       pretty-error: 2.1.2
       tapable: 1.1.3
@@ -13394,7 +13394,7 @@ packages:
       '@types/tapable': 1.0.6
       '@types/webpack': 4.41.32
       html-minifier-terser: 5.1.1
-      loader-utils: 1.4.0
+      loader-utils: 1.4.2
       lodash: 4.17.21
       pretty-error: 2.1.2
       tapable: 1.1.3
@@ -15324,6 +15324,14 @@ packages:
 
   /loader-utils/1.4.0:
     resolution: {integrity: sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 1.0.1
+
+  /loader-utils/1.4.2:
+    resolution: {integrity: sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==}
     engines: {node: '>=4.0.0'}
     dependencies:
       big.js: 5.2.2
@@ -20754,7 +20762,7 @@ packages:
       global-modules: 2.0.0
       import-local: 2.0.0
       interpret: 1.4.0
-      loader-utils: 1.4.0
+      loader-utils: 1.4.2
       supports-color: 6.1.0
       v8-compile-cache: 2.3.0
       webpack: 4.44.2_webpack-cli@3.3.12

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "759a62e446b61b2ceea405459fed06537a607417",
+  "pnpmShrinkwrapHash": "f1b5560754a56b0869694a51e1c98b1885312bd3",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -25,7 +25,7 @@
     "@microsoft/load-themed-styles": "^2.0.14"
   },
   "dependencies": {
-    "loader-utils": "~1.1.0"
+    "loader-utils": "1.4.2"
   },
   "devDependencies": {
     "@microsoft/load-themed-styles": "workspace:*",

--- a/webpack/loader-raw-script/package.json
+++ b/webpack/loader-raw-script/package.json
@@ -16,7 +16,7 @@
     "_phase:test": "heft test --no-build"
   },
   "dependencies": {
-    "loader-utils": "~1.1.0"
+    "loader-utils": "1.4.2"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",

--- a/webpack/webpack4-localization-plugin/package.json
+++ b/webpack/webpack4-localization-plugin/package.json
@@ -32,7 +32,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@types/node": "12.20.24",
     "@types/tapable": "1.0.6",
-    "loader-utils": "~1.1.0",
+    "loader-utils": "1.4.2",
     "lodash": "~4.17.15",
     "minimatch": "~3.0.3"
   },


### PR DESCRIPTION
## Summary

Resolving critical GitHub advisory: https://github.com/advisories/GHSA-76p3-8jx3-jpfq

## Details

Updated [Webpack/loader-utils](https://github.com/webpack/loader-utils) to version 1.4.2

## How it was tested

node: v16.18.0
OS: windows 10

After updates ran:

`rush install`, `rush build`, `rush test` to verify that no install/build/test was affected.