### PR TITLE
[rush] Simplify JSON Schema loading.

### DIFF
--- a/common/changes/@microsoft/rush/simpler-schema-imports_2022-12-05-08-35.json
+++ b/common/changes/@microsoft/rush/simpler-schema-imports_2022-12-05-08-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/api/ApprovedPackagesConfiguration.ts
+++ b/libraries/rush-lib/src/api/ApprovedPackagesConfiguration.ts
@@ -6,6 +6,7 @@ import { JsonFile, JsonSchema, FileSystem, NewlineKind, InternalError } from '@r
 
 import { Utilities } from '../utilities/Utilities';
 import { JsonSchemaUrls } from '../logic/JsonSchemaUrls';
+import schemaJson from '../schemas/approved-packages.schema.json';
 
 /**
  * Part of IApprovedPackagesJson.
@@ -53,9 +54,7 @@ export class ApprovedPackagesItem {
  * @public
  */
 export class ApprovedPackagesConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/approved-packages.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   public items: ApprovedPackagesItem[] = [];
 

--- a/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -19,6 +19,7 @@ import { RushUserConfiguration } from './RushUserConfiguration';
 import { EnvironmentConfiguration } from './EnvironmentConfiguration';
 import { CacheEntryId, GetCacheEntryIdFunction } from '../logic/buildCache/CacheEntryId';
 import type { CloudBuildCacheProviderFactory, RushSession } from '../pluginFramework/RushSession';
+import schemaJson from '../schemas/build-cache.schema.json';
 
 /**
  * Describes the file structure for the "common/config/rush/build-cache.json" config file.
@@ -63,9 +64,7 @@ interface IBuildCacheConfigurationOptions {
  * @beta
  */
 export class BuildCacheConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '..', 'schemas', 'build-cache.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   /**
    * Indicates whether the build cache feature is enabled.

--- a/libraries/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/libraries/rush-lib/src/api/CommandLineConfiguration.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema, FileSystem } from '@rushstack/node-core-library';
 import type { CommandLineParameter } from '@rushstack/ts-command-line';
 
@@ -20,6 +19,7 @@ import type {
   IChoiceListParameterJson,
   IPhasedCommandWithoutPhasesJson
 } from './CommandLineJson';
