### PR TITLE
[rush] Revert creation of custom git hooks

### DIFF
--- a/common/changes/@microsoft/rush/user-danade-RevertGitHooksCHange_2023-01-26-00-13.json
+++ b/common/changes/@microsoft/rush/user-danade-RevertGitHooksCHange_2023-01-26-00-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Revert generation of scripts in the Git hooks folder due to various git-related issues",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

This reverts changes brought in by https://github.com/microsoft/rushstack/pull/3873

## Details

Reverts the change due to a few issues encountered when attempting to integrate into our own repository:
- Linux-based issues caused by not `chmod -x`-ing the scripts commited to the common/git-hooks, causing permissions errors when running hooks on Linux-based devices
- Issues with compatibility with `git lfs`, causing the error `This should be run through Git's pre-push hook.  Run 'git lfs update' to install it.` even when running through the pre-push hook

It just seems like this change requires a bit more time to bake/test, so for now, going to revert.

CC @stekycz 