### PR TITLE
[rush] get file hashs under git submodule paths when calculating build cache id

### DIFF
--- a/common/changes/@microsoft/rush/fix-build-cache-submodules_2022-11-15-04-53.json
+++ b/common/changes/@microsoft/rush/fix-build-cache-submodules_2022-11-15-04-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Supports git submodule in build cache",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodules_2022-11-15-04-53.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodules_2022-11-15-04-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "get file hashs under git submodule paths when getting repo state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodules_2022-11-15-04-53.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodules_2022-11-15-04-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/package-deps-hash",
-      "comment": "get file hashs under git submodule paths when getting repo state",
+      "comment": "Get file hashes under git submodule paths when analyzing repo state",
       "type": "patch"
     }
   ],

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -247,7 +247,7 @@ export function applyWorkingTreeState(
 }
 
 /**
- * Get the list of all git submodules path
+ * Get the list of all git submodule paths
  * @param rootDirectory - The root directory of the Git repository
  * @param gitPath - The path to the Git executable
  * @internal

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -252,7 +252,7 @@ export function applyWorkingTreeState(
  * @param gitPath - The path to the Git executable
  * @internal
  */
-export function getSubmodulePaths(rootDirectory: string, gitPath?: string): string[] {
+function getSubmodulePaths(rootDirectory: string, gitPath?: string): string[] {
   const submodulePaths: string[] = [];
 
   const submoduleStatusResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
@@ -288,11 +288,7 @@ export function getSubmodulePaths(rootDirectory: string, gitPath?: string): stri
  * @param gitPath - The path to the Git executable
  * @internal
  */
-export function applySubmodulesTreeState(
-  rootDirectory: string,
-  state: Map<string, string>,
-  gitPath?: string
-): void {
+function applySubmodulesTreeState(rootDirectory: string, state: Map<string, string>, gitPath?: string): void {
   const submodulePaths: string[] = getSubmodulePaths(rootDirectory, gitPath);
 
   if (submodulePaths.length === 0) {

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -186,7 +186,7 @@ export function applyWorkingTreeState(
 ): void {
   const statusResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
     gitPath || 'git',
-    ['--no-optional-locks', 'status', '-z', '-u', '--no-renames', '--'],
+    ['--no-optional-locks', 'status', '-z', '-u', '--no-renames', '--ignore-submodules', '--'],
     {
       currentWorkingDirectory: rootDirectory
     }
@@ -247,6 +247,109 @@ export function applyWorkingTreeState(
 }
 
 /**
+ * Get the list of all git submodules path
+ * @param rootDirectory - The root directory of the Git repository
+ * @param gitPath - The path to the Git executable
+ * @internal
+ */
+export function getSubmodulePaths(rootDirectory: string, gitPath?: string): string[] {
+  const submodulePaths: string[] = [];
+
+  const submoduleStatusResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+    gitPath || 'git',
+    ['submodule', 'status'],
+    {
+      currentWorkingDirectory: rootDirectory
+    }
+  );
+
+  if (submoduleStatusResult.status !== 0) {
+    ensureGitMinimumVersion(gitPath);
+
+    throw new Error(
+      `git submodule status exited with status ${submoduleStatusResult.status}: ${submoduleStatusResult.stderr}`
+    );
+  }
+
+  // <hash> <path> (heads/main)\n
+  submoduleStatusResult.stdout.split('\n').forEach((line) => {
+    if (line) {
+      const [, submodulePath] = line.trim().split(' ');
+      submodulePaths.push(submodulePath);
+    }
+  });
+  return submodulePaths;
+}
+
+/**
+ * Augments the state value with modifications that are in git submodules
+ * @param rootDirectory - The root directory of the Git repository
+ * @param state - The current map of git path -> object hash. Will be mutated.
+ * @param gitPath - The path to the Git executable
+ * @internal
+ */
+export function applySubmodulesTreeState(
+  rootDirectory: string,
+  state: Map<string, string>,
+  gitPath?: string
+): void {
+  const submodulePaths: string[] = getSubmodulePaths(rootDirectory, gitPath);
+
+  if (submodulePaths.length === 0) {
+    return;
+  }
+
+  const submoduleLsTreeResult: child_process.SpawnSyncReturns<string> = Executable.spawnSync(
+    gitPath || 'git',
+    ['submodule', 'foreach', 'git', '--no-optional-locks', 'ls-tree', '-r', '--full-name', 'HEAD', '--'],
+    {
+      currentWorkingDirectory: rootDirectory
+    }
+  );
+
+  if (submoduleLsTreeResult.status !== 0) {
+    ensureGitMinimumVersion(gitPath);
+
+    throw new Error(
+      `git ls-tree for submodules exited with status ${submoduleLsTreeResult.status}: ${submoduleLsTreeResult.stderr}`
+    );
+  }
+
+  const stateBySubmodulePath: Record<string, Record<string, string>> = {};
+
+  let currentSubmodulePath: string = '';
+
+  // Entering '<submoduleFolder>'\n
+  // <mode> <type> <newhash>\t<path>\n
+  submoduleLsTreeResult.stdout.split('\n').forEach((line) => {
+    if (line) {
+      line = line.trim();
+      const submodulePath: string | undefined = line.match(/'(.*)'/)?.[1];
+      if (submodulePath) {
+        currentSubmodulePath = submodulePath;
+        stateBySubmodulePath[currentSubmodulePath] = {};
+      } else {
+        const tabIndex: number = line.indexOf('\t');
+        const filePath: string = line.slice(tabIndex + 1);
+
+        // The newHash will be all zeros if the file is deleted, or a hash if it exists
+        const hash: string = line.slice(tabIndex - 40, tabIndex);
+        if (stateBySubmodulePath[currentSubmodulePath] === undefined) {
+          stateBySubmodulePath[currentSubmodulePath] = {};
+        }
+        stateBySubmodulePath[currentSubmodulePath][filePath] = hash;
+      }
+    }
+  });
+
+  for (const submodulePath of submodulePaths) {
+    for (const [filePath, hash] of Object.entries(stateBySubmodulePath[submodulePath])) {
+      state.set(`${submodulePath}/${filePath}`, hash);
+    }
+  }
+}
+
+/**
  * Gets the object hashes for all files in the Git repo, combining the current commit with working tree state.
  * @param currentWorkingDirectory - The working directory. Only used to find the repository root.
  * @param gitPath - The path to the Git executable
@@ -270,6 +373,8 @@ export function getRepoState(currentWorkingDirectory: string, gitPath?: string):
   }
 
   const state: Map<string, string> = parseGitLsTree(lsTreeResult.stdout);
+
+  applySubmodulesTreeState(rootDirectory, state, gitPath);
 
   applyWorkingTreeState(rootDirectory, state, gitPath);
 

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -309,7 +309,7 @@ export function _parseGitSubmoduleForEachGitLsTree(output: string): Record<strin
   output.split('\n').forEach((line) => {
     if (line) {
       line = line.trim();
-      const submodulePath: string | undefined = line.match(/'(.*)'/)?.[1];
+      const submodulePath: string | undefined = line.match(/\s'(.*)'$/)?.[1];
       if (submodulePath) {
         currentSubmodulePath = submodulePath;
         stateBySubmodulePath[currentSubmodulePath] = {};

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { parseGitStatus, parseGitVersion } from '../getRepoState';
+import {
+  parseGitStatus,
+  parseGitVersion,
+  _parseGitSubmoduleStatus,
+  _parseGitSubmoduleForEachGitLsTree
+} from '../getRepoState';
 
 describe(parseGitVersion.name, () => {
   it('Can parse valid git version responses', () => {
@@ -85,5 +90,48 @@ describe(parseGitStatus.name, () => {
     expect(result.get(files[0])).toEqual(false);
     expect(result.get(files[1])).toEqual(false);
     expect(result.get(files[2])).toEqual(true);
+  });
+});
+
+describe(_parseGitSubmoduleStatus.name, () => {
+  it('Can parse valid git submodule status responses', () => {
+    expect(
+      _parseGitSubmoduleStatus(` 964eb484a347b0aac4e68995139080fb0d4bc1c4 submodule1 (heads/main)
+ 964eb484a347b0aac4e68995139080fb0d4bc1c4 submodule2 (heads/main)`)
+    ).toEqual(['submodule1', 'submodule2']);
+  });
+});
+
+describe(_parseGitSubmoduleForEachGitLsTree.name, () => {
+  it('Can parse valid git submodule foreach ls-tree responses', () => {
+    expect(
+      _parseGitSubmoduleForEachGitLsTree(`Entering 'submodule1'
+100644 blob 9f818da416c78e02c82dbd1899fe21ca2975e77d${'\t'}.gitignore
+100644 blob 0cb89e60375d44cb4f8cefc2be036042f5aaf95f${'\t'}env/config/rush-project.json
+100644 blob 0a26f06602cd2dab7d7220ae6724f964630efd10${'\t'}env/package.json
+100644 blob 46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f${'\t'}env/src/index.ts
+100644 blob da13b3825764a87531ab94a94260a2dbcc2bb8c0${'\t'}env/tsconfig.json
+进入 'submodule2'
+100644 blob 9f818da416c78e02c82dbd1899fe21ca2975e77d${'\t'}.gitignore
+100644 blob 0cb89e60375d44cb4f8cefc2be036042f5aaf95f${'\t'}env/config/rush-project.json
+100644 blob 0a26f06602cd2dab7d7220ae6724f964630efd10${'\t'}env/package.json
+100644 blob 46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f${'\t'}env/src/index.ts
+100644 blob da13b3825764a87531ab94a94260a2dbcc2bb8c0${'\t'}env/tsconfig.json`)
+    ).toEqual({
+      submodule1: {
+        '.gitignore': '9f818da416c78e02c82dbd1899fe21ca2975e77d',
+        'env/config/rush-project.json': '0cb89e60375d44cb4f8cefc2be036042f5aaf95f',
+        'env/package.json': '0a26f06602cd2dab7d7220ae6724f964630efd10',
+        'env/src/index.ts': '46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f',
+        'env/tsconfig.json': 'da13b3825764a87531ab94a94260a2dbcc2bb8c0'
+      },
+      submodule2: {
+        '.gitignore': '9f818da416c78e02c82dbd1899fe21ca2975e77d',
+        'env/config/rush-project.json': '0cb89e60375d44cb4f8cefc2be036042f5aaf95f',
+        'env/package.json': '0a26f06602cd2dab7d7220ae6724f964630efd10',
+        'env/src/index.ts': '46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f',
+        'env/tsconfig.json': 'da13b3825764a87531ab94a94260a2dbcc2bb8c0'
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/microsoft/rushstack/issues/1711

1. Analyzing state no more complain about submodule paths
2. File hashs under git submodule paths are taken into consideration when calculating build cache id

## Details

1. get all submodule paths by `git submodule status`
2. get file hashs under all submodule paths by `git submodule foreach git --no-optional-locks ls-tree -r --full-name HEAD`
3. apply file hashs under all submodule paths to repo state.

## How it was tested

Tested in this repo: https://github.com/chengcyber/rush-build-cache-submodule-demo

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
