### PR TITLE
[rush] Add a feature (behind the "cleanInstallAfterNpmrcChanges" experiment) that will cause a clean install to be performed if the common/temp/.npmrc file has changed since the last install.

### DIFF
--- a/common/changes/@microsoft/rush/main_2022-11-22-21-57.json
+++ b/common/changes/@microsoft/rush/main_2022-11-22-21-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a feature (behind the \"cleanInstallAfterNpmrcChanges\" experiment) that will cause a clean install to be performed if the common/temp/.npmrc file has changed since the last install.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -228,6 +228,14 @@ export interface _IBuiltInPluginConfiguration extends _IRushPluginConfigurationB
     pluginPackageFolder: string;
 }
 
+// @internal (undocumented)
+export interface _ICheckNpmrcOptions {
+    // (undocumented)
+    rushVerb?: string;
+    // (undocumented)
+    statePropertiesToIgnore?: string[];
+}
+
 // @beta (undocumented)
 export interface ICloudBuildCacheProvider {
     // (undocumented)
@@ -298,6 +306,7 @@ export interface IExecutionResult {
 // @beta
 export interface IExperimentsJson {
     buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
+    cleanInstallAfterNpmrcChanges?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     phasedCommands?: boolean;
@@ -545,11 +554,13 @@ export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
 // @internal
 export class _LastInstallFlag {
     constructor(folderPath: string, state?: JsonObject);
-    checkValidAndReportStoreIssues(rushVerb: string): boolean;
+    checkValidAndReportStoreIssues(options: _ICheckNpmrcOptions & {
+        rushVerb: string;
+    }): boolean;
     clear(): void;
     create(): void;
     protected get flagName(): string;
-    isValid(): boolean;
+    isValid(options?: _ICheckNpmrcOptions): boolean;
     get path(): string;
 }
 

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -40,5 +40,11 @@
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "phasedCommands": true
+  /*[LINE "HYPOTHETICAL"]*/ "phasedCommands": true,
+
+  /**
+   * If true, perform a clean install after when running `rush install` or `rush update` if the
+   * `.npmrc` file has changed since the last install.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "cleanInstallAfterNpmrcChanges": true
 }

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -46,6 +46,12 @@ export interface IExperimentsJson {
    * in common/config/rush/command-line.json.
    */
   phasedCommands?: boolean;
+
+  /**
+   * If true, perform a clean install after when running `rush install` or `rush update` if the
+   * `.npmrc` file has changed since the last install.
+   */
+  cleanInstallAfterNpmrcChanges?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
+++ b/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
@@ -82,7 +82,7 @@ describe(LastInstallFlag.name, () => {
 
     flag1.create();
     expect(() => {
-      flag2.checkValidAndReportStoreIssues('install');
+      flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' });
     }).toThrowError(/PNPM store path/);
   });
 
@@ -97,8 +97,25 @@ describe(LastInstallFlag.name, () => {
 
     flag1.create();
     expect(() => {
-      flag2.checkValidAndReportStoreIssues('install');
+      flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' });
     }).not.toThrow();
-    expect(flag2.checkValidAndReportStoreIssues('install')).toEqual(false);
+    expect(flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' })).toEqual(false);
+  });
+
+  it("ignores a specified option that doesn't match", () => {
+    const flag1: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, {
+      option1: 'a',
+      option2: 'b'
+    });
+    const flag2: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, {
+      option1: 'a',
+      option2: 'c'
+    });
+
+    flag1.create();
+    expect(() => {
+      flag2.isValid({ statePropertiesToIgnore: ['option2'] });
+    }).not.toThrow();
+    expect(flag2.isValid({ statePropertiesToIgnore: ['option2'] })).toEqual(true);
   });
 });

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -68,7 +68,10 @@ export { EventHooks, Event } from './api/EventHooks';
 
 export { ChangeManager } from './api/ChangeManager';
 
