### PR TITLE
[rush] Fix an issue where 'rush add' does not update the approved packages files.

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-add_2023-01-25-06-56.json
+++ b/common/changes/@microsoft/rush/fix-rush-add_2023-01-25-06-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with `rush add` where the approved packages files aren't updated.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.89.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -656,6 +656,7 @@ export class PackageJsonDependency {
 
 // @public (undocumented)
 export class PackageJsonEditor {
+    protected constructor(filepath: string, data: IPackageJson);
     // (undocumented)
     addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;
     get dependencyList(): ReadonlyArray<PackageJsonDependency>;
@@ -881,7 +882,7 @@ export class RushConfigurationProject {
     get isMainProject(): boolean;
     // @deprecated
     get localDependencyProjects(): ReadonlyArray<RushConfigurationProject>;
-    readonly packageJson: IPackageJson;
+    get packageJson(): IPackageJson;
     // @beta
     readonly packageJsonEditor: PackageJsonEditor;
     readonly packageName: string;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -656,6 +656,7 @@ export class PackageJsonDependency {
 
 // @public (undocumented)
 export class PackageJsonEditor {
+    // @internal
     protected constructor(filepath: string, data: IPackageJson);
     // (undocumented)
     addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -66,6 +66,9 @@ export class PackageJsonEditor {
 
   public readonly filePath: string;
 
+  /**
+   * @internal
+   */
   protected constructor(filepath: string, data: IPackageJson) {
     this.filePath = filepath;
     this._sourceData = data;

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -66,7 +66,7 @@ export class PackageJsonEditor {
 
   public readonly filePath: string;
 
-  private constructor(filepath: string, data: IPackageJson) {
+  protected constructor(filepath: string, data: IPackageJson) {
     this.filePath = filepath;
     this._sourceData = data;
     this._modified = false;

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -7,10 +7,11 @@ import { JsonFile, IPackageJson, FileSystem, FileConstants, JsonSyntax } from '@
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { VersionPolicy, LockStepVersionPolicy } from './VersionPolicy';
-import { PackageJsonEditor } from './PackageJsonEditor';
+import type { PackageJsonEditor } from './PackageJsonEditor';
 import { RushConstants } from '../logic/RushConstants';
 import { PackageNameParsers } from './PackageNameParsers';
 import { DependencySpecifier, DependencySpecifierType } from '../logic/DependencySpecifier';
+import { SaveCallbackPackageJsonEditor } from './SaveCallbackPackageJsonEditor';
 
 /**
  * This represents the JSON data object for a project entry in the rush.json configuration file.
@@ -61,6 +62,7 @@ export class RushConfigurationProject {
   private _versionPolicy: VersionPolicy | undefined = undefined;
   private _dependencyProjects: Set<RushConfigurationProject> | undefined = undefined;
   private _consumingProjects: Set<RushConfigurationProject> | undefined = undefined;
+  private _packageJson: IPackageJson;
 
   /**
    * The name of the NPM package.  An error is reported if this name is not
@@ -121,7 +123,9 @@ export class RushConfigurationProject {
   /**
    * The parsed NPM "package.json" file from projectFolder.
    */
-  public readonly packageJson: IPackageJson;
+  public get packageJson(): IPackageJson {
+    return this._packageJson;
+  }
 
   /**
    * A useful wrapper around the package.json file for making modifications
@@ -208,7 +212,7 @@ export class RushConfigurationProject {
     const packageJsonFilename: string = path.join(this.projectFolder, FileConstants.PackageJson);
 
     try {
-      this.packageJson = JsonFile.load(packageJsonFilename, { jsonSyntax: JsonSyntax.Strict });
+      this._packageJson = JsonFile.load(packageJsonFilename, { jsonSyntax: JsonSyntax.Strict });
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(
@@ -258,7 +262,15 @@ export class RushConfigurationProject {
       );
     }
 
-    this.packageJsonEditor = PackageJsonEditor.fromObject(this.packageJson, packageJsonFilename);
+    this.packageJsonEditor = SaveCallbackPackageJsonEditor.fromObjectWithCallback({
+      object: this.packageJson,
+      filename: packageJsonFilename,
+      onSaved: (newObject) => {
+        // Just update the in-memory copy, don't bother doing the validation again
+        this._packageJson = newObject;
+        this._dependencyProjects = undefined; // Reset the cached dependency projects
+      }
+    });
 
     this.tempProjectName = tempProjectName;
 

--- a/libraries/rush-lib/src/api/SaveCallbackPackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/SaveCallbackPackageJsonEditor.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { IPackageJson } from '@rushstack/node-core-library';
+import { PackageJsonEditor } from './PackageJsonEditor';
+
+export interface IFromObjectOptions {
+  object: IPackageJson;
+  filename: string;
+  onSaved?: (newObject: IPackageJson) => void;
+}
+
+export class SaveCallbackPackageJsonEditor extends PackageJsonEditor {
+  private readonly _onSaved: ((newObject: IPackageJson) => void) | undefined;
+
+  private constructor(options: IFromObjectOptions) {
+    super(options.filename, options.object);
+
+    this._onSaved = options.onSaved;
+  }
+
+  public static fromObjectWithCallback(options: IFromObjectOptions): SaveCallbackPackageJsonEditor {
+    return new SaveCallbackPackageJsonEditor(options);
+  }
+
+  public saveIfModified(): boolean {
+    const modified: boolean = super.saveIfModified();
+    if (this._onSaved) {
+      this._onSaved(this.saveToObject());
+    }
+
+    return modified;
+  }
+}

--- a/libraries/rush-lib/src/api/test/__snapshots__/RushConfiguration.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/RushConfiguration.test.ts.snap
@@ -1,3 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RushConfiguration RushConfigurationProject correctly updates the packageJson property after the packageJson is edited by packageJsonEditor: dependencyProjects after 1`] = `
+Array [
+  "project2",
+]
+`;
+
+exports[`RushConfiguration RushConfigurationProject correctly updates the packageJson property after the packageJson is edited by packageJsonEditor: dependencyProjects before 1`] = `Array []`;
+
+exports[`RushConfiguration RushConfigurationProject correctly updates the packageJson property after the packageJson is edited by packageJsonEditor: devDependencies after 1`] = `
+Object {
+  "project2": "1.0.0",
+}
+`;
+
+exports[`RushConfiguration RushConfigurationProject correctly updates the packageJson property after the packageJson is edited by packageJsonEditor: devDependencies before 1`] = `undefined`;
+
 exports[`RushConfiguration fails to load repo/rush-repository-url-urls.json 1`] = `"The 'repository.url' field cannot be used when 'repository.urls' is present"`;


### PR DESCRIPTION
## Summary

Right now, if you run `rush add -p <some package that's new to the repo>`, the [`non`]`browser-approved-packages.json` file isn't updated.

## Details

This happens because after the `packageJsonEditor` saves the file, it doesn't update the `packageJson` `RushConfigurationProject` property with the new `package.json` contents. This PR fixes that.

## How it was tested

Added a unit test, and ran `rush add -p @radix-ui/react-dialog` in a repo that isn't already using `@radix-ui/react-dialog`.