### PR TITLE
[rush] Improve the experience during a rush operation when the cached credentials have expired.

### DIFF
--- a/common/changes/@microsoft/rush/improve-expired-credentials-experience_2022-12-21-18-33.json
+++ b/common/changes/@microsoft/rush/improve-expired-credentials-experience_2022-12-21-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve the experience during a rush operation when the cached credentials have expired. Now, a warning is printed instead of an error being thrown and the operation halted.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/improve-expired-credentials-experience_2022-12-21-18-34.json
+++ b/common/changes/@microsoft/rush/improve-expired-credentials-experience_2022-12-21-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING API CHANGE IN @rushstack/rush-azure-storage-build-cache-plugin) Change the signature of `AzureAuthenticationBase.tryGetCachedCredentialAsync` to optionally take an object describing the behavior when credentials have expired. The behavior of the function without an argument is unchanged.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -29,7 +29,9 @@ export abstract class AzureAuthenticationBase {
     // (undocumented)
     protected abstract _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
     // (undocumented)
-    tryGetCachedCredentialAsync(doNotThrowIfExpired?: boolean): Promise<ICredentialCacheEntry | undefined>;
+    tryGetCachedCredentialAsync(options?: ITryGetCachedCredentialOptionsThrow | ITryGetCachedCredentialOptionsIgnore): Promise<ICredentialCacheEntry | undefined>;
+    // (undocumented)
+    tryGetCachedCredentialAsync(options: ITryGetCachedCredentialOptionsLogWarning): Promise<ICredentialCacheEntry | undefined>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
     updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresAfter?: Date): Promise<void>;
@@ -62,6 +64,9 @@ export class AzureStorageAuthentication extends AzureAuthenticationBase {
 }
 
 // @public (undocumented)
+export type ExpiredCredentialBehavior = 'logWarning' | 'throwError' | 'ignore';
+
+// @public (undocumented)
 export interface IAzureAuthenticationBaseOptions {
     // (undocumented)
     azureEnvironment?: AzureEnvironmentName;
@@ -85,6 +90,30 @@ export interface ICredentialResult {
     credentialString: string;
     // (undocumented)
     expiresOn?: Date;
+}
+
+// @public (undocumented)
+export interface ITryGetCachedCredentialOptionsBase {
+    expiredCredentialBehavior?: ExpiredCredentialBehavior;
+    // (undocumented)
+    terminal?: ITerminal;
+}
+
+// @public (undocumented)
+export interface ITryGetCachedCredentialOptionsIgnore extends ITryGetCachedCredentialOptionsBase {
+    expiredCredentialBehavior: 'ignore';
+}
+
+// @public (undocumented)
+export interface ITryGetCachedCredentialOptionsLogWarning extends ITryGetCachedCredentialOptionsBase {
+    expiredCredentialBehavior: 'logWarning';
+    // (undocumented)
+    terminal: ITerminal;
+}
+
+// @public (undocumented)
+export interface ITryGetCachedCredentialOptionsThrow extends ITryGetCachedCredentialOptionsBase {
+    expiredCredentialBehavior: 'throwError';
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
@@ -60,7 +60,7 @@ export class AzureStorageBuildCacheProvider
     terminal: ITerminal,
     cacheId: string
   ): Promise<Buffer | undefined> {
-    const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId);
+    const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId, terminal);
 
     try {
       const blobExists: boolean = await blobClient.exists();
@@ -128,7 +128,7 @@ export class AzureStorageBuildCacheProvider
       return false;
     }
 
-    const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId);
+    const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId, terminal);
     const blockBlobClient: BlockBlobClient = blobClient.getBlockBlobClient();
     let blobAlreadyExists: boolean = false;
 
@@ -175,17 +175,21 @@ export class AzureStorageBuildCacheProvider
     }
   }
 
-  private async _getBlobClientForCacheIdAsync(cacheId: string): Promise<BlobClient> {
-    const client: ContainerClient = await this._getContainerClientAsync();
+  private async _getBlobClientForCacheIdAsync(cacheId: string, terminal: ITerminal): Promise<BlobClient> {
+    const client: ContainerClient = await this._getContainerClientAsync(terminal);
     const blobName: string = this._blobPrefix ? `${this._blobPrefix}/${cacheId}` : cacheId;
     return client.getBlobClient(blobName);
   }
 
-  private async _getContainerClientAsync(): Promise<ContainerClient> {
+  private async _getContainerClientAsync(terminal: ITerminal): Promise<ContainerClient> {
     if (!this._containerClient) {
       let sasString: string | undefined = this._environmentCredential;
       if (!sasString) {
-        const credentialEntry: ICredentialCacheEntry | undefined = await this.tryGetCachedCredentialAsync();
+        const credentialEntry: ICredentialCacheEntry | undefined = await this.tryGetCachedCredentialAsync({
+          expiredCredentialBehavior: 'logWarning',
+          terminal
+        });
+
         sasString = credentialEntry?.credential;
       }
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
@@ -6,7 +6,12 @@ export {
   AzureAuthenticationBase,
   type IAzureAuthenticationBaseOptions,
   type ICredentialResult,
-  type AzureEnvironmentName
+  type AzureEnvironmentName,
+  type ITryGetCachedCredentialOptionsBase,
+  type ITryGetCachedCredentialOptionsLogWarning,
+  type ITryGetCachedCredentialOptionsThrow,
+  type ITryGetCachedCredentialOptionsIgnore,
+  type ExpiredCredentialBehavior
 } from './AzureAuthenticationBase';
 export {
   AzureStorageAuthentication,


### PR DESCRIPTION
## Summary

Currently, if a user has expired build cache credentials and attempts run a cached operation in a Rush repo, the operation will error. This change instead prints a warning and attempts to continue without credentials.

## Details

See the example screenshots below from user with expired credentials for a repo with cache backed by Azure Storage that allows anonymous access.

Before:
![image](https://user-images.githubusercontent.com/5010588/208979865-144f6751-8a68-4e19-aa95-cf2c2a06b73d.png)

After:
![image](https://user-images.githubusercontent.com/5010588/208979677-11fcdf02-a31a-4a03-a966-ae02f5c66b75.png)

## How it was tested

Tested in the above mentioned repo.