### PR TITLE
[rush] cacheDir and stateDir to storePath during pnpm install if pnpmStore is local

### DIFF
--- a/common/changes/@microsoft/rush/feat-pnpm-cache-store-dir_2022-12-08-07-42.json
+++ b/common/changes/@microsoft/rush/feat-pnpm-cache-store-dir_2022-12-08-07-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Set cacheDir and stateDir to storePath during pnpm install if pnpmStore is local",
+      "comment": "Fix an issue where when the package manager is pnpm@>=6.1.0, and `pnpmStore` is set to `\"local\"`, a global cache was still used.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/feat-pnpm-cache-store-dir_2022-12-08-07-42.json
+++ b/common/changes/@microsoft/rush/feat-pnpm-cache-store-dir_2022-12-08-07-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Set cacheDir and stateDir to storePath during pnpm install if pnpmStore is local",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -325,6 +325,8 @@ export class RushPnpmCommandLineParser {
 
     if (rushConfiguration.pnpmOptions.pnpmStorePath) {
       pnpmEnvironmentMap.set('NPM_CONFIG_STORE_DIR', rushConfiguration.pnpmOptions.pnpmStorePath);
+      pnpmEnvironmentMap.set('NPM_CONFIG_CACHE_DIR', rushConfiguration.pnpmOptions.pnpmStorePath);
+      pnpmEnvironmentMap.set('NPM_CONFIG_STATE_DIR', rushConfiguration.pnpmOptions.pnpmStorePath);
     }
 
     if (rushConfiguration.pnpmOptions.environmentVariables) {

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -45,6 +45,8 @@ import { PnpmfileConfiguration } from '../pnpm/PnpmfileConfiguration';
  * Pnpm don't support --ignore-compatibility-db, so use --config.ignoreCompatibilityDb for now.
  */
 export const pnpmIgnoreCompatibilityDbParameter: string = '--config.ignoreCompatibilityDb';
+const pnpmCacheDirParameter: string = '--config.cacheDir';
+const pnpmStateDirParameter: string = '--config.stateDir';
 
 export interface IInstallManagerOptions {
   /**
@@ -167,7 +169,7 @@ export abstract class BaseInstallManager {
       console.log(
         colors.red(
           'Project filtering arguments can only be used when running in a workspace environment. Run the ' +
-            'command again without specifying these arguments.'
+          'command again without specifying these arguments.'
         )
       );
       throw new AlreadyReportedError();
@@ -179,7 +181,7 @@ export abstract class BaseInstallManager {
       console.log(
         colors.red(
           'Project filtering arguments cannot be used when running "rush update". Run the command again ' +
-            'without specifying these arguments.'
+          'without specifying these arguments.'
         )
       );
       throw new AlreadyReportedError();
@@ -588,6 +590,10 @@ export abstract class BaseInstallManager {
         EnvironmentConfiguration.pnpmStorePathOverride
       ) {
         args.push('--store', this.rushConfiguration.pnpmOptions.pnpmStorePath);
+        if (semver.gte(this.rushConfiguration.packageManagerToolVersion, '6.10.0')) {
+          args.push(`${pnpmCacheDirParameter}=${this.rushConfiguration.pnpmOptions.pnpmStorePath}`);
+          args.push(`${pnpmStateDirParameter}=${this.rushConfiguration.pnpmOptions.pnpmStorePath}`);
+        }
       }
 
       const { pnpmVerifyStoreIntegrity } = EnvironmentConfiguration;
@@ -630,9 +636,9 @@ export abstract class BaseInstallManager {
       ) {
         this._terminal.writeWarningLine(
           'Warning: Your rush.json specifies a pnpmVersion with a known issue ' +
-            'that may cause unintended version selections.' +
-            " It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. " +
-            'For details see: https://rushjs.io/link/pnpm-issue-5132'
+          'that may cause unintended version selections.' +
+          " It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. " +
+          'For details see: https://rushjs.io/link/pnpm-issue-5132'
         );
       }
       if (


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This PR closes https://github.com/microsoft/rushstack/issues/3804

## Details

When pnpm, pnpmVersion >= 6.10.0, pnpmStore: "local", specifying `cache-dir` and `state-dir` to `store-dir` during pnpm install.

## How it was tested

Tested in rushstack repo

![2022-12-09 at 09 11](https://user-images.githubusercontent.com/16147702/206600310-18d9722c-f6c4-446f-abaf-5e96b0cbe160.png)



<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
