### PR TITLE
[rush] fix performance regression from supporting git submodules

### DIFF
--- a/common/changes/@microsoft/rush/fix-build-cache-submodule_2022-11-17-04-33.json
+++ b/common/changes/@microsoft/rush/fix-build-cache-submodule_2022-11-17-04-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix performance regression from supporting git submodules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodule_2022-11-17-04-33.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-build-cache-submodule_2022-11-17-04-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Refactor the logic of getting file hashes under git submodule paths",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -300,9 +300,9 @@ export function getRepoState(currentWorkingDirectory: string, gitPath?: string):
   const state: Map<string, string> = files;
 
   // Existence check for the .gitmodules file
-  const hasSubmodules: boolean = FileSystem.exists(`${rootDirectory}/.gitmodules`);
+  const hasSubmodules: boolean = submodules.size > 0 && FileSystem.exists(`${rootDirectory}/.gitmodules`);
 
-  if (hasSubmodules && submodules.size > 0) {
+  if (hasSubmodules) {
     for (const submodulePath of submodules.keys()) {
       const submoduleState: Map<string, string> = getRepoState(`${rootDirectory}/${submodulePath}`, gitPath);
       for (const [filePath, hash] of submoduleState) {

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -44,10 +44,10 @@ describe(parseGitLsTree.name, () => {
     const hash: string = '3451bccdc831cb43d7a70ed8e628dcf9c7f888c8';
 
     const output: string = `100644 blob ${hash}\t${filename}\x00`;
-    const changes: Map<string, string> = parseGitLsTree(output);
+    const { files } = parseGitLsTree(output);
 
-    expect(changes.size).toEqual(1); // Expect there to be exactly 1 change
-    expect(changes.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
+    expect(files.size).toEqual(1); // Expect there to be exactly 1 change
+    expect(files.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
   });
 
   it('can handle a submodule', () => {
@@ -55,10 +55,10 @@ describe(parseGitLsTree.name, () => {
     const hash: string = 'c5880bf5b0c6c1f2e2c43c95beeb8f0a808e8bac';
 
     const output: string = `160000 commit ${hash}\t${filename}\x00`;
-    const changes: Map<string, string> = parseGitLsTree(output);
+    const { submodules } = parseGitLsTree(output);
 
-    expect(changes.size).toEqual(1); // Expect there to be exactly 1 change
-    expect(changes.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
+    expect(submodules.size).toEqual(1); // Expect there to be exactly 1 submodule change
+    expect(submodules.get(filename)).toEqual(hash); // Expect the hash to be ${hash}
   });
 
   it('can handle multiple lines', () => {
@@ -68,12 +68,18 @@ describe(parseGitLsTree.name, () => {
     const filename2: string = 'src/foo bar/tsd.d.ts';
     const hash2: string = '0123456789abcdef1234567890abcdef01234567';
 
-    const output: string = `100644 blob ${hash1}\t${filename1}\x00100666 blob ${hash2}\t${filename2}\0`;
-    const changes: Map<string, string> = parseGitLsTree(output);
+    const filename3: string = 'submodule/src/index.ts';
+    const hash3: string = 'fedcba9876543210fedcba9876543210fedcba98';
 
-    expect(changes.size).toEqual(2); // Expect there to be exactly 2 changes
-    expect(changes.get(filename1)).toEqual(hash1); // Expect the hash to be ${hash1}
-    expect(changes.get(filename2)).toEqual(hash2); // Expect the hash to be ${hash2}
+    const output: string = `100644 blob ${hash1}\t${filename1}\x00100666 blob ${hash2}\t${filename2}\x00106666 commit ${hash3}\t${filename3}\0`;
+    const { files, submodules } = parseGitLsTree(output);
+
+    expect(files.size).toEqual(2); // Expect there to be exactly 2 changes
+    expect(files.get(filename1)).toEqual(hash1); // Expect the hash to be ${hash1}
+    expect(files.get(filename2)).toEqual(hash2); // Expect the hash to be ${hash2}
+
+    expect(submodules.size).toEqual(1); // Expect there to be exactly 1 submodule changes
+    expect(submodules.get(filename3)).toEqual(hash3); // Expect the hash to be ${hash3}
   });
 });
 

--- a/libraries/package-deps-hash/src/test/getRepoState.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoState.test.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import {
-  parseGitStatus,
-  parseGitVersion,
-  _parseGitSubmoduleStatus,
-  _parseGitSubmoduleForEachGitLsTree
-} from '../getRepoState';
+import { parseGitStatus, parseGitVersion } from '../getRepoState';
 
 describe(parseGitVersion.name, () => {
   it('Can parse valid git version responses', () => {
@@ -90,48 +85,5 @@ describe(parseGitStatus.name, () => {
     expect(result.get(files[0])).toEqual(false);
     expect(result.get(files[1])).toEqual(false);
     expect(result.get(files[2])).toEqual(true);
-  });
-});
-
-describe(_parseGitSubmoduleStatus.name, () => {
-  it('Can parse valid git submodule status responses', () => {
-    expect(
-      _parseGitSubmoduleStatus(` 964eb484a347b0aac4e68995139080fb0d4bc1c4 submodule1 (heads/main)
- 964eb484a347b0aac4e68995139080fb0d4bc1c4 submodule2 (heads/main)`)
-    ).toEqual(['submodule1', 'submodule2']);
-  });
-});
-
-describe(_parseGitSubmoduleForEachGitLsTree.name, () => {
-  it('Can parse valid git submodule foreach ls-tree responses', () => {
-    expect(
-      _parseGitSubmoduleForEachGitLsTree(`Entering 'submodule1'
-100644 blob 9f818da416c78e02c82dbd1899fe21ca2975e77d${'\t'}.gitignore
-100644 blob 0cb89e60375d44cb4f8cefc2be036042f5aaf95f${'\t'}env/config/rush-project.json
-100644 blob 0a26f06602cd2dab7d7220ae6724f964630efd10${'\t'}env/package.json
-100644 blob 46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f${'\t'}env/src/index.ts
-100644 blob da13b3825764a87531ab94a94260a2dbcc2bb8c0${'\t'}env/tsconfig.json
-进入 'submodule2'
-100644 blob 9f818da416c78e02c82dbd1899fe21ca2975e77d${'\t'}.gitignore
-100644 blob 0cb89e60375d44cb4f8cefc2be036042f5aaf95f${'\t'}env/config/rush-project.json
-100644 blob 0a26f06602cd2dab7d7220ae6724f964630efd10${'\t'}env/package.json
-100644 blob 46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f${'\t'}env/src/index.ts
-100644 blob da13b3825764a87531ab94a94260a2dbcc2bb8c0${'\t'}env/tsconfig.json`)
-    ).toEqual({
-      submodule1: {
-        '.gitignore': '9f818da416c78e02c82dbd1899fe21ca2975e77d',
-        'env/config/rush-project.json': '0cb89e60375d44cb4f8cefc2be036042f5aaf95f',
-        'env/package.json': '0a26f06602cd2dab7d7220ae6724f964630efd10',
-        'env/src/index.ts': '46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f',
-        'env/tsconfig.json': 'da13b3825764a87531ab94a94260a2dbcc2bb8c0'
-      },
-      submodule2: {
-        '.gitignore': '9f818da416c78e02c82dbd1899fe21ca2975e77d',
-        'env/config/rush-project.json': '0cb89e60375d44cb4f8cefc2be036042f5aaf95f',
-        'env/package.json': '0a26f06602cd2dab7d7220ae6724f964630efd10',
-        'env/src/index.ts': '46decf4a1c9b2f8d94150fcdfcd13df46c1ff12f',
-        'env/tsconfig.json': 'da13b3825764a87531ab94a94260a2dbcc2bb8c0'
-      }
-    });
   });
 });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes https://github.com/microsoft/rushstack/issues/3750

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Refactor the logic in `getRepoState`:
1. Detecting git submodule by checking the existence of `.gitmodule` file
2. Recursively invoking `getRepoState` instead of running `git submodule foreach` command

## How it was tested

Run `rush build -o heft-web-rig` on MacOS 12 and Windows 10
- MacOS: `Analyzing repo state... DONE (0.31 seconds)`
- Windows: `Analyzing repo state... DONE (0.46 seconds)`

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
