### PR TITLE
[rush] Fix rush pnpm patch commit

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-pnpm-patch-commit_2022-11-29-13-05.json
+++ b/common/changes/@microsoft/rush/fix-rush-pnpm-patch-commit_2022-11-29-13-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix rush-pnpm patch-commit, it can be run from the root of monorepo",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -281,6 +281,14 @@ export class RushPnpmCommandLineParser {
             );
             throw new AlreadyReportedError();
           }
+          // patch-commit internally calls installation under cwd instead of the common/temp folder
+          // It throws missing package.json error, so in this case, we need to set the dir to the common/temp folder here
+          if (pnpmArgs.indexOf('--dir') < 0 && pnpmArgs.indexOf('-C') < 0) {
+            if (!FileSystem.exists(`${process.cwd()}/package.json`)) {
+              pnpmArgs.push('--dir');
+              pnpmArgs.push(this._rushConfiguration.commonTempFolder);
+            }
+          }
           break;
         }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

As @elliot-nelson pointed out at https://github.com/microsoft/rushstack/pull/3554#issuecomment-1325058523, `rush-pnpm patch-commit` fails when run from the root of monorepo, this PR fixes it and make `rush-pnpm patch-commit` works from the repo root folder.

## Details

The reason `rush-pnpm patch-commit` fails is because `pnpm patch-commit` internally calls a logic which tries to read package.json file under `procss.cwd`. While the actual top-level package.json in Rush.js monorepo is under `common/temp/package.json`. So when `${cwd}/package.json` doesn't exists and `-C` or `--dir` CLI parameter is not specified, internally specifies `--dir common/temp` parameter for `rush-pnpm patch-commit`

## How it was tested

Tested it with this repo: https://github.com/chengcyber/rush-pnpm-patch-demo

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
