### PR TITLE
[package-deps-hash] Parallelize getRepoState

### DIFF
--- a/common/changes/@microsoft/rush/repo-state-performance_2022-12-10-00-54.json
+++ b/common/changes/@microsoft/rush/repo-state-performance_2022-12-10-00-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use getRepoStateAsync to optimize performance of calculating repository state.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/repo-state-performance_2022-12-10-00-54.json
+++ b/common/changes/@rushstack/package-deps-hash/repo-state-performance_2022-12-10-00-54.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/package-deps-hash",
-      "comment": "Add getRepoStateAsync API for faster repository state calculation.",
-      "type": "minor"
+      "comment": "Add getRepoStateAsync API for faster repository state calculation. Remove synchronous getRepoState API.",
+      "type": "major"
     }
   ],
   "packageName": "@rushstack/package-deps-hash"

--- a/common/changes/@rushstack/package-deps-hash/repo-state-performance_2022-12-10-00-54.json
+++ b/common/changes/@rushstack/package-deps-hash/repo-state-performance_2022-12-10-00-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Add getRepoStateAsync API for faster repository state calculation.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -20,9 +20,6 @@ export function getRepoChanges(currentWorkingDirectory: string, revision?: strin
 export function getRepoRoot(currentWorkingDirectory: string, gitPath?: string): string;
 
 // @beta
-export function getRepoState(currentWorkingDirectory: string, gitPath?: string): Map<string, string>;
-
-// @beta
 export function getRepoStateAsync(rootDirectory: string, additionalRelativePathsToHash?: string[], gitPath?: string): Promise<Map<string, string>>;
 
 // @beta

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -23,6 +23,9 @@ export function getRepoRoot(currentWorkingDirectory: string, gitPath?: string): 
 export function getRepoState(currentWorkingDirectory: string, gitPath?: string): Map<string, string>;
 
 // @beta
+export function getRepoStateAsync(rootDirectory: string, additionalRelativePathsToHash?: string[], gitPath?: string): Promise<Map<string, string>>;
+
+// @beta
 export interface IFileDiffStatus {
     // (undocumented)
     mode: string;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -740,7 +740,7 @@ export class ProjectChangeAnalyzer {
     // Warning: (ae-forgotten-export) The symbol "IRawRepoState" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
-    _ensureInitialized(terminal: ITerminal): IRawRepoState | undefined;
+    _ensureInitializedAsync(terminal: ITerminal): Promise<IRawRepoState | undefined>;
     // (undocumented)
     _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
     getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -19,5 +19,6 @@ export {
   getRepoChanges,
   getRepoRoot,
   getRepoState,
+  getRepoStateAsync,
   ensureGitMinimumVersion
 } from './getRepoState';

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -18,7 +18,6 @@ export {
   IFileDiffStatus,
   getRepoChanges,
   getRepoRoot,
-  getRepoState,
   getRepoStateAsync,
   ensureGitMinimumVersion
 } from './getRepoState';

--- a/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
+++ b/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getRepoStateAsync can handle adding one file 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync can handle adding two files 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/b.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync can handle changing one file 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync can handle removing one file 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync can handle uncommitted filenames with spaces and non-ASCII characters 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/a  file name.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/a file.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/newFile批把.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync can parse committed files 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;
+
+exports[`getRepoStateAsync handles requests for additional files 1`] = `
+Object {
+  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+  "testProject/log.log": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+}
+`;

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -85,7 +85,8 @@ describe(parseGitLsTree.name, () => {
 
 describe(getRepoStateAsync.name, () => {
   it('can parse committed files', async () => {
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
     const expectedFiles: Map<string, string> = new Map(
       Object.entries({
@@ -109,7 +110,8 @@ describe(getRepoStateAsync.name, () => {
 
     FileSystem.writeFile(tempFilePath, 'a');
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
@@ -141,7 +143,8 @@ describe(getRepoStateAsync.name, () => {
     FileSystem.writeFile(tempFilePath1, 'a');
     FileSystem.writeFile(tempFilePath2, 'a');
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
@@ -173,7 +176,8 @@ describe(getRepoStateAsync.name, () => {
 
     FileSystem.deleteFile(testFilePath);
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
@@ -204,7 +208,8 @@ describe(getRepoStateAsync.name, () => {
 
     FileSystem.writeFile(testFilePath, 'abc');
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
@@ -240,7 +245,8 @@ describe(getRepoStateAsync.name, () => {
     FileSystem.writeFile(tempFilePath2, 'a');
     FileSystem.writeFile(tempFilePath3, 'a');
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname);
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
@@ -274,7 +280,8 @@ describe(getRepoStateAsync.name, () => {
 
     FileSystem.writeFile(tempFilePath1, 'a');
 
-    const results: Map<string, string> = await getRepoStateAsync(__dirname, [
+    const repoRoot: string = getRepoRoot(__dirname);
+    const results: Map<string, string> = await getRepoStateAsync(repoRoot, [
       `${TEST_PREFIX}testProject/log.log`
     ]);
     const filteredResults: Map<string, string> = getRelevantEntries(results);

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -30,6 +30,14 @@ function getRelevantEntries(results: Map<string, string>): Map<string, string> {
   return relevantResults;
 }
 
+function checkSnapshot(results: Map<string, string>): void {
+  const asObject: Record<string, string> = {};
+  for (const [key, value] of results) {
+    asObject[key] = value;
+  }
+  expect(asObject).toMatchSnapshot();
+}
+
 describe(getRepoRoot.name, () => {
   it(`returns the correct directory`, () => {
     const root: string = getRepoRoot(__dirname);
@@ -88,6 +96,7 @@ describe(getRepoStateAsync.name, () => {
     const repoRoot: string = getRepoRoot(__dirname);
     const results: Map<string, string> = await getRepoStateAsync(repoRoot);
     const filteredResults: Map<string, string> = getRelevantEntries(results);
+    checkSnapshot(filteredResults);
     const expectedFiles: Map<string, string> = new Map(
       Object.entries({
         'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -115,6 +124,7 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -148,6 +158,7 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -181,6 +192,7 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -213,6 +225,7 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -250,6 +263,8 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
+
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',
@@ -287,6 +302,7 @@ describe(getRepoStateAsync.name, () => {
     const filteredResults: Map<string, string> = getRelevantEntries(results);
 
     try {
+      checkSnapshot(filteredResults);
       const expectedFiles: Map<string, string> = new Map(
         Object.entries({
           'nestedTestProject/src/file 1.txt': 'c7b2f707ac99ca522f965210a7b6b0b109863f34',

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -353,7 +353,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     terminal.write('Analyzing repo state... ');
     const repoStateStopwatch: Stopwatch = new Stopwatch();
     repoStateStopwatch.start();
-    projectChangeAnalyzer._ensureInitialized(terminal);
+    await projectChangeAnalyzer._ensureInitializedAsync(terminal);
     repoStateStopwatch.stop();
     terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
     terminal.writeLine();

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -1,11 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+jest.mock(`@rushstack/package-deps-hash`, () => {
+  return {
+    getRepoRoot(dir: string): string {
+      return dir;
+    },
+    getRepoStateAsync(): ReadonlyMap<string, string> {
+      return new Map();
+    },
+    getRepoChangesAsync(): ReadonlyMap<string, string> {
+      return new Map();
+    }
+  };
+});
+
 import './mockRushCommandLineParser';
 
 import * as path from 'path';
 import { FileSystem, JsonFile, Path, PackageJsonLookup } from '@rushstack/node-core-library';
-import { RushCommandLineParser } from '../RushCommandLineParser';
+import type { RushCommandLineParser as RushCommandLineParserType } from '../RushCommandLineParser';
 import { LastLinkFlagFactory } from '../../api/LastLinkFlag';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import { ITelemetryData } from '../../logic/Telemetry';
@@ -31,7 +45,7 @@ interface IChildProcessModuleMock {
  * Interface definition for a test instance for the RushCommandLineParser.
  */
 interface IParserTestInstance {
-  parser: RushCommandLineParser;
+  parser: RushCommandLineParserType;
   spawnMock: jest.Mock;
 }
 
@@ -66,7 +80,10 @@ const __dirnameInLib: string = getDirnameInLib();
 /**
  * Helper to set up a test instance for RushCommandLineParser.
  */
-function getCommandLineParserInstance(repoName: string, taskName: string): IParserTestInstance {
+async function getCommandLineParserInstanceAsync(
+  repoName: string,
+  taskName: string
+): Promise<IParserTestInstance> {
   // Run these tests in the /lib folder because some of them require compiled output
   // Point to the test repo folder
   const startPath: string = `${__dirnameInLib}/${repoName}`;
@@ -76,11 +93,13 @@ function getCommandLineParserInstance(repoName: string, taskName: string): IPars
   FileSystem.deleteFolder(`${startPath}/a/.rush/temp`);
   FileSystem.deleteFolder(`${startPath}/b/.rush/temp`);
 
+  const { RushCommandLineParser } = await import('../RushCommandLineParser');
+
   // Create a Rush CLI instance. This instance is heavy-weight and relies on setting process.exit
   // to exit and clear the Rush file lock. So running multiple `it` or `describe` test blocks over the same test
   // repo will fail due to contention over the same lock which is kept until the test runner process
   // ends.
-  const parser: RushCommandLineParser = new RushCommandLineParser({ cwd: startPath });
+  const parser: RushCommandLineParserType = new RushCommandLineParser({ cwd: startPath });
 
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid
@@ -104,8 +123,8 @@ function pathEquals(actual: string, expected: string): void {
 const SPAWN_ARG_ARGS: number = 1;
 const SPAWN_ARG_OPTIONS: number = 2;
 
-describe(RushCommandLineParser.name, () => {
-  describe(RushCommandLineParser.prototype.execute.name, () => {
+describe('RushCommandLineParser', () => {
+  describe('execute', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -114,7 +133,7 @@ describe(RushCommandLineParser.name, () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'basicAndRunBuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'build');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
 
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
@@ -146,7 +165,7 @@ describe(RushCommandLineParser.name, () => {
       describe("'rebuild' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'basicAndRunRebuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'rebuild');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
 
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
@@ -180,7 +199,7 @@ describe(RushCommandLineParser.name, () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'overrideRebuildAndRunBuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'build');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
 
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
@@ -212,7 +231,7 @@ describe(RushCommandLineParser.name, () => {
       describe("'rebuild' action", () => {
         it(`executes the package's 'rebuild' script`, async () => {
           const repoName: string = 'overrideRebuildAndRunRebuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'rebuild');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
 
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
@@ -246,7 +265,7 @@ describe(RushCommandLineParser.name, () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'overrideAndDefaultBuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'build');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
           // There should be 1 build per package
@@ -278,7 +297,7 @@ describe(RushCommandLineParser.name, () => {
         it(`executes the package's 'build' script`, async () => {
           // broken
           const repoName: string = 'overrideAndDefaultRebuildActionRepo';
-          const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'rebuild');
+          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
           await expect(instance.parser.execute()).resolves.toEqual(true);
 
           // There should be 1 build per package
@@ -311,9 +330,9 @@ describe(RushCommandLineParser.name, () => {
       it(`throws an error when starting Rush`, async () => {
         const repoName: string = 'overrideBuildAsGlobalCommandRepo';
 
-        await expect(() => {
-          getCommandLineParserInstance(repoName, 'doesnt-matter');
-        }).toThrowErrorMatchingInlineSnapshot(
+        await expect(async () => {
+          await getCommandLineParserInstanceAsync(repoName, 'doesnt-matter');
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
           `"command-line.json defines a command \\"build\\" using the command kind \\"global\\". This command can only be designated as a command kind \\"bulk\\" or \\"phased\\"."`
         );
       });
@@ -323,9 +342,9 @@ describe(RushCommandLineParser.name, () => {
       it(`throws an error when starting Rush`, async () => {
         const repoName: string = 'overrideRebuildAsGlobalCommandRepo';
 
-        await expect(() => {
-          getCommandLineParserInstance(repoName, 'doesnt-matter');
-        }).toThrowErrorMatchingInlineSnapshot(
+        await expect(async () => {
+          await getCommandLineParserInstanceAsync(repoName, 'doesnt-matter');
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
           `"command-line.json defines a command \\"rebuild\\" using the command kind \\"global\\". This command can only be designated as a command kind \\"bulk\\" or \\"phased\\"."`
         );
       });
@@ -335,9 +354,9 @@ describe(RushCommandLineParser.name, () => {
       it(`throws an error when starting Rush`, async () => {
         const repoName: string = 'overrideBuildWithSimultaneousProcessesRepo';
 
-        await expect(() => {
-          getCommandLineParserInstance(repoName, 'doesnt-matter');
-        }).toThrowErrorMatchingInlineSnapshot(
+        await expect(async () => {
+          await getCommandLineParserInstanceAsync(repoName, 'doesnt-matter');
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
           `"command-line.json defines a command \\"build\\" using \\"safeForSimultaneousRushProcesses=true\\". This configuration is not supported for \\"build\\"."`
         );
       });
@@ -347,9 +366,9 @@ describe(RushCommandLineParser.name, () => {
       it(`throws an error when starting Rush`, async () => {
         const repoName: string = 'overrideRebuildWithSimultaneousProcessesRepo';
 
-        await expect(() => {
-          getCommandLineParserInstance(repoName, 'doesnt-matter');
-        }).toThrowErrorMatchingInlineSnapshot(
+        await expect(async () => {
+          await getCommandLineParserInstanceAsync(repoName, 'doesnt-matter');
+        }).rejects.toThrowErrorMatchingInlineSnapshot(
           `"command-line.json defines a command \\"rebuild\\" using \\"safeForSimultaneousRushProcesses=true\\". This configuration is not supported for \\"rebuild\\"."`
         );
       });
@@ -358,7 +377,7 @@ describe(RushCommandLineParser.name, () => {
     describe('in repo plugin custom flushTelemetry', () => {
       it('creates a custom telemetry file', async () => {
         const repoName: string = 'tapFlushTelemetryAndRunBuildActionRepo';
-        const instance: IParserTestInstance = getCommandLineParserInstance(repoName, 'build');
+        const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
         const telemetryFilePath: string = `${instance.parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
         FileSystem.deleteFile(telemetryFilePath);
 

--- a/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -46,12 +46,12 @@ describe(ProjectChangeAnalyzer.name, () => {
 
     const subject: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
 
-    subject['_getRepoDeps'] = jest.fn(() => {
-      return {
+    subject['_getRepoDepsAsync'] = jest.fn(() => {
+      return Promise.resolve({
         gitPath: 'git',
         hashes: files,
         rootDir: ''
-      };
+      });
     });
 
     return subject;
@@ -255,7 +255,7 @@ describe(ProjectChangeAnalyzer.name, () => {
       expect(await subject._tryGetProjectDependenciesAsync(projects[0], terminal)).toEqual(
         new Map([['apps/apple/core.js', 'a101']])
       );
-      expect(subject['_getRepoDeps']).toHaveBeenCalledTimes(1);
+      expect(subject['_getRepoDepsAsync']).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary
Prototypes parallelizing as many of the Git calls involved in calculating the state used by `ProjectChangeAnalyzer` as possible.

## Details
Parallelizes the following operations:
- `git ls-tree HEAD` for the state of the committed tree
- `git status` for the working tree state
- `git hash-object` on the project shrinkwrap files

The following operation still needs to run serially:
- `git hash-object` for changed files in the working tree, though it can use the same process invocation and delay passing the filenames on stdin

Reduces time for initializing `ProjectChangeAnalyzer` on my Windows dev box for the rushstack repository from 0.5 seconds to 0.3 seconds.
Reduces time for initializing `ProjectChangeAnalyzer` on my Windows dev box for an internal repository from 2.2 seconds to 1.5 seconds.

Related #3750

## How it was tested
Comparing invocations of `rush build -o heft-web-rig` to `node ./apps/rush/lib/start-dev.js build -o heft-web-rig` with respect to the timing of the `Analyzing repo state...` section.