### PR TITLE
[rush] Fix an issue where scripts were compiled into the wrong folder name.

### DIFF
--- a/common/changes/@microsoft/rush/fix-create-scripts_2023-01-22-03-09.json
+++ b/common/changes/@microsoft/rush/fix-create-scripts_2023-01-22-03-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a regression where the 'dist/scripts' folder name was named 'dist/undefined'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/PathConstants.ts
+++ b/libraries/rush-lib/src/utilities/PathConstants.ts
@@ -16,7 +16,7 @@ export const assetsFolderPath: string = `${rushLibFolderRootPath}/assets`;
 /**
  * The folder name ("scripts") where the scripts in rush-lib are built.
  */
-const scriptsFolderName: string = 'scripts';
+export const scriptsFolderName: string = 'scripts';
 
 export const pnpmfileShimFilename: string = 'PnpmfileShim.js';
 export const installRunScriptFilename: string = 'install-run.js';


### PR DESCRIPTION
## Summary

The `export` for the "scripts" folder name was accidentally removed from `pathConstants.ts`, causing the scripts to get compiled into an "undefined" folder.

This puts the export back.

## How it was tested

Confirmed that the folder structure is as expected and that `rush install` works.