### PR TITLE
[rush] bug fix: TarExecutable module tries to write to closed file

### DIFF
--- a/common/changes/@microsoft/rush/enelson-tar-exec-bug_2022-11-25-15-11.json
+++ b/common/changes/@microsoft/rush/enelson-tar-exec-bug_2022-11-25-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an intermittent issue when writing tar log files",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/TarExecutable.ts
+++ b/libraries/rush-lib/src/utilities/TarExecutable.ts
@@ -160,7 +160,8 @@ export class TarExecutable {
       childProcess.stdin!.end();
     }
 
-    const [tarExitCode] = await events.once(childProcess, 'exit');
+    // Wait for process to exit and all streams to close
+    const [tarExitCode] = await events.once(childProcess, 'close');
 
     fileWriter.write(
       ['======== END PROCESS OUTPUT ========', '', `Exited with code "${tarExitCode}"`].join('\n')


### PR DESCRIPTION
## Summary

When under load (for example, restoring multiple very large projects from build cache at the same time), the `TarExecutable` module can accidentally call `FileWriter.write` after `FileWriter.close` has already been called on the log file.

Instead of using the `exit` event, we can use [the close event](https://nodejs.org/api/child_process.html#event-close) (which triggers after the process has exited and all of its streams have been closed), which guarantees no more stdio will come through the pipe.

## Details

In `TarExecutable`, we set up event handlers for `stdout` and `stderr` data, and then write that output to the opened log file. If the process is doing a lot of asynchronous I/O, one of these callbacks (for a request to do a synchronous write to the log file) can back up to the point that one occurs after we have closed the log file.

When this happens the output looks like this:

```console
/home/runner/work/xxx/common/temp/install-run/@microsoft+rush@5.83.2/node_modules/@rushstack/node-core-library/lib/FileWriter.js:43
            throw new Error(`Cannot write to file, file descriptor has already been released.`);
            ^

Error: Cannot write to file, file descriptor has already been released.
    at FileWriter.write (/home/runner/work/xxx/common/temp/install-run/@microsoft+rush@5.83.2/node_modules/@rushstack/node-core-library/lib/FileWriter.js:43:19)
    at Socket.<anonymous> (/home/runner/work/xxx/common/temp/install-run/@microsoft+rush@5.83.2/node_modules/@microsoft/rush-lib/lib/utilities/TarExecutable.js:136:62)
    at Socket.emit (node:events:527:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
Error: Process completed with exit code 1.
```

## How it was tested

Tested change in local repo and appears to work as expected.