+import schemaJson from '../schemas/command-line.schema.json';
 
 export interface IShellCommandTokenContext {
   packageFolder: string;
@@ -169,9 +169,7 @@ interface ICommandLineConfigurationOptions {
  * Custom Commands and Options for the Rush Command Line
  */
 export class CommandLineConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/command-line.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   public readonly commands: Map<string, Command> = new Map();
   public readonly phases: Map<string, IPhase> = new Map();

--- a/libraries/rush-lib/src/api/CommonVersionsConfiguration.ts
+++ b/libraries/rush-lib/src/api/CommonVersionsConfiguration.ts
@@ -11,8 +11,10 @@ import {
   FileSystem,
   Sort
 } from '@rushstack/node-core-library';
+
 import { PackageNameParsers } from './PackageNameParsers';
 import { JsonSchemaUrls } from '../logic/JsonSchemaUrls';
+import schemaJson from '../schemas/common-versions.schema.json';
 
 /**
  * Part of the ICommonVersionsJson structure.
@@ -55,9 +57,7 @@ interface ICommonVersionsJson {
  * @public
  */
 export class CommonVersionsConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/common-versions.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _preferredVersions: ProtectableMap<string, string>;
   private _allowedAlternativeVersions: ProtectableMap<string, string[]>;

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema, FileSystem } from '@rushstack/node-core-library';
+
+import schemaJson from '../schemas/experiments.schema.json';
 
 /**
  * This interface represents the raw experiments.json file which allows repo
@@ -60,9 +61,7 @@ export interface IExperimentsJson {
  * @public
  */
 export class ExperimentsConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.resolve(__dirname, '..', 'schemas', 'experiments.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _jsonFileName: string;
 

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -37,6 +37,7 @@ import { RushPluginsConfiguration } from './RushPluginsConfiguration';
 import { IPnpmOptionsJson, PnpmOptionsConfiguration } from '../logic/pnpm/PnpmOptionsConfiguration';
 import { INpmOptionsJson, NpmOptionsConfiguration } from '../logic/npm/NpmOptionsConfiguration';
 import { IYarnOptionsJson, YarnOptionsConfiguration } from '../logic/yarn/YarnOptionsConfiguration';
+import schemaJson from '../schemas/rush.schema.json';
 
 import type * as DependencyAnalyzerModuleType from '../logic/DependencyAnalyzer';
 import { PackageManagerOptionsConfigurationBase } from '../logic/base/BasePackageManagerOptionsConfiguration';
@@ -204,9 +205,7 @@ export interface ITryFindRushJsonLocationOptions {
  * @public
  */
 export class RushConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/rush.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _variants: Set<string>;
   private readonly _pathTrees: Map<string, LookupByPath<RushConfigurationProject>>;

--- a/libraries/rush-lib/src/api/RushPluginsConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushPluginsConfiguration.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema } from '@rushstack/node-core-library';
+
+import schemaJson from '../schemas/rush-plugins.schema.json';
 
 /**
  * @internal
@@ -21,9 +22,7 @@ interface IRushPluginsConfigurationJson {
 }
 
 export class RushPluginsConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '..', 'schemas', 'rush-plugins.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _jsonFilename: string;
 

--- a/libraries/rush-lib/src/api/RushUserConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushUserConfiguration.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import { Utilities } from '../utilities/Utilities';
 import { RushConstants } from '../logic/RushConstants';
+import schemaJson from '../schemas/rush-user-settings.schema.json';
 
 interface IRushUserSettingsJson {
   buildCacheFolder?: string;
@@ -17,9 +18,7 @@ interface IRushUserSettingsJson {
  * @beta
  */
 export class RushUserConfiguration {
-  private static _schema: JsonSchema = JsonSchema.fromFile(
-    path.resolve(__dirname, '..', 'schemas', 'rush-user-settings.schema.json')
-  );
+  private static _schema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   /**
    * If provided, store build cache in the specified folder. Must be an absolute path.

--- a/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
+++ b/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema, FileSystem } from '@rushstack/node-core-library';
 
 import { VersionPolicy, BumpType, LockStepVersionPolicy } from './VersionPolicy';
 import { RushConfigurationProject } from './RushConfigurationProject';
+import schemaJson from '../schemas/version-policies.schema.json';
 
 export interface IVersionPolicyJson {
   policyName: string;
@@ -47,9 +47,7 @@ export interface IVersionPolicyDependencyJson {
  * @public
  */
 export class VersionPolicyConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/version-policies.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _jsonFileName: string;
 

--- a/libraries/rush-lib/src/logic/ChangeFiles.ts
+++ b/libraries/rush-lib/src/logic/ChangeFiles.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema, Import } from '@rushstack/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';
 import { IChangeInfo } from '../api/ChangeManagement';
 import { IChangelog } from '../api/Changelog';
 import { RushConfiguration } from '../api/RushConfiguration';
+import schemaJson from '../schemas/change-file.schema.json';
 
 const glob: typeof import('glob') = Import.lazy('glob', require);
 
@@ -34,9 +34,7 @@ export class ChangeFiles {
     changedPackages: string[],
     rushConfiguration: RushConfiguration
   ): void {
-    const schema: JsonSchema = JsonSchema.fromFile(
-      path.resolve(__dirname, '..', 'schemas', 'change-file.schema.json')
-    );
+    const schema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
     const projectsWithChangeDescriptions: Set<string> = new Set<string>();
     newChangeFilePaths.forEach((filePath) => {

--- a/libraries/rush-lib/src/logic/ChangelogGenerator.ts
+++ b/libraries/rush-lib/src/logic/ChangelogGenerator.ts
@@ -11,6 +11,7 @@ import { IChangeInfo, ChangeType } from '../api/ChangeManagement';
 import { IChangelog, IChangeLogEntry, IChangeLogComment, IChangeLogEntryComments } from '../api/Changelog';
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { RushConfiguration } from '../api/RushConfiguration';
+import schemaJson from '../schemas/changelog.schema.json';
 
 const CHANGELOG_JSON: string = 'CHANGELOG.json';
 const CHANGELOG_MD: string = 'CHANGELOG.md';
@@ -20,9 +21,7 @@ export class ChangelogGenerator {
   /**
    * The JSON Schema for Changelog file (changelog.schema.json).
    */
-  public static readonly jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '..', 'schemas', 'changelog.schema.json')
-  );
+  public static readonly jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   /**
    * Updates the appropriate changelogs with the given changes.

--- a/libraries/rush-lib/src/logic/CredentialCache.ts
+++ b/libraries/rush-lib/src/logic/CredentialCache.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema, LockFile, Import } from '@rushstack/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';
 import { RushUserConfiguration } from '../api/RushUserConfiguration';
+import schemaJson from '../schemas/credentials.schema.json';
 
 const lodash: typeof import('lodash') = Import.lazy('lodash', require);
 
@@ -70,9 +70,7 @@ export class CredentialCache /* implements IDisposable */ {
   public static async initializeAsync(options: ICredentialCacheOptions): Promise<CredentialCache> {
     const rushUserFolderPath: string = RushUserConfiguration.getRushUserFolderPath();
     const cacheFilePath: string = `${rushUserFolderPath}/${CACHE_FILENAME}`;
-    const jsonSchema: JsonSchema = JsonSchema.fromFile(
-      path.resolve(__dirname, '..', 'schemas', 'credentials.schema.json')
-    );
+    const jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
     let loadedJson: ICredentialCacheJson | undefined;
     try {

--- a/libraries/rush-lib/src/logic/RepoStateFile.ts
+++ b/libraries/rush-lib/src/logic/RepoStateFile.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema, NewlineKind } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { PnpmShrinkwrapFile } from './pnpm/PnpmShrinkwrapFile';
 import { CommonVersionsConfiguration } from '../api/CommonVersionsConfiguration';
+import schemaJson from '../schemas/repo-state.schema.json';
 
 /**
  * This interface represents the raw repo-state.json file
@@ -34,9 +34,7 @@ interface IRepoStateJson {
  * @public
  */
 export class RepoStateFile {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/repo-state.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private _variant: string | undefined;
   private _pnpmShrinkwrapHash: string | undefined;

--- a/libraries/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
+++ b/libraries/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
@@ -4,7 +4,9 @@
 import colors from 'colors/safe';
 import * as path from 'path';
 import { FileSystem, JsonFile, JsonSchema } from '@rushstack/node-core-library';
+
 import { RushConfiguration } from '../../api/RushConfiguration';
+import schemaJson from '../../schemas/deploy-scenario.schema.json';
 
 // Describes IDeployScenarioJson.projectSettings
 export interface IDeployScenarioProjectJson {
@@ -31,9 +33,7 @@ export class DeployScenarioConfiguration {
   // Example: "deploy-the-thing123"
   private static _scenarioNameRegExp: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../../schemas/deploy-scenario.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   public readonly json: IDeployScenarioJson;
 

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonObject, JsonSchema } from '@rushstack/node-core-library';
+
 import {
   IPackageManagerOptionsJsonBase,
   PackageManagerOptionsConfigurationBase
 } from '../base/BasePackageManagerOptionsConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
+import schemaJson from '../../schemas/pnpm-config.schema.json';
 
 /**
  * This represents the available PNPM store options
@@ -100,9 +101,7 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
  * @public
  */
 export class PnpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.resolve(__dirname, '../../schemas/pnpm-config.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private readonly _json: JsonObject;
   private _globalPatchedDependencies: Record<string, string> | undefined;

--- a/libraries/rush-lib/src/logic/setup/ArtifactoryConfiguration.ts
+++ b/libraries/rush-lib/src/logic/setup/ArtifactoryConfiguration.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema, FileSystem } from '@rushstack/node-core-library';
+
+import schemaJson from '../../schemas/artifactory.schema.json';
 
 export interface IArtifactoryPackageRegistryJson {
   enabled: boolean;
@@ -35,9 +36,7 @@ export interface IArtifactoryJson {
  * It configures the "rush setup" command.
  */
 export class ArtifactoryConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.resolve(__dirname, '..', '..', 'schemas', 'artifactory.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   private readonly _jsonFileName: string;
 

--- a/libraries/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -10,12 +10,14 @@ import {
   JsonSchema
 } from '@rushstack/node-core-library';
 import * as path from 'path';
+
 import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { IRushPluginConfigurationBase } from '../../api/RushPluginsConfiguration';
 import { RushConstants } from '../../logic/RushConstants';
 import { IRushPlugin } from '../IRushPlugin';
 import { RushSdk } from './RushSdk';
+import schemaJson from '../../schemas/rush-plugin-manifest.schema.json';
 
 export interface IRushPluginManifest {
   pluginName: string;
@@ -39,9 +41,7 @@ export interface IPluginLoaderOptions<TPluginConfiguration extends IRushPluginCo
 export abstract class PluginLoaderBase<
   TPluginConfiguration extends IRushPluginConfigurationBase = IRushPluginConfigurationBase
 > {
-  protected static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../../schemas/rush-plugin-manifest.schema.json')
-  );
+  protected static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
 
   public readonly packageName: Readonly<string>;
   public readonly pluginName: Readonly<string>;

--- a/libraries/rush-lib/tsconfig.json
+++ b/libraries/rush-lib/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "types": ["heft-jest", "node"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
This PR replaces all of the `JsonSchema.fromFile` instances with `JsonSchema.fromLoadedObject` in `rush-lib`. This improves bundleability of `rush-lib`.