### PR TITLE
[webpack5-localization-plugin] drop _initializeAndValidateOptions into thisCompilation hook 

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/issue-3887_2023-01-11-18-21.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/issue-3887_2023-01-11-18-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Fix errors where `compiler.webpack` was not accessible when using the plugin.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This PR moves the `_initializeAndValidateOptions` function into the `compiler.hooks.thisCompilation` hook (where by this time `compiler.webpack` will be set).

Fixes #3887 