### PR TITLE
[rush] fix lastLinkFlag path

### DIFF
--- a/common/changes/@microsoft/rush/fix-child-class-property_2022-12-09-05-51.json
+++ b/common/changes/@microsoft/rush/fix-child-class-property_2022-12-09-05-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix LastLinkFlag path",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-child-class-property_2022-12-09-05-51.json
+++ b/common/changes/@microsoft/rush/fix-child-class-property_2022-12-09-05-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix LastLinkFlag path",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -562,7 +562,7 @@ export class _LastInstallFlag {
     }): boolean;
     clear(): void;
     create(): void;
-    protected readonly flagName: string;
+    protected get flagName(): string;
     isValid(options?: _ILockfileValidityCheckOptions): boolean;
     readonly path: string;
 }

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -36,11 +36,6 @@ export class LastInstallFlag {
   public readonly path: string;
 
   /**
-   * Returns the name of the flag file
-   */
-  protected readonly flagName: string = LAST_INSTALL_FLAG_FILE_NAME;
-
-  /**
    * Creates a new LastInstall flag
    * @param folderPath - the folder that this flag is managing
    * @param state - optional, the state that should be managed or compared
@@ -142,6 +137,13 @@ export class LastInstallFlag {
    */
   public clear(): void {
     FileSystem.deleteFile(this.path);
+  }
+
+  /**
+   * Returns the name of the flag file
+   */
+  protected get flagName(): string {
+    return LAST_INSTALL_FLAG_FILE_NAME;
   }
 }
 

--- a/libraries/rush-lib/src/api/LastLinkFlag.ts
+++ b/libraries/rush-lib/src/api/LastLinkFlag.ts
@@ -13,8 +13,6 @@ export const LAST_LINK_FLAG_FILE_NAME: string = 'last-link.flag';
  * @internal
  */
 export class LastLinkFlag extends LastInstallFlag {
-  protected readonly flagName: string = LAST_LINK_FLAG_FILE_NAME;
-
   /**
    * @override
    */
@@ -33,6 +31,15 @@ export class LastLinkFlag extends LastInstallFlag {
    */
   public checkValidAndReportStoreIssues(): boolean {
     throw new InternalError('Not implemented');
+  }
+
+  /**
+   * Returns the name of the flag file
+   *
+   * @override
+   */
+  protected get flagName(): string {
+    return LAST_LINK_FLAG_FILE_NAME;
   }
 }
 

--- a/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
+++ b/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
 import { FileSystem } from '@rushstack/node-core-library';
 
-import { LastInstallFlag } from '../LastInstallFlag';
+import { LastInstallFlag, LAST_INSTALL_FLAG_FILE_NAME } from '../LastInstallFlag';
 
 const TEMP_DIR_PATH: string = `${__dirname}/temp`;
 
@@ -14,6 +15,11 @@ describe(LastInstallFlag.name, () => {
 
   afterEach(() => {
     FileSystem.ensureEmptyFolder(TEMP_DIR_PATH);
+  });
+
+  it('can get correct path', () => {
+    const flag: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH);
+    expect(path.basename(flag.path)).toEqual(LAST_INSTALL_FLAG_FILE_NAME);
   });
 
   it('can create and remove a flag in an empty directory', () => {

--- a/libraries/rush-lib/src/api/test/LastLinkFlag.test.ts
+++ b/libraries/rush-lib/src/api/test/LastLinkFlag.test.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { FileSystem } from '@rushstack/node-core-library';
+
+import { LastLinkFlag, LAST_LINK_FLAG_FILE_NAME } from '../LastLinkFlag';
+
+const TEMP_DIR_PATH: string = `${__dirname}/temp`;
+
+describe(LastLinkFlag.name, () => {
+  beforeEach(() => {
+    FileSystem.ensureEmptyFolder(TEMP_DIR_PATH);
+  });
+
+  afterEach(() => {
+    FileSystem.ensureEmptyFolder(TEMP_DIR_PATH);
+  });
+
+  it('can get correct path', () => {
+    const flag: LastLinkFlag = new LastLinkFlag(TEMP_DIR_PATH);
+    expect(path.basename(flag.path)).toEqual(LAST_LINK_FLAG_FILE_NAME);
+  });
+});


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

I saw there is a refactoring to eliminate useless getter by https://github.com/microsoft/rushstack/pull/3809

However, i found an issue in `LastLinkFlag.path`. This PR fixes it. I carefully reviewed PR 3809, and this is the only issue.

## Details

In current main branch, LastInstallFlag set `this.path` by `this.flagName`

![fd875ad5-8956-4a86-893b-ce19b4a88a98](https://user-images.githubusercontent.com/16147702/206634023-034279fa-fa6f-497f-82c5-9c575cb6a587.jpeg)

while, LastLinkFlag set `this.path` by `this.flagName` by extending LastInstallFlag

![50203e8a-98e6-4892-974a-315b94b4f933](https://user-images.githubusercontent.com/16147702/206634055-95cc48b1-4a2a-46be-a767-c94ef38fd81c.jpeg)

Actually, this won't work. Here is a minimal demo of this kind of class usage.

![2022-12-09 at 11 44](https://user-images.githubusercontent.com/16147702/206634075-4a1f1ad9-56c5-46d1-96a7-342491540832.png)




## How it was tested

Add a test for LastLinkFlag

Before:
![image](https://user-images.githubusercontent.com/16147702/206634350-400226b0-5a81-4ab4-99bf-5bab3ca49fa0.png)

After this PR:

test passed


## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
