### PR TITLE
Extract some types exported from async-loaded that are referenced in sync-loaded modules into their own files.

### DIFF
--- a/common/changes/@microsoft/rush/move-rush-lib-types_2022-12-21-07-16.json
+++ b/common/changes/@microsoft/rush/move-rush-lib-types_2022-12-21-07-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -26,7 +26,8 @@ import { PurgeManager } from '../logic/PurgeManager';
 
 import type { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 import type { SpawnSyncReturns } from 'child_process';
-import type { BaseInstallManager, IInstallManagerOptions } from '../logic/base/BaseInstallManager';
+import type { BaseInstallManager } from '../logic/base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../logic/base/BaseInstallManagerTypes';
 
 const lodash: typeof import('lodash') = Import.lazy('lodash', require);
 const semver: typeof import('semver') = Import.lazy('semver', require);

--- a/libraries/rush-lib/src/cli/actions/AddAction.ts
+++ b/libraries/rush-lib/src/cli/actions/AddAction.ts
@@ -8,9 +8,11 @@ import { BaseAddAndRemoveAction } from './BaseAddAndRemoveAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { DependencySpecifier } from '../../logic/DependencySpecifier';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
-
-import { SemVerStyle } from '../../logic/PackageJsonUpdater';
-import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
+import {
+  type IPackageForRushAdd,
+  type IPackageJsonUpdaterRushAddOptions,
+  SemVerStyle
+} from '../../logic/PackageJsonUpdaterTypes';
 
 export class AddAction extends BaseAddAndRemoveAction {
   protected readonly _allFlag: CommandLineFlagParameter;
@@ -79,7 +81,7 @@ export class AddAction extends BaseAddAndRemoveAction {
     });
   }
 
