### PR TITLE
[@microsoft/rush-lib] add support for clone depth

### DIFF
--- a/common/changes/@microsoft/rush/refactor-git-merge-base_2022-12-06-13-01.json
+++ b/common/changes/@microsoft/rush/refactor-git-merge-base_2022-12-06-13-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for submodule (such as in gitlab ci)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -235,7 +235,7 @@ export class Git {
         'merge-base',
         '--',
         'HEAD',
-        targetBranch
+        `origin/${targetBranch}`
       ]);
       const result: string = output.trim();
 


### PR DESCRIPTION
**before update**
in gitlab ci , the next shell will get error
`git --no-optional-locks merge-base -- HEAD main` 
output: fatal: Not a valid object name master

**after update**
you get correct result
`git --no-optional-locks merge-base -- HEAD origin/main`
output: xxxxf65a6a911e7240802650d77f08713d0aa55