### PR TITLE
Enelson/buildcachetemp

### DIFF
--- a/common/changes/@microsoft/rush/enelson-buildcachetemp_2022-11-30-12-56.json
+++ b/common/changes/@microsoft/rush/enelson-buildcachetemp_2022-11-30-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Writing local build cache is more robust on a network drive.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -239,8 +239,13 @@ export class ProjectBuildCache {
     const tarUtility: TarExecutable | undefined = await ProjectBuildCache._tryGetTarUtility(terminal);
     if (tarUtility) {
       const finalLocalCacheEntryPath: string = this._localBuildCacheProvider.getCacheEntryPath(cacheId);
+
       // Derive the temp file from the destination path to ensure they are on the same volume
-      const tempLocalCacheEntryPath: string = `${finalLocalCacheEntryPath}.temp`;
+      // In the case of a shared network drive containing the build cache, we also need to make
+      // sure the the temp path won't be shared by two parallel rush builds.
+      const randomSuffix: string = crypto.randomBytes(8).toString('hex');
+      const tempLocalCacheEntryPath: string = `${finalLocalCacheEntryPath}-${randomSuffix}.temp`;
+
       const logFilePath: string = this._getTarLogFilePath();
       const tarExitCode: number = await tarUtility.tryCreateArchiveFromProjectPathsAsync({
         archivePath: tempLocalCacheEntryPath,


### PR DESCRIPTION
## Summary

When writing a local build cache entry, we tar up the build output folders into a temp file based on the computed final output file for the cache entry, and once tar is successful, we move that file on top of the target file (in an attempt to prevent corrupted entries if there are issues).

But, if multiple rush builds are attempting to write the same cache entry at the same time, these tar processes will end up writing to the same temp file. This PR fixes that by adding a random sequence to the end of the temp file name.

Potentially fixes #3783.

## Details

## How it was tested

 - Runs locally on rushstack and our local monorepo
 - I don't have a way to recreate the symptom, so this is guesswork.
