### PR TITLE
[rush] Ship a webpacked version of rush-lib.

### DIFF
--- a/common/changes/@microsoft/rush/webpack-rush-lib_2022-12-08-09-01.json
+++ b/common/changes/@microsoft/rush/webpack-rush-lib_2022-12-08-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Include a bundled copy of rush-lib under that package's 'dist' folder.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -211,6 +211,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@rushstack/webpack-preserve-dynamic-require-plugin",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@rushstack/webpack4-localization-plugin",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -143,6 +143,18 @@
           "optional": true
         }
       }
+    },
+
+    "scss-parser": {
+      "dependencies": {
+        "lodash": "~4.17.15"
+      }
+    },
+
+    "query-ast": {
+      "dependencies": {
+        "lodash": "~4.17.15"
+      }
     }
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 lockfileVersion: 5.4
 
-packageExtensionsChecksum: 4cee63805d63bd8991d4c7a30da2ca02
+packageExtensionsChecksum: 41333d2d0915bdc80c909c31c409a3a2
 
 importers:
 
@@ -1826,12 +1826,14 @@ importers:
       '@rushstack/heft': workspace:*
       '@rushstack/heft-config-file': workspace:*
       '@rushstack/heft-node-rig': workspace:*
+      '@rushstack/heft-webpack5-plugin': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@rushstack/package-deps-hash': workspace:*
       '@rushstack/rig-package': workspace:*
       '@rushstack/stream-collator': workspace:*
       '@rushstack/terminal': workspace:*
       '@rushstack/ts-command-line': workspace:*
+      '@rushstack/webpack-preserve-dynamic-require-plugin': workspace:*
       '@types/cli-table': 0.3.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -1848,6 +1850,7 @@ importers:
       '@types/ssri': ~7.1.0
       '@types/strict-uri-encode': 2.0.0
       '@types/tar': 6.1.1
+      '@types/webpack-env': 1.13.0
       '@yarnpkg/lockfile': ~1.0.2
       builtin-modules: ~3.1.0
       cli-table: ~0.3.1
@@ -1875,6 +1878,7 @@ importers:
       tapable: 2.2.1
       tar: ~6.1.11
       true-case-path: ~2.2.1
+      webpack: ~5.68.0
     dependencies:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/heft-config-file': link:../heft-config-file
@@ -1917,6 +1921,8 @@ importers:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
+      '@rushstack/webpack-preserve-dynamic-require-plugin': link:../../webpack/preserve-dynamic-require-plugin
       '@types/cli-table': 0.3.0
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
@@ -1932,6 +1938,8 @@ importers:
       '@types/ssri': 7.1.1
       '@types/strict-uri-encode': 2.0.0
       '@types/tar': 6.1.1
+      '@types/webpack-env': 1.13.0
+      webpack: 5.68.0
 
   ../../libraries/rush-sdk:
     specifiers:
@@ -9050,10 +9058,6 @@ packages:
       is-windows: 1.0.2
     dev: false
 
-  /big.js/3.2.0:
-    resolution: {integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==}
-    dev: false
-
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -10877,11 +10881,6 @@ packages:
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  /emojis-list/2.1.0:
-    resolution: {integrity: sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==}
-    engines: {node: '>= 0.10'}
-    dev: false
-
   /emojis-list/3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -12655,7 +12654,7 @@ packages:
   /generic-names/2.0.1:
     resolution: {integrity: sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==}
     dependencies:
-      loader-utils: 1.1.0
+      loader-utils: 1.4.2
     dev: false
 
   /gensync/1.0.0-beta.2:
@@ -14845,11 +14844,6 @@ packages:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: true
 
-  /json5/0.5.1:
-    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
-    hasBin: true
-    dev: false
-
   /json5/1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
@@ -15081,15 +15075,6 @@ packages:
   /loader-runner/4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
