### PR TITLE
[rush] Create custom git hooks instead of copy

### DIFF
--- a/common/changes/@microsoft/rush/stekycz-git-hooks-exec_2023-01-05-10-36.json
+++ b/common/changes/@microsoft/rush/stekycz-git-hooks-exec_2023-01-05-10-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "[rush] Create custom git hooks instead of copy",
+      "comment": "Generate scripts in the Git hooks folder referring to the actual hook implementations in-place in the Rush `common/git-hooks/` folder instead of copying the scripts to the Git hooks folder.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/stekycz-git-hooks-exec_2023-01-05-10-36.json
+++ b/common/changes/@microsoft/rush/stekycz-git-hooks-exec_2023-01-05-10-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush] Create custom git hooks instead of copy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -449,11 +449,22 @@ export abstract class BaseInstallManager {
         // Clear the currently installed git hooks and install fresh copies
         FileSystem.ensureEmptyFolder(hookDestination);
 
+        // Find the relative path from Git hooks directory to the directory storing the actual scripts.
+        const hookRelativePath: string = path.relative(hookDestination, hookSource);
+
         // Only copy files that look like Git hook names
         const filteredHookFilenames: string[] = hookFilenames.filter((x) => /^[a-z\-]+/.test(x));
         for (const filename of filteredHookFilenames) {
-          // Copy the file.  Important: For Bash scripts, the EOL must not be CRLF.
-          const hookFileContent: string = FileSystem.readFile(path.join(hookSource, filename));
+          const hookFileContent: string = `#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_IMPLEMENTATION_PATH="$SCRIPT_DIR/${hookRelativePath}/${filename}"
+if [[ -f "$SCRIPT_IMPLEMENTATION_PATH" ]]; then
+  exec "$SCRIPT_IMPLEMENTATION_PATH"
+else
+  echo "The ${filename} Git hook does not exist in your version of the repo. Either remove the ${filename} hook file (e.g. '.git/hooks/${filename}') in case this feature is not used anymore in main branch. Otherwise, updating your branch to current mainstream will solve the issue."
+fi
+`;
+          // Create the hook file.  Important: For Bash scripts, the EOL must not be CRLF.
           FileSystem.writeFile(path.join(hookDestination, filename), hookFileContent, {
             convertLineEndings: NewlineKind.Lf
           });

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -462,7 +462,7 @@ SCRIPT_IMPLEMENTATION_PATH="$SCRIPT_DIR/${hookRelativePath}/${filename}"
 if [[ -f "$SCRIPT_IMPLEMENTATION_PATH" ]]; then
   exec "$SCRIPT_IMPLEMENTATION_PATH"
 else
-  echo "The ${filename} Git hook no longer exists in your version of the repo. Run 'rush install' or 'rush update' to refresh your installed Git hooks."
+  echo "The ${filename} Git hook no longer exists in your version of the repo. Run 'rush install' or 'rush update' to refresh your installed Git hooks." >&2
 fi
 `;
           // Create the hook file.  Important: For Bash scripts, the EOL must not be CRLF.

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -16,7 +16,8 @@ import {
   FileSystemStats,
   ConsoleTerminalProvider,
   Terminal,
-  ITerminalProvider
+  ITerminalProvider,
+  Path
 } from '@rushstack/node-core-library';
 import { PrintUtilities } from '@rushstack/terminal';
 
@@ -450,7 +451,7 @@ export abstract class BaseInstallManager {
         FileSystem.ensureEmptyFolder(hookDestination);
 
         // Find the relative path from Git hooks directory to the directory storing the actual scripts.
-        const hookRelativePath: string = path.relative(hookDestination, hookSource);
+        const hookRelativePath: string = Path.convertToSlashes(path.relative(hookDestination, hookSource));
 
         // Only copy files that look like Git hook names
         const filteredHookFilenames: string[] = hookFilenames.filter((x) => /^[a-z\-]+/.test(x));

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -462,7 +462,7 @@ SCRIPT_IMPLEMENTATION_PATH="$SCRIPT_DIR/${hookRelativePath}/${filename}"
 if [[ -f "$SCRIPT_IMPLEMENTATION_PATH" ]]; then
   exec "$SCRIPT_IMPLEMENTATION_PATH"
 else
-  echo "The ${filename} Git hook does not exist in your version of the repo. Either remove the ${filename} hook file (e.g. '.git/hooks/${filename}') in case this feature is not used anymore in main branch. Otherwise, updating your branch to current mainstream will solve the issue."
+  echo "The ${filename} Git hook no longer exists in your version of the repo. Run 'rush install' or 'rush update' to refresh your installed Git hooks."
 fi
 `;
           // Create the hook file.  Important: For Bash scripts, the EOL must not be CRLF.


### PR DESCRIPTION
## Summary

Fixes #3816

## Details

I change copy of the script to create a new script from inlined template. The template might be another file but I chose simple solution now because the script is very simple. I can move it to a template file if needed but I would need guidance to where the file should be placed and what templating should be leveraged to hardcode specific values.

I am trying to keep the script universal to work even the directory of the repo is renamed. That is why I do not use absolute paths and I detect the script directory.

## How it was tested

I am not sure how to test these changes from the branch. However, I use the pattern of executing another script in one of my private repos.

## Impacted documentation

The [Git Hooks](https://rushjs.io/pages/maintainer/git_hooks/) documentation might need an update.