### PR TITLE
[rush] Autoinstaller logout respects --quiet parameter

### DIFF
--- a/common/changes/@microsoft/rush/feat-autoinstaller-restrict-console-output_2022-11-18-13-47.json
+++ b/common/changes/@microsoft/rush/feat-autoinstaller-restrict-console-output_2022-11-18-13-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Autoinstaller logout respects --quiet parameter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -14,6 +14,7 @@ import { InstallHelpers } from './installManager/InstallHelpers';
 import { RushGlobalFolder } from '../api/RushGlobalFolder';
 import { RushConstants } from './RushConstants';
 import { LastInstallFlag } from '../api/LastInstallFlag';
+import { RushCommandLineParser } from '../cli/RushCommandLineParser';
 
 interface IAutoinstallerOptions {
   autoinstallerName: string;
@@ -30,7 +31,8 @@ export class Autoinstaller {
   public constructor(options: IAutoinstallerOptions) {
     this.name = options.autoinstallerName;
     this._rushConfiguration = options.rushConfiguration;
-    this._restrictConsoleOutput = options.restrictConsoleOutput || false;
+    this._restrictConsoleOutput =
+      options.restrictConsoleOutput ?? RushCommandLineParser.shouldRestrictConsoleOutput();
 
     Autoinstaller.validateName(this.name);
   }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

This PR makes "Autoinstaller"'s logout respects --quiet parameter

Before: 

<img width="691" alt="image" src="https://user-images.githubusercontent.com/16147702/202719838-9f6d5f42-33c7-475b-88ca-25660d59fba5.png">

After:

<img width="659" alt="image" src="https://user-images.githubusercontent.com/16147702/202719906-e94fc94d-2c11-463e-9e2e-63095ba4aaf1.png">



## Details

Change the default value of `restrictConsoleOutput` to `RushCommandLineParser.shouldRestrictConsoleOutput();`

## How it was tested

Tested locally with this repo

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
