### PR TITLE
[module-minifier] Include terser version in config hash

### DIFF
--- a/common/changes/@rushstack/module-minifier/terser-version-hash_2023-01-24-19-28.json
+++ b/common/changes/@rushstack/module-minifier/terser-version-hash_2023-01-24-19-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Include terser package version in config hash.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/module-minifier/terser-version-hash_2023-01-24-19-28.json
+++ b/common/changes/@rushstack/module-minifier/terser-version-hash_2023-01-24-19-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/module-minifier",
-      "comment": "Include terser package version in config hash.",
+      "comment": "Ensure updates to the version of Terser trigger a hash change.",
       "type": "patch"
     }
   ],

--- a/libraries/module-minifier/src/LocalMinifier.ts
+++ b/libraries/module-minifier/src/LocalMinifier.ts
@@ -44,8 +44,11 @@ export class LocalMinifier implements IModuleMinifier {
         : {}
     };
 
+    const { version: terserVersion } = require('terser/package.json');
+
     this._configHash = createHash('sha256')
       .update(LocalMinifier.name, 'utf8')
+      .update(`terser@${terserVersion}`)
       .update(serialize(terserOptions))
       .digest('base64');
 

--- a/libraries/module-minifier/src/WorkerPoolMinifier.ts
+++ b/libraries/module-minifier/src/WorkerPoolMinifier.ts
@@ -66,8 +66,11 @@ export class WorkerPoolMinifier implements IModuleMinifier {
       workerScriptPath: require.resolve('./MinifierWorker')
     });
 
+    const { version: terserVersion } = require('terser/package.json');
+
     this._configHash = createHash('sha256')
       .update(WorkerPoolMinifier.name, 'utf8')
+      .update(`terser@${terserVersion}`)
       .update(serialize(terserOptions))
       .digest('base64');
 

--- a/libraries/module-minifier/src/test/LocalMinifier.test.ts
+++ b/libraries/module-minifier/src/test/LocalMinifier.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IMinifierConnection } from '../types';
+
+let terserVersion: string = '1.0.0';
+jest.mock('terser/package.json', () => {
+  return {
+    get version(): string {
+      return terserVersion;
+    }
+  };
+});
+
+describe('LocalMinifier', () => {
+  it('Includes terserOptions in config hash', async () => {
+    const { LocalMinifier } = await import('../LocalMinifier');
+    type LocalMinifier = typeof LocalMinifier.prototype;
+
+    const minifier1: LocalMinifier = new LocalMinifier({
+      terserOptions: {
+        ecma: 5
+      }
+    });
+    const minifier2: LocalMinifier = new LocalMinifier({
+      terserOptions: {
+        ecma: 2015
+      }
+    });
+
+    const connection1: IMinifierConnection = await minifier1.connect();
+    await connection1.disconnect();
+    const connection2: IMinifierConnection = await minifier2.connect();
+    await connection2.disconnect();
+
+    expect(connection1.configHash).toMatchSnapshot('ecma5');
+    expect(connection2.configHash).toMatchSnapshot('ecma2015');
+    expect(connection1.configHash !== connection2.configHash);
+  });
+
+  it('Includes terser package version in config hash', async () => {
+    const { LocalMinifier } = await import('../LocalMinifier');
+    type LocalMinifier = typeof LocalMinifier.prototype;
+
+    terserVersion = '5.9.1';
+    const minifier1: LocalMinifier = new LocalMinifier({});
+    terserVersion = '5.16.2';
+    const minifier2: LocalMinifier = new LocalMinifier({});
+
+    const connection1: IMinifierConnection = await minifier1.connect();
+    await connection1.disconnect();
+    const connection2: IMinifierConnection = await minifier2.connect();
+    await connection2.disconnect();
+
+    expect(connection1.configHash).toMatchSnapshot('terser-5.9.1');
+    expect(connection2.configHash).toMatchSnapshot('terser-5.16.1');
+    expect(connection1.configHash !== connection2.configHash);
+  });
+});