-
-  /loader-utils/1.1.0:
-    resolution: {integrity: sha512-gkD9aSEG9UGglyPcDJqY9YBTUtCLKaBK6ihD2VP1d1X60lTfFspNZNulGBBbUZLkPygy4LySYHyxBpq+VhjObQ==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      big.js: 3.2.0
-      emojis-list: 2.1.0
-      json5: 0.5.1
-    dev: false
 
   /loader-utils/1.4.2:
     resolution: {integrity: sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==}
@@ -17390,6 +17375,7 @@ packages:
     resolution: {integrity: sha512-KFJFSvODCBjIH5HbHvITj9EEZKYUU6VX0T5CuB1ayvjUoUaZkKMi6eeby5Tf8DMukyZHlJQOE1+f3vevKUe6eg==}
     dependencies:
       invariant: 2.2.4
+      lodash: 4.17.21
     dev: false
 
   /querystring-es3/0.2.1:
@@ -18436,6 +18422,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       invariant: 2.2.4
+      lodash: 4.17.21
     dev: false
 
   /secure-json-parse/2.5.0:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "5aacaab0b25c1fb04d98a1be45eb615d50fd605c",
+  "pnpmShrinkwrapHash": "46a9dd946116eec4ae725ba521bb38588feec2bf",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/libraries/rush-lib/.npmignore
+++ b/libraries/rush-lib/.npmignore
@@ -29,5 +29,7 @@
 
 # (Add your project-specific overrides here)
 !/assets/**
-lib/__mocks__/**
-!lib-esnext/**
+/lib/__mocks__/**
+/lib/logic/pnpm/PnpmfileShim*
+/lib/scripts/**
+/lib-esnext/**

--- a/libraries/rush-lib/.npmignore
+++ b/libraries/rush-lib/.npmignore
@@ -30,3 +30,4 @@
 # (Add your project-specific overrides here)
 !/assets/**
 lib/__mocks__/**
+!lib-esnext/**

--- a/libraries/rush-lib/config/heft.json
+++ b/libraries/rush-lib/config/heft.json
@@ -66,5 +66,11 @@
         }
       ]
     }
+  ],
+
+  "heftPlugins": [
+    {
+      "plugin": "@rushstack/heft-webpack5-plugin"
+    }
   ]
 }

--- a/libraries/rush-lib/config/typescript.json
+++ b/libraries/rush-lib/config/typescript.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@rushstack/heft-node-rig/profiles/default/config/typescript.json",
+
+  "additionalModuleKindsToEmit": [
+    {
+      "moduleKind": "esnext",
+      "outFolderName": "lib-esnext"
+    }
+  ]
+}

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -12,7 +12,7 @@
   },
   "engineStrict": true,
   "homepage": "https://rushjs.io",
-  "main": "lib/index.js",
+  "main": "dist/rush-lib.js",
   "typings": "dist/rush-lib.d.ts",
   "scripts": {
     "build": "heft build --clean",
@@ -37,8 +37,8 @@
     "colors": "~1.2.1",
     "figures": "3.0.0",
     "git-repo-info": "~2.1.0",
-    "glob": "~7.0.5",
     "glob-escape": "~0.0.2",
+    "glob": "~7.0.5",
     "https-proxy-agent": "~5.0.0",
     "ignore": "~5.1.6",
     "inquirer": "~7.3.3",
@@ -62,8 +62,10 @@
   "devDependencies": {
     "@pnpm/logger": "4.0.0",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
+    "@rushstack/heft-webpack5-plugin": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@rushstack/webpack-preserve-dynamic-require-plugin": "workspace:*",
     "@types/cli-table": "0.3.0",
     "@types/glob": "7.1.1",
     "@types/heft-jest": "1.0.1",
@@ -78,7 +80,9 @@
     "@types/semver": "7.3.5",
     "@types/ssri": "~7.1.0",
     "@types/strict-uri-encode": "2.0.0",
-    "@types/tar": "6.1.1"
+    "@types/tar": "6.1.1",
+    "@types/webpack-env": "1.13.0",
+    "webpack": "~5.68.0"
   },
   "publishOnlyDependencies": {
     "@rushstack/rush-amazon-s3-build-cache-plugin": "workspace:*",

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -432,6 +432,7 @@ export class RushPnpmCommandLineParser {
     };
 
     const installManagerFactoryModule: typeof import('../logic/InstallManagerFactory') = await import(
+      /* webpackChunkName: 'InstallManagerFactory' */
       '../logic/InstallManagerFactory'
     );
     const installManager: BaseInstallManager =

