### PR TITLE
[rush] Fix a typo in template artifactory.json

### DIFF
--- a/common/changes/@microsoft/rush/enelson-artifactoryjson_2022-11-30-21-03.json
+++ b/common/changes/@microsoft/rush/enelson-artifactoryjson_2022-11-30-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a typo in the artifactory.json template",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/artifactory.json
@@ -103,7 +103,7 @@
        * Overrides the message that normally prompts:
        * "What is your Artifactory API key?"
        */
-      // "locateApiKey": ""
+      // "apiKeyPrompt": ""
     }
   }
 }


### PR DESCRIPTION
## Summary

 - Fix typo

## Details

The recently added "apiKeyPrompt" property was incorrectly copy+pasted in the template file comments.

## How it was tested

 - N/A

