### PR TITLE
[repo] File automatic doc tickets to the rushstack-websites repo

### DIFF
--- a/.github/workflows/file-doc-tickets.yml
+++ b/.github/workflows/file-doc-tickets.yml
@@ -1,0 +1,86 @@
+################################################################################
+# When pull requests are merged to the main branch, evaluate the pull request
+# body and file a documentation ticket against the rushstack-websites repo
+# with a corresponding documentation task.
+#
+# The pull request body must contain non-comment, non-whitespace text below
+# the "Impacted documentation" header in the PR template to file a
+# documentation ticket.
+################################################################################
+name: File Doc Tickets
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  file-tickets:
+    name: File Tickets
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Parse PR body
+        run: |
+          cat <<-"EOF" > event.json
+          ${{ toJson(github.event) }}
+          EOF
+
+          cat <<-"EOF" | node
+          const fs = require('fs');
+
+          const EVENT_FILE = 'event.json';
+          const RESULT_FILE = 'issue.md';
+          const DELIMITER = '## Impacted documentation';
+
+          const event = JSON.parse(fs.readFileSync(EVENT_FILE, 'utf8'));
+          const strippedBody = event.pull_request.body.replace(/<!-+(.|\r|\n)+?-+>/g, '');
+          const delimIndex = strippedBody.indexOf(DELIMITER);
+
+          if (delimIndex < 0) {
+            console.log('No documentation tasks detected -- skipping doc ticket.');
+            process.exit(0);
+          }
+
+          const delimBody = strippedBody.substring(delimIndex + DELIMITER.length).trim();
+
+          if (delimBody.length === 0) {
+            console.log('No documentation tasks detected -- skipping doc ticket.');
+            process.exit(0);
+          }
+
+          const quotedBody = delimBody.split('\n').map(line => `> ${line}`).join('\n');
+          fs.writeFileSync(RESULT_FILE, [
+            '### Summary',
+            '',
+            'Follow up on documentation tasks from ' + event.pull_request.html_url + '.',
+            '',
+            '### Details',
+            '',
+            'This ticket was generated automatically. Suggested documentation updates:',
+            '',
+            quotedBody,
+            ''
+          ].join('\n'), 'utf8');
+
+          EOF
+
+          if [ -f issue.md ]; then
+            echo "FILE_TICKET=1" >> $GITHUB_ENV
+          fi
+      - name: File ticket
+        if: ${{ env.FILE_TICKET == '1' }}
+        uses: peter-evans/create-issue-from-file@af31b99c72f9e91877aea8a2d96fd613beafac84 # @v4 (locked)
+        with:
+          repository: microsoft/rushstack-websites
+          token: '${{ secrets.RUSHSTACK_WEBSITES_TOKEN }}'
+          title: '[doc] ${{ github.event.pull_request.title }}'
+          content-filepath: ./issue.md
+          labels: |
+            automated


### PR DESCRIPTION
## Summary

This is a suggested improvement to the CI/CD workflow for the `rushstack` repo. This GitHub Actions workflow will automatically file documentation tickets on the `rushstack-websites` repo whenever a pull request is merged that contains non-whitespace, non-comment content under the **Impacted documentation** header.

## Details

Based on some contributor feedback, @octogonz recently added a section where we could ask the contributor if there's any doc pages that the PR would impact. This is valuable information, but right now it's up to a contributor or maintainer to remember this section was filled in.

This change takes the information entered by the contributor and files a "doc ticket"; this doc ticket can then be closed by a doc PR (either by the contributor or by a maintainer). Since the doc ticket automatically mentions the original PR, and the doc PR will close the doc ticket, this has the nice side benefit of automatic link chains between code changes and documentation updates.

## How it was tested

 - See my trial run in the `elliot-nelson` fork: https://github.com/elliot-nelson/rushstack-websites/issues/3

## Next steps

 - If interested, _before_ merging, follow following steps:
   - `rushstack-websites` admin should create a new GitHub fine-grained developer token (repo: rushstack-websites only; permission: read/write on issues only) and add it to _this_ repo, under Secrets > Actions, with the name `RUSHSTACK_WEBSITES_TOKEN`
 - Current implementation is an embedded node script in YAML, which nobody loves; it's written this way because it avoids cloning the repo (current GH Action cost on-merge is ~5 seconds, which seems reasonable). If we are willing to eat a clone, you could clean this up by breaking up the node script and other steps into composite actions.  
