### PR TITLE
[rush] Support CI build log folding using env vars

### DIFF
--- a/common/changes/@microsoft/rush/enelson-rushloggroup_2022-12-05-19-11.json
+++ b/common/changes/@microsoft/rush/enelson-rushloggroup_2022-12-05-19-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add RUSH_BUILD_FOLDING_HEADER and RUSH_BUILD_FOLDING_FOOTER environment variables.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -149,6 +149,8 @@ export class EnvironmentConfiguration {
     static get buildCacheCredential(): string | undefined;
     static get buildCacheEnabled(): boolean | undefined;
     static get buildCacheWriteAllowed(): boolean | undefined;
+    static get buildFoldingFooter(): string | undefined;
+    static get buildFoldingHeader(): string | undefined;
     // Warning: (ae-forgotten-export) The symbol "IEnvironment" needs to be exported by the entry point index.d.ts
     //
     // @internal
@@ -173,6 +175,9 @@ export enum EnvironmentVariableNames {
     RUSH_BUILD_CACHE_CREDENTIAL = "RUSH_BUILD_CACHE_CREDENTIAL",
     RUSH_BUILD_CACHE_ENABLED = "RUSH_BUILD_CACHE_ENABLED",
     RUSH_BUILD_CACHE_WRITE_ALLOWED = "RUSH_BUILD_CACHE_WRITE_ALLOWED",
+    // (undocumented)
+    RUSH_BUILD_FOLDING_FOOTER = "RUSH_BUILD_FOLDING_FOOTER",
+    RUSH_BUILD_FOLDING_HEADER = "RUSH_BUILD_FOLDING_HEADER",
     RUSH_DEPLOY_TARGET_FOLDER = "RUSH_DEPLOY_TARGET_FOLDER",
     RUSH_GIT_BINARY_PATH = "RUSH_GIT_BINARY_PATH",
     RUSH_GLOBAL_FOLDER = "RUSH_GLOBAL_FOLDER",

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -154,6 +154,44 @@ export enum EnvironmentVariableNames {
   RUSH_TAR_BINARY_PATH = 'RUSH_TAR_BINARY_PATH',
 
   /**
+   * If defined, when Rush runs any bulk or phased command in verbose mode, this line will be
+   * printed above the build output. The following variables are provided as interpolated values
+   * if desired:
+   *
+   *   - `${taskName}` - the name of the task being executed (as printed in the header)
+   *
+   * This value is useful for folding long build output in CI environments. Here are some suggested
+   * values for this environment variable:
+   *
+   *   - GitHub Actions:
+   *     - `::group::${taskName}`
+   *   - Azure Devops:
+   *     - `##[group]${taskName}`
+   *   - Travis CI:
+   *     - `travis_fold:start:${taskName}`
+   */
+  RUSH_BUILD_FOLDING_HEADER = 'RUSH_BUILD_FOLDING_HEADER',
+
+  /*
+   * If defined, when Rush runs any bulk or phased command in verbose mode, this line will be
+   * printed below the build output. The following variables are provided as interpolated values
+   * if desired:
+   *
+   *   - `${taskName}` - the name of the task being executed (as printed in the header)
+   *
+   * This value is useful for folding long build output in CI environments. Here are some suggested
+   * values for this environment variable:
+   *
+   *   - GitHub Actions:
+   *     - `::endgroup::`
+   *   - Azure Devops:
+   *     - `##[endgroup]`
+   *   - Travis CI:
+   *     - `travis_fold:end:${taskName}`
+   */
+  RUSH_BUILD_FOLDING_FOOTER = 'RUSH_BUILD_FOLDING_FOOTER',
+
+  /**
    * When Rush executes shell scripts, it sometimes changes the working directory to be a project folder or
    * the repository root folder.  The original working directory (where the Rush command was invoked) is assigned
    * to the the child process's `RUSH_INVOKED_FOLDER` environment variable, in case it is needed by the script.
@@ -199,6 +237,10 @@ export class EnvironmentConfiguration {
   private static _gitBinaryPath: string | undefined;
 
   private static _tarBinaryPath: string | undefined;
+
+  private static _buildFoldingHeader: string | undefined;
+
+  private static _buildFoldingFooter: string | undefined;
 
   /**
    * An override for the common/temp folder path.
@@ -309,6 +351,26 @@ export class EnvironmentConfiguration {
   public static get tarBinaryPath(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._tarBinaryPath;
+  }
+
+  /**
+   * If defined, when Rush runs any bulk or phased command in verbose mode, this line will be
+   * printed above the build output.
+   * See {@link EnvironmentVariableNames.RUSH_BUILD_FOLDING_HEADER}
+   */
+  public static get buildFoldingHeader(): string | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._buildFoldingHeader;
+  }
+
+  /**
+   * If defined, when Rush runs any bulk or phased command in verbose mode, this line will be
+   * printed below the build output.
+   * See {@link EnvironmentVariableNames.RUSH_BUILD_FOLDING_FOOTER}
+   */
+  public static get buildFoldingFooter(): string | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._buildFoldingFooter;
   }
 
   /**
@@ -428,8 +490,13 @@ export class EnvironmentConfiguration {
             break;
           }
 
-          case EnvironmentVariableNames.RUSH_TAR_BINARY_PATH: {
-            EnvironmentConfiguration._tarBinaryPath = value;
+          case EnvironmentVariableNames.RUSH_BUILD_FOLDING_HEADER: {
+            EnvironmentConfiguration._buildFoldingHeader = value;
+            break;
+          }
+
+          case EnvironmentVariableNames.RUSH_BUILD_FOLDING_FOOTER: {
+            EnvironmentConfiguration._buildFoldingFooter = value;
             break;
           }
 

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -490,6 +490,11 @@ export class EnvironmentConfiguration {
             break;
           }
 
+          case EnvironmentVariableNames.RUSH_TAR_BINARY_PATH: {
+            EnvironmentConfiguration._tarBinaryPath = value;
+            break;
+          }
+
           case EnvironmentVariableNames.RUSH_BUILD_FOLDING_HEADER: {
             EnvironmentConfiguration._buildFoldingHeader = value;
             break;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -22,7 +22,7 @@ import {
   OperationExecutionManager
 } from '../../logic/operations/OperationExecutionManager';
 import { RushConstants } from '../../logic/RushConstants';
-import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
+import { EnvironmentVariableNames, EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { LastLinkFlag, LastLinkFlagFactory } from '../../api/LastLinkFlag';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
@@ -335,7 +335,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       quietMode: isQuietMode,
       debugMode: this.parser.isDebug,
       parallelism,
-      changedProjectsOnly
+      changedProjectsOnly,
+      projectLogHeader: EnvironmentConfiguration.buildFoldingHeader,
+      projectLogFooter: EnvironmentConfiguration.buildFoldingFooter
     };
 
     const internalOptions: IRunPhasesOptions = {


### PR DESCRIPTION
## Summary

Allow monorepo maintainers to fold long build logs in CI using simple header and footer environment variables.

Fixes #2198.

## Details

Since this behavior typically doesn't make sense on local machines, going with environment variables makes the most sense.

Although this behavior is called "grouping" by both GitHub and Azure, I think this word is rather ambiguous; log _folding_ is much more specific and better describes the actual functionality you get. I've proposed `RUSH_BUILD_FOLDING_HEADER` and `RUSH_BUILD_FOLDING_FOOTER` but am open to alternatives!

## How it was tested

 - Tested locally to verify output with env vars on and off, verbose on and off.
