### PR TITLE
[rush] Restore log files when cache hit

### DIFF
--- a/common/changes/@microsoft/rush/feat-build-cache-log_2023-01-11-16-25.json
+++ b/common/changes/@microsoft/rush/feat-build-cache-log_2023-01-11-16-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Restore log files when cache hit",
+      "comment": "Include operation log files in the cache, and restore them during cache hits.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/feat-build-cache-log_2023-01-11-16-25.json
+++ b/common/changes/@microsoft/rush/feat-build-cache-log_2023-01-11-16-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Restore log files when cache hit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -389,6 +389,24 @@ export interface IOperationExecutionResult {
     readonly stopwatch: IStopwatchResult;
 }
 
+// @internal (undocumented)
+export interface _IOperationMetadata {
+    // (undocumented)
+    durationInSeconds: number;
+    // (undocumented)
+    errorLogPath: string;
+    // (undocumented)
+    logPath: string;
+}
+
+// @internal (undocumented)
+export interface _IOperationMetadataManagerOptions {
+    // (undocumented)
+    phase: IPhase;
+    // (undocumented)
+    rushProject: RushConfigurationProject;
+}
+
 // @alpha
 export interface IOperationOptions {
     phase?: IPhase | undefined;
@@ -412,7 +430,7 @@ export interface IOperationRunnerContext {
     collatedWriter: CollatedWriter;
     debugMode: boolean;
     // @internal
-    _operationStateFile?: _OperationStateFile;
+    _operationMetadataManager?: _OperationMetadataManager;
     quietMode: boolean;
     stdioSummarizer: StdioSummarizer;
     stopwatch: IStopwatchResult;
@@ -421,9 +439,9 @@ export interface IOperationRunnerContext {
 // @internal (undocumented)
 export interface _IOperationStateFileOptions {
     // (undocumented)
-    phase: IPhase;
+    metadataFolder: string;
     // (undocumented)
-    rushProject: RushConfigurationProject;
+    projectFolder: string;
 }
 
 // @internal (undocumented)
@@ -616,10 +634,28 @@ export class Operation {
 }
 
 // @internal
+export class _OperationMetadataManager {
+    constructor(options: _IOperationMetadataManagerOptions);
+    get relativeFilepaths(): string[];
+    // (undocumented)
+    saveAsync({ durationInSeconds, logPath, errorLogPath }: _IOperationMetadata): Promise<void>;
+    // (undocumented)
+    readonly stateFile: _OperationStateFile;
+    // (undocumented)
+    tryRestoreAsync({ terminal, logPath, errorLogPath }: {
+        terminal: ITerminal;
+        logPath: string;
+        errorLogPath: string;
+    }): Promise<void>;
+}
+
+// @internal
 export class _OperationStateFile {
     constructor(options: _IOperationStateFileOptions);
-    readonly filename: string;
-    static getFilenameRelativeToProjectRoot(phase: IPhase): string;
+    // (undocumented)
+    static filename: string;
+    readonly filepath: string;
+    readonly relativeFilepath: string;
     // (undocumented)
     get state(): _IOperationStateJson | undefined;
     // (undocumented)

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -126,3 +126,8 @@ export {
   IOperationStateFileOptions as _IOperationStateFileOptions,
   IOperationStateJson as _IOperationStateJson
 } from './logic/operations/OperationStateFile';
+export {
+  OperationMetadataManager as _OperationMetadataManager,
+  IOperationMetadataManagerOptions as _IOperationMetadataManagerOptions,
+  IOperationMetaData as _IOperationMetadata
+} from './logic/operations/OperationMetadataManager';

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -5,7 +5,7 @@ import type { StdioSummarizer } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
-import type { OperationStateFile } from './OperationStateFile';
+import type { OperationMetadataManager } from './OperationMetadataManager';
 import type { IStopwatchResult } from '../../utilities/Stopwatch';
 
 /**
@@ -31,11 +31,11 @@ export interface IOperationRunnerContext {
    */
   stdioSummarizer: StdioSummarizer;
   /**
-   * Object used to record state of the operation.
+   * Object used to manage metadata of the operation.
    *
    * @internal
    */
-  _operationStateFile?: OperationStateFile;
+  _operationMetadataManager?: OperationMetadataManager;
   /**
    * Object used to track elapsed time.
    */

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -9,7 +9,7 @@ import { OperationStatus } from './OperationStatus';
 import { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
 import { Operation } from './Operation';
 import { Stopwatch } from '../../utilities/Stopwatch';
-import { OperationStateFile } from './OperationStateFile';
+import { OperationMetadataManager } from './OperationMetadataManager';
 
 export interface IOperationExecutionRecordContext {
   streamCollator: StreamCollator;
@@ -81,7 +81,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public readonly runner: IOperationRunner;
   public readonly weight: number;
-  public readonly _operationStateFile: OperationStateFile | undefined;
+  public readonly _operationMetadataManager: OperationMetadataManager | undefined;
 
   private readonly _context: IOperationExecutionRecordContext;
 
@@ -99,7 +99,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
     this.runner = runner;
     this.weight = operation.weight;
     if (operation.associatedPhase && operation.associatedProject) {
-      this._operationStateFile = new OperationStateFile({
+      this._operationMetadataManager = new OperationMetadataManager({
         phase: operation.associatedPhase,
         rushProject: operation.associatedProject
       });
@@ -129,7 +129,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public get nonCachedDurationMs(): number | undefined {
     // Lazy calculated because the state file is created/restored later on
-    return this._operationStateFile?.state?.nonCachedDurationMs;
+    return this._operationMetadataManager?.stateFile.state?.nonCachedDurationMs;
   }
 
   public async executeAsync(onResult: (record: OperationExecutionRecord) => void): Promise<void> {

--- a/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
@@ -114,7 +114,7 @@ export class OperationMetadataManager {
     terminal.writeLine('');
     terminal.writeLine(`Restoring cached log file at ${this._logPath}`);
     try {
-      const logReadStream: fs.readStream = fs.createReadStream(this._logPath, {
+      const logReadStream: fs.ReadStream = fs.createReadStream(this._logPath, {
         encoding: 'utf-8'
       });
       for await (const data of logReadStream) {

--- a/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
@@ -113,21 +113,12 @@ export class OperationMetadataManager {
     terminal.writeLine('');
     terminal.writeLine(`Restoring cached log file at ${this._logPath}`);
     try {
-      await new Promise<void>((resolve, reject) => {
-        const logReadStream: fs.ReadStream = fs.createReadStream(this._logPath, {
-          encoding: 'utf-8'
-        });
-
-        logReadStream.on('data', (data) => {
-          terminal.write(data);
-        });
-        logReadStream.on('end', () => {
-          resolve();
-        });
-        logReadStream.on('error', (e) => {
-          reject(e);
-        });
+      const logReadStream: fs.readStream = fs.createReadStream(this._logPath, {
+        encoding: 'utf-8'
       });
+      for await (const data of logReadStream) {
+        terminal.write(data);
+      }
     } catch (e) {
       if (!FileSystem.isNotExistError(e)) {
         throw e;

--- a/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'fs';
+import { FileSystem, ITerminal } from '@rushstack/node-core-library';
+
+import { OperationStateFile } from './OperationStateFile';
+import { RushConstants } from '../RushConstants';
+
+import type { IPhase } from '../../api/CommandLineConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { IOperationStateJson } from './OperationStateFile';
+
+/**
+ * @internal
+ */
+export interface IOperationMetadataManagerOptions {
+  rushProject: RushConfigurationProject;
+  phase: IPhase;
+}
+
+/**
+ * @internal
+ */
+export interface IOperationMetaData {
+  durationInSeconds: number;
+  logPath: string;
+  errorLogPath: string;
+}
+
+/**
+ * A helper class for managing the meta files of a operation.
+ *
+ * @internal
+ */
+export class OperationMetadataManager {
+  public readonly stateFile: OperationStateFile;
+  private _metadataFolder: string;
+  private _logPath: string;
+  private _errorLogPath: string;
+  private _relativeLogPath: string;
+  private _relativeErrorLogPath: string;
+
+  public constructor(options: IOperationMetadataManagerOptions) {
+    const { rushProject, phase } = options;
+    const { projectFolder } = rushProject;
+
+    const identifier: string = phase.logFilenameIdentifier;
+    this._metadataFolder = `${RushConstants.projectRushFolderName}/${RushConstants.rushTempFolderName}/operation/${identifier}`;
+
+    this.stateFile = new OperationStateFile({
+      projectFolder: projectFolder,
+      metadataFolder: this._metadataFolder
+    });
+
+    this._relativeLogPath = `${this._metadataFolder}/all.log`;
+    this._relativeErrorLogPath = `${this._metadataFolder}/error.log`;
+    this._logPath = `${projectFolder}/${this._relativeLogPath}`;
+    this._errorLogPath = `${projectFolder}/${this._relativeErrorLogPath}`;
+  }
+
+  /**
+   * Returns the relative paths of the metadata files to project folder.
+   *
+   * Example: `.rush/temp/operation/_phase_build/state.json`
+   * Example: `.rush/temp/operation/_phase_build/all.log`
+   * Example: `.rush/temp/operation/_phase_build/error.log`
+   */
+  public get relativeFilepaths(): string[] {
+    return [this.stateFile.relativeFilepath, this._relativeLogPath, this._relativeErrorLogPath];
+  }
+
+  public async saveAsync({ durationInSeconds, logPath, errorLogPath }: IOperationMetaData): Promise<void> {
+    const state: IOperationStateJson = {
+      nonCachedDurationMs: durationInSeconds * 1000
+    };
+    await this.stateFile.writeAsync(state);
+
+    try {
+      await FileSystem.copyFileAsync({
+        sourcePath: logPath,
+        destinationPath: this._logPath
+      });
+    } catch (e) {
+      if (!FileSystem.isNotExistError(e)) {
+        throw e;
+      }
+    }
+    try {
+      await FileSystem.copyFileAsync({
+        sourcePath: errorLogPath,
+        destinationPath: this._relativeLogPath
+      });
+    } catch (e) {
+      if (!FileSystem.isNotExistError(e)) {
+        throw e;
+      }
+    }
+  }
+
+  public async tryRestoreAsync({
+    terminal,
+    logPath,
+    errorLogPath
+  }: {
+    terminal: ITerminal;
+    logPath: string;
+    errorLogPath: string;
+  }): Promise<void> {
+    await this.stateFile.tryRestoreAsync();
+
+    // Append cached log into current log file
+    terminal.writeLine('');
+    terminal.writeLine(`Restoring cached log file at ${this._logPath}`);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const logReadStream: fs.ReadStream = fs.createReadStream(this._logPath, {
+          encoding: 'utf-8'
+        });
+
+        logReadStream.on('data', (data) => {
+          terminal.write(data);
+        });
+        logReadStream.on('end', () => {
+          resolve();
+        });
+        logReadStream.on('error', (e) => {
+          reject(e);
+        });
+      });
+    } catch (e) {
+      if (!FileSystem.isNotExistError(e)) {
+        throw e;
+      }
+    }
+
+    // Try to restore cached error log as error log file
+    try {
+      await FileSystem.copyFileAsync({
+        sourcePath: this._errorLogPath,
+        destinationPath: errorLogPath
+      });
+    } catch (e) {
+      if (!FileSystem.isNotExistError(e)) {
+        throw e;
+      }
+    }
+  }
+}

--- a/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
@@ -83,7 +83,7 @@ export class OperationMetadataManager {
       },
       {
         sourcePath: errorLogPath,
-        destinationPath: this._relativeLogPath
+        destinationPath: this._errorLogPath
       }
     ];
 

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -33,7 +33,7 @@ import { IOperationSettings, RushProjectConfiguration } from '../../api/RushProj
 import { CollatedTerminalProvider } from '../../utilities/CollatedTerminalProvider';
 import { RushConstants } from '../RushConstants';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
-import { OperationStateFile } from './OperationStateFile';
+import { OperationMetadataManager } from './OperationMetadataManager';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
@@ -208,17 +208,17 @@ export class ShellOperationRunner implements IOperationRunner {
       }
 
       let projectDeps: IProjectDeps | undefined;
-      let trackedFiles: string[] | undefined;
+      let trackedProjectFiles: string[] | undefined;
       try {
         const fileHashes: Map<string, string> | undefined =
           await this._projectChangeAnalyzer._tryGetProjectDependenciesAsync(this._rushProject, terminal);
 
         if (fileHashes) {
           const files: { [filePath: string]: string } = {};
-          trackedFiles = [];
+          trackedProjectFiles = [];
           for (const [filePath, fileHash] of fileHashes) {
             files[filePath] = fileHash;
-            trackedFiles.push(filePath);
+            trackedProjectFiles.push(filePath);
           }
 
           projectDeps = {
@@ -264,10 +264,11 @@ export class ShellOperationRunner implements IOperationRunner {
       //
       let buildCacheReadAttempted: boolean = false;
       if (this._isCacheReadAllowed) {
-        const projectBuildCache: ProjectBuildCache | undefined = await this._tryGetProjectBuildCacheAsync(
+        const projectBuildCache: ProjectBuildCache | undefined = await this._tryGetProjectBuildCacheAsync({
           terminal,
-          trackedFiles
-        );
+          trackedProjectFiles,
+          operationMetadataManager: context._operationMetadataManager
+        });
 
         buildCacheReadAttempted = !!projectBuildCache;
         const restoreFromCacheSuccess: boolean | undefined =
@@ -275,7 +276,11 @@ export class ShellOperationRunner implements IOperationRunner {
 
         if (restoreFromCacheSuccess) {
           // Restore the original state of the operation without cache
-          await context._operationStateFile?.tryRestoreAsync();
+          await context._operationMetadataManager?.tryRestoreAsync({
+            terminal,
+            logPath: projectLogWritable.logPath,
+            errorLogPath: projectLogWritable.errorLogPath
+          });
           return OperationStatus.FromCache;
         }
       }
@@ -373,18 +378,24 @@ export class ShellOperationRunner implements IOperationRunner {
           ensureFolderExists: true
         });
 
-        // If the operation without cache was successful, we can save the state to disk
+        // If the operation without cache was successful, we can save the metadata to disk
         const { duration: durationInSeconds } = context.stopwatch;
-        await context._operationStateFile?.writeAsync({
-          nonCachedDurationMs: durationInSeconds * 1000
+        await context._operationMetadataManager?.saveAsync({
+          durationInSeconds,
+          logPath: projectLogWritable.logPath,
+          errorLogPath: projectLogWritable.errorLogPath
         });
 
         // If the command is successful, we can calculate project hash, and no dependencies were skipped,
         // write a new cache entry.
         const setCacheEntryPromise: Promise<boolean> | undefined = this.isCacheWriteAllowed
-          ? (await this._tryGetProjectBuildCacheAsync(terminal, trackedFiles))?.trySetCacheEntryAsync(
-              terminal
-            )
+          ? (
+              await this._tryGetProjectBuildCacheAsync({
+                terminal,
+                trackedProjectFiles,
+                operationMetadataManager: context._operationMetadataManager
+              })
+            )?.trySetCacheEntryAsync(terminal)
           : undefined;
 
         const [, cacheWriteSuccess] = await Promise.all([writeProjectStatePromise, setCacheEntryPromise]);
@@ -410,10 +421,15 @@ export class ShellOperationRunner implements IOperationRunner {
     }
   }
 
-  private async _tryGetProjectBuildCacheAsync(
-    terminal: ITerminal,
-    trackedProjectFiles: string[] | undefined
-  ): Promise<ProjectBuildCache | undefined> {
+  private async _tryGetProjectBuildCacheAsync({
+    terminal,
+    trackedProjectFiles,
+    operationMetadataManager
+  }: {
+    terminal: ITerminal;
+    trackedProjectFiles: string[] | undefined;
+    operationMetadataManager: OperationMetadataManager | undefined;
+  }): Promise<ProjectBuildCache | undefined> {
     if (this._projectBuildCache === UNINITIALIZED) {
       this._projectBuildCache = undefined;
 
@@ -442,7 +458,7 @@ export class ShellOperationRunner implements IOperationRunner {
               const projectOutputFolderNames: ReadonlyArray<string> =
                 operationSettings.outputFolderNames || [];
               const additionalProjectOutputFilePaths: ReadonlyArray<string> = [
-                OperationStateFile.getFilenameRelativeToProjectRoot(this._phase)
+                ...(operationMetadataManager?.relativeFilepaths || [])
               ];
               const additionalContext: Record<string, string> = {};
               if (operationSettings.dependsOnEnvVars) {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This PR add a feature: restoring operation log files when cache hit

## Details

Introduce a new "OperationMetadataManager"

1. when a task successful without cache, save the log files into `.rush/temp/operation/<identifier>/all.log` and `.rush/temp/operation/<identifier>/error.log`.
2. when a task successful with cache hit, append the `all.log` file content to current operation log and copy the error log if exists.

## How it was tested

Tested in rushstack and a repo without phase commands.

1. Save the log file
![2023-01-12 at 15 19](https://user-images.githubusercontent.com/16147702/212002572-4d605840-18c5-4e9d-b47c-5dba7ced04fe.png)

2. Append the cached log content to current log
![2023-01-12 at 15 21](https://user-images.githubusercontent.com/16147702/212002895-c89b2b62-5cc8-4784-8e23-bb01ed16d889.png)


## Impacted documentation

 Nope


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