-export { LastInstallFlag as _LastInstallFlag } from './api/LastInstallFlag';
+export {
+  LastInstallFlag as _LastInstallFlag,
+  ICheckNpmrcOptions as _ICheckNpmrcOptions
+} from './api/LastInstallFlag';
 
 export {
   VersionPolicyDefinitionName,

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -33,6 +33,10 @@
     "phasedCommands": {
       "description": "If true, the phased commands feature is enabled. To use this feature, create a \"phased\" command in common/config/rush/command-line.json.",
       "type": "boolean"
+    },
+    "cleanInstallAfterNpmrcChanges": {
+      "description": "If true, perform a clean install after when running `rush install` or `rush update` if the `.npmrc` file has changed since the last install.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -69,8 +69,11 @@ function _parsePackageSpecifier(rawPackageSpecifier: string): IPackageSpecifier 
  * home directory.
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities.copyAndTrimNpmrcFile()
+ *
+ * @returns
+ * The text of the the .npmrc.
  */
-function _copyAndTrimNpmrcFile(logger: ILogger, sourceNpmrcPath: string, targetNpmrcPath: string): void {
+function _copyAndTrimNpmrcFile(logger: ILogger, sourceNpmrcPath: string, targetNpmrcPath: string): string {
   logger.info(`Transforming ${sourceNpmrcPath}`); // Verbose
   logger.info(`  --> "${targetNpmrcPath}"`);
   let npmrcFileLines: string[] = fs.readFileSync(sourceNpmrcPath).toString().split('\n');
@@ -114,7 +117,10 @@ function _copyAndTrimNpmrcFile(logger: ILogger, sourceNpmrcPath: string, targetN
     }
   }
 
-  fs.writeFileSync(targetNpmrcPath, resultLines.join(os.EOL));
+  const combinedNpmrc: string = resultLines.join(os.EOL);
+  fs.writeFileSync(targetNpmrcPath, combinedNpmrc);
+
+  return combinedNpmrc;
 }
 
 /**
@@ -122,13 +128,16 @@ function _copyAndTrimNpmrcFile(logger: ILogger, sourceNpmrcPath: string, targetN
  * If the source .npmrc file not exist, then syncNpmrc() will delete an .npmrc that is found in the target folder.
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities._syncNpmrc()
+ *
+ * @returns
+ * The text of the the synced .npmrc, if one exists. If one does not exist, then undefined is returned.
  */
 function _syncNpmrc(
   logger: ILogger,
   sourceNpmrcFolder: string,
   targetNpmrcFolder: string,
   useNpmrcPublish?: boolean
-): void {
+): string | undefined {
   const sourceNpmrcPath: string = path.join(
     sourceNpmrcFolder,
     !useNpmrcPublish ? '.npmrc' : '.npmrc-publish'
@@ -136,7 +145,7 @@ function _syncNpmrc(
   const targetNpmrcPath: string = path.join(targetNpmrcFolder, '.npmrc');
   try {
     if (fs.existsSync(sourceNpmrcPath)) {
-      _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath);
+      return _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath);
     } else if (fs.existsSync(targetNpmrcPath)) {
       // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
       logger.info(`Deleting ${targetNpmrcPath}`); // Verbose

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -487,8 +487,11 @@ export class Utilities {
    * home directory.
    *
    * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH _copyAndTrimNpmrcFile() FROM scripts/install-run.ts
+   *
+   * @returns
+   * The text of the the .npmrc.
    */
-  public static copyAndTrimNpmrcFile(sourceNpmrcPath: string, targetNpmrcPath: string): void {
+  public static copyAndTrimNpmrcFile(sourceNpmrcPath: string, targetNpmrcPath: string): string {
     console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
     console.log(`  --> "${targetNpmrcPath}"`);
     let npmrcFileLines: string[] = FileSystem.readFile(sourceNpmrcPath).split('\n');
@@ -532,7 +535,10 @@ export class Utilities {
       }
     }
 
-    FileSystem.writeFile(targetNpmrcPath, resultLines.join(os.EOL));
+    const combinedNpmrc: string = resultLines.join(os.EOL);
+    FileSystem.writeFile(targetNpmrcPath, combinedNpmrc);
+
+    return combinedNpmrc;
   }
 
   /**
@@ -558,12 +564,15 @@ export class Utilities {
    * If the source .npmrc file not exist, then syncNpmrc() will delete an .npmrc that is found in the target folder.
    *
    * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH _syncNpmrc() FROM scripts/install-run.ts
+   *
+   * @returns
+   * The text of the the synced .npmrc, if one exists. If one does not exist, then undefined is returned.
    */
   public static syncNpmrc(
     sourceNpmrcFolder: string,
     targetNpmrcFolder: string,
     useNpmrcPublish?: boolean
-  ): void {
+  ): string | undefined {
     const sourceNpmrcPath: string = path.join(
       sourceNpmrcFolder,
       !useNpmrcPublish ? '.npmrc' : '.npmrc-publish'
@@ -571,7 +580,7 @@ export class Utilities {
     const targetNpmrcPath: string = path.join(targetNpmrcFolder, '.npmrc');
     try {
       if (FileSystem.exists(sourceNpmrcPath)) {
-        Utilities.copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath);
+        return Utilities.copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath);
       } else if (FileSystem.exists(targetNpmrcPath)) {
         // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
         console.log(`Deleting ${targetNpmrcPath}`); // Verbose


### PR DESCRIPTION
## Summary

Right now, Rush does not clear out the `common/temp/node_modules` folder if the `.npmrc` file changed since the last install. This can produce unexpected behavior, for instance if the `hoist` option is changed in under PNPM.

This PR adds a new feature (under a new "cleanInstallAfterNpmrcChanges" experiment) that triggers a clean install if the hash of the `.npmrc` file has changed since the last install.

## How it was tested

Included a unit test for the `LastInstallFlag` class and manually confirmed that changing the `.npmrc ` does not trigger a clean install with the experiment off and does with the experiment turned on.