### PR TITLE
[lockfile-explorer] Use a search input field for the filter bar

### DIFF
--- a/apps/lockfile-explorer-web/src/containers/LockfileViewer/index.tsx
+++ b/apps/lockfile-explorer-web/src/containers/LockfileViewer/index.tsx
@@ -164,9 +164,9 @@ export const LockfileViewer = (): JSX.Element | ReactNull => {
       />
       <div className={`${styles.ViewContents} ${appStyles.ContainerCard}`}>
         <div className={styles.LockfileFilterBar}>
-          <h5>Filter:</h5>
           <input
-            type="text"
+            type="search"
+            placeholder="Filter..."
             value={activeFilters[LockfileEntryFilter.Project] ? projectFilter : packageFilter}
             onChange={updateFilter(
               activeFilters[LockfileEntryFilter.Project]

--- a/apps/lockfile-explorer-web/src/containers/LockfileViewer/styles.scss
+++ b/apps/lockfile-explorer-web/src/containers/LockfileViewer/styles.scss
@@ -26,6 +26,9 @@
   margin-bottom: 12px;
 
   input {
+    border: solid 1px #666;
+    border-radius: 4px;
+    padding: 0.4em;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary

 - Small quality-of-life improvement for the Filter bar.

## Details

 - The `"search"` input type adds some built-in browser behaviors:
   - Pressing ESC key while in field will clear the field and leave cursor ready to type
   - Clicking browser-provided "clear" icon will clear the field and leave cursor ready to type
 - Small modernization tweaks (placeholder text instead of label, padding increase, subtle rounded corner) 

## How it was tested

Tested in Chrome and Safari on MacOS.

![Kapture 2022-11-18 at 19 43 42](https://user-images.githubusercontent.com/58273/202825597-351917d7-e75a-4d45-b7e9-b1e133aa8918.gif)

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
