### PR TITLE
Fix regression with localhost certificates

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/cert-fixes_2022-11-11-23-28.json
+++ b/common/changes/@rushstack/debug-certificate-manager/cert-fixes_2022-11-11-23-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Mark X.509 issuerAltName extension non-critical, since Firefox doesn't understand it.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/cert-fixes_2022-11-11-23-28.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/cert-fixes_2022-11-11-23-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "Serve the CA certificate alongside the TLS certificate.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/rush-serve-plugin/cert-fixes_2022-11-11-23-28.json
+++ b/common/changes/@rushstack/rush-serve-plugin/cert-fixes_2022-11-11-23-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "Serve the CA certificate alongside the TLS certificate.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
+++ b/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
@@ -124,7 +124,8 @@ export class DevCertPlugin implements IHeftPlugin {
             options: {
               minVersion: 'TLSv1.3',
               key: certificate.pemKey,
-              cert: certificate.pemCertificate
+              cert: certificate.pemCertificate,
+              ca: certificate.pemCaCertificate
             }
           }
         };
@@ -133,7 +134,8 @@ export class DevCertPlugin implements IHeftPlugin {
           ...originalDevServer,
           https: {
             key: certificate.pemKey,
-            cert: certificate.pemCertificate
+            cert: certificate.pemCertificate,
+            ca: certificate.pemCaCertificate
           }
         };
       }

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -295,7 +295,7 @@ export class CertificateManager {
       {
         name: 'issuerAltName',
         altNames,
-        critical: true
+        critical: false
       },
       {
         name: 'keyUsage',
@@ -380,7 +380,7 @@ export class CertificateManager {
       {
         name: 'issuerAltName',
         altNames: issuerAltNames,
-        critical: true
+        critical: false
       },
       {
         name: 'keyUsage',

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -150,6 +150,7 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
 
       const server: https.Server = https.createServer(
         {
+          ca: certificate.pemCaCertificate,
           cert: certificate.pemCertificate,
           key: certificate.pemKey
         },


### PR DESCRIPTION
## Summary
Updates consumers of debug-certificate-manager to serve the CA certificate in addition to the TLS certificate.
Updates debug-certificate-manager to mark the X.509 `issuerAltName` extension as non-critical, since Firefox doesn't understand it.

## Details


## How it was tested
Local debugging with newly generated certs in various browsers. Chrome, Edge, Firefox.