-  public getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushAddOptions {
+  public getUpdateOptions(): IPackageJsonUpdaterRushAddOptions {
     const projects: RushConfigurationProject[] = super.getProjects();
 
     if (this._caretFlag.value && this._exactFlag.value) {
@@ -88,7 +90,7 @@ export class AddAction extends BaseAddAndRemoveAction {
       );
     }
 
-    const packagesToAdd: PackageJsonUpdaterType.IPackageForRushAdd[] = [];
+    const packagesToAdd: IPackageForRushAdd[] = [];
 
     for (const specifiedPackageName of this.specifiedPackageNameList) {
       /**
@@ -121,7 +123,7 @@ export class AddAction extends BaseAddAndRemoveAction {
       /**
        * RangeStyle
        */
-      let rangeStyle: PackageJsonUpdaterType.SemVerStyle;
+      let rangeStyle: SemVerStyle;
       if (version && version !== 'latest') {
         if (this._exactFlag.value || this._caretFlag.value) {
           throw new Error(

--- a/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseAddAndRemoveAction.ts
@@ -6,6 +6,10 @@ import type { CommandLineFlagParameter, CommandLineStringListParameter } from '@
 import { BaseRushAction, type IBaseRushActionOptions } from './BaseRushAction';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
+import type {
+  IPackageForRushUpdate,
+  IPackageJsonUpdaterRushBaseUpdateOptions
+} from '../../logic/PackageJsonUpdaterTypes';
 
 export interface IBasePackageJsonUpdaterRushOptions {
   /**
@@ -15,7 +19,7 @@ export interface IBasePackageJsonUpdaterRushOptions {
   /**
    * The dependencies to be added.
    */
-  packagesToHandle: PackageJsonUpdaterType.IPackageForRushUpdate[];
+  packagesToHandle: IPackageForRushUpdate[];
   /**
    * If specified, "rush update" will not be run after updating the package.json file(s).
    */
@@ -49,7 +53,7 @@ export abstract class BaseAddAndRemoveAction extends BaseRushAction {
     });
   }
 
-  protected abstract getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushBaseUpdateOptions;
+  protected abstract getUpdateOptions(): IPackageJsonUpdaterRushBaseUpdateOptions;
 
   protected getProjects(): RushConfigurationProject[] {
     if (this._allFlag.value) {

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -11,7 +11,8 @@ import type {
 
 import { BaseRushAction, IBaseRushActionOptions } from './BaseRushAction';
 import { Event } from '../../api/EventHooks';
-import { BaseInstallManager, IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
+import type { BaseInstallManager } from '../../logic/base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../../logic/base/BaseInstallManagerTypes';
 import { PurgeManager } from '../../logic/PurgeManager';
 import { SetupChecks } from '../../logic/SetupChecks';
 import { StandardScriptUpdater } from '../../logic/StandardScriptUpdater';

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -5,7 +5,7 @@ import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 import { ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library';
 
 import { BaseInstallAction } from './BaseInstallAction';
-import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../../logic/base/BaseInstallManagerTypes';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 

--- a/libraries/rush-lib/src/cli/actions/RemoveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/RemoveAction.ts
@@ -7,8 +7,10 @@ import type { CommandLineFlagParameter, CommandLineStringListParameter } from '@
 import { BaseAddAndRemoveAction } from './BaseAddAndRemoveAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';
-
-import type * as PackageJsonUpdaterType from '../../logic/PackageJsonUpdater';
+import type {
+  IPackageForRushRemove,
+  IPackageJsonUpdaterRushRemoveOptions
+} from '../../logic/PackageJsonUpdaterTypes';
 
 export class RemoveAction extends BaseAddAndRemoveAction {
   protected readonly _allFlag: CommandLineFlagParameter;
@@ -46,10 +48,10 @@ export class RemoveAction extends BaseAddAndRemoveAction {
     });
   }
 
-  public getUpdateOptions(): PackageJsonUpdaterType.IPackageJsonUpdaterRushRemoveOptions {
+  public getUpdateOptions(): IPackageJsonUpdaterRushRemoveOptions {
     const projects: RushConfigurationProject[] = super.getProjects();
 
-    const packagesToRemove: PackageJsonUpdaterType.IPackageForRushRemove[] = [];
+    const packagesToRemove: IPackageForRushRemove[] = [];
 
     for (const specifiedPackageName of this.specifiedPackageNameList) {
       /**

--- a/libraries/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAction.ts
@@ -4,7 +4,7 @@
 import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 import { BaseInstallAction } from './BaseInstallAction';
-import { IInstallManagerOptions } from '../../logic/base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../../logic/base/BaseInstallManagerTypes';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 
 export class UpdateAction extends BaseInstallAction {

--- a/libraries/rush-lib/src/cli/actions/test/AddAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/AddAction.test.ts
@@ -3,7 +3,8 @@
 
 import '../../test/mockRushCommandLineParser';
 
-import { IPackageJsonUpdaterRushAddOptions, PackageJsonUpdater } from '../../../logic/PackageJsonUpdater';
+import { PackageJsonUpdater } from '../../../logic/PackageJsonUpdater';
+import type { IPackageJsonUpdaterRushAddOptions } from '../../../logic/PackageJsonUpdaterTypes';
 import { RushCommandLineParser } from '../../RushCommandLineParser';
 import { AddAction } from '../AddAction';
 

--- a/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
@@ -3,7 +3,8 @@
 
 import '../../test/mockRushCommandLineParser';
 
-import { PackageJsonUpdater, IPackageJsonUpdaterRushRemoveOptions } from '../../../logic/PackageJsonUpdater';
+import { PackageJsonUpdater } from '../../../logic/PackageJsonUpdater';
+import type { IPackageJsonUpdaterRushRemoveOptions } from '../../../logic/PackageJsonUpdaterTypes';
 import { RushCommandLineParser } from '../../RushCommandLineParser';
 import { RemoveAction } from '../RemoveAction';
 import { VersionMismatchFinderProject } from '../../../logic/versionMismatch/VersionMismatchFinderProject';

--- a/libraries/rush-lib/src/logic/InstallManagerFactory.ts
+++ b/libraries/rush-lib/src/logic/InstallManagerFactory.ts
@@ -6,7 +6,8 @@ import { PurgeManager } from './PurgeManager';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushGlobalFolder } from '../api/RushGlobalFolder';
 
-import type { BaseInstallManager, IInstallManagerOptions } from './base/BaseInstallManager';
+import type { BaseInstallManager } from './base/BaseInstallManager';
+import type { IInstallManagerOptions } from './base/BaseInstallManagerTypes';
 
 export class InstallManagerFactory {
   public static async getInstallManagerAsync(

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -6,7 +6,8 @@ import * as semver from 'semver';
 import { ConsoleTerminalProvider, Terminal, ITerminalProvider, Colors } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
-import { BaseInstallManager, IInstallManagerOptions } from './base/BaseInstallManager';
+import { BaseInstallManager } from './base/BaseInstallManager';
+import { IInstallManagerOptions } from './base/BaseInstallManagerTypes';
 import { InstallManagerFactory } from './InstallManagerFactory';
 import { VersionMismatchFinder } from './versionMismatch/VersionMismatchFinder';
 import { PurgeManager } from './PurgeManager';
@@ -19,62 +20,13 @@ import { VersionMismatchFinderProject } from './versionMismatch/VersionMismatchF
 import { RushConstants } from './RushConstants';
 import { InstallHelpers } from './installManager/InstallHelpers';
 import type { DependencyAnalyzer, IDependencyAnalysis } from './DependencyAnalyzer';
-
-/**
- * The type of SemVer range specifier that is prepended to the version
- */
-export const enum SemVerStyle {
-  Exact = 'exact',
-  Caret = 'caret',
-  Tilde = 'tilde',
-  Passthrough = 'passthrough'
-}
-
-export interface IPackageForRushUpdate {
-  packageName: string;
-}
-
-export interface IPackageForRushAdd extends IPackageForRushUpdate {
-  /**
-   * The style of range that should be used if the version is automatically detected.
-   */
-  rangeStyle: SemVerStyle;
-
-  /**
-   * If not undefined, the latest version will be used (that doesn't break ensureConsistentVersions).
-   * If specified, the latest version meeting the SemVer specifier will be used as the basis.
-   */
-  version?: string;
-}
-
-export interface IPackageForRushRemove extends IPackageForRushUpdate {}
-
-export interface IPackageJsonUpdaterRushBaseUpdateOptions {
-  /**
-   * The projects whose package.jsons should get updated
-   */
-  projects: RushConfigurationProject[];
-  /**
-   * The dependencies to be added or removed.
-   */
-  packagesToUpdate: IPackageForRushUpdate[];
-  /**
-   * If specified, "rush update" will not be run after updating the package.json file(s).
-   */
-  skipUpdate: boolean;
-  /**
-   * If specified, "rush update" will be run in debug mode.
-   */
-  debugInstall: boolean;
-  /**
-   * actionName
-   */
-  actionName: string;
-  /**
-   * The variant to consider when performing installations and validating shrinkwrap updates.
-   */
-  variant?: string | undefined;
-}
+import {
+  type IPackageForRushAdd,
+  type IPackageJsonUpdaterRushAddOptions,
+  type IPackageJsonUpdaterRushBaseUpdateOptions,
+  type IPackageJsonUpdaterRushRemoveOptions,
+  SemVerStyle
+} from './PackageJsonUpdaterTypes';
 
 /**
  * Options for adding a dependency to a particular project.
@@ -105,29 +57,6 @@ export interface IPackageJsonUpdaterRushUpgradeOptions {
    */
   variant?: string | undefined;
 }
-
-/**
- * Configuration options for adding or updating a dependency in a single project
- */
-export interface IPackageJsonUpdaterRushAddOptions extends IPackageJsonUpdaterRushBaseUpdateOptions {
-  /**
-   * Whether or not this dependency should be added as a devDependency or a regular dependency.
-   */
-  devDependency: boolean;
-  /**
-   * If specified, other packages that use this dependency will also have their package.json's updated.
-   */
-  updateOtherPackages: boolean;
-  /**
-   * The dependencies to be added.
-   */
-  packagesToUpdate: IPackageForRushAdd[];
-}
-
-/**
- * Options for remove a dependency from a particular project.
- */
-export interface IPackageJsonUpdaterRushRemoveOptions extends IPackageJsonUpdaterRushBaseUpdateOptions {}
 
 /**
  * Configuration options for adding or updating a dependency in single project

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -6,8 +6,8 @@ import * as semver from 'semver';
 import { ConsoleTerminalProvider, Terminal, ITerminalProvider, Colors } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
-import { BaseInstallManager } from './base/BaseInstallManager';
-import { IInstallManagerOptions } from './base/BaseInstallManagerTypes';
+import type { BaseInstallManager } from './base/BaseInstallManager';
+import type { IInstallManagerOptions } from './base/BaseInstallManagerTypes';
 import { InstallManagerFactory } from './InstallManagerFactory';
 import { VersionMismatchFinder } from './versionMismatch/VersionMismatchFinder';
 import { PurgeManager } from './PurgeManager';

--- a/libraries/rush-lib/src/logic/PackageJsonUpdaterTypes.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdaterTypes.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { RushConfigurationProject } from '../api/RushConfigurationProject';
+
+/**
+ * The type of SemVer range specifier that is prepended to the version
+ */
+export const enum SemVerStyle {
+  Exact = 'exact',
+  Caret = 'caret',
+  Tilde = 'tilde',
+  Passthrough = 'passthrough'
+}
+
+export interface IPackageForRushUpdate {
+  packageName: string;
+}
+
+export interface IPackageForRushAdd extends IPackageForRushUpdate {
+  /**
+   * The style of range that should be used if the version is automatically detected.
+   */
+  rangeStyle: SemVerStyle;
+
+  /**
+   * If not undefined, the latest version will be used (that doesn't break ensureConsistentVersions).
+   * If specified, the latest version meeting the SemVer specifier will be used as the basis.
+   */
+  version?: string;
+}
+
+export interface IPackageForRushRemove extends IPackageForRushUpdate {}
+
+export interface IPackageJsonUpdaterRushBaseUpdateOptions {
+  /**
+   * The projects whose package.jsons should get updated
+   */
+  projects: RushConfigurationProject[];
+  /**
+   * The dependencies to be added or removed.
+   */
+  packagesToUpdate: IPackageForRushUpdate[];
+  /**
+   * If specified, "rush update" will not be run after updating the package.json file(s).
+   */
+  skipUpdate: boolean;
+  /**
+   * If specified, "rush update" will be run in debug mode.
+   */
+  debugInstall: boolean;
+  /**
+   * actionName
+   */
+  actionName: string;
+  /**
+   * The variant to consider when performing installations and validating shrinkwrap updates.
+   */
+  variant?: string | undefined;
+}
+
+/**
+ * Configuration options for adding or updating a dependency in a single project
+ */
+export interface IPackageJsonUpdaterRushAddOptions extends IPackageJsonUpdaterRushBaseUpdateOptions {
+  /**
+   * Whether or not this dependency should be added as a devDependency or a regular dependency.
+   */
+  devDependency: boolean;
+  /**
+   * If specified, other packages that use this dependency will also have their package.json's updated.
+   */
+  updateOtherPackages: boolean;
+  /**
+   * The dependencies to be added.
+   */
+  packagesToUpdate: IPackageForRushAdd[];
+}
+
+/**
+ * Options for remove a dependency from a particular project.
+ */
+export interface IPackageJsonUpdaterRushRemoveOptions extends IPackageJsonUpdaterRushBaseUpdateOptions {}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -40,6 +40,7 @@ import { PolicyValidator } from '../policy/PolicyValidator';
 import { WebClient, WebClientResponse } from '../../utilities/WebClient';
 import { SetupPackageRegistry } from '../setup/SetupPackageRegistry';
 import { PnpmfileConfiguration } from '../pnpm/PnpmfileConfiguration';
+import type { IInstallManagerOptions } from './BaseInstallManagerTypes';
 
 /**
  * Pnpm don't support --ignore-compatibility-db, so use --config.ignoreCompatibilityDb for now.
@@ -47,83 +48,6 @@ import { PnpmfileConfiguration } from '../pnpm/PnpmfileConfiguration';
 export const pnpmIgnoreCompatibilityDbParameter: string = '--config.ignoreCompatibilityDb';
 const pnpmCacheDirParameter: string = '--config.cacheDir';
 const pnpmStateDirParameter: string = '--config.stateDir';
-
-export interface IInstallManagerOptions {
-  /**
-   * Whether the global "--debug" flag was specified.
-   */
-  debug: boolean;
-
-  /**
-   * Whether or not Rush will automatically update the shrinkwrap file.
-   * True for "rush update", false for "rush install".
-   */
-  allowShrinkwrapUpdates: boolean;
-
-  /**
-   * Whether to check the validation before install only, without actually installing anything.
-   */
-  checkOnly: boolean;
-
-  /**
-   * Whether to skip policy checks.
-   */
-  bypassPolicy: boolean;
-
-  /**
-   * Whether to skip linking, i.e. require "rush link" to be done manually later.
-   */
-  noLink: boolean;
-
-  /**
-   * Whether to delete the shrinkwrap file before installation, i.e. so that all dependencies
-   * will be upgraded to the latest SemVer-compatible version.
-   */
-  fullUpgrade: boolean;
-
-  /**
-   * Whether to force an update to the shrinkwrap file even if it appears to be unnecessary.
-   * Normally Rush uses heuristics to determine when "pnpm install" can be skipped,
-   * but sometimes the heuristics can be inaccurate due to external influences
-   * (pnpmfile.js script logic, registry changes, etc).
-   */
-  recheckShrinkwrap: boolean;
-
-  /**
-   * The value of the "--network-concurrency" command-line parameter, which
-   * is a diagnostic option used to troubleshoot network failures.
-   *
-   * Currently only supported for PNPM.
-   */
-  networkConcurrency: number | undefined;
-
-  /**
-   * Whether or not to collect verbose logs from the package manager.
-   * If specified when using PNPM, the logs will be in /common/temp/pnpm.log
-   */
-  collectLogFile: boolean;
-
-  /**
-   * The variant to consider when performing installations and validating shrinkwrap updates.
-   */
-  variant?: string | undefined;
-
-  /**
-   * Retry the install the specified number of times
-   */
-  maxInstallAttempts: number;
-
-  /**
-   * Filters to be passed to PNPM during installation, if applicable.
-   * These restrict the scope of a workspace installation.
-   */
-  pnpmFilterArguments: string[];
-
-  /**
-   * Callback to invoke between preparing the common/temp folder and running installation.
-   */
-  beforeInstallAsync?: () => Promise<void>;
-}
 
 /**
  * This class implements common logic between "rush install" and "rush update".

--- a/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export interface IInstallManagerOptions {
+  /**
+   * Whether the global "--debug" flag was specified.
+   */
+  debug: boolean;
+
+  /**
+   * Whether or not Rush will automatically update the shrinkwrap file.
+   * True for "rush update", false for "rush install".
+   */
+  allowShrinkwrapUpdates: boolean;
+
+  /**
+   * Whether to check the validation before install only, without actually installing anything.
+   */
+  checkOnly: boolean;
+
+  /**
+   * Whether to skip policy checks.
+   */
+  bypassPolicy: boolean;
+
+  /**
+   * Whether to skip linking, i.e. require "rush link" to be done manually later.
+   */
+  noLink: boolean;
+
+  /**
+   * Whether to delete the shrinkwrap file before installation, i.e. so that all dependencies
+   * will be upgraded to the latest SemVer-compatible version.
+   */
+  fullUpgrade: boolean;
+
+  /**
+   * Whether to force an update to the shrinkwrap file even if it appears to be unnecessary.
+   * Normally Rush uses heuristics to determine when "pnpm install" can be skipped,
+   * but sometimes the heuristics can be inaccurate due to external influences
+   * (pnpmfile.js script logic, registry changes, etc).
+   */
+  recheckShrinkwrap: boolean;
+
+  /**
+   * The value of the "--network-concurrency" command-line parameter, which
+   * is a diagnostic option used to troubleshoot network failures.
+   *
+   * Currently only supported for PNPM.
+   */
+  networkConcurrency: number | undefined;
+
+  /**
+   * Whether or not to collect verbose logs from the package manager.
+   * If specified when using PNPM, the logs will be in /common/temp/pnpm.log
+   */
+  collectLogFile: boolean;
+
+  /**
+   * The variant to consider when performing installations and validating shrinkwrap updates.
+   */
+  variant?: string | undefined;
+
+  /**
+   * Retry the install the specified number of times
+   */
+  maxInstallAttempts: number;
+
+  /**
+   * Filters to be passed to PNPM during installation, if applicable.
+   * These restrict the scope of a workspace installation.
+   */
+  pnpmFilterArguments: string[];
+
+  /**
+   * Callback to invoke between preparing the common/temp folder and running installation.
+   */
+  beforeInstallAsync?: () => Promise<void>;
+}

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -18,7 +18,8 @@ import {
 } from '@rushstack/node-core-library';
 import { PrintUtilities } from '@rushstack/terminal';
 
-import { BaseInstallManager, IInstallManagerOptions } from '../base/BaseInstallManager';
+import { BaseInstallManager } from '../base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../base/BaseInstallManagerTypes';
 import { BaseShrinkwrapFile } from '../../logic/base/BaseShrinkwrapFile';
 import { IRushTempPackageJson } from '../../logic/base/BasePackage';
 import { RushConfigurationProject } from '../../api/RushConfigurationProject';

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { FileSystem, FileConstants, AlreadyReportedError, Async } from '@rushstack/node-core-library';
 
-import { BaseInstallManager, IInstallManagerOptions } from '../base/BaseInstallManager';
+import { BaseInstallManager } from '../base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../base/BaseInstallManagerTypes';
 import { BaseShrinkwrapFile } from '../../logic/base/BaseShrinkwrapFile';
 import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
 import { PackageJsonEditor, DependencyType } from '../../api/PackageJsonEditor';

--- a/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
+++ b/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
@@ -4,11 +4,8 @@ import * as path from 'path';
 import { ConsoleTerminalProvider } from '@rushstack/node-core-library';
 
 import { PurgeManager } from '../PurgeManager';
-import {
-  BaseInstallManager,
-  IInstallManagerOptions,
-  pnpmIgnoreCompatibilityDbParameter
-} from '../base/BaseInstallManager';
+import { BaseInstallManager, pnpmIgnoreCompatibilityDbParameter } from '../base/BaseInstallManager';
+import type { IInstallManagerOptions } from '../base/BaseInstallManagerTypes';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { RushGlobalFolder } from '../../api/RushGlobalFolder';


### PR DESCRIPTION
This is required by https://github.com/microsoft/rushstack/pull/3840