### PR TITLE
[rush] Autoinstaller "all" functionality

### DIFF
--- a/common/changes/@microsoft/rush/enelson-autoinstaller3_2022-11-28-22-07.json
+++ b/common/changes/@microsoft/rush/enelson-autoinstaller3_2022-11-28-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "The \"rush update-autoinstaller\" command now supports multiple --name parameters, or a new --all flag.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/enelson-autoinstaller3_2022-11-28-22-11.json
+++ b/common/changes/@microsoft/rush/enelson-autoinstaller3_2022-11-28-22-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "The \"rush install\" and \"rush update\" commands now support \"--autoinstallers\" flag, to apply the installs or updates to your existing autoinstaller folders.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -22,6 +22,7 @@ import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismat
 import { Variants } from '../../api/Variants';
 import { RushConstants } from '../../logic/RushConstants';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
+import { Autoinstaller } from '../../logic/Autoinstaller';
 
 const installManagerFactoryModule: typeof import('../../logic/InstallManagerFactory') = Import.lazy(
   '../../logic/InstallManagerFactory',
@@ -40,6 +41,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
   protected readonly _debugPackageManagerParameter: CommandLineFlagParameter;
   protected readonly _maxInstallAttempts: CommandLineIntegerParameter;
   protected readonly _ignoreHooksParameter: CommandLineFlagParameter;
+  protected readonly _autoinstallersParameter: CommandLineFlagParameter;
   /*
    * Subclasses can initialize the _selectionParameters property in order for
    * the parameters to be written to the telemetry file
@@ -89,6 +91,10 @@ export abstract class BaseInstallAction extends BaseRushAction {
     this._ignoreHooksParameter = this.defineFlagParameter({
       parameterLongName: '--ignore-hooks',
       description: `Skips execution of the "eventHooks" scripts defined in rush.json. Make sure you know what you are skipping.`
+    });
+    this._autoinstallersParameter = this.defineFlagParameter({
+      parameterLongName: '--autoinstallers',
+      description: `After installing all packages, also refresh the install for all existing autoinstallers.`
     });
     this._variant = this.defineStringParameter(Variants.VARIANT_PARAMETER);
   }
@@ -152,6 +158,14 @@ export abstract class BaseInstallAction extends BaseRushAction {
     let installSuccessful: boolean = true;
     try {
       await installManager.doInstallAsync();
+
+      if (this._autoinstallersParameter.value) {
+        if (installManagerOptions.allowShrinkwrapUpdates) {
+          Autoinstaller.updateAutoinstallers(this.rushConfiguration);
+        } else {
+          await Autoinstaller.prepareAutoinstallersAsync(this.rushConfiguration);
+        }
+      }
 
       if (warnAboutScriptUpdate) {
         console.log(

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -1,40 +1,55 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import { CommandLineStringListParameter, CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class UpdateAutoinstallerAction extends BaseRushAction {
-  private readonly _name: CommandLineStringParameter;
+  private readonly _names: CommandLineStringListParameter;
+  private readonly _allFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'update-autoinstaller',
       summary: 'Updates autoinstaller package dependencies',
-      documentation: 'Use this command to regenerate the shrinkwrap file for an autoinstaller folder.',
+      documentation: 'Use this command to regenerate the lockfile for an autoinstaller folder.',
       parser
     });
 
-    this._name = this.defineStringParameter({
+    this._names = this.defineStringListParameter({
       parameterLongName: '--name',
       argumentName: 'AUTOINSTALLER_NAME',
-      required: true,
       description:
-        'Specifies the name of the autoinstaller, which must be one of the folders under common/autoinstallers.'
+        'Specifies the name of the autoinstaller, which must be one of the folders under common/autoinstallers. Provide this' +
+        ' option more than once to update multiple autoinstallers. Required unless --all is specified.'
+    });
+
+    this._allFlag = this.defineFlagParameter({
+      parameterLongName: '--all',
+      description:
+        'If this flag is provided, all existing autoinstallers in the autoinstallers folder will be detected and updated. Not compatible with --name parameter.'
     });
   }
 
   protected async runAsync(): Promise<void> {
-    const autoinstallerName: string = this._name.value!;
+    let autoinstallerNames: string[] | undefined = [];
 
-    const autoinstaller: Autoinstaller = new Autoinstaller({
-      autoinstallerName,
-      rushConfiguration: this.rushConfiguration
-    });
-    autoinstaller.update();
+    if (this._names.values.length > 0) {
+      if (this._allFlag.value) {
+        throw new Error(`${this._allFlag.longName} is not compatible with ${this._names.longName}`);
+      }
+      autoinstallerNames.push(...this._names.values);
+    } else if (this._allFlag.value) {
+      autoinstallerNames = undefined;
+    } else {
+      console.log(this.renderHelpText() + '\n');
+      throw new Error(`Specify ${this._names.longName} parameter or the ${this._allFlag.longName} flag.`);
+    }
+
+    Autoinstaller.updateAutoinstallers(this.rushConfiguration, autoinstallerNames);
 
     console.log('\nSuccess.');
   }

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -8,8 +8,8 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class UpdateAutoinstallerAction extends BaseRushAction {
-  private readonly _names: CommandLineStringListParameter;
-  private readonly _allFlag: CommandLineFlagParameter;
+  private readonly _namesParameter: CommandLineStringListParameter;
+  private readonly _allParameter: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -19,7 +19,7 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
       parser
     });
 
-    this._names = this.defineStringListParameter({
+    this._namesParameter = this.defineStringListParameter({
       parameterLongName: '--name',
       argumentName: 'AUTOINSTALLER_NAME',
       description:
@@ -27,7 +27,7 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
         ' option more than once to update multiple autoinstallers. Required unless --all is specified.'
     });
 
-    this._allFlag = this.defineFlagParameter({
+    this._allParameter = this.defineFlagParameter({
       parameterLongName: '--all',
       description:
         'If this flag is provided, all existing autoinstallers in the autoinstallers folder will be detected and updated. Not compatible with --name parameter.'
@@ -37,16 +37,20 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
   protected async runAsync(): Promise<void> {
     let autoinstallerNames: string[] | undefined = [];
 
-    if (this._names.values.length > 0) {
-      if (this._allFlag.value) {
-        throw new Error(`${this._allFlag.longName} is not compatible with ${this._names.longName}`);
+    if (this._namesParameter.values.length > 0) {
+      if (this._allParameter.value) {
+        throw new Error(
+          `${this._allParameter.longName} is not compatible with ${this._namesParameter.longName}`
+        );
       }
-      autoinstallerNames.push(...this._names.values);
-    } else if (this._allFlag.value) {
+      autoinstallerNames.push(...this._namesParameter.values);
+    } else if (this._allParameter.value) {
       autoinstallerNames = undefined;
     } else {
       console.log(this.renderHelpText() + '\n');
-      throw new Error(`Specify ${this._names.longName} parameter or the ${this._allFlag.longName} flag.`);
+      throw new Error(
+        `Specify ${this._namesParameter.longName} parameter or the ${this._allParameter.longName} flag.`
+      );
     }
 
     Autoinstaller.updateAutoinstallers(this.rushConfiguration, autoinstallerNames);

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -4,7 +4,14 @@
 import colors from 'colors/safe';
 import * as path from 'path';
 
-import { FileSystem, IPackageJson, JsonFile, LockFile, NewlineKind } from '@rushstack/node-core-library';
+import {
+  FileSystem,
+  FolderItem,
+  IPackageJson,
+  JsonFile,
+  LockFile,
+  NewlineKind
+} from '@rushstack/node-core-library';
 import { Utilities } from '../utilities/Utilities';
 
 import { PackageName, IParsedPackageNameOrError } from '@rushstack/node-core-library';
@@ -155,7 +162,14 @@ export class Autoinstaller {
     }
   }
 
-  public update(): void {
+  /**
+   * Update this autoinstaller, installing the latest packages defined in the package.json file
+   * and regenerating the lockfile.
+   *
+   * Returns `true` if the lockfile was updated and should be committed to git, or `false` if
+   * the autoinstaller folder is already up-to-date.
+   */
+  public update(): boolean {
     const autoinstallerPackageJsonPath: string = path.join(this.folderFullPath, 'package.json');
 
     if (!FileSystem.exists(autoinstallerPackageJsonPath)) {
@@ -210,9 +224,7 @@ export class Autoinstaller {
     }
 
     if (!FileSystem.exists(this.shrinkwrapFilePath)) {
-      throw new Error(
-        'The package manager did not create the expected shrinkwrap file: ' + this.shrinkwrapFilePath
-      );
+      throw new Error('The package manager did not create the expected lockfile: ' + this.shrinkwrapFilePath);
     }
 
     const newFileContents: string = FileSystem.readFile(this.shrinkwrapFilePath, {
@@ -220,17 +232,115 @@ export class Autoinstaller {
     });
     if (oldFileContents !== newFileContents) {
       this._logIfConsoleOutputIsNotRestricted(
-        colors.green('The shrinkwrap file has been updated.') + '  Please commit the updated file:'
+        colors.green('The lockfile has been updated.') + '  Please commit the updated file:'
       );
       this._logIfConsoleOutputIsNotRestricted(`\n  ${this.shrinkwrapFilePath}`);
+      return true;
     } else {
       this._logIfConsoleOutputIsNotRestricted(colors.green('Already up to date.'));
+      return false;
     }
   }
 
   private _logIfConsoleOutputIsNotRestricted(message?: string): void {
     if (!this._restrictConsoleOutput) {
       console.log(message);
+    }
+  }
+
+  public static getAutoinstallerNames(rushConfiguration: RushConfiguration): string[] {
+    const autoinstallerNames: string[] = [];
+    const files: FolderItem[] = FileSystem.exists(rushConfiguration.commonAutoinstallersFolder)
+      ? FileSystem.readFolderItems(rushConfiguration.commonAutoinstallersFolder)
+      : [];
+
+    for (const file of files) {
+      if (
+        file.isDirectory() &&
+        FileSystem.exists(path.join(rushConfiguration.commonAutoinstallersFolder, file.name, 'package.json'))
+      ) {
+        autoinstallerNames.push(file.name);
+      }
+    }
+
+    return autoinstallerNames;
+  }
+
+  public static async prepareAutoinstallersAsync(
+    rushConfiguration: RushConfiguration,
+    specificNames?: string[]
+  ): Promise<void> {
+    const autoinstallerNames: string[] = [];
+
+    if (specificNames) {
+      autoinstallerNames.push(...specificNames);
+    } else {
+      autoinstallerNames.push(...Autoinstaller.getAutoinstallerNames(rushConfiguration));
+    }
+
+    for (const autoinstallerName of autoinstallerNames) {
+      const autoinstaller: Autoinstaller = new Autoinstaller({
+        autoinstallerName,
+        rushConfiguration
+      });
+      await autoinstaller.prepareAsync();
+      console.log('');
+    }
+
+    console.log(colors.gray('='.repeat(79)));
+
+    if (autoinstallerNames.length === 0) {
+      console.log('\nNo autoinstallers to prepare.');
+      return;
+    }
+
+    console.log(colors.green(`\n${autoinstallerNames.length} autoinstaller(s) prepared.`));
+  }
+
+  public static updateAutoinstallers(rushConfiguration: RushConfiguration, specificNames?: string[]): void {
+    const autoinstallerNames: string[] = [];
+
+    if (specificNames) {
+      autoinstallerNames.push(...specificNames);
+    } else {
+      autoinstallerNames.push(...Autoinstaller.getAutoinstallerNames(rushConfiguration));
+    }
+
+    const updated: Autoinstaller[] = [];
+    const skipped: Autoinstaller[] = [];
+
+    for (const autoinstallerName of autoinstallerNames) {
+      const autoinstaller: Autoinstaller = new Autoinstaller({
+        autoinstallerName,
+        rushConfiguration
+      });
+      if (autoinstaller.update()) {
+        updated.push(autoinstaller);
+      } else {
+        skipped.push(autoinstaller);
+      }
+      console.log('');
+    }
+
+    console.log(colors.gray('='.repeat(79)));
+
+    if (skipped.length + updated.length === 0) {
+      console.log('\nNo autoinstallers to update.');
+      return;
+    }
+
+    if (skipped.length > 0) {
+      console.log(colors.green(`\n${skipped.length} autoinstaller(s) already up to date.`));
+    }
+
+    if (updated.length > 0) {
+      console.log(
+        colors.green(`\n${updated.length} autoinstaller(s) were updated. `) +
+          `Please commit the updated files:\n`
+      );
+      for (const autoinstaller of updated) {
+        console.log(`  ${autoinstaller.shrinkwrapFilePath}`);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

A small pile of quality-of-life improvements for dealing with autoinstallers:

 - `rush update-autoinstaller --name folder1 --name folder2`
 - `rush update-autoinstaller --all`
 - `rush update --autoinstallers`
 - `rush install --autoinstallers`
 - All autoinstaller human-readable output now refers to _lockfiles_ instead of _shrinkwrap files_.

## Details

### Updating multiple autoinstallers

Following in the vein of `rush add`, you can now provide the `--name` parameter multiple times when updating an autoinstaller. Useful for specifically targeting 2 or more autoinstaller folders.

The output of the `update-autoinstaller` command has been updated to provide a summary of the autoinstallers that were updated and what new lockfiles should be committed to source control.

```console
rush update-autoinstaller --name rush-plugins --name rush-prettier
```

### Updating all autoinstallers

When your monorepo reaches 4-5 autoinstallers, it becomes easier to simply "mass update" them and evaluate the _result_ of the command (ensuring it matches your expectations) rather than typing out specific folder names.

```console
rush update-autoinstaller --all
```

### Convenience method: update + autoinstaller update

After a maintenance update frenzy, with multiple package.json changes spread across project and autoinstaller folders alike, a single command to make sure _everything_ is updated is a nice time saver.

```console
rush update --autoinstallers

# Roughly equivalent to:
rush update && rush update-autoinstaller --all
```

### New functionality: prepare all autoinstallers

A sibling command for `rush update --autoinstaller`, `rush install --autoinstaller` is unique in that it provides a feature that doesn't exist in Rush today: a way to _prepare all of your autoinstallers for use_ (without waiting until someone actually calls a related rush global command defined in `command-line.json`).

This is very useful for situations where processes outside of Rush's control expect autoinstallers to be up-to-date. A great example is the common `common/autoinstallers/rush-prettier` autoinstaller, which might also be used by VSCode, WebStorm, etc. If you've upgraded prettier or added new prettier plugins to your autoinstaller, `rush install --autoinstallers` can immediately fix "Missing plugin" errors for your VSCode developers.

## How it was tested

 - Tested installs and updates, with and without autoinstallers, in the rushstack repo (and local monorepo)
 - Tested update-autoinstaller with all and with multiple names in local monorepo (and rushstack repo)
