### PR TITLE
[package-deps-hash] Fix getRepoStateAsync

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/package-deps-bug_2023-01-23-21-55.json
+++ b/common/changes/@rushstack/package-deps-hash/package-deps-bug_2023-01-23-21-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Fix bug in parseGitHashObject when 0 hashes are expected.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -83,13 +83,17 @@ export function parseGitLsTree(output: string): IGitTreeState {
 export function* parseGitHashObject(
   output: string,
   filePaths: ReadonlyArray<string>
-): Iterable<[string, string]> {
+): IterableIterator<[string, string]> {
+  const expected: number = filePaths.length;
+  if (expected === 0) {
+    return;
+  }
+
   output = output.trim();
 
   let last: number = 0;
   let i: number = 0;
   let index: number = output.indexOf('\n', last);
-  const expected: number = filePaths.length;
   for (; i < expected && index > 0; i++) {
     const hash: string = output.slice(last, index);
     yield [filePaths[i], hash];
@@ -97,15 +101,15 @@ export function* parseGitHashObject(
     index = output.indexOf('\n', last);
   }
 
-  // Handle last line
+  // Handle last line. Will be non-empty to due trim() call.
   if (index < 0) {
     const hash: string = output.slice(last);
     yield [filePaths[i], hash];
     i++;
   }
 
-  if (i < expected) {
-    throw new Error(`Expected ${expected} hashes from "git hash-object" but only received ${i}`);
+  if (i !== expected) {
+    throw new Error(`Expected ${expected} hashes from "git hash-object" but received ${i}`);
   }
 }
 

--- a/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
+++ b/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
@@ -82,3 +82,23 @@ Object {
   "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
 }
 `;
+
+exports[`parseGitHashObject can parse multiple entries 1`] = `
+Map {
+  "a" => "11",
+  "b" => "22",
+  "c" => "33",
+}
+`;
+
+exports[`parseGitHashObject can parse multiple entries with trailing whitespace 1`] = `
+Map {
+  "a" => "11",
+  "b" => "22",
+  "c" => "33",
+}
+`;
+
+exports[`parseGitHashObject throws if too few hashes are provided 1`] = `"Expected 3 hashes from \\"git hash-object\\" but received 2"`;
+
+exports[`parseGitHashObject throws if too many hashes are provided 1`] = `"Expected 2 hashes from \\"git hash-object\\" but received 3"`;


### PR DESCRIPTION
## Summary
Fixes #3913 .

## Details
Fixed a bug in `parseGitHashObject` in which it would return a bogus entry `[undefined, '']` if no file paths were requested to be hashed.

## How it was tested
Added unit tests specific to `parseGitHashObject`.

## Impacted documentation
None