--- a/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
@@ -70,7 +70,9 @@ export abstract class BaseAddAndRemoveAction extends BaseRushAction {
   }
 
   public async runAsync(): Promise<void> {
-    const packageJsonUpdater: typeof PackageJsonUpdaterType = await import('../../logic/PackageJsonUpdater');
+    const packageJsonUpdater: typeof PackageJsonUpdaterType = await import(
+      /* webpackChunkName: 'PackageJsonUpdater' */ '../../logic/PackageJsonUpdater'
+    );
     const updater: PackageJsonUpdaterType.PackageJsonUpdater = new packageJsonUpdater.PackageJsonUpdater(
       this.rushConfiguration,
       this.rushGlobalFolder

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -135,6 +135,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     const installManagerOptions: IInstallManagerOptions = await this.buildInstallOptionsAsync();
 
     const installManagerFactoryModule: typeof import('../../logic/InstallManagerFactory') = await import(
+      /* webpackChunkName: 'InstallManagerFactory' */
       '../../logic/InstallManagerFactory'
     );
     const installManager: BaseInstallManager =

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -82,7 +82,10 @@ export class DeployAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    const deployManagerModule: typeof deployManagerType = await import('../../logic/deploy/DeployManager');
+    const deployManagerModule: typeof deployManagerType = await import(
+      /* webpackChunkName: 'DeployManager' */
+      '../../logic/deploy/DeployManager'
+    );
     const deployManager: deployManagerType.DeployManager = new deployManagerModule.DeployManager(
       this.rushConfiguration
     );

--- a/libraries/rush-lib/src/cli/actions/LinkAction.ts
+++ b/libraries/rush-lib/src/cli/actions/LinkAction.ts
@@ -34,6 +34,7 @@ export class LinkAction extends BaseRushAction {
 
   protected async runAsync(): Promise<void> {
     const linkManagerFactoryModule: typeof import('../../logic/LinkManagerFactory') = await import(
+      /* webpackChunkName: 'LinkManagerFactory' */
       '../../logic/LinkManagerFactory'
     );
     const linkManager: BaseLinkManager = linkManagerFactoryModule.LinkManagerFactory.getLinkManager(

--- a/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
@@ -46,8 +46,8 @@ export class UpgradeInteractiveAction extends BaseRushAction {
 
   public async runAsync(): Promise<void> {
     const [{ PackageJsonUpdater }, { InteractiveUpgrader }] = await Promise.all([
-      import('../../logic/PackageJsonUpdater'),
-      import('../../logic/InteractiveUpgrader')
+      import(/* webpackChunkName: 'PackageJsonUpdater' */ '../../logic/PackageJsonUpdater'),
+      import(/* webpackChunkName: 'InteractiveUpgrader' */ '../../logic/InteractiveUpgrader')
     ]);
 
     const packageJsonUpdater: PackageJsonUpdaterType.PackageJsonUpdater = new PackageJsonUpdater(

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -99,7 +99,10 @@ export class VersionAction extends BaseRushAction {
     const userEmail: string = git.getGitEmail();
 
     this._validateInput();
-    const versionManagerModule: typeof VersionManagerType = await import('../../logic/VersionManager');
+    const versionManagerModule: typeof VersionManagerType = await import(
+      /* webpackChunkName: 'VersionManager' */
+      '../../logic/VersionManager'
+    );
     const versionManager: VersionManagerType.VersionManager = new versionManagerModule.VersionManager(
       this.rushConfiguration,
       userEmail,

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -232,7 +232,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
   public async runAsync(): Promise<void> {
     if (this._alwaysInstall || this._installParameter?.value) {
-      const { doBasicInstallAsync } = await import('../../logic/installManager/doBasicInstallAsync');
+      const { doBasicInstallAsync } = await import(
+        /* webpackChunkName: 'doBasicInstallAsync' */
+        '../../logic/installManager/doBasicInstallAsync'
+      );
 
       await doBasicInstallAsync({
         rushConfiguration: this.rushConfiguration,
@@ -267,7 +270,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
     if (showTimeline) {
-      const { ConsoleTimelinePlugin } = await import('../../logic/operations/ConsoleTimelinePlugin');
+      const { ConsoleTimelinePlugin } = await import(
+        /* webpackChunkName: 'ConsoleTimelinePlugin' */
+        '../../logic/operations/ConsoleTimelinePlugin'
+      );
       new ConsoleTimelinePlugin(terminal).apply(this.hooks);
     }
     // Enable the standard summary
@@ -400,7 +406,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       initialCreateOperationsContext;
 
     // Use async import so that we don't pay the cost for sync builds
-    const { ProjectWatcher } = await import('../../logic/ProjectWatcher');
+    const { ProjectWatcher } = await import(
+      /* webpackChunkName: 'ProjectWatcher' */
+      '../../logic/ProjectWatcher'
+    );
 
     const projectWatcher: typeof ProjectWatcher.prototype = new ProjectWatcher({
       debounceMs: this._watchDebounceMs,

--- a/libraries/rush-lib/src/logic/InstallManagerFactory.ts
+++ b/libraries/rush-lib/src/logic/InstallManagerFactory.ts
@@ -24,6 +24,7 @@ export class InstallManagerFactory {
     }
 
     const rushInstallManagerModule: typeof import('./installManager/RushInstallManager') = await import(
+      /* webpackChunkName: 'RushInstallManager' */
       './installManager/RushInstallManager'
     );
     return new rushInstallManagerModule.RushInstallManager(

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -187,7 +187,10 @@ export class PackageJsonUpdater {
    */
   public async doRushUpgradeAsync(options: IPackageJsonUpdaterRushUpgradeOptions): Promise<void> {
     const { projects, packagesToAdd, updateOtherPackages, skipUpdate, debugInstall, variant } = options;
-    const { DependencyAnalyzer } = await import('./DependencyAnalyzer');
+    const { DependencyAnalyzer } = await import(
+      /* webpackChunkName: 'DependencyAnalyzer' */
+      './DependencyAnalyzer'
+    );
     const dependencyAnalyzer: DependencyAnalyzer = DependencyAnalyzer.forRushConfiguration(
       this._rushConfiguration
     );
@@ -387,7 +390,10 @@ export class PackageJsonUpdater {
   ): Promise<IUpdateProjectOptions[]> {
     const { projects, packagesToUpdate, devDependency, updateOtherPackages, variant } = options;
 
-    const { DependencyAnalyzer } = await import('./DependencyAnalyzer');
+    const { DependencyAnalyzer } = await import(
+      /* webpackChunkName: 'DependencyAnalyzer' */
+      './DependencyAnalyzer'
+    );
     const dependencyAnalyzer: DependencyAnalyzer = DependencyAnalyzer.forRushConfiguration(
       this._rushConfiguration
     );

--- a/libraries/rush-lib/src/logic/pnpm/PnpmfileShim.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmfileShim.ts
@@ -39,7 +39,7 @@ function init(context: IPnpmfileContext | any): IPnpmfileContext {
   if (!settings) {
     // Initialize the settings from file
     if (!context.pnpmfileShimSettings) {
-      context.pnpmfileShimSettings = require('./pnpmfileSettings.json');
+      context.pnpmfileShimSettings = __non_webpack_require__('./pnpmfileSettings.json');
     }
     settings = context.pnpmfileShimSettings!;
   } else if (!context.pnpmfileShimSettings) {

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -4,13 +4,13 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
-import {
+const {
   installAndRun,
   findRushJsonFolder,
   RUSH_JSON_FILENAME,
-  runWithErrorAndStatusCode,
-  ILogger
-} from './install-run';
+  runWithErrorAndStatusCode
+}: typeof import('./install-run') = __non_webpack_require__('./install-run');
+import type { ILogger } from '../utilities/npmrcUtilities';
 
 const PACKAGE_NAME: string = '@microsoft/rush';
 const RUSH_PREVIEW_VERSION: string = 'RUSH_PREVIEW_VERSION';

--- a/libraries/rush-lib/src/scripts/install-run-rushx.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rushx.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See the @microsoft/rush package's LICENSE file for license information.
 
-import './install-run-rush';
+__non_webpack_require__('./install-run-rush');

--- a/libraries/rush-lib/src/utilities/PathConstants.ts
+++ b/libraries/rush-lib/src/utilities/PathConstants.ts
@@ -24,6 +24,6 @@ export const installRunRushScriptFilename: string = 'install-run-rush.js';
 export const installRunRushxScriptFilename: string = 'install-run-rushx.js';
 
 /**
- * The path to the scripts folder under "lib"
+ * The path to the scripts folder in rush-lib/dist.
  */
-export const scriptsFolderPath: string = `${rushLibFolderRootPath}/lib/${scriptsFolderName}`;
+export const scriptsFolderPath: string = `${rushLibFolderRootPath}/dist/${scriptsFolderName}`;

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -15,6 +15,7 @@ import {
 import type * as stream from 'stream';
 
 import { RushConfiguration } from '../api/RushConfiguration';
+import { syncNpmrc } from './npmrcUtilities';
 
 export type UNINITIALIZED = 'UNINITIALIZED';
 export const UNINITIALIZED: UNINITIALIZED = 'UNINITIALIZED';
@@ -125,6 +126,8 @@ interface ICreateEnvironmentForRushCommandOptions {
 }
 
 export class Utilities {
+  public static syncNpmrc: typeof syncNpmrc = syncNpmrc;
+
   /**
    * Get the user's home directory. On windows this looks something like "C:\users\username\" and on UNIX
    * this looks something like "/home/username/"
@@ -476,72 +479,6 @@ export class Utilities {
   }
 
   /**
-   * As a workaround, copyAndTrimNpmrcFile() copies the .npmrc file to the target folder, and also trims
-   * unusable lines from the .npmrc file.
-   *
-   * Why are we trimming the .npmrc lines?  NPM allows environment variables to be specified in
-   * the .npmrc file to provide different authentication tokens for different registry.
-   * However, if the environment variable is undefined, it expands to an empty string, which
-   * produces a valid-looking mapping with an invalid URL that causes an error.  Instead,
-   * we'd prefer to skip that line and continue looking in other places such as the user's
-   * home directory.
-   *
-   * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH _copyAndTrimNpmrcFile() FROM scripts/install-run.ts
-   *
-   * @returns
-   * The text of the the .npmrc.
-   */
-  public static copyAndTrimNpmrcFile(sourceNpmrcPath: string, targetNpmrcPath: string): string {
-    console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
-    console.log(`  --> "${targetNpmrcPath}"`);
-    let npmrcFileLines: string[] = FileSystem.readFile(sourceNpmrcPath).split('\n');
-    npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
-    const resultLines: string[] = [];
-
-    // This finds environment variable tokens that look like "${VAR_NAME}"
-    const expansionRegExp: RegExp = /\$\{([^\}]+)\}/g;
-
-    // Comment lines start with "#" or ";"
-    const commentRegExp: RegExp = /^\s*[#;]/;
-
-    // Trim out lines that reference environment variables that aren't defined
-    for (const line of npmrcFileLines) {
-      let lineShouldBeTrimmed: boolean = false;
-
-      // Ignore comment lines
-      if (!commentRegExp.test(line)) {
-        const environmentVariables: string[] | null = line.match(expansionRegExp);
-        if (environmentVariables) {
-          for (const token of environmentVariables) {
-            // Remove the leading "${" and the trailing "}" from the token
-            const environmentVariableName: string = token.substring(2, token.length - 1);
-
-            // Is the environment variable defined?
-            if (!process.env[environmentVariableName]) {
-              // No, so trim this line
-              lineShouldBeTrimmed = true;
-              break;
-            }
-          }
-        }
-      }
-
-      if (lineShouldBeTrimmed) {
-        // Example output:
-        // "; MISSING ENVIRONMENT VARIABLE: //my-registry.com/npm/:_authToken=${MY_AUTH_TOKEN}"
-        resultLines.push('; MISSING ENVIRONMENT VARIABLE: ' + line);
-      } else {
-        resultLines.push(line);
-      }
-    }
-
-    const combinedNpmrc: string = resultLines.join('\n');
-    FileSystem.writeFile(targetNpmrcPath, combinedNpmrc);
-
-    return combinedNpmrc;
-  }
-
-  /**
    * Copies the file "sourcePath" to "destinationPath", overwriting the target file location.
    * If the source file does not exist, then the target file is deleted.
    */
@@ -556,38 +493,6 @@ export class Utilities {
         console.log(`Deleting ${destinationPath}`);
         FileSystem.deleteFile(destinationPath);
       }
-    }
-  }
-
-  /**
-   * syncNpmrc() copies the .npmrc file to the target folder, and also trims unusable lines from the .npmrc file.
-   * If the source .npmrc file not exist, then syncNpmrc() will delete an .npmrc that is found in the target folder.
-   *
-   * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH _syncNpmrc() FROM scripts/install-run.ts
-   *
-   * @returns
-   * The text of the the synced .npmrc, if one exists. If one does not exist, then undefined is returned.
-   */
-  public static syncNpmrc(
-    sourceNpmrcFolder: string,
-    targetNpmrcFolder: string,
-    useNpmrcPublish?: boolean
-  ): string | undefined {
-    const sourceNpmrcPath: string = path.join(
-      sourceNpmrcFolder,
-      !useNpmrcPublish ? '.npmrc' : '.npmrc-publish'
-    );
-    const targetNpmrcPath: string = path.join(targetNpmrcFolder, '.npmrc');
-    try {
-      if (FileSystem.exists(sourceNpmrcPath)) {
-        return Utilities.copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath);
-      } else if (FileSystem.exists(targetNpmrcPath)) {
-        // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
-        console.log(`Deleting ${targetNpmrcPath}`); // Verbose
-        FileSystem.deleteFile(targetNpmrcPath);
-      }
-    } catch (e) {
-      throw new Error(`Error syncing .npmrc file: ${e}`);
     }
   }
 

--- a/libraries/rush-lib/src/utilities/npmrcUtilities.ts
+++ b/libraries/rush-lib/src/utilities/npmrcUtilities.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// IMPORTANT - do not use any non-built-in libraries in this file
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ILogger {
+  info: (string: string) => void;
+  error: (string: string) => void;
+}
+
+/**
+ * As a workaround, copyAndTrimNpmrcFile() copies the .npmrc file to the target folder, and also trims
+ * unusable lines from the .npmrc file.
+ *
+ * Why are we trimming the .npmrc lines?  NPM allows environment variables to be specified in
+ * the .npmrc file to provide different authentication tokens for different registry.
+ * However, if the environment variable is undefined, it expands to an empty string, which
+ * produces a valid-looking mapping with an invalid URL that causes an error.  Instead,
+ * we'd prefer to skip that line and continue looking in other places such as the user's
+ * home directory.
+ *
+ * @returns
+ * The text of the the .npmrc.
+ */
+function _copyAndTrimNpmrcFile(logger: ILogger, sourceNpmrcPath: string, targetNpmrcPath: string): string {
+  logger.info(`Transforming ${sourceNpmrcPath}`); // Verbose
+  logger.info(`  --> "${targetNpmrcPath}"`);
+  let npmrcFileLines: string[] = fs.readFileSync(sourceNpmrcPath).toString().split('\n');
+  npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
+  const resultLines: string[] = [];
+
+  // This finds environment variable tokens that look like "${VAR_NAME}"
+  const expansionRegExp: RegExp = /\$\{([^\}]+)\}/g;
+
+  // Comment lines start with "#" or ";"
+  const commentRegExp: RegExp = /^\s*[#;]/;
+
+  // Trim out lines that reference environment variables that aren't defined
+  for (const line of npmrcFileLines) {
+    let lineShouldBeTrimmed: boolean = false;
+
+    // Ignore comment lines
+    if (!commentRegExp.test(line)) {
+      const environmentVariables: string[] | null = line.match(expansionRegExp);
+      if (environmentVariables) {
+        for (const token of environmentVariables) {
+          // Remove the leading "${" and the trailing "}" from the token
+          const environmentVariableName: string = token.substring(2, token.length - 1);
+
+          // Is the environment variable defined?
+          if (!process.env[environmentVariableName]) {
+            // No, so trim this line
+            lineShouldBeTrimmed = true;
+            break;
+          }
+        }
+      }
+    }
+
+    if (lineShouldBeTrimmed) {
+      // Example output:
+      // "; MISSING ENVIRONMENT VARIABLE: //my-registry.com/npm/:_authToken=${MY_AUTH_TOKEN}"
+      resultLines.push('; MISSING ENVIRONMENT VARIABLE: ' + line);
+    } else {
+      resultLines.push(line);
+    }
+  }
+
+  const combinedNpmrc: string = resultLines.join('\n');
+  fs.writeFileSync(targetNpmrcPath, combinedNpmrc);
+
+  return combinedNpmrc;
+}
+
+/**
+ * syncNpmrc() copies the .npmrc file to the target folder, and also trims unusable lines from the .npmrc file.
+ * If the source .npmrc file not exist, then syncNpmrc() will delete an .npmrc that is found in the target folder.
+ *
+ * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities._syncNpmrc()
+ *
+ * @returns
+ * The text of the the synced .npmrc, if one exists. If one does not exist, then undefined is returned.
+ */
+export function syncNpmrc(
+  sourceNpmrcFolder: string,
+  targetNpmrcFolder: string,
+  useNpmrcPublish?: boolean,
+  logger: ILogger = {
+    info: console.log,
+    error: console.error
+  }
+): string | undefined {
+  const sourceNpmrcPath: string = path.join(
+    sourceNpmrcFolder,
+    !useNpmrcPublish ? '.npmrc' : '.npmrc-publish'
+  );
+  const targetNpmrcPath: string = path.join(targetNpmrcFolder, '.npmrc');
+  try {
+    if (fs.existsSync(sourceNpmrcPath)) {
+      return _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath);
+    } else if (fs.existsSync(targetNpmrcPath)) {
+      // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
+      logger.info(`Deleting ${targetNpmrcPath}`); // Verbose
+      fs.unlinkSync(targetNpmrcPath);
+    }
+  } catch (e) {
+    throw new Error(`Error syncing .npmrc file: ${e}`);
+  }
+}

--- a/libraries/rush-lib/tsconfig.json
+++ b/libraries/rush-lib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "types": ["heft-jest", "node"],
+    "types": ["heft-jest", "node", "webpack-env"],
     "skipLibCheck": true,
     "resolveJsonModule": true
   }

--- a/libraries/rush-lib/webpack.config.js
+++ b/libraries/rush-lib/webpack.config.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const webpack = require('webpack');
+const { PackageJsonLookup } = require('@rushstack/node-core-library');
+const { PreserveDynamicRequireWebpackPlugin } = require('@rushstack/webpack-preserve-dynamic-require-plugin');
+const PathConstants = require('./lib/utilities/PathConstants');
+
+const scriptEntryOption = {
+  filename: `${PathConstants.scriptsFolderName}/[name]`,
+  library: {
+    type: 'commonjs2'
+  }
+};
+
+module.exports = () => {
+  const packageJson = PackageJsonLookup.loadOwnPackageJson(__dirname);
+
+  const externalDependencyNames = new Set([
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
+    ...Object.keys(packageJson.optionalDependencies || {}),
+    ...Object.keys(packageJson.devDependencies || {})
+  ]);
+
+  return {
+    mode: 'development', // So the output isn't minified
+    devtool: 'source-map',
+    entry: {
+      ['rush-lib']: {
+        import: `${__dirname}/lib-esnext/index.js`,
+        library: {
+          type: 'commonjs'
+        }
+      },
+      [PathConstants.pnpmfileShimFilename]: {
+        import: `${__dirname}/lib-esnext/logic/pnpm/PnpmfileShim.js`,
+        ...scriptEntryOption
+      },
+      [PathConstants.installRunScriptFilename]: {
+        import: `${__dirname}/lib-esnext/scripts/install-run.js`,
+        ...scriptEntryOption
+      },
+      [PathConstants.installRunRushScriptFilename]: {
+        import: `${__dirname}/lib-esnext/scripts/install-run-rush.js`,
+        ...scriptEntryOption
+      },
+      [PathConstants.installRunRushxScriptFilename]: {
+        import: `${__dirname}/lib-esnext/scripts/install-run-rushx.js`,
+        ...scriptEntryOption
+      }
+    },
+    output: {
+      path: `${__dirname}/dist`,
+      filename: '[name].js',
+      chunkFilename: 'chunks/[name].js'
+    },
+    target: 'node',
+    plugins: [
+      new PreserveDynamicRequireWebpackPlugin(),
+      new webpack.ids.DeterministicModuleIdsPlugin({
+        maxLength: 6
+      })
+    ],
+    externals: [
+      ({ request }, callback) => {
+        let packageName;
+        let firstSlashIndex = request.indexOf('/');
+        if (firstSlashIndex === -1) {
+          packageName = request;
+        } else if (request.startsWith('@')) {
+          let secondSlash = request.indexOf('/', firstSlashIndex + 1);
+          if (secondSlash === -1) {
+            packageName = request;
+          } else {
+            packageName = request.substring(0, secondSlash);
+          }
+        } else {
+          packageName = request.substring(0, firstSlashIndex);
+        }
+
+        if (externalDependencyNames.has(packageName)) {
+          callback(null, `commonjs ${request}`);
+        } else {
+          callback();
+        }
+      }
+    ]
+  };
+};


### PR DESCRIPTION
## Summary

This PR includes a bundled copy of `rush-lib` in that project's `dist` folder.

## Details

This significantly improves the initialization time of `rush-lib`. Here are some metrics:

```
$ node -e "(() => { const start = Date.now(); require('./lib/index') ; const time = Date.now() - start; console.log('time: ' + time + 'ms');})()"
time: 1146ms
$ node -e "(() => { const start = Date.now(); require('./dist/rush-lib') ; const time = Date.now() - start; console.log('time: ' + time + 'ms');})()"
time: 757ms
```

Note that only the files local to `rush-lib` are bundled. Everything else is externalized.

## How it was tested

Tested `rush init`, `rush install`, `rush update`, `rush build`, and `rush upgrade-interactive`. All work as expected.

## Impacted documentation

This probably warrants some mention in documentation.