### PR TITLE
[heft-serverless-stack-plugin] Add support for Serverless-Stack 1.2.0 and later versions

### DIFF
--- a/common/changes/@rushstack/heft-serverless-stack-plugin/fkjellberg-sst-fix_2022-11-29-17-39.json
+++ b/common/changes/@rushstack/heft-serverless-stack-plugin/fkjellberg-sst-fix_2022-11-29-17-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-serverless-stack-plugin",
+      "comment": "Add support for Serverless-Stack 1.2.0 and later versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-serverless-stack-plugin"
+}

--- a/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
+++ b/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
@@ -71,12 +71,7 @@ export class ServerlessStackPlugin implements IHeftPlugin<IServerlessStackPlugin
       );
     }
 
-    const sstCliEntryPoint: string = path.join(sstCliPackagePath, 'bin/scripts.js');
-    if (!FileSystem.exists(sstCliEntryPoint)) {
-      throw new Error(
-        `The ${TASK_NAME} task cannot start because the entry point was not found:\n` + sstCliEntryPoint
-      );
-    }
+    const sstCliEntryPoint: string = this._getSstCliEntryPoint(sstCliPackagePath);
 
     this._logger.terminal.writeVerboseLine('Found SST package in' + sstCliPackagePath);
 
@@ -195,6 +190,24 @@ export class ServerlessStackPlugin implements IHeftPlugin<IServerlessStackPlugin
     if (lastLine !== '') {
       write(lastLine);
     }
+  }
+
+  private _getSstCliEntryPoint(sstCliPackagePath: string): string {
+    // Entry point for SST prior to v1.2.0
+    let sstCliEntryPoint: string = path.join(sstCliPackagePath, 'bin/scripts.js');
+    if (FileSystem.exists(sstCliEntryPoint)) {
+      return sstCliEntryPoint;
+    }
+
+    // Entry point for SST v1.2.0 and later
+    sstCliEntryPoint = path.join(sstCliPackagePath, 'bin/scripts.mjs');
+    if (FileSystem.exists(sstCliEntryPoint)) {
+      return sstCliEntryPoint;
+    }
+
+    throw new Error(
+      `The ${TASK_NAME} task cannot start because the entry point was not found:\n${sstCliEntryPoint}`
+    );
   }
 
   // The SST CLI emits a script "<project folder>/.build/run.js" with a bunch of phantom dependencies

--- a/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
+++ b/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
@@ -206,7 +206,7 @@ export class ServerlessStackPlugin implements IHeftPlugin<IServerlessStackPlugin
     }
 
     throw new Error(
-      `The ${TASK_NAME} task cannot start because the entry point was not found:\n${sstCliEntryPoint}`
+      `The ${TASK_NAME} task cannot start because the entry point was not found: ${sstCliEntryPoint}`
     );
   }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

The entry point used by `heft-serverless-stack-plugin` to spawn Serverless-Stack changed from `bin/scripts.js` to `bin/scripts.mjs`in the v1.2.0 release. This PR adds support for both entry points and thus makes the plugin to work with all existing releases of Serverless-Stack.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

The change was tested in a separate repo by manually patching the plugin and running `rushx start` to deploy and start the Serverless-Stack application on AWS.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
