### PR TITLE
[rush] Ensure autoinstaller lockfile is deleted

### DIFF
--- a/common/changes/@microsoft/rush/enelson-autoinstaller_2022-11-12-03-19.json
+++ b/common/changes/@microsoft/rush/enelson-autoinstaller_2022-11-12-03-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Ensure autoinstaller lockfiles are not leftover after an error",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

If an error occurs while autoinstaller is prepared, a lockfile is left behind, which makes updating autoinstallers a little more annoying.

This is specifically an issue for your "rush-plugins" autoinstaller, if you have one, because every time you run "update-autoinstaller" you'll leave a lockfile behind, which you can then accidentally commit with your other files. 

> Reviewer tip: review with [whitespace off](https://github.com/microsoft/rushstack/pull/3746/files?w=1).

## Details

- Ensure that if an error occurs (e.g. pnpm generates an error), the lockfile is still deleted.

## How it was tested

- Touched `package.json` in a local `rush-plugins` autoinstaller and ran `rush update-autoinstaller` on it, confirmed no lockfile was left behind.
