### PR TITLE
[rush] Add default value for watchDebounceMs to the schema

### DIFF
--- a/common/changes/@microsoft/rush/enelson-debounce_2022-11-30-20-17.json
+++ b/common/changes/@microsoft/rush/enelson-debounce_2022-11-30-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Document default value for watchDebounceMs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -917,6 +917,7 @@ export class RushConstants {
     static readonly commonFolderName: string;
     static readonly commonVersionsFilename: string;
     static readonly defaultMaxInstallAttempts: number;
+    static readonly defaultWatchDebounceMs: number;
     static readonly experimentsFilename: string;
     static readonly globalCommandKind: 'global';
     static readonly hashDelimiter: string;

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -396,7 +396,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
         initialPhases: command.phases,
         watchPhases: command.watchPhases,
-        watchDebounceMs: command.watchDebounceMs ?? 1000,
+        watchDebounceMs: command.watchDebounceMs ?? RushConstants.defaultWatchDebounceMs,
         phases: commandLineConfiguration.phases,
 
         alwaysWatch: command.alwaysWatch,

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -127,7 +127,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     this._disableBuildCache = options.disableBuildCache;
     this._initialPhases = options.initialPhases;
     this._watchPhases = options.watchPhases;
-    this._watchDebounceMs = options.watchDebounceMs ?? 1000;
+    this._watchDebounceMs = options.watchDebounceMs ?? RushConstants.defaultWatchDebounceMs;
     this._alwaysWatch = options.alwaysWatch;
     this._alwaysInstall = options.alwaysInstall;
     this._knownPhases = options.phases;

--- a/libraries/rush-lib/src/logic/RushConstants.ts
+++ b/libraries/rush-lib/src/logic/RushConstants.ts
@@ -257,4 +257,11 @@ export class RushConstants {
    * The expected prefix for phase names in "common/config/rush/command-line.json"
    */
   public static readonly phaseNamePrefix: '_phase:' = '_phase:';
+
+  /**
+   * The default debounce value for Rush multi-project watch mode. When watching, controls
+   * how long to wait after the last encountered file system event before execution. If another
+   * file system event occurs in this interval, the timeout will reset.
+   */
+  public static readonly defaultWatchDebounceMs: number = 1000;
 }

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -202,7 +202,7 @@
                 },
                 "debounceMs": {
                   "title": "Debounce Timeout in Milliseconds",
-                  "description": "When watching, how long to wait after the last encountered file system event before execution. If another file system event occurs in this interval, the timeout will reset.",
+                  "description": "When watching, how long to wait after the last encountered file system event before execution. If another file system event occurs in this interval, the timeout will reset. Defaults to 1000ms (1 second).",
                   "type": "number"
                 },
                 "watchPhases": {


### PR DESCRIPTION
## Summary

Surface the "default watch mode debounce value" by mentioning it in the schema and moving it to the `RushConstants` list.

## Details

 - Make the default value a rush constant and refer to it rather than inlining it.
 - Mention the current default value in the schema (typically this would be mirrored in a configuration file comment but this functionality is so new it is not yet documented anywhere but the schema).

## How it was tested

 - Build passes
 - Watch mode in local monorepo works as expected