--- a/libraries/module-minifier/src/test/WorkerPoolMinifier.test.ts
+++ b/libraries/module-minifier/src/test/WorkerPoolMinifier.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IMinifierConnection } from '../types';
+
+let terserVersion: string = '1.0.0';
+jest.mock('terser/package.json', () => {
+  return {
+    get version(): string {
+      return terserVersion;
+    }
+  };
+});
+
+describe('WorkerPoolMinifier', () => {
+  it('Includes terserOptions in config hash', async () => {
+    const { WorkerPoolMinifier } = await import('../WorkerPoolMinifier');
+    type WorkerPoolMinifier = typeof WorkerPoolMinifier.prototype;
+
+    const minifier1: WorkerPoolMinifier = new WorkerPoolMinifier({
+      terserOptions: {
+        ecma: 5
+      }
+    });
+    const minifier2: WorkerPoolMinifier = new WorkerPoolMinifier({
+      terserOptions: {
+        ecma: 2015
+      }
+    });
+
+    const connection1: IMinifierConnection = await minifier1.connect();
+    await connection1.disconnect();
+    const connection2: IMinifierConnection = await minifier2.connect();
+    await connection2.disconnect();
+
+    expect(connection1.configHash).toMatchSnapshot('ecma5');
+    expect(connection2.configHash).toMatchSnapshot('ecma2015');
+    expect(connection1.configHash !== connection2.configHash);
+  });
+
+  it('Includes terser package version in config hash', async () => {
+    const { WorkerPoolMinifier } = await import('../WorkerPoolMinifier');
+    type WorkerPoolMinifier = typeof WorkerPoolMinifier.prototype;
+
+    terserVersion = '5.9.1';
+    const minifier1: WorkerPoolMinifier = new WorkerPoolMinifier({});
+    terserVersion = '5.16.2';
+    const minifier2: WorkerPoolMinifier = new WorkerPoolMinifier({});
+
+    const connection1: IMinifierConnection = await minifier1.connect();
+    await connection1.disconnect();
+    const connection2: IMinifierConnection = await minifier2.connect();
+    await connection2.disconnect();
+
+    expect(connection1.configHash).toMatchSnapshot('terser-5.9.1');
+    expect(connection2.configHash).toMatchSnapshot('terser-5.16.1');
+    expect(connection1.configHash !== connection2.configHash);
+  });
+});

--- a/libraries/module-minifier/src/test/__snapshots__/LocalMinifier.test.ts.snap
+++ b/libraries/module-minifier/src/test/__snapshots__/LocalMinifier.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocalMinifier Includes terser package version in config hash: terser-5.9.1 1`] = `"4EVkVBAkdvF45JdRt44fWqn3HDW5t4dHo0zmzpQrWtc="`;
+
+exports[`LocalMinifier Includes terser package version in config hash: terser-5.16.1 1`] = `"3tk4bireIeb1adtnntg0kD4LU91VU+hweuk5GEkvX9A="`;
+
+exports[`LocalMinifier Includes terserOptions in config hash: ecma5 1`] = `"xpQ+VFd1iTb0qFjWnrRxNm25O1Z77Oy9Ppi+VG9SFEQ="`;
+
+exports[`LocalMinifier Includes terserOptions in config hash: ecma2015 1`] = `"IvCYjNIccj8xYkftaoV19M8WU5Vzy+06PL6gzGVUYxI="`;

--- a/libraries/module-minifier/src/test/__snapshots__/WorkerPoolMinifier.test.ts.snap
+++ b/libraries/module-minifier/src/test/__snapshots__/WorkerPoolMinifier.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkerPoolMinifier Includes terser package version in config hash: terser-5.9.1 1`] = `"0cjBnphY49XdxkmLxJLfNoRQbl3R6HdeT8WNl56oZWk="`;
+
+exports[`WorkerPoolMinifier Includes terser package version in config hash: terser-5.16.1 1`] = `"dYinCy9XUHWWDXSIwq7F/GvAYLxxv3WjZdHIpd2sZpc="`;
+
+exports[`WorkerPoolMinifier Includes terserOptions in config hash: ecma5 1`] = `"FcgklO/zYzwo0R2IM6OKH5uLA0hXVekjeqmFqKweKCg="`;
+
+exports[`WorkerPoolMinifier Includes terserOptions in config hash: ecma2015 1`] = `"Vku2B3kuB95N1Xo2q8J/nAJrmxwXV+fQmmUwp4xj+Xk="`;


### PR DESCRIPTION
## Summary
Includes the version string from the installed version of `terser` in the config hash for `@rushstack/module-minifier` for the minifier implementations that use `terser`.

## Details
Added to both `LocalMinifier` and `WorkerPoolMinifier`.

## How it was tested
Added unit tests for the config hash strings.