### PR TITLE
[heft-typescript-plugin] Fix incremental watch mode

### DIFF
--- a/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
+++ b/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
@@ -39,6 +39,10 @@ export interface IExtendedTypeScript {
    */
   performance: {
     /**
+     * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/performance.ts#L119-L121
+     */
+    disable(): void;
+    /**
      * https://github.com/microsoft/TypeScript/blob/5f597e69b2e3b48d788cb548df40bcb703c8adb1/src/compiler/performance.ts#L110-L116
      */
     enable(): void;


### PR DESCRIPTION
## Summary
Adds use of the `runIncremental` hook in `@rushstack/heft-typescript-plugin`.
Uses `oldProgram` and source file caching to get incremental rebuild, whether the `incremental` tsconfig setting is used or not.
Builds are faster if `incremental` is set, since less type-checking happens.

## Details
Single file changes (if not deep in the graph) can execute in <100ms for the TypeScript portion now.

## How it was tested
Running heft in watch mode in `rush-lib` and in `heft-node-everything-test`. Changed file, monitored performance and output files.