### PR TITLE
[rush] Customize instructions if node version is unsupported

### DIFF
--- a/common/changes/@microsoft/rush/enelson-nodeversion_2022-12-01-11-34.json
+++ b/common/changes/@microsoft/rush/enelson-nodeversion_2022-12-01-11-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add \"nodeSupportedVersionInstructions\" property to rush.json, allowing maintainers to provide additional instructions if the user's node version is unsupported.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/terminal/enelson-nodeversion_2022-12-01-11-34.json
+++ b/common/changes/@rushstack/terminal/enelson-nodeversion_2022-12-01-11-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "The wrapWords method now respects existing spaces and newlines in a pre-formatted message.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -50,7 +50,7 @@
    * additional instructions that will display below the warning, if there's a specific
    * tool or script you'd like the user to use to get in line with the expected version.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "nodeSupportedVersionInstructions": "Run 'nvm use' to switch to the expected node version.",
+  /*[LINE "HYPOTHETICAL"]*/ "nodeSupportedVersionInstructions": "Run 'nvs use' to switch to the expected node version.",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -45,6 +45,14 @@
   "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
 
   /**
+   * If the version check above fails, Rush will display a message showing the current
+   * node version and the supported version range. You can use this setting to provide
+   * additional instructions that will display below the warning, if there's a specific
+   * tool or script you'd like the user to use to get in line with the expected version.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "nodeSupportedVersionInstructions": "Run 'nvm use' to switch to the expected node version.",
+
+  /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases
    * spend six months in a stabilization period before the first Long Term Support (LTS) version.
    * For example, 8.9.0 was the first LTS version of Node.js 8.  Pre-LTS versions are not recommended

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -162,6 +162,7 @@ export interface IRushConfigurationJson {
   rushVersion: string;
   repository?: IRushRepositoryJson;
   nodeSupportedVersionRange?: string;
+  nodeSupportedVersionInstructions?: string;
   suppressNodeLtsWarning?: boolean;
   projectFolderMinDepth?: number;
   projectFolderMaxDepth?: number;
@@ -306,10 +307,15 @@ export class RushConfiguration {
         );
       }
       if (!semver.satisfies(process.version, rushConfigurationJson.nodeSupportedVersionRange)) {
-        const message: string =
+        let message: string =
           `Your dev environment is running Node.js version ${process.version} which does` +
           ` not meet the requirements for building this repository.  (The rush.json configuration` +
           ` requires nodeSupportedVersionRange="${rushConfigurationJson.nodeSupportedVersionRange}")`;
+
+        if (rushConfigurationJson.nodeSupportedVersionInstructions) {
+          message += '\n\n' + rushConfigurationJson.nodeSupportedVersionInstructions;
+        }
+
         if (EnvironmentConfiguration.allowUnsupportedNodeVersion) {
           console.warn(message);
         } else {

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -408,7 +408,15 @@ export class RushCommandLineParser extends CommandLineParser {
   private _reportErrorAndSetExitCode(error: Error): void {
     if (!(error instanceof AlreadyReportedError)) {
       const prefix: string = 'ERROR: ';
-      console.error(os.EOL + colors.red(PrintUtilities.wrapWords(prefix + error.message)));
+
+      // The colors package will eat multi-newlines, which could break formatting
+      // in user-specified messages and instructions, so we prefer to color each
+      // line individually.
+      const message: string = PrintUtilities.wrapWords(prefix + error.message)
+        .split(/\r?\n/)
+        .map((line) => colors.red(line))
+        .join('\n');
+      console.error(os.EOL + message);
     }
 
     if (this._debugParameter.value) {

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { ITerminal } from '@rushstack/node-core-library';
+import { PrintUtilities } from '@rushstack/terminal';
 import colors from 'colors/safe';
 import { IPhase } from '../../api/CommandLineConfiguration';
 import {
@@ -180,7 +181,7 @@ export function _printTimeline(terminal: ITerminal, result: IExecutionResult): v
   // Do some calculations to determine what size timeline chart we need.
   //
 
-  const maxWidth: number = process.stdout.columns || TIMELINE_WIDTH;
+  const maxWidth: number = PrintUtilities.getConsoleWidth() || TIMELINE_WIDTH;
   const chartWidth: number = maxWidth - longestNameLength - longestDurationLength - 4;
   //
   // Loop through all operations, assembling some statistics about operations and

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -10,7 +10,7 @@ import colors from 'colors/safe';
 
 import { Terminal } from '@rushstack/node-core-library';
 import { CollatedTerminal } from '@rushstack/stream-collator';
-import { MockWritable } from '@rushstack/terminal';
+import { MockWritable, PrintUtilities } from '@rushstack/terminal';
 
 import { OperationExecutionManager, IOperationExecutionManagerOptions } from '../OperationExecutionManager';
 import { _printOperationStatus } from '../OperationResultSummarizerPlugin';
@@ -65,6 +65,7 @@ describe(OperationExecutionManager.name, () => {
   });
 
   beforeEach(() => {
+    jest.spyOn(PrintUtilities, 'getConsoleWidth').mockReturnValue(90);
     mockWritable.reset();
   });
 

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -403,37 +403,37 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "=============================================================================================================
+    "text": "==========================================================================================
 ",
   },
   Object {
     "kind": "O",
-    "text": "[cyan]success with warnings (success)[default] [yellow]!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!![default] [white]0.2s[default]
+    "text": "[cyan]success with warnings (success)[default] [yellow]!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!![default] [white]0.2s[default]
 ",
   },
   Object {
     "kind": "O",
-    "text": "=============================================================================================================
+    "text": "==========================================================================================
 ",
   },
   Object {
     "kind": "O",
-    "text": "LEGEND:                                                                                      Total Work: 0.2s
+    "text": "LEGEND:                                                                   Total Work: 0.2s
 ",
   },
   Object {
     "kind": "O",
-    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op                                 Wall Clock: 0.2s
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op              Wall Clock: 0.2s
 ",
   },
   Object {
     "kind": "O",
-    "text": "                                                                                      Max Parallelism Used: 1
+    "text": "                                                                   Max Parallelism Used: 1
 ",
   },
   Object {
     "kind": "O",
-    "text": "                                                                                    Avg Parallelism Used: 1.0
+    "text": "                                                                 Avg Parallelism Used: 1.0
 ",
   },
   Object {

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -56,6 +56,10 @@
       "description": "A node-semver expression (e.g. \">=1.2.3 <2.0.0\", see https://github.com/npm/node-semver) indicating which versions of Node.js can safely be used to build this repository.  If omitted, no validation is performed.",
       "type": "string"
     },
+    "nodeSupportedVersionInstructions": {
+      "description": "If specified, when a rush command fails due to an unsupported node version, this additional instructional message is printed below the failure message.",
+      "type": "string"
+    },
     "suppressNodeLtsWarning": {
       "description": "Rush normally prints a warning if it detects a pre-LTS Node.js version. If you are testing pre-LTS versions in preparation for supporting the first LTS version, you can use this setting to disable Rush's warning.",
       "type": "boolean"

--- a/libraries/terminal/src/PrintUtilities.ts
+++ b/libraries/terminal/src/PrintUtilities.ts
@@ -41,8 +41,21 @@ export class PrintUtilities {
       maxLineLength = PrintUtilities.getConsoleWidth() || DEFAULT_CONSOLE_WIDTH;
     }
 
-    const wrap: (textToWrap: string) => string = wordwrap(indent, maxLineLength, { mode: 'soft' });
-    return wrap(text);
+    // Apply word wrapping and the provided indent, while also respecting existing newlines
+    // and prefix spaces that may exist in the text string already.
+    const lines: string[] = text.split(/\r?\n/);
+    const wrappedLines: string[] = lines.map((line) => {
+      const startingSpace: RegExpMatchArray | null = line.match(/^ +/);
+      const addlIndent: number = startingSpace?.[0]?.length || 0;
+
+      if (addlIndent > 0) {
+        line = line.replace(/^ +/, '');
+      }
+
+      return wordwrap(indent! + addlIndent, maxLineLength! - indent! - addlIndent, { mode: 'soft' })(line);
+    });
+
+    return wrappedLines.join('\n');
   }
 
   /**

--- a/libraries/terminal/src/test/PrintUtilities.test.ts
+++ b/libraries/terminal/src/test/PrintUtilities.test.ts
@@ -6,46 +6,85 @@ import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-lib
 import { PrintUtilities } from '../PrintUtilities';
 
 describe(PrintUtilities.name, () => {
+  let terminalProvider: StringBufferTerminalProvider;
+  let terminal: Terminal;
+
+  beforeEach(() => {
+    terminalProvider = new StringBufferTerminalProvider(false);
+    terminal = new Terminal(terminalProvider);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function validateOutput(expectedWidth: number): void {
+    const outputLines: string[] = terminalProvider
+      .getOutput({ normalizeSpecialCharacters: true })
+      .split('[n]');
+    expect(outputLines).toMatchSnapshot();
+
+    expect(outputLines[0].trim().length).toEqual(expectedWidth);
+  }
+
+  describe(PrintUtilities.wrapWords.name, () => {
+    it('respects spaces and newlines in a pre-formatted message', () => {
+      const userMessage: string = [
+        'An error occurred while pushing commits to git remote. Please make sure you have installed and enabled git lfs. The easiest way to do that is run the provided setup script:',
+        '',
+        '    common/scripts/setup.sh',
+        ''
+      ].join('\n');
+
+      const result: string = PrintUtilities.wrapWords(userMessage, 50, 4);
+      expect(result.split(/\n/)).toMatchSnapshot();
+    });
+
+    it('applies pre-existing indents on both margins', () => {
+      const message: string = [
+        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.',
+        '',
+        '    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.',
+        '',
+        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa.'
+      ].join('\n');
+
+      const result: string = PrintUtilities.wrapWords(message, 50);
+      expect(result.split(/\n/)).toMatchSnapshot();
+    });
+  });
+
   describe(PrintUtilities.printMessageInBox.name, () => {
     const MESSAGE: string =
       'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.';
 
-    let terminalProvider: StringBufferTerminalProvider;
-    let terminal: Terminal;
-
-    beforeEach(() => {
-      terminalProvider = new StringBufferTerminalProvider(false);
-      terminal = new Terminal(terminalProvider);
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
-    function validateOutput(expectedWidth: number): void {
-      const outputLines: string[] = terminalProvider
-        .getOutput({ normalizeSpecialCharacters: true })
-        .split('[n]');
-      expect(outputLines).toMatchSnapshot();
-
-      expect(outputLines[0].trim().length).toEqual(expectedWidth);
-    }
-
-    it('Correctly prints a narrow box', () => {
+    it('prints a long message wrapped in narrow box', () => {
       PrintUtilities.printMessageInBox(MESSAGE, terminal, 20);
       validateOutput(20);
     });
 
-    it('Correctly prints a wide box', () => {
+    it('prints a long message wrapped in a wide box', () => {
       PrintUtilities.printMessageInBox(MESSAGE, terminal, 300);
       validateOutput(300);
     });
 
-    it('Correctly gets the console width', () => {
+    it('prints a long message wrapped in a box using the console width', () => {
       jest.spyOn(PrintUtilities, 'getConsoleWidth').mockReturnValue(65);
 
       PrintUtilities.printMessageInBox(MESSAGE, terminal);
       validateOutput(32);
+    });
+
+    it('respects spaces and newlines in a pre-formatted message', () => {
+      const userMessage: string = [
+        'An error occurred while pushing commits to git remote. Please make sure you have installed and enabled git lfs. The easiest way to do that is run the provided setup script:',
+        '',
+        '    common/scripts/setup.sh',
+        ''
+      ].join('\n');
+
+      PrintUtilities.printMessageInBox(userMessage, terminal, 50);
+      validateOutput(50);
     });
   });
 });

--- a/libraries/terminal/src/test/__snapshots__/PrintUtilities.test.ts.snap
+++ b/libraries/terminal/src/test/__snapshots__/PrintUtilities.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PrintUtilities printMessageInBox Correctly gets the console width 1`] = `
+exports[`PrintUtilities printMessageInBox prints a long message wrapped in a box using the console width 1`] = `
 Array [
   " ╔══════════════════════════════╗ ",
   " ║    Lorem ipsum dolor sit     ║ ",
@@ -19,7 +19,16 @@ Array [
 ]
 `;
 
-exports[`PrintUtilities printMessageInBox Correctly prints a narrow box 1`] = `
+exports[`PrintUtilities printMessageInBox prints a long message wrapped in a wide box 1`] = `
+Array [
+  " ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗ ",
+  " ║                                              Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.                                               ║ ",
+  " ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝ ",
+  "",
+]
+`;
+
+exports[`PrintUtilities printMessageInBox prints a long message wrapped in narrow box 1`] = `
 Array [
   " ╔══════════════════╗ ",
   " ║      Lorem       ║ ",
@@ -52,72 +61,45 @@ Array [
 ]
 `;
 
-exports[`PrintUtilities printMessageInBox Correctly prints a wide box 1`] = `
+exports[`PrintUtilities printMessageInBox respects spaces and newlines in a pre-formatted message 1`] = `
 Array [
-  " ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗ ",
-  " ║                                              Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.                                               ║ ",
-  " ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝ ",
+  " ╔════════════════════════════════════════════════╗ ",
+  " ║    An error occurred while pushing commits     ║ ",
+  " ║      to git remote. Please make sure you       ║ ",
+  " ║    have installed and enabled git lfs. The     ║ ",
+  " ║       easiest way to do that is run the        ║ ",
+  " ║             provided setup script:             ║ ",
+  " ║                                                ║ ",
+  " ║            common/scripts/setup.sh             ║ ",
+  " ║                                                ║ ",
+  " ╚════════════════════════════════════════════════╝ ",
   "",
 ]
 `;
 
-exports[`Utilities printMessageInBox Correctly gets the console width 1`] = `
+exports[`PrintUtilities wrapWords applies pre-existing indents on both margins 1`] = `
 Array [
-  " ╔══════════════════════════════╗ ",
-  " ║    Lorem ipsum dolor sit     ║ ",
-  " ║      amet, consectetuer      ║ ",
-  " ║       adipiscing elit.       ║ ",
-  " ║      Maecenas porttitor      ║ ",
-  " ║     congue massa. Fusce      ║ ",
-  " ║      posuere, magna sed      ║ ",
-  " ║     pulvinar ultricies,      ║ ",
-  " ║         purus lectus         ║ ",
-  " ║    malesuada libero, sit     ║ ",
-  " ║      amet commodo magna      ║ ",
-  " ║       eros quis urna.        ║ ",
-  " ╚══════════════════════════════╝ ",
+  "Lorem ipsum dolor sit amet, consectetuer",
+  "adipiscing elit. Maecenas porttitor congue massa.",
   "",
+  "    Lorem ipsum dolor sit amet, consectetuer",
+  "    adipiscing elit. Maecenas porttitor",
+  "    congue massa.",
+  "",
+  "Lorem ipsum dolor sit amet, consectetuer",
+  "adipiscing elit. Maecenas porttitor congue massa.",
 ]
 `;
 
-exports[`Utilities printMessageInBox Correctly prints a narrow box 1`] = `
+exports[`PrintUtilities wrapWords respects spaces and newlines in a pre-formatted message 1`] = `
 Array [
-  " ╔══════════════════╗ ",
-  " ║      Lorem       ║ ",
-  " ║      ipsum       ║ ",
-  " ║    dolor sit     ║ ",
-  " ║      amet,       ║ ",
-  " ║   consectetuer   ║ ",
-  " ║    adipiscing    ║ ",
-  " ║      elit.       ║ ",
-  " ║     Maecenas     ║ ",
-  " ║    porttitor     ║ ",
-  " ║      congue      ║ ",
-  " ║      massa.      ║ ",
-  " ║      Fusce       ║ ",
-  " ║     posuere,     ║ ",
-  " ║    magna sed     ║ ",
-  " ║     pulvinar     ║ ",
-  " ║    ultricies,    ║ ",
-  " ║      purus       ║ ",
-  " ║      lectus      ║ ",
-  " ║    malesuada     ║ ",
-  " ║     libero,      ║ ",
-  " ║     sit amet     ║ ",
-  " ║     commodo      ║ ",
-  " ║      magna       ║ ",
-  " ║    eros quis     ║ ",
-  " ║      urna.       ║ ",
-  " ╚══════════════════╝ ",
-  "",
-]
-`;
-
-exports[`Utilities printMessageInBox Correctly prints a wide box 1`] = `
-Array [
-  " ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗ ",
-  " ║                                              Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.                                               ║ ",
-  " ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝ ",
-  "",
+  "    An error occurred while pushing commits",
+  "    to git remote. Please make sure you have",
+  "    installed and enabled git lfs. The",
+  "    easiest way to do that is run the",
+  "    provided setup script:",
+  "    ",
+  "        common/scripts/setup.sh",
+  "    ",
 ]
 `;


### PR DESCRIPTION
## Summary

Adds an additional Rush configuration property, which provides additional instructions to the user if their node version is not supported by the monorepo.

Fixes #3405.

## Details

The change to Rush was very straightforward, but getting the message formatting properly took some experimentation.

My test case involves a long, pre-formatted message...

```js
{
    "nodeSupportedVersionInstructions": "**NOTE**: For the best developer experience, use the node version specified in the\nmonorepo's .nvmrc file. The easiest way to do this is to update your default nvm\nversion and then re-run the script script:\n\n    nvm use 16.15.0\n    nvm alias default 16.15.0\n    common/scripts/setup.sh\n",
}
```

And the intent is for this message to be displayed exactly as formatted...

<img width="1364" alt="Screen Shot 2022-12-01 at 6 08 58 AM" src="https://user-images.githubusercontent.com/58273/205039767-527011bf-5fca-4aa8-a1c6-4efd6720ad63.png">

To achieve this some additional tweaks had to be made:

 - Work around some (buggy?) multi-newline-squashing behavior in `colors` by coloring each line in error output.
 - Modify the way the `wrapWords` utility works by wrapping each existing line, and treating existing spaces as indents.
 - And finally, an (unrelated) unit test was fixed which behaved differently in CI vs local.

> In my opinion, the change to `wrapWords` is warranted, because without it displaying user-provided pre-formatted messages to any exception that bubbles up to be displayed to a user isn't possible. It does have side effects, the biggest one being that we are respecting existing newlines in messages -- if you run wrapWords on a pre-formatted paragraph block with newlines that is longer than maxWidth, you are going to end up with a ragged line after my changes, rather than a nice block. (In spirit, we are moving from "github-flavored newlines" to "classic markdown newlines".)
>
> I scanned all existing uses of `PrintUtilities.wrapWords` in Rush and in every case, messages are passed in as one long line that expects to be wrapped, so I'm pretty sure this side effect won't cause user-visible regressions.

## How it was tested

 - Tested using various instructional messages in local monorepo.
 - Additional unit tests for `PrintUtilities`.
