### PR TITLE
[heft-webpack] Log nested errors/warnings

### DIFF
--- a/common/changes/@rushstack/heft-webpack4-plugin/webpack-nested-errors_2022-12-01-21-37.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/webpack-nested-errors_2022-12-01-21-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Log errors and warnings from nested compilations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/webpack-nested-errors_2022-12-01-21-37.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/webpack-nested-errors_2022-12-01-21-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Log errors and warnings from nested compilations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackPlugin.ts
@@ -268,14 +268,33 @@ export class WebpackPlugin implements IHeftPlugin {
 
   private _emitErrors(logger: ScopedLogger, stats: WebpackStats | WebpackCompilation.MultiStats): void {
     if (stats.hasErrors() || stats.hasWarnings()) {
-      const serializedStats: WebpackStats.ToJsonOutput = stats.toJson('errors-warnings');
+      const serializedStats: WebpackStats.ToJsonOutput[] = [stats.toJson('errors-warnings')];
 
-      for (const warning of serializedStats.warnings as (string | Error)[]) {
-        logger.emitWarning(warning instanceof Error ? warning : new Error(warning));
+      const warnings: Error[] = [];
+      const errors: Error[] = [];
+
+      for (const compilationStats of serializedStats) {
+        for (const warning of compilationStats.warnings as (string | Error)[]) {
+          warnings.push(warning instanceof Error ? warning : new Error(warning));
+        }
+
+        for (const error of compilationStats.errors as (string | Error)[]) {
+          errors.push(error instanceof Error ? error : new Error(error));
+        }
+
+        if (compilationStats.children) {
+          for (const child of compilationStats.children) {
+            serializedStats.push(child);
+          }
+        }
       }
 
-      for (const error of serializedStats.errors as (string | Error)[]) {
-        logger.emitError(error instanceof Error ? error : new Error(error));
+      for (const warning of warnings) {
+        logger.emitWarning(warning);
+      }
+
+      for (const error of errors) {
+        logger.emitError(error);
       }
     }
   }

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackPlugin.ts
@@ -277,18 +277,37 @@ export class WebpackPlugin implements IHeftPlugin {
     stats: WebpackStats | WebpackMultiStats
   ): void {
     if (stats.hasErrors() || stats.hasWarnings()) {
-      const serializedStats: WebpackStatsCompilation = stats.toJson('errors-warnings');
+      const serializedStats: WebpackStatsCompilation[] = [stats.toJson('errors-warnings')];
 
-      if (serializedStats.warnings) {
-        for (const warning of serializedStats.warnings) {
-          logger.emitWarning(this._normalizeError(buildFolder, warning));
+      const errors: Error[] = [];
+      const warnings: Error[] = [];
+
+      for (const compilationStats of serializedStats) {
+        if (compilationStats.warnings) {
+          for (const warning of compilationStats.warnings) {
+            warnings.push(this._normalizeError(buildFolder, warning));
+          }
+        }
+
+        if (compilationStats.errors) {
+          for (const error of compilationStats.errors) {
+            errors.push(this._normalizeError(buildFolder, error));
+          }
+        }
+
+        if (compilationStats.children) {
+          for (const child of compilationStats.children) {
+            serializedStats.push(child);
+          }
         }
       }
 
-      if (serializedStats.errors) {
-        for (const error of serializedStats.errors) {
-          logger.emitError(this._normalizeError(buildFolder, error));
-        }
+      for (const warning of warnings) {
+        logger.emitWarning(warning);
+      }
+
+      for (const error of errors) {
+        logger.emitError(error);
       }
     }
   }


### PR DESCRIPTION
## Summary
Ensures that logging from webpack includes errors and warnings that originate in webpack child compiler instances.

## Details
The stats `hasErrors()` function includes errors from child compilations, but these errors don't get propagated into the top level `errors` or `warnings` arrays. This PR updates the Heft logger to also enumerate errors and warnings in all child compilations.

## How it was tested
Debugger validation of the location of nested errors.