### PR TITLE
[rush] Fix strictPeerDependencies in latest PNPM 7

### DIFF
--- a/common/changes/@microsoft/rush/enelson-strict_2022-12-08-18-21.json
+++ b/common/changes/@microsoft/rush/enelson-strict_2022-12-08-18-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix strictPeerDependencies in all versions of pnpm 7",
+      "comment": "Fix a problem where the \"strictPeerDependencies\" setting wasn't applied for some versions of PNPM 7 due to unexpected changes of PNPM's default value (GitHub #3828)",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/enelson-strict_2022-12-08-18-21.json
+++ b/common/changes/@microsoft/rush/enelson-strict_2022-12-08-18-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix strictPeerDependencies in all versions of pnpm 7",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -616,16 +616,10 @@ export abstract class BaseInstallManager {
         args.push('--network-concurrency', options.networkConcurrency.toString());
       }
 
-      if (semver.gte(this.rushConfiguration.packageManagerToolVersion, '7.0.0')) {
-        // pnpm >= 7.0.0 handles peer dependencies strict by default
-        if (this.rushConfiguration.pnpmOptions.strictPeerDependencies === false) {
-          args.push('--no-strict-peer-dependencies');
-        }
+      if (this.rushConfiguration.pnpmOptions.strictPeerDependencies === false) {
+        args.push('--no-strict-peer-dependencies');
       } else {
-        // pnpm < 7.0.0 does not handle peer dependencies strict by default
-        if (this.rushConfiguration.pnpmOptions.strictPeerDependencies) {
-          args.push('--strict-peer-dependencies');
-        }
+        args.push('--strict-peer-dependencies');
       }
 
       if (


### PR DESCRIPTION
## Summary

For a brief period (PNPM 7.0 - PNPM 7.13.5), the `strictPeerDependencies` setting was on by default in PNPM, and Rush's code changed to reflect this.

Now that the default has flipped back, Rush's handling of the flag is incorrect.

We discussed this in https://github.com/pnpm/pnpm/issues/5766 but PNPM said the change was intentional.  In the future, Rush should not rely on default values of important PNPM settings because the defaults can change in a PATCH release of PNPM.

## Details

 - Rush now passes an explicit on or off command-line flag for strictPeerDependencies regardless of PNPM version.

## How it was tested

 - Tested pnpm 6.35.1, 7.13.0 and 7.17.1

## Impacted documentation

N/A

