### PR TITLE
[webpack5-load-themed-styles-loader] make webpack optional peer

### DIFF
--- a/common/changes/@microsoft/webpack5-load-themed-styles-loader/feature-include-webpack-peer-deps_2023-01-11-04-41.json
+++ b/common/changes/@microsoft/webpack5-load-themed-styles-loader/feature-include-webpack-peer-deps_2023-01-11-04-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/webpack5-load-themed-styles-loader",
+      "comment": "Make webpack@5 an optional peer dependency.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/webpack5-load-themed-styles-loader"
+}

--- a/webpack/webpack5-load-themed-styles-loader/package.json
+++ b/webpack/webpack5-load-themed-styles-loader/package.json
@@ -16,7 +16,13 @@
     "_phase:test": "heft test --no-build"
   },
   "peerDependencies": {
-    "@microsoft/load-themed-styles": "^2.0.19"
+    "@microsoft/load-themed-styles": "^2.0.19",
+    "webpack": "^5"
+  },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@microsoft/load-themed-styles": "workspace:*",


### PR DESCRIPTION
This PR makes webpack@5 an optional peer dependency for this loader. The types explicitly depend on webpack@5's types from its package. 