### PR TITLE
[rush] Tweak an incorrect changelog message

### DIFF
--- a/apps/rush/CHANGELOG.json
+++ b/apps/rush/CHANGELOG.json
@@ -41,7 +41,7 @@
             "comment": "Add a \"dependsOnEnvVars\" configuration option to operations in rush-project.json. The variables specified in this option are included in the cache key hash calculation."
           },
           {
-            "comment": "The \"rush change\" user prompts can now be customized."
+            "comment": "The \"rush setup\" user prompts can now be customized."
           },
           {
             "comment": "Make autoinstaller logging respect the `--quiet` parameter."


### PR DESCRIPTION
## Summary

This changelog message says that rush _change_ user prompts are customizable, but actually it is rush _setup_ user prompts.

(Oops.)

## Details

 - Patching changelog source, which should automatically update the markdown during the next publish.
