### PR TITLE
[rush] Add install-run-rush-pnpm.js script

### DIFF
--- a/common/changes/@microsoft/rush/stekycz-install-run-rush-pnpm_2023-01-05-09-13.json
+++ b/common/changes/@microsoft/rush/stekycz-install-run-rush-pnpm_2023-01-05-09-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add install-run-rush-pnpm.js script",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
+++ b/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
@@ -7,6 +7,7 @@ import { RushConfiguration } from '../api/RushConfiguration';
 import {
   installRunRushScriptFilename,
   installRunRushxScriptFilename,
+  installRunRushPnpmScriptFilename,
   installRunScriptFilename,
   scriptsFolderPath
 } from '../utilities/PathConstants';
@@ -61,6 +62,19 @@ const _scripts: IScriptSpecifier[] = [
       '// An example usage would be:',
       '//',
       `//    node common/scripts/${installRunRushxScriptFilename} custom-command`
+    ]
+  },
+  {
+    scriptName: installRunRushPnpmScriptFilename,
+    headerLines: [
+      '// This script is intended for usage in an automated build environment where the Rush command may not have',
+      '// been preinstalled, or may have an unpredictable version.  This script will automatically install the version of Rush',
+      '// specified in the rush.json configuration file (if not already installed), and then pass a command-line to the',
+      '// rush-pnpm command.',
+      '//',
+      '// An example usage would be:',
+      '//',
+      `//    node common/scripts/${installRunRushPnpmScriptFilename} pnpm-command`
     ]
   }
 ];

--- a/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
+++ b/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
@@ -63,7 +63,10 @@ const _scripts: IScriptSpecifier[] = [
       '//',
       `//    node common/scripts/${installRunRushxScriptFilename} custom-command`
     ]
-  },
+  }
+];
+
+const _pnpmOnlyScripts: IScriptSpecifier[] = [
   {
     scriptName: installRunRushPnpmScriptFilename,
     headerLines: [
@@ -79,6 +82,14 @@ const _scripts: IScriptSpecifier[] = [
   }
 ];
 
+const getScripts = (rushConfiguration: RushConfiguration): IScriptSpecifier[] => {
+  if (rushConfiguration.packageManager === 'pnpm') {
+    return _scripts.concat(_pnpmOnlyScripts);
+  }
+
+  return _scripts;
+};
+
 /**
  * Checks whether the common/scripts files are up to date, and recopies them if needed.
  * This is used by the "rush install" and "rush update" commands.
@@ -93,7 +104,7 @@ export class StandardScriptUpdater {
 
     let anyChanges: boolean = false;
     await Async.forEachAsync(
-      _scripts,
+      getScripts(rushConfiguration),
       async (script: IScriptSpecifier) => {
         const changed: boolean = await StandardScriptUpdater._updateScriptOrThrowAsync(
           script,
@@ -118,7 +129,7 @@ export class StandardScriptUpdater {
    */
   public static async validateAsync(rushConfiguration: RushConfiguration): Promise<void> {
     await Async.forEachAsync(
-      _scripts,
+      getScripts(rushConfiguration),
       async (script: IScriptSpecifier) => {
         await StandardScriptUpdater._updateScriptOrThrowAsync(script, rushConfiguration, true);
       },

--- a/libraries/rush-lib/src/scripts/install-run-rush-pnpm.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush-pnpm.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See the @microsoft/rush package's LICENSE file for license information.
+
+__non_webpack_require__('./install-run-rush');

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -43,6 +43,17 @@ function _getRushVersion(logger: ILogger): string {
   }
 }
 
+function _getBin(scriptName: string): string {
+  switch (scriptName.toLowerCase()) {
+    case 'install-run-rush-pnpm.js':
+      return 'rush-pnpm';
+    case 'install-run-rushx.js':
+      return 'rushx';
+    default:
+      return 'rush';
+  }
+}
+
 function _run(): void {
   const [
     nodePath /* Ex: /bin/node */,
@@ -53,7 +64,7 @@ function _run(): void {
   // Detect if this script was directly invoked, or if the install-run-rushx script was invokved to select the
   // appropriate binary inside the rush package to run
   const scriptName: string = path.basename(scriptPath);
-  const bin: string = scriptName.toLowerCase() === 'install-run-rushx.js' ? 'rushx' : 'rush';
+  const bin: string = _getBin(scriptName);
   if (!nodePath || !scriptPath) {
     throw new Error('Unexpected exception: could not detect node path or script path');
   }
@@ -82,7 +93,9 @@ function _run(): void {
 
   if (!commandFound) {
     console.log(`Usage: ${scriptName} <command> [args...]`);
-    if (scriptName === 'install-run-rush.js') {
+    if (scriptName === 'install-run-rush-pnpm.js') {
+      console.log(`Example: ${scriptName} pnpm-command`);
+    } else if (scriptName === 'install-run-rush.js') {
       console.log(`Example: ${scriptName} build --to myproject`);
     } else {
       console.log(`Example: ${scriptName} custom-command`);

--- a/libraries/rush-lib/src/utilities/PathConstants.ts
+++ b/libraries/rush-lib/src/utilities/PathConstants.ts
@@ -22,6 +22,7 @@ export const pnpmfileShimFilename: string = 'PnpmfileShim.js';
 export const installRunScriptFilename: string = 'install-run.js';
 export const installRunRushScriptFilename: string = 'install-run-rush.js';
 export const installRunRushxScriptFilename: string = 'install-run-rushx.js';
+export const installRunRushPnpmScriptFilename: string = 'install-run-rush-pnpm.js';
 
 /**
  * The path to the scripts folder in rush-lib/dist.

--- a/libraries/rush-lib/webpack.config.js
+++ b/libraries/rush-lib/webpack.config.js
@@ -117,6 +117,10 @@ module.exports = () => {
       [PathConstants.installRunRushxScriptFilename]: {
         import: `${__dirname}/lib-esnext/scripts/install-run-rushx.js`,
         ...SCRIPT_ENTRY_OPTIONS
+      },
+      [PathConstants.installRunRushPnpmScriptFilename]: {
+        import: `${__dirname}/lib-esnext/scripts/install-run-rush-pnpm.js`,
+        ...SCRIPT_ENTRY_OPTIONS
       }
     })
   ];


### PR DESCRIPTION
## Summary

Fixes #3851

## Details

The solution completely solves the issue.

## How it was tested

I did not test this code but I have tested the script updated manually in my other private repo.

## Impacted documentation

It would be nice to mention it in [Enabling CI builds](https://rushjs.io/pages/maintainer/enabling_ci_builds/#install-run-rushjs-for-bootstrapping-rush). However, `install-run-rushx.js` is not there as well. The same probably applies to [Config files](https://rushjs.io/pages/advanced/config_files/#temporary-files-created-by-rush).