### PR TITLE
Add "Impacted documentation" section to PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,10 +57,26 @@
      Pushing additional commits with "small" fixes often invalidates testing.
 --------------------------------------------------------------------------->
 
+## Impacted documentation
+
 <!--------------------------------------------------------------------------
-👉 STEP 7: Don't forget to run "rush change":
+👉 STEP 7: Does your PR affect anything that is discussed in the
+     website documentation?
+
+     If you're able to fix the docs (thank you!), paste a URL for that PR.
+     Otherwise, paste the URLs of each affected web page, so we're aware.
+     If no docs are impacted, you can delete this section.
+
+     If you modified a JSON schema, remember to update init templates such as:
+     rush-lib/assets/rush-init/*.json
+     api-extractor/src/schemas/api-extractor-template.json
+--------------------------------------------------------------------------->
+
+<!--------------------------------------------------------------------------
+👉 STEP 8: Don't forget to run "rush change":
 
      https://rushjs.io/pages/best_practices/change_logs/
 --------------------------------------------------------------------------->
+
 
 <!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,12 +60,11 @@
 ## Impacted documentation
 
 <!--------------------------------------------------------------------------
-👉 STEP 7: Does your PR affect anything that is discussed in the
-     website documentation?
-
-     If you're able to fix the docs (thank you!), paste a URL for that PR.
-     Otherwise, paste the URLs of each affected web page, so we're aware.
-     If no docs are impacted, you can delete this section.
+👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
+     If so, please paste the URL of each affected web page, so we will
+     remember to update the documentation after your PR is merged.
+     (Updating the website is appreciated but not required.)
+     If no docs are impacted, delete the "Impacted documentation" section.
 
      If you modified a JSON schema, remember to update init templates such as:
      rush-lib/assets/rush-init/*.json


### PR DESCRIPTION
Update PULL_REQUEST_TEMPLATE.md based on [this Zulip discussion](https://rushstack.zulipchat.com/#narrow/stream/279883-contributor-helpline/topic/Getting.20started.20with.20the.20stack/near/314554132).

PR authors can't always do the work to fix the documentation, but they can at least help identify what work needs to be done, so we don't overlook this.