### PR TITLE
[lockfile-explorer] Fix an issue where --production assets were excluded from release

### DIFF
--- a/apps/lockfile-explorer/config/heft.json
+++ b/apps/lockfile-explorer/config/heft.json
@@ -133,7 +133,7 @@
         {
           "sourceFolder": "node_modules/@rushstack/lockfile-explorer-web/dist",
           "destinationFolders": ["dist"],
-          "fileExtensions": [".js", ".html", ".svg"]
+          "fileExtensions": [".js", ".html", ".svg", ".css", ".txt"]
         },
         {
           "sourceFolder": "assets",

--- a/common/changes/@rushstack/lockfile-explorer/octogonz-lfx-bundling-fix_2022-11-18-05-20.json
+++ b/common/changes/@rushstack/lockfile-explorer/octogonz-lfx-bundling-fix_2022-11-18-05-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "Fix an issue where some assets were not packaged in the production release",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer"
+}


### PR DESCRIPTION
## Summary

The `--production` build mode generates `dist/*.css` files which were not included in the published package.

 

## How it was tested

Reproed the problem by publishing locally, then confirmed that this PR fixes it.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
