### PR TITLE
[dev-cert-plugin] Fix Webpack auto-refresh issues caused by mismatched hostname

### DIFF
--- a/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-FixWebpackStart_2022-11-14-20-23.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/user-danade-FixWebpackStart_2022-11-14-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "Fix Webpack auto-refresh issues caused by mismatched hostname",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
+++ b/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
@@ -101,7 +101,7 @@ export class DevCertPlugin implements IHeftPlugin {
       const { devServer: originalDevServer } = webpackConfiguration;
       const hostname: string | undefined = certificate.subjectAltNames?.[0];
       if (webpackDevServerMajorVersion && webpackDevServerMajorVersion === 4) {
-        let client: WebpackDevServerConfig['client'] = originalDevServer?.client;
+        const client: WebpackDevServerConfig['client'] = originalDevServer?.client;
         if (hostname) {
           if (typeof client === 'object') {
             const { webSocketURL } = client;

--- a/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
+++ b/heft-plugins/heft-dev-cert-plugin/src/DevCertPlugin.ts
@@ -106,7 +106,7 @@ export class DevCertPlugin implements IHeftPlugin {
           if (typeof client === 'object') {
             const { webSocketURL } = client;
             if (typeof webSocketURL === 'object') {
-              client = {
+              originalDevServer!.client = {
                 ...client,
                 webSocketURL: {
                   ...webSocketURL,


### PR DESCRIPTION
## Summary

Mismatched hostnames supplied to the Webpack devserver can cause auto-refresh to stop working in some scenarios. This fix ensures that the value is correctly set in the Webpack configuration.

## How it was tested

Locally ran start mode.