### PR TITLE
[api-extractor] Introduce sort modifier to api extractor and dts rollup to avoid spurious reports between builds

### DIFF
--- a/apps/api-extractor/src/analyzer/Span.ts
+++ b/apps/api-extractor/src/analyzer/Span.ts
@@ -77,7 +77,7 @@ export class SpanModification {
   /**
    * Used if the parent span has Span.sortChildren=true.
    */
-  public sortKey: string | undefined;
+  public sortKey: number | string | undefined;
 
   /**
    * Optionally configures getModifiedText() to search for a "/*" doc comment and indent it.

--- a/apps/api-extractor/src/generators/ApiReportGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiReportGenerator.ts
@@ -268,6 +268,10 @@ export class ApiReportGenerator {
     let recurseChildren: boolean = true;
     let sortChildren: boolean = false;
 
+    if (span?.parent?.kind === ts.SyntaxKind.UnionType) {
+      DtsEmitHelpers.modifySpanChildrenWithSort(span);
+    }
+
     switch (span.kind) {
       case ts.SyntaxKind.JSDocComment:
         span.modification.skipAll();

--- a/apps/api-extractor/src/generators/DtsEmitHelpers.ts
+++ b/apps/api-extractor/src/generators/DtsEmitHelpers.ts
@@ -170,4 +170,39 @@ export class DtsEmitHelpers {
       }
     }
   }
+
+  public static modifySpanChildrenWithSort(span: Span): void {
+    span.modification.sortChildren = true;
+
+    let startIndex: number = 0;
+
+    if (span.children[0]?.kind === ts.SyntaxKind.BarToken) {
+      startIndex = 1;
+    }
+
+    for (let sortingIndex: number = 0; sortingIndex < span.children.length; sortingIndex++) {
+      const childToBeSorted: Span = span.children[sortingIndex];
+
+      if (childToBeSorted.kind === ts.SyntaxKind.BarToken) {
+        childToBeSorted.modification.sortKey = sortingIndex;
+        continue;
+      }
+
+      childToBeSorted.modification.sortKey = childToBeSorted.modification.sortKey || startIndex;
+
+      for (let compareIndex: number = sortingIndex + 1; compareIndex < span.children.length; compareIndex++) {
+        const childToBeCompared: Span = span.children[compareIndex];
+
+        if (childToBeSorted.getText() > childToBeCompared.getText()) {
+          childToBeSorted.modification.sortKey =
+            ((childToBeSorted.modification.sortKey as number) || startIndex) + 1;
+        } else {
+          childToBeCompared.modification.sortKey =
+            ((childToBeCompared.modification.sortKey as number) || startIndex) + 1;
+        }
+      }
+
+      childToBeSorted.modification.sortKey = (childToBeSorted.modification.sortKey as number) * 2;
+    }
+  }
 }

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -253,6 +253,11 @@ export class DtsRollupGenerator {
     const previousSpan: Span | undefined = span.previousSibling;
 
     let recurseChildren: boolean = true;
+
+    if (span?.parent?.kind === ts.SyntaxKind.UnionType) {
+      DtsEmitHelpers.modifySpanChildrenWithSort(span);
+    }
+
     switch (span.kind) {
       case ts.SyntaxKind.JSDocComment:
         // If the @packageDocumentation comment seems to be attached to one of the regular API items,

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.md
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.md
@@ -131,8 +131,8 @@ export interface IDocInterface4 {
         children: string;
     }) => boolean;
     generic: Generic<number>;
-    numberOrFunction: number | (() => number);
-    stringOrNumber: string | number;
+    numberOrFunction: (() => number) | number;
+    stringOrNumber: number | string;
 }
 
 // @public

--- a/build-tests/api-extractor-scenarios/etc/docReferencesAlias/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/docReferencesAlias/api-extractor-scenarios.api.md
@@ -13,7 +13,7 @@ export class Item {
 // @public (undocumented)
 export interface renamed_Options {
     // (undocumented)
-    color: 'red' | 'blue';
+    color: 'blue' | 'red';
     // (undocumented)
     name: string;
 }

--- a/build-tests/api-extractor-scenarios/etc/docReferencesAlias/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/docReferencesAlias/rollup.d.ts
@@ -6,7 +6,7 @@ export declare class Item {
 /** @public */
 export declare interface renamed_Options {
     name: string;
-    color: 'red' | 'blue';
+    color: 'blue' | 'red';
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/docReferencesNamespaceAlias/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/docReferencesNamespaceAlias/api-extractor-scenarios.api.md
@@ -13,7 +13,7 @@ export class Item {
 // @public (undocumented)
 interface Options {
     // (undocumented)
-    color: 'red' | 'blue';
+    color: 'blue' | 'red';
     // (undocumented)
     name: string;
     // (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/docReferencesNamespaceAlias/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/docReferencesNamespaceAlias/rollup.d.ts
@@ -6,7 +6,7 @@ export declare class Item {
 /** @public */
 declare interface Options {
     name: string;
-    color: 'red' | 'blue';
+    color: 'blue' | 'red';
     subOptions: SubOptions;
 }
 

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
@@ -19,7 +19,7 @@ export { Lib2Interface }
 
 declare interface Options {
     name: string;
-    color: 'red' | 'blue';
+    color: 'blue' | 'red';
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/mergedDeclarations/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/mergedDeclarations/api-extractor-scenarios.api.md
@@ -15,7 +15,7 @@ export interface MergedClassAndInterface {
     // (undocumented)
     anotherProp: boolean;
     // (undocumented)
-    someMethod(x: string | boolean): void;
+    someMethod(x: boolean | string): void;
 }
 
 // @public (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/mergedDeclarations/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/mergedDeclarations/rollup.d.ts
@@ -6,7 +6,7 @@ export declare class MergedClassAndInterface {
 /** @public */
 export declare interface MergedClassAndInterface {
     anotherProp: boolean;
-    someMethod(x: string | boolean): void;
+    someMethod(x: boolean | string): void;
 }
 
 /** @public */

--- a/build-tests/api-extractor-scenarios/etc/typeLiterals/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/typeLiterals/api-extractor-scenarios.api.md
@@ -10,10 +10,10 @@ export class ClassWithTypeLiterals {
         x: number;
         y: number;
     }): void;
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/typeLiterals/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/typeLiterals/rollup.d.ts
@@ -6,10 +6,10 @@ export declare class ClassWithTypeLiterals {
         y: number;
     }): void;
     /** type literal output  */
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 export { }

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
@@ -135,10 +135,10 @@ export declare class ClassWithTypeLiterals {
         y: number;
     }): void;
     /** type literal output  */
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 /**

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
@@ -135,10 +135,10 @@ export declare class ClassWithTypeLiterals {
         y: number;
     }): void;
     /** type literal output  */
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 /**

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
@@ -135,10 +135,10 @@ export declare class ClassWithTypeLiterals {
         y: number;
     }): void;
     /** type literal output  */
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 /**

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
@@ -74,10 +74,10 @@ export class ClassWithTypeLiterals {
         x: number;
         y: number;
     }): void;
-    method2(): {
+    method2(): undefined | {
         classValue: ClassWithTypeLiterals;
         callback: () => number;
-    } | undefined;
+    };
 }
 
 // @public (undocumented)

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -5,13 +5,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.8.tgz
+      '@rushstack/heft': file:rushstack-heft-0.49.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.8.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -19,13 +19,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.48.8.tgz
+      '@rushstack/heft': file:rushstack-heft-0.49.0.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.48.8.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.0.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -83,7 +83,7 @@ packages:
     dev: true
 
   /@microsoft/tsdoc-config/0.16.1:
-    resolution: {integrity: sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==}
+    resolution: {integrity: sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz}
     dependencies:
       '@microsoft/tsdoc': 0.14.1
       ajv: 6.12.6
@@ -92,11 +92,11 @@ packages:
     dev: true
 
   /@microsoft/tsdoc/0.14.1:
-    resolution: {integrity: sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==}
+    resolution: {integrity: sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz}
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz}
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -104,12 +104,12 @@ packages:
     dev: true
 
   /@nodelib/fs.stat/2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz}
     engines: {node: '>= 8'}
     dev: true
 
   /@nodelib/fs.walk/1.2.7:
-    resolution: {integrity: sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==}
+    resolution: {integrity: sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz}
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
@@ -117,23 +117,23 @@ packages:
     dev: true
 
   /@types/argparse/1.0.38:
-    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/argparse/-/argparse-1.0.38.tgz}
     dev: true
 
   /@types/json-schema/7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/json-schema/-/json-schema-7.0.11.tgz}
     dev: true
 
   /@types/node/12.20.24:
-    resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
+    resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/node/-/node-12.20.24.tgz}
     dev: true
 
   /@types/tapable/1.0.6:
-    resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==}
+    resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/tapable/-/tapable-1.0.6.tgz}
     dev: true
 
   /@typescript-eslint/eslint-plugin/5.38.1_dgdlt47nc666rkw3n5usybcqsa:
-    resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
+    resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -144,7 +144,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.38.1_esueefhpt5ql6xiqdj4wcgwfzi
-      '@typescript-eslint/scope-manager': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.38.1
       '@typescript-eslint/type-utils': 5.38.1_esueefhpt5ql6xiqdj4wcgwfzi
       '@typescript-eslint/utils': 5.38.1_esueefhpt5ql6xiqdj4wcgwfzi
       debug: 4.3.4
@@ -159,7 +159,7 @@ packages:
     dev: true
 
   /@typescript-eslint/experimental-utils/5.38.1_esueefhpt5ql6xiqdj4wcgwfzi:
-    resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==}
+    resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/experimental-utils/-/experimental-utils-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -172,7 +172,7 @@ packages:
     dev: true
 
   /@typescript-eslint/parser/5.38.1_esueefhpt5ql6xiqdj4wcgwfzi:
-    resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==}
+    resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/parser/-/parser-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -181,8 +181,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/types': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/types': 5.38.1
       '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
       debug: 4.3.4
       eslint: 8.7.0
@@ -191,18 +191,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==}
+  /@typescript-eslint/scope-manager/5.38.1:
+    resolution: {integrity: sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/visitor-keys': 5.38.1_typescript@4.8.4
-    transitivePeerDependencies:
-      - typescript
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
     dev: true
 
   /@typescript-eslint/type-utils/5.38.1_esueefhpt5ql6xiqdj4wcgwfzi:
-    resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==}
+    resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/type-utils/-/type-utils-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -221,17 +219,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==}
+  /@typescript-eslint/types/5.38.1:
+    resolution: {integrity: sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      typescript: 4.8.4
     dev: true
 
   /@typescript-eslint/typescript-estree/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==}
+    resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -239,8 +233,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/visitor-keys': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -252,14 +246,14 @@ packages:
     dev: true
 
   /@typescript-eslint/utils/5.38.1_esueefhpt5ql6xiqdj4wcgwfzi:
-    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
+    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/types': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/types': 5.38.1
       '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
       eslint: 8.7.0
       eslint-scope: 5.1.1
@@ -269,14 +263,12 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==}
+  /@typescript-eslint/visitor-keys/5.38.1:
+    resolution: {integrity: sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/types': 5.38.1
       eslint-visitor-keys: 3.3.0
-    transitivePeerDependencies:
-      - typescript
     dev: true
 
   /acorn-jsx/5.3.2_acorn@8.7.1:
@@ -322,7 +314,7 @@ packages:
     dev: true
 
   /anymatch/3.1.2:
-    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/anymatch/-/anymatch-3.1.2.tgz}
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
@@ -340,7 +332,7 @@ packages:
     dev: true
 
   /array-includes/3.1.5:
-    resolution: {integrity: sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==}
+    resolution: {integrity: sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/array-includes/-/array-includes-3.1.5.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -351,12 +343,12 @@ packages:
     dev: true
 
   /array-union/2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/array-union/-/array-union-2.1.0.tgz}
     engines: {node: '>=8'}
     dev: true
 
   /array.prototype.flatmap/1.3.0:
-    resolution: {integrity: sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==}
+    resolution: {integrity: sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -370,7 +362,7 @@ packages:
     dev: true
 
   /binary-extensions/2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/binary-extensions/-/binary-extensions-2.2.0.tgz}
     engines: {node: '>=8'}
     dev: true
 
@@ -382,7 +374,7 @@ packages:
     dev: true
 
   /braces/3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/braces/-/braces-3.0.2.tgz}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
@@ -394,7 +386,7 @@ packages:
     dev: true
 
   /call-bind/1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/call-bind/-/call-bind-1.0.2.tgz}
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.1
@@ -423,7 +415,7 @@ packages:
     dev: true
 
   /chokidar/3.4.3:
-    resolution: {integrity: sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==}
+    resolution: {integrity: sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/chokidar/-/chokidar-3.4.3.tgz}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.2
@@ -459,7 +451,7 @@ packages:
     dev: true
 
   /colors/1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
+    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/colors/-/colors-1.2.5.tgz}
     engines: {node: '>=0.1.90'}
     dev: true
 
@@ -497,7 +489,7 @@ packages:
     dev: true
 
   /define-properties/1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/define-properties/-/define-properties-1.1.4.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
@@ -510,14 +502,14 @@ packages:
     dev: true
 
   /dir-glob/3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/dir-glob/-/dir-glob-3.0.1.tgz}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
     dev: true
 
   /doctrine/2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/doctrine/-/doctrine-2.1.0.tgz}
     engines: {node: '>=0.10.0'}
     dependencies:
       esutils: 2.0.3
@@ -531,7 +523,7 @@ packages:
     dev: true
 
   /es-abstract/1.20.1:
-    resolution: {integrity: sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==}
+    resolution: {integrity: sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/es-abstract/-/es-abstract-1.20.1.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -560,13 +552,13 @@ packages:
     dev: true
 
   /es-shim-unscopables/1.0.0:
-    resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
+    resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz}
     dependencies:
       has: 1.0.3
     dev: true
 
   /es-to-primitive/1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/es-to-primitive/-/es-to-primitive-1.2.1.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       is-callable: 1.2.4
@@ -585,7 +577,7 @@ packages:
     dev: true
 
   /eslint-plugin-promise/6.0.0_eslint@8.7.0:
-    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -594,7 +586,7 @@ packages:
     dev: true
 
   /eslint-plugin-react/7.27.1_eslint@8.7.0:
-    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
+    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -617,14 +609,14 @@ packages:
     dev: true
 
   /eslint-plugin-tsdoc/0.2.16:
-    resolution: {integrity: sha512-F/RWMnyDQuGlg82vQEFHQtGyWi7++XJKdYNn0ulIbyMOFqYIjoJOUdE6olORxgwgLkpJxsCJpJbTHgxJ/ggfXw==}
+    resolution: {integrity: sha512-F/RWMnyDQuGlg82vQEFHQtGyWi7++XJKdYNn0ulIbyMOFqYIjoJOUdE6olORxgwgLkpJxsCJpJbTHgxJ/ggfXw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.16.tgz}
     dependencies:
       '@microsoft/tsdoc': 0.14.1
       '@microsoft/tsdoc-config': 0.16.1
     dev: true
 
   /eslint-scope/5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/eslint-scope/-/eslint-scope-5.1.1.tgz}
     engines: {node: '>=8.0.0'}
     dependencies:
       esrecurse: 4.3.0
@@ -733,7 +725,7 @@ packages:
     dev: true
 
   /estraverse/4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/estraverse/-/estraverse-4.3.0.tgz}
     engines: {node: '>=4.0'}
     dev: true
 
@@ -752,7 +744,7 @@ packages:
     dev: true
 
   /fast-glob/3.2.11:
-    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
+    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fast-glob/-/fast-glob-3.2.11.tgz}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -771,7 +763,7 @@ packages:
     dev: true
 
   /fastq/1.11.0:
-    resolution: {integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==}
+    resolution: {integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fastq/-/fastq-1.11.0.tgz}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -784,7 +776,7 @@ packages:
     dev: true
 
   /fill-range/7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fill-range/-/fill-range-7.0.1.tgz}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
@@ -803,7 +795,7 @@ packages:
     dev: true
 
   /fs-extra/7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fs-extra/-/fs-extra-7.0.1.tgz}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
       graceful-fs: 4.2.6
@@ -816,7 +808,7 @@ packages:
     dev: true
 
   /fsevents/2.1.3:
-    resolution: {integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==}
+    resolution: {integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fsevents/-/fsevents-2.1.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     deprecated: '"Please update to latest v2.3 or v2.2"'
@@ -829,7 +821,7 @@ packages:
     dev: true
 
   /function.prototype.name/1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/function.prototype.name/-/function.prototype.name-1.1.5.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -843,11 +835,11 @@ packages:
     dev: true
 
   /functions-have-names/1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/functions-have-names/-/functions-have-names-1.2.3.tgz}
     dev: true
 
   /get-intrinsic/1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
+    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/get-intrinsic/-/get-intrinsic-1.1.1.tgz}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -855,7 +847,7 @@ packages:
     dev: true
 
   /get-symbol-description/1.0.0:
-    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/get-symbol-description/-/get-symbol-description-1.0.0.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -863,12 +855,12 @@ packages:
     dev: true
 
   /glob-escape/0.0.2:
-    resolution: {integrity: sha512-L/cXYz8x7qer1HAyUQ+mbjcUsJVdpRxpAf7CwqHoNBs9vTpABlGfNN4tzkDxt+u3Z7ZncVyKlCNPtzb0R/7WbA==}
+    resolution: {integrity: sha512-L/cXYz8x7qer1HAyUQ+mbjcUsJVdpRxpAf7CwqHoNBs9vTpABlGfNN4tzkDxt+u3Z7ZncVyKlCNPtzb0R/7WbA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/glob-escape/-/glob-escape-0.0.2.tgz}
     engines: {node: '>= 0.10'}
     dev: true
 
   /glob-parent/5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==, tarball: https://packages.atlassian.com/api/npm/npm-remote/glob-parent/-/glob-parent-5.1.2.tgz}
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
@@ -882,7 +874,7 @@ packages:
     dev: true
 
   /glob/7.0.6:
-    resolution: {integrity: sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==}
+    resolution: {integrity: sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.0.6.tgz}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -918,7 +910,7 @@ packages:
     dev: true
 
   /globby/11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/globby/-/globby-11.1.0.tgz}
     engines: {node: '>=10'}
     dependencies:
       array-union: 2.1.0
@@ -930,11 +922,11 @@ packages:
     dev: true
 
   /graceful-fs/4.2.6:
-    resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==}
+    resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/graceful-fs/-/graceful-fs-4.2.6.tgz}
     dev: true
 
   /has-bigints/1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-bigints/-/has-bigints-1.0.2.tgz}
     dev: true
 
   /has-flag/3.0.0:
@@ -948,18 +940,18 @@ packages:
     dev: true
 
   /has-property-descriptors/1.0.0:
-    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
+    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz}
     dependencies:
       get-intrinsic: 1.1.1
     dev: true
 
   /has-symbols/1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-symbols/-/has-symbols-1.0.3.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /has-tostringtag/1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
+    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-tostringtag/-/has-tostringtag-1.0.0.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
@@ -986,7 +978,7 @@ packages:
     dev: true
 
   /import-lazy/4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/import-lazy/-/import-lazy-4.0.0.tgz}
     engines: {node: '>=8'}
     dev: true
 
@@ -1007,7 +999,7 @@ packages:
     dev: true
 
   /internal-slot/1.0.3:
-    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
+    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/internal-slot/-/internal-slot-1.0.3.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.1.1
@@ -1016,30 +1008,30 @@ packages:
     dev: true
 
   /is-bigint/1.0.2:
-    resolution: {integrity: sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==}
+    resolution: {integrity: sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-bigint/-/is-bigint-1.0.2.tgz}
     dev: true
 
   /is-binary-path/2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-binary-path/-/is-binary-path-2.1.0.tgz}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
     dev: true
 
   /is-boolean-object/1.1.1:
-    resolution: {integrity: sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==}
+    resolution: {integrity: sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-boolean-object/-/is-boolean-object-1.1.1.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
     dev: true
 
   /is-callable/1.2.4:
-    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
+    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-callable/-/is-callable-1.2.4.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-core-module/2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-core-module/-/is-core-module-2.11.0.tgz}
     dependencies:
       has: 1.0.3
     dev: true
@@ -1051,7 +1043,7 @@ packages:
     dev: true
 
   /is-date-object/1.0.4:
-    resolution: {integrity: sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==}
+    resolution: {integrity: sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-date-object/-/is-date-object-1.0.4.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -1075,22 +1067,22 @@ packages:
     dev: true
 
   /is-negative-zero/2.0.2:
-    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
+    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-negative-zero/-/is-negative-zero-2.0.2.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-number-object/1.0.5:
-    resolution: {integrity: sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==}
+    resolution: {integrity: sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-number-object/-/is-number-object-1.0.5.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /is-number/7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-number/-/is-number-7.0.0.tgz}
     engines: {node: '>=0.12.0'}
     dev: true
 
   /is-regex/1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
+    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-regex/-/is-regex-1.1.4.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1098,27 +1090,27 @@ packages:
     dev: true
 
   /is-shared-array-buffer/1.0.2:
-    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
+    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz}
     dependencies:
       call-bind: 1.0.2
     dev: true
 
   /is-string/1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-string/-/is-string-1.0.7.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: true
 
   /is-symbol/1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
+    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-symbol/-/is-symbol-1.0.4.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
     dev: true
 
   /is-weakref/1.0.2:
-    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
+    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/is-weakref/-/is-weakref-1.0.2.tgz}
     dependencies:
       call-bind: 1.0.2
     dev: true
@@ -1128,7 +1120,7 @@ packages:
     dev: true
 
   /jju/1.4.0:
-    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/jju/-/jju-1.4.0.tgz}
     dev: true
 
   /js-tokens/4.0.0:
@@ -1159,18 +1151,18 @@ packages:
     dev: true
 
   /jsonfile/4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/jsonfile/-/jsonfile-4.0.0.tgz}
     optionalDependencies:
       graceful-fs: 4.2.6
     dev: true
 
   /jsonpath-plus/4.0.0:
-    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==}
+    resolution: {integrity: sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz}
     engines: {node: '>=10.0'}
     dev: true
 
   /jsx-ast-utils/2.4.1:
-    resolution: {integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==}
+    resolution: {integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.5
@@ -1186,11 +1178,11 @@ packages:
     dev: true
 
   /lodash.get/4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lodash.get/-/lodash.get-4.4.2.tgz}
     dev: true
 
   /lodash.isequal/4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lodash.isequal/-/lodash.isequal-4.5.0.tgz}
     dev: true
 
   /lodash.merge/4.6.2:
@@ -1198,26 +1190,26 @@ packages:
     dev: true
 
   /loose-envify/1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/loose-envify/-/loose-envify-1.4.0.tgz}
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
     dev: true
 
   /lru-cache/6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lru-cache/-/lru-cache-6.0.0.tgz}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
     dev: true
 
   /merge2/1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/merge2/-/merge2-1.4.1.tgz}
     engines: {node: '>= 8'}
     dev: true
 
   /micromatch/4.0.4:
-    resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
+    resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/micromatch/-/micromatch-4.0.4.tgz}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.2
@@ -1256,26 +1248,26 @@ packages:
     dev: true
 
   /normalize-path/3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/normalize-path/-/normalize-path-3.0.0.tgz}
     engines: {node: '>=0.10.0'}
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object-assign/-/object-assign-4.1.1.tgz}
     engines: {node: '>=0.10.0'}
     dev: true
 
   /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object-inspect/-/object-inspect-1.12.2.tgz}
     dev: true
 
   /object-keys/1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object-keys/-/object-keys-1.1.1.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /object.assign/4.1.2:
-    resolution: {integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==}
+    resolution: {integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object.assign/-/object.assign-4.1.2.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1285,7 +1277,7 @@ packages:
     dev: true
 
   /object.entries/1.1.5:
-    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==}
+    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object.entries/-/object.entries-1.1.5.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1294,7 +1286,7 @@ packages:
     dev: true
 
   /object.fromentries/2.0.5:
-    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
+    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object.fromentries/-/object.fromentries-2.0.5.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1303,14 +1295,14 @@ packages:
     dev: true
 
   /object.hasown/1.1.1:
-    resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==}
+    resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object.hasown/-/object.hasown-1.1.1.tgz}
     dependencies:
       define-properties: 1.1.4
       es-abstract: 1.20.1
     dev: true
 
   /object.values/1.1.5:
-    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==}
+    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/object.values/-/object.values-1.1.5.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1358,12 +1350,12 @@ packages:
     dev: true
 
   /path-type/4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/path-type/-/path-type-4.0.0.tgz}
     engines: {node: '>=8'}
     dev: true
 
   /picomatch/2.3.0:
-    resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
+    resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/picomatch/-/picomatch-2.3.0.tgz}
     engines: {node: '>=8.6'}
     dev: true
 
@@ -1373,13 +1365,13 @@ packages:
     dev: true
 
   /prettier/2.3.1:
-    resolution: {integrity: sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==}
+    resolution: {integrity: sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-2.3.1.tgz}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
 
   /prop-types/15.7.2:
-    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==}
+    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/prop-types/-/prop-types-15.7.2.tgz}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -1392,22 +1384,22 @@ packages:
     dev: true
 
   /queue-microtask/1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/queue-microtask/-/queue-microtask-1.2.3.tgz}
     dev: true
 
   /react-is/16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-16.13.1.tgz}
     dev: true
 
   /readdirp/3.5.0:
-    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
+    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/readdirp/-/readdirp-3.5.0.tgz}
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.0
     dev: true
 
   /regexp.prototype.flags/1.4.3:
-    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
+    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1426,7 +1418,7 @@ packages:
     dev: true
 
   /resolve/1.19.0:
-    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
+    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/resolve/-/resolve-1.19.0.tgz}
     dependencies:
       is-core-module: 2.11.0
       path-parse: 1.0.7
@@ -1440,7 +1432,7 @@ packages:
     dev: true
 
   /resolve/1.22.1:
-    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/resolve/-/resolve-1.22.1.tgz}
     hasBin: true
     dependencies:
       is-core-module: 2.11.0
@@ -1449,14 +1441,14 @@ packages:
     dev: true
 
   /resolve/2.0.0-next.3:
-    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==}
+    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/resolve/-/resolve-2.0.0-next.3.tgz}
     dependencies:
       is-core-module: 2.11.0
       path-parse: 1.0.7
     dev: true
 
   /reusify/1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/reusify/-/reusify-1.0.4.tgz}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
@@ -1468,7 +1460,7 @@ packages:
     dev: true
 
   /run-parallel/1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/run-parallel/-/run-parallel-1.2.0.tgz}
     dependencies:
       queue-microtask: 1.2.3
     dev: true
@@ -1479,12 +1471,12 @@ packages:
     dev: true
 
   /semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-6.3.0.tgz}
     hasBin: true
     dev: true
 
   /semver/7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-7.3.7.tgz}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -1504,7 +1496,7 @@ packages:
     dev: true
 
   /side-channel/1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/side-channel/-/side-channel-1.0.4.tgz}
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
@@ -1512,7 +1504,7 @@ packages:
     dev: true
 
   /slash/3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/slash/-/slash-3.0.0.tgz}
     engines: {node: '>=8'}
     dev: true
 
@@ -1521,12 +1513,12 @@ packages:
     dev: true
 
   /string-argv/0.3.1:
-    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/string-argv/-/string-argv-0.3.1.tgz}
     engines: {node: '>=0.6.19'}
     dev: true
 
   /string.prototype.matchall/4.0.7:
-    resolution: {integrity: sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==}
+    resolution: {integrity: sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
@@ -1539,7 +1531,7 @@ packages:
     dev: true
 
   /string.prototype.trimend/1.0.5:
-    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==}
+    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==, tarball: https://packages.atlassian.com/api/npm/npm-remote/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
@@ -1547,7 +1539,7 @@ packages:
     dev: true
 
   /string.prototype.trimstart/1.0.5:
-    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
+    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
@@ -1581,12 +1573,12 @@ packages:
     dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz}
     engines: {node: '>= 0.4'}
     dev: true
 
   /tapable/1.1.3:
-    resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
+    resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tapable/-/tapable-1.1.3.tgz}
     engines: {node: '>=6'}
     dev: true
 
@@ -1595,14 +1587,14 @@ packages:
     dev: true
 
   /to-regex-range/5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/to-regex-range/-/to-regex-range-5.0.1.tgz}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
 
   /true-case-path/2.2.1:
-    resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
+    resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/true-case-path/-/true-case-path-2.2.1.tgz}
     dev: true
 
   /tslib/1.14.1:
@@ -1642,7 +1634,7 @@ packages:
     dev: true
 
   /tsutils/3.21.0_typescript@4.8.4:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tsutils/-/tsutils-3.21.0.tgz}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
@@ -1670,7 +1662,7 @@ packages:
     dev: true
 
   /unbox-primitive/1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/unbox-primitive/-/unbox-primitive-1.0.2.tgz}
     dependencies:
       call-bind: 1.0.2
       has-bigints: 1.0.2
@@ -1679,7 +1671,7 @@ packages:
     dev: true
 
   /universalify/0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/universalify/-/universalify-0.1.2.tgz}
     engines: {node: '>= 4.0.0'}
     dev: true
 
@@ -1694,12 +1686,12 @@ packages:
     dev: true
 
   /validator/13.7.0:
-    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
+    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/validator/-/validator-13.7.0.tgz}
     engines: {node: '>= 0.10'}
     dev: true
 
   /which-boxed-primitive/1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
+    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz}
     dependencies:
       is-bigint: 1.0.2
       is-boolean-object: 1.1.1
@@ -1726,11 +1718,11 @@ packages:
     dev: true
 
   /yallist/4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/yallist/-/yallist-4.0.0.tgz}
     dev: true
 
   /z-schema/5.0.3:
-    resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==}
+    resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/z-schema/-/z-schema-5.0.3.tgz}
     engines: {node: '>=8.0.0'}
     hasBin: true
     dependencies:
@@ -1821,15 +1813,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.48.8.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.48.8.tgz}
+  file:../temp/tarballs/rushstack-heft-0.49.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.49.0.tgz}
     name: '@rushstack/heft'
-    version: 0.48.8
+    version: 0.49.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.4.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.3.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz
       '@types/tapable': 1.0.6
@@ -1844,21 +1836,21 @@ packages:
       true-case-path: 2.2.1
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.3.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.4.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.4.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.11.3
+    version: 0.11.4
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.53.3.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       jsonpath-plus: 4.0.0
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.53.2.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.53.3.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.53.3.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.53.2
+    version: 3.53.3
     dependencies:
       '@types/node': 12.20.24
       colors: 1.2.5

--- a/common/changes/@microsoft/api-extractor/api-extractor-sort-modifier-for-union-spans-in-generators_2023-01-09-04-30.json
+++ b/common/changes/@microsoft/api-extractor/api-extractor-sort-modifier-for-union-spans-in-generators_2023-01-09-04-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Introduces sort modifier in ApiReportGenerator and DtsRollupGenerator for union types to avoid spurious outputs between builds",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/reviews/api/heft-webpack4-plugin.api.md
+++ b/common/reviews/api/heft-webpack4-plugin.api.md
@@ -22,7 +22,7 @@ export interface IWebpackBuildStageProperties extends IBuildStageProperties {
 
 // @public (undocumented)
 export interface IWebpackBundleSubstageProperties extends IBundleSubstageProperties {
-    webpackConfiguration?: webpack.Configuration | webpack.Configuration[] | null;
+    webpackConfiguration?: null | webpack.Configuration | webpack.Configuration[];
 }
 
 // @public (undocumented)

--- a/common/reviews/api/heft-webpack5-plugin.api.md
+++ b/common/reviews/api/heft-webpack5-plugin.api.md
@@ -17,12 +17,12 @@ export default _default;
 // @public (undocumented)
 export interface IWebpackBuildStageProperties extends IBuildStageProperties {
     // (undocumented)
-    webpackStats?: webpack.Stats | webpack.MultiStats;
+    webpackStats?: webpack.MultiStats | webpack.Stats;
 }
 
 // @public (undocumented)
 export interface IWebpackBundleSubstageProperties extends IBundleSubstageProperties {
-    webpackConfiguration?: webpack.Configuration | webpack.Configuration[] | null;
+    webpackConfiguration?: null | webpack.Configuration | webpack.Configuration[];
 }
 
 // @public (undocumented)

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -69,7 +69,7 @@ export class CompileSubstageHooks extends BuildSubstageHooksBase {
 }
 
 // @beta (undocumented)
-export type CustomActionParameterType = string | boolean | number | ReadonlyArray<string> | undefined;
+export type CustomActionParameterType = ReadonlyArray<string> | boolean | number | string | undefined;
 
 // @beta
 export class HeftCommandLine {
@@ -134,7 +134,7 @@ export interface IBuildStageContext extends IStageContext<BuildStageHooks, IBuil
 // @public (undocumented)
 export interface IBuildStageProperties {
     // @beta (undocumented)
-    emitExtensionForTests?: '.js' | '.cjs' | '.mjs';
+    emitExtensionForTests?: '.cjs' | '.js' | '.mjs';
     // @beta (undocumented)
     emitFolderNameForTests?: string;
     // @beta (undocumented)
@@ -201,7 +201,7 @@ export interface ICustomActionOptions<TParameters> {
     // (undocumented)
     actionName: string;
     // (undocumented)
-    callback: (parameters: TParameters) => void | Promise<void>;
+    callback: (parameters: TParameters) => Promise<void> | void;
     // (undocumented)
     documentation: string;
     // (undocumented)

--- a/common/reviews/api/localization-utilities.api.md
+++ b/common/reviews/api/localization-utilities.api.md
@@ -103,7 +103,7 @@ export function parseResJson({ content, ignoreString, filePath }: IParseFileOpti
 export function parseResx(options: IParseResxOptions): ILocalizationFile;
 
 // @public (undocumented)
-export type ParserKind = 'resx' | 'loc.json' | 'resjson';
+export type ParserKind = 'loc.json' | 'resjson' | 'resx';
 
 // @public
 export class TypingsGenerator extends StringValuesTypingsGenerator {

--- a/common/reviews/api/rush-amazon-s3-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-amazon-s3-build-cache-plugin.api.md
@@ -18,9 +18,9 @@ export class AmazonS3Client {
     // (undocumented)
     getObjectAsync(objectName: string): Promise<Buffer | undefined>;
     // (undocumented)
-    _getSha256Hmac(key: string | Buffer, data: string): Buffer;
+    _getSha256Hmac(key: Buffer | string, data: string): Buffer;
     // (undocumented)
-    _getSha256Hmac(key: string | Buffer, data: string, encoding: 'hex'): string;
+    _getSha256Hmac(key: Buffer | string, data: string, encoding: 'hex'): string;
     // (undocumented)
     static tryDeserializeCredentials(credentialString: string | undefined): IAmazonS3Credentials | undefined;
     // (undocumented)

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -29,7 +29,7 @@ export abstract class AzureAuthenticationBase {
     // (undocumented)
     protected abstract _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
     // (undocumented)
-    tryGetCachedCredentialAsync(options?: ITryGetCachedCredentialOptionsThrow | ITryGetCachedCredentialOptionsIgnore): Promise<ICredentialCacheEntry | undefined>;
+    tryGetCachedCredentialAsync(options?: ITryGetCachedCredentialOptionsIgnore | ITryGetCachedCredentialOptionsThrow): Promise<ICredentialCacheEntry | undefined>;
     // (undocumented)
     tryGetCachedCredentialAsync(options: ITryGetCachedCredentialOptionsLogWarning): Promise<ICredentialCacheEntry | undefined>;
     // (undocumented)
@@ -64,7 +64,7 @@ export class AzureStorageAuthentication extends AzureAuthenticationBase {
 }
 
 // @public (undocumented)
-export type ExpiredCredentialBehavior = 'logWarning' | 'throwError' | 'ignore';
+export type ExpiredCredentialBehavior = 'ignore' | 'logWarning' | 'throwError';
 
 // @public (undocumented)
 export interface IAzureAuthenticationBaseOptions {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -514,13 +514,13 @@ export interface ITelemetryData {
     readonly durationInSeconds: number;
     // (undocumented)
     readonly extraData?: {
-        [key: string]: string | number | boolean;
+        [key: string]: boolean | number | string;
     };
     readonly machineInfo?: ITelemetryMachineInfo;
     readonly name: string;
     readonly operationResults?: Record<string, ITelemetryOperationResult>;
     readonly platform?: string;
-    readonly result: 'Succeeded' | 'Failed';
+    readonly result: 'Failed' | 'Succeeded';
     readonly rushVersion?: string;
     readonly timestampMs?: number;
 }
@@ -692,7 +692,7 @@ export abstract class PackageManager {
 }
 
 // @public
-export type PackageManagerName = 'pnpm' | 'npm' | 'yarn';
+export type PackageManagerName = 'npm' | 'pnpm' | 'yarn';
 
 // @public
 export abstract class PackageManagerOptionsConfigurationBase implements IPackageManagerOptionsJsonBase {
@@ -726,13 +726,13 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     readonly pnpmStorePath: string;
     readonly preventManualShrinkwrapChanges: boolean;
     readonly strictPeerDependencies: boolean;
-    readonly unsupportedPackageJsonSettings: unknown | undefined;
+    readonly unsupportedPackageJsonSettings: undefined | unknown;
     updateGlobalPatchedDependencies(patchedDependencies: Record<string, string> | undefined): void;
     readonly useWorkspaces: boolean;
 }
 
 // @public
-export type PnpmStoreOptions = 'local' | 'global';
+export type PnpmStoreOptions = 'global' | 'local';
 
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -49,7 +49,7 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> e
     // (undocumented)
     getAdditionalOutputFiles?: (relativePath: string) => string[];
     // (undocumented)
-    parseAndGenerateTypings: (fileContents: string, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
+    parseAndGenerateTypings: (fileContents: string, filePath: string, relativePath: string) => Promise<TTypingsResult> | TTypingsResult;
 }
 
 // @public

--- a/common/reviews/api/webpack4-localization-plugin.api.md
+++ b/common/reviews/api/webpack4-localization-plugin.api.md
@@ -19,7 +19,7 @@ export interface IDefaultLocaleOptions {
 // @public (undocumented)
 export interface ILocaleData {
     // (undocumented)
-    [locFilePath: string]: string | ILocaleFileData;
+    [locFilePath: string]: ILocaleFileData | string;
 }
 
 // @public (undocumented)
@@ -80,7 +80,7 @@ export interface ILocalizationStatsOptions {
 export interface ILocalizedData {
     defaultLocale: IDefaultLocaleOptions;
     ignoreMissingResxComments?: boolean;
-    normalizeResxNewlines?: 'lf' | 'crlf';
+    normalizeResxNewlines?: 'crlf' | 'lf';
     passthroughLocale?: IPassthroughLocaleOptions;
     pseudolocales?: IPseudolocalesOptions;
     resolveMissingTranslatedStrings?: (locales: string[], filePath: string) => IResolvedMissingTranslations;
@@ -116,7 +116,7 @@ export interface IPseudolocalesOptions {
 // @public (undocumented)
 export interface IResolvedMissingTranslations {
     // (undocumented)
-    [localeName: string]: string | ILocaleFileData;
+    [localeName: string]: ILocaleFileData | string;
 }
 
 // @internal (undocumented)

--- a/common/reviews/api/webpack4-module-minifier-plugin.api.md
+++ b/common/reviews/api/webpack4-module-minifier-plugin.api.md
@@ -42,7 +42,7 @@ export interface _IAcornComment {
     // (undocumented)
     start: number;
     // (undocumented)
-    type: 'Line' | 'Block';
+    type: 'Block' | 'Line';
     // (undocumented)
     value: string;
 }
@@ -52,7 +52,7 @@ export interface IAssetInfo {
     chunk: webpack.compilation.Chunk;
     externalNames: Map<string, string>;
     fileName: string;
-    modules: (string | number)[];
+    modules: (number | string)[];
     source: Source;
 }
 
@@ -69,7 +69,7 @@ export interface IDehydratedAssets {
 export interface IExtendedModule extends webpack.compilation.Module {
     external?: boolean;
     hasDependencies(callback: (dep: webpack.compilation.Dependency) => boolean | void): boolean;
-    id: string | number | null;
+    id: null | number | string;
     identifier(): string;
     modules?: IExtendedModule[];
     readableIdentifier(requestShortener: unknown): string;
@@ -87,7 +87,7 @@ export interface IModuleInfo {
 }
 
 // @public
-export type IModuleMap = Map<string | number, IModuleInfo>;
+export type IModuleMap = Map<number | string, IModuleInfo>;
 
 export { IModuleMinificationCallback }
 
@@ -105,7 +105,7 @@ export { IModuleMinifierFunction }
 
 // @public
 export interface IModuleMinifierPluginHooks {
-    finalModuleId: SyncWaterfallHook<string | number | undefined, webpack.compilation.Compilation>;
+    finalModuleId: SyncWaterfallHook<number | string | undefined, webpack.compilation.Compilation>;
     postProcessCodeFragment: SyncWaterfallHook<ReplaceSource, IPostProcessFragmentContext>;
     rehydrateAssets: AsyncSeriesWaterfallHook<IDehydratedAssets, webpack.compilation.Compilation>;
 }
@@ -135,7 +135,7 @@ export interface _INormalModuleFactoryModuleData {
 export interface IPostProcessFragmentContext {
     compilation: webpack.compilation.Compilation;
     loggingName: string;
-    module: webpack.compilation.Module | undefined;
+    module: undefined | webpack.compilation.Module;
 }
 
 // @internal

--- a/common/reviews/api/webpack5-localization-plugin.api.md
+++ b/common/reviews/api/webpack5-localization-plugin.api.md
@@ -30,7 +30,7 @@ export interface ILocaleElementMap {
 }
 
 // @public
-export type ILocaleFileData = string | ILocaleFileObject | ReadonlyMap<string, string>;
+export type ILocaleFileData = ILocaleFileObject | ReadonlyMap<string, string> | string;
 
 // @public (undocumented)
 export interface ILocaleFileObject {
@@ -82,7 +82,7 @@ export interface ILocalizedData {
     defaultLocale: IDefaultLocaleOptions;
     passthroughLocale?: IPassthroughLocaleOptions;
     pseudolocales?: IPseudolocalesOptions;
-    resolveMissingTranslatedStrings?: (locales: string[], localizedFileKey: string, loaderContext: LoaderContext<{}>) => Promise<IResolvedMissingTranslations> | IResolvedMissingTranslations;
+    resolveMissingTranslatedStrings?: (locales: string[], localizedFileKey: string, loaderContext: LoaderContext<{}>) => IResolvedMissingTranslations | Promise<IResolvedMissingTranslations>;
     translatedStrings: ILocalizedStrings;
 }
 

--- a/common/reviews/api/webpack5-module-minifier-plugin.api.md
+++ b/common/reviews/api/webpack5-module-minifier-plugin.api.md
@@ -56,7 +56,7 @@ export interface IModuleInfo {
 }
 
 // @public
-export type IModuleMap = Map<string | number, IModuleInfo>;
+export type IModuleMap = Map<number | string, IModuleInfo>;
 
 // @public
 export interface IModuleMinifierPluginHooks {


### PR DESCRIPTION
**Summary**
Fixed https://github.com/microsoft/rushstack/issues/1958

**Details**
API reports and DTS rollouts generated show signs of spurious inferred union types between incremental build. This implementation simply introduces a sort modifier to sort all union type in DTS rollups and API reports.

**How was it tested**
Tested against reports within the repository generated automatically.