### PR TITLE
[rush] Allow maintainer to customize "rush setup" prompt messages

### DIFF
--- a/common/changes/@microsoft/rush/enelson-setup-prompts_2022-11-19-01-21.json
+++ b/common/changes/@microsoft/rush/enelson-setup-prompts_2022-11-19-01-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "The \"rush change\" user prompts can now be customized.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
@@ -92,6 +92,18 @@
        * button if you haven't already done so previously."
        */
       // "locateApiKey": ""
+
+      /**
+       * Overrides the message that normally prompts:
+       * "What is your Artifactory user name?"
+       */
+      // "userNamePrompt": ""
+
+      /**
+       * Overrides the message that normally prompts:
+       * "What is your Artifactory API key?"
+       */
+      // "locateApiKey": ""
     }
   }
 }

--- a/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -29,6 +29,8 @@ interface IArtifactoryCustomizableMessages {
   visitWebsite: string;
   locateUserName: string;
   locateApiKey: string;
+  userNamePrompt: string;
+  apiKeyPrompt: string;
 }
 
 const defaultMessages: IArtifactoryCustomizableMessages = {
@@ -39,7 +41,9 @@ const defaultMessages: IArtifactoryCustomizableMessages = {
   locateUserName: 'Your user name appears in the upper-right corner of the JFrog website.',
   locateApiKey:
     'Click "Edit Profile" on the JFrog website.  Click the "Generate API Key"' +
-    " button if you haven't already done so previously."
+    " button if you haven't already done so previously.",
+  userNamePrompt: 'What is your Artifactory user name?',
+  apiKeyPrompt: 'What is your Artifactory API key?'
 };
 
 export interface ISetupPackageRegistryOptions {
@@ -243,7 +247,7 @@ export class SetupPackageRegistry {
     this._writeInstructionBlock(this._messages.locateUserName);
 
     let artifactoryUser: string = await TerminalInput.promptLine({
-      message: 'What is your Artifactory user name?'
+      message: this._messages.userNamePrompt
     });
     this._terminal.writeLine();
 
@@ -257,7 +261,7 @@ export class SetupPackageRegistry {
     this._writeInstructionBlock(this._messages.locateApiKey);
 
     let artifactoryKey: string = await TerminalInput.promptPasswordLine({
-      message: 'What is your Artifactory API key?'
+      message: this._messages.apiKeyPrompt
     });
     this._terminal.writeLine();
 

--- a/libraries/rush-lib/src/schemas/artifactory.schema.json
+++ b/libraries/rush-lib/src/schemas/artifactory.schema.json
@@ -62,6 +62,14 @@
             "locateApiKey": {
               "description": "Overrides the message that normally says: \"Click 'Edit Profile' on the JFrog website.  Click the 'Generate API Key' button if you haven't already done so previously.\"",
               "type": "string"
+            },
+            "userNamePrompt": {
+              "description": "Overrides the message that normally prompts: \"What is your Artifactory user name?\"",
+              "type": "string"
+            },
+            "apiKeyPrompt": {
+              "description": "Overrides the message that normally prompts: \"What is your Artifactory API key?\"",
+              "type": "string"
             }
           },
 


### PR DESCRIPTION
## Summary

 - Give monorepo maintainers a little more control over the "rush setup" flow.

## Details

If you've heavily customized the informational instruction messages for your "rush setup" flow, you can end up with some mismatches in terminology between the instructions and the prompt messages. This change ensures that pretty much all of the happy-path flow can be customized by the maintainer.

## How it was tested

 - Confirmed works out-of-box in local monorepo
 - Confirmed customized user name and API key messages work in local monorepo
