### PR TITLE
[webpack5-localization-plugin] Make `LocalizationPlugin._stringKeys` a public property

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/issue-3858_2022-12-20-04-53.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/issue-3858_2022-12-20-04-53.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/webpack5-localization-plugin",
       "comment": "Convert LocalizationPlugin._stringKeys to public stringKeys property.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/webpack5-localization-plugin"

--- a/common/changes/@rushstack/webpack5-localization-plugin/issue-3858_2022-12-20-04-53.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/issue-3858_2022-12-20-04-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Convert LocalizationPlugin._stringKeys to public stringKeys property.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/reviews/api/webpack5-localization-plugin.api.md
+++ b/common/reviews/api/webpack5-localization-plugin.api.md
@@ -134,6 +134,8 @@ export class LocalizationPlugin implements WebpackPluginInstance {
     getDataForSerialNumber(serialNumber: string): _IStringPlaceholder | undefined;
     // (undocumented)
     getPlaceholder(localizedFileKey: string, stringName: string): _IStringPlaceholder | undefined;
+    // (undocumented)
+    readonly stringKeys: Map<string, _IStringPlaceholder>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
+++ b/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
@@ -78,7 +78,7 @@ export function getPluginInstance(compiler: Compiler | undefined): LocalizationP
  * @public
  */
 export class LocalizationPlugin implements WebpackPluginInstance {
-  private readonly _stringKeys: Map<string, IStringPlaceholder> = new Map();
+  public readonly stringKeys: Map<string, IStringPlaceholder> = new Map();
 
   private readonly _options: ILocalizationPluginOptions;
   private readonly _resolvedTranslatedStringsFromOptions: Map<
@@ -461,7 +461,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
    */
   public getPlaceholder(localizedFileKey: string, stringName: string): IStringPlaceholder | undefined {
     const stringKey: string = `${localizedFileKey}?${stringName}`;
-    return this._stringKeys.get(stringKey);
+    return this.stringKeys.get(stringKey);
   }
 
   /**
@@ -485,7 +485,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
     const resultObject: Record<string, string> = {};
     for (const [stringName, stringValue] of localizedFileData) {
       const stringKey: string = `${localizedFileKey}?${stringName}`;
-      let placeholder: IStringPlaceholder | undefined = this._stringKeys.get(stringKey);
+      let placeholder: IStringPlaceholder | undefined = this.stringKeys.get(stringKey);
       if (!placeholder) {
         // TODO: This may need to be a deterministic identifier to support watch / incremental compilation
         const suffix: string = `${this._stringPlaceholderCounter++}`;
@@ -501,7 +501,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
           stringName
         };
 
-        this._stringKeys.set(stringKey, placeholder);
+        this.stringKeys.set(stringKey, placeholder);
         this._stringPlaceholderMap.set(suffix, placeholder);
       }
 
@@ -520,7 +520,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
   ): void {
     for (const [stringName, stringValue] of localizedFileData) {
       const stringKey: string = `${localizedFileKey}?${stringName}`;
-      const placeholder: IStringPlaceholder | undefined = this._stringKeys.get(stringKey);
+      const placeholder: IStringPlaceholder | undefined = this.stringKeys.get(stringKey);
       if (placeholder) {
         placeholder.valuesByLocale.set(localeName, stringValue);
       }


### PR DESCRIPTION
Fixes #3858 

This PR updates updates `LocalizationPlugin._stringKeys` to `LocalizationPlugin.stringKeys` and making it a public property. This aligns its capabilities with its webpack 4 plugin counterpart. 

Since this was already a private property, this should only be a SemVer minor operation and I've specified as such in the change file. 