### PR TITLE
[api-documenter] Emit bold/italic using Markdown instead of HTML elements

### DIFF
--- a/apps/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -250,19 +250,19 @@ export class MarkdownEmitter {
       }
 
       if (context.boldRequested) {
-        writer.write('<b>');
+        writer.write('**');
       }
       if (context.italicRequested) {
-        writer.write('<i>');
+        writer.write('_');
       }
 
       writer.write(this.getEscapedText(middle));
 
       if (context.italicRequested) {
-        writer.write('</i>');
+        writer.write('_');
       }
       if (context.boldRequested) {
-        writer.write('</b>');
+        writer.write('**');
       }
     }
 

--- a/apps/api-documenter/src/markdown/test/CustomMarkdownEmitter.test.ts
+++ b/apps/api-documenter/src/markdown/test/CustomMarkdownEmitter.test.ts
@@ -159,7 +159,12 @@ test('render Markdown from TSDoc', () => {
             new DocParagraph({ configuration }, [new DocPlainText({ configuration, text: 'Cell 1' })])
           ]),
           new DocTableCell({ configuration }, [
-            new DocParagraph({ configuration }, [new DocPlainText({ configuration, text: 'Cell 2' })])
+            new DocParagraph({ configuration }, [new DocPlainText({ configuration, text: 'Cell 2' })]),
+            new DocParagraph({ configuration }, [
+              new DocEmphasisSpan({ configuration, bold: true }, [
+                new DocPlainText({ configuration, text: 'bold text' })
+              ])
+            ])
           ])
         ])
       ]
@@ -176,5 +181,6 @@ test('render Markdown from TSDoc', () => {
     }
   });
 
-  expect(stringBuilder).toMatchSnapshot();
+  expect(stringBuilder.toString()).toMatchSnapshot();
+  console.log(stringBuilder.toString());
 });

--- a/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
+++ b/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
@@ -1,12 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render Markdown from TSDoc 1`] = `
-StringBuilder {
-  "_chunks": Array [
-    "
+"
 ## Simple bold test
 
-This is a <b>bold</b> word.
+This is a **bold** word.
 
 ## All whitespace bold
 
@@ -14,27 +12,27 @@ This is a <b>bold</b> word.
 
 ## Newline bold
 
-<b>line 1</b> <b>line 2</b>
+**line 1** **line 2**
 
 ## Newline bold with spaces
 
-  <b>line 1</b>    <b>line 2</b>    <b>line 3</b>  
+  **line 1**    **line 2**    **line 3**  
 
 ## Adjacent bold regions
 
-<b>one</b><b>two</b> <b>three</b> <b>four</b>non-bold<!-- --><b>five</b>
+**one**<!-- -->**two** **three** **four**<!-- -->non-bold<!-- -->**five**
 
 ## Adjacent to other characters
 
-[a link](./index.md)<!-- --><b>bold</b>non-boldmore-non-bold
+[a link](./index.md)<!-- -->**bold**<!-- -->non-boldmore-non-bold
 
 ## Unknown block tag
 
-<b>bold</b>non-boldmore-non-bold
+**bold**<!-- -->non-boldmore-non-bold
 
 ## Bad characters
 
-<b>\\\\*one\\\\*two\\\\*</b><b>three\\\\*four</b>
+**\\\\*one\\\\*two\\\\***<!-- -->**three\\\\*four**
 
 ## Characters that should be escaped
 
@@ -54,9 +52,7 @@ HTML escape: &amp;quot;
 
 |  Header 1 | Header 2 |
 |  --- | --- |
-|  Cell 1 | Cell 2 |
+|  Cell 1 | <p>Cell 2</p><p>**bold text**</p> |
 
-",
-  ],
-}
+"
 `;

--- a/apps/api-extractor/build-tests.cmd
+++ b/apps/api-extractor/build-tests.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 @SETLOCAL
-rush build -t api-extractor-lib1-test -t api-extractor-lib2-test -t api-extractor-lib3-test -t api-extractor-scenarios -t api-extractor-test-01 -t api-extractor-test-02 -t api-extractor-test-03 -t api-extractor-test-04 -t api-documenter-test
+rush test -t api-extractor-lib1-test -t api-extractor-lib2-test -t api-extractor-lib3-test -t api-extractor-scenarios -t api-extractor-test-01 -t api-extractor-test-02 -t api-extractor-test-03 -t api-extractor-test-04 -t api-documenter-test

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.fourthprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.fourthprop.md
@@ -6,7 +6,7 @@
 
 A fourth prop
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 fourthProp: number;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.md
@@ -5,12 +5,12 @@
 ## Class1 class
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class Class1 extends Class2<number> 
 ```
-<b>Extends:</b> [Class2](./api-documenter-scenarios.class2.md)<!-- -->&lt;number&gt;
+**Extends:** [Class2](./api-documenter-scenarios.class2.md)<!-- -->&lt;number&gt;
 
 ## Properties
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.secondprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.secondprop.md
@@ -6,7 +6,7 @@
 
 A second prop. Overrides `Class2.secondProp`<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 secondProp: boolean;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.someoverload.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class1.someoverload.md
@@ -6,7 +6,7 @@
 
 Some overload. Overrides `Class3.someOverload`<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someOverload(x: boolean | string): void;
@@ -18,7 +18,7 @@ someOverload(x: boolean | string): void;
 |  --- | --- | --- |
 |  x | boolean \| string |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.md
@@ -5,12 +5,12 @@
 ## Class2 class
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class Class2<T> extends Namespace1.Class3 
 ```
-<b>Extends:</b> [Namespace1.Class3](./api-documenter-scenarios.namespace1.class3.md)
+**Extends:** [Namespace1.Class3](./api-documenter-scenarios.namespace1.class3.md)
 
 ## Properties
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.secondprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.secondprop.md
@@ -6,7 +6,7 @@
 
 A second prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 secondProp: boolean | string;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.somemethod.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.somemethod.md
@@ -6,7 +6,7 @@
 
 Some method. Overrides `Class3.someMethod`<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someMethod(x: boolean): void;
@@ -18,7 +18,7 @@ someMethod(x: boolean): void;
 |  --- | --- | --- |
 |  x | boolean |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.thirdprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.class2.thirdprop.md
@@ -6,7 +6,7 @@
 
 A third prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 thirdProp: T;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.classlikevariable.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.classlikevariable.md
@@ -6,7 +6,7 @@
 
 Some class-like variable.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 ClassLikeVariable: {

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsanonymousclass.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsanonymousclass.md
@@ -6,12 +6,12 @@
 
 Some class that extends an anonymous class.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class ExtendsAnonymousClass extends ExtendsAnonymousClass_base 
 ```
-<b>Extends:</b> ExtendsAnonymousClass\_base
+**Extends:** ExtendsAnonymousClass\_base
 
-<i>(Some inherited members may not be shown because they are not represented in the documentation.)</i>
+_(Some inherited members may not be shown because they are not represented in the documentation.)_
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsclassfromanotherpackage.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsclassfromanotherpackage.md
@@ -6,12 +6,12 @@
 
 Some class that extends a class from another package. This base class is not in any API doc model.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class ExtendsClassFromAnotherPackage extends Extractor 
 ```
-<b>Extends:</b> Extractor
+**Extends:** Extractor
 
-<i>(Some inherited members may not be shown because they are not represented in the documentation.)</i>
+_(Some inherited members may not be shown because they are not represented in the documentation.)_
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsclasslikevariable.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsclasslikevariable.md
@@ -6,12 +6,12 @@
 
 Some class that extends a class-like variable.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class ExtendsClassLikeVariable extends ClassLikeVariable 
 ```
-<b>Extends:</b> ClassLikeVariable
+**Extends:** ClassLikeVariable
 
-<i>(Some inherited members may not be shown because they are not represented in the documentation.)</i>
+_(Some inherited members may not be shown because they are not represented in the documentation.)_
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsunexportedclass.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.extendsunexportedclass.md
@@ -6,12 +6,12 @@
 
 Some class that extends an unexported class.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class ExtendsUnexportedClass extends UnexportedClass 
 ```
-<b>Extends:</b> UnexportedClass
+**Extends:** UnexportedClass
 
-<i>(Some inherited members may not be shown because they are not represented in the documentation.)</i>
+_(Some inherited members may not be shown because they are not represented in the documentation.)_
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsinterfaceliketypealias.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsinterfaceliketypealias.md
@@ -6,14 +6,14 @@
 
 Some interface that extends an interface-like type alias as well as another interface.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IExtendsInterfaceLikeTypeAlias extends IInterfaceLikeTypeAlias, IInterface1 
 ```
-<b>Extends:</b> [IInterfaceLikeTypeAlias](./api-documenter-scenarios.iinterfaceliketypealias.md)<!-- -->, [IInterface1](./api-documenter-scenarios.iinterface1.md)
+**Extends:** [IInterfaceLikeTypeAlias](./api-documenter-scenarios.iinterfaceliketypealias.md)<!-- -->, [IInterface1](./api-documenter-scenarios.iinterface1.md)
 
-<i>(Some inherited members may not be shown because they are not represented in the documentation.)</i>
+_(Some inherited members may not be shown because they are not represented in the documentation.)_
 
 ## Properties
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.md
@@ -6,12 +6,12 @@
 
 Some interface that extends multiple interfaces.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IExtendsMultipleInterfaces extends IInterface1, IInterface2 
 ```
-<b>Extends:</b> [IInterface1](./api-documenter-scenarios.iinterface1.md)<!-- -->, [IInterface2](./api-documenter-scenarios.iinterface2.md)
+**Extends:** [IInterface1](./api-documenter-scenarios.iinterface1.md)<!-- -->, [IInterface2](./api-documenter-scenarios.iinterface2.md)
 
 ## Properties
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.secondprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.secondprop.md
@@ -6,7 +6,7 @@
 
 A second prop. Overrides `IInterface1.someProp`<!-- -->.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 secondProp: boolean;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.thirdprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iextendsmultipleinterfaces.thirdprop.md
@@ -6,7 +6,7 @@
 
 A third prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 thirdProp: string;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.md
@@ -5,7 +5,7 @@
 ## IInterface1 interface
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IInterface1 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.secondprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.secondprop.md
@@ -6,7 +6,7 @@
 
 A second prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 secondProp: boolean | string;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.someprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface1.someprop.md
@@ -6,7 +6,7 @@
 
 Some prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someProp: number;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface2.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface2.md
@@ -5,7 +5,7 @@
 ## IInterface2 interface
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IInterface2 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface2.someprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterface2.someprop.md
@@ -6,7 +6,7 @@
 
 Some prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someProp: number;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterfaceliketypealias.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.iinterfaceliketypealias.md
@@ -6,7 +6,7 @@
 
 Some interface-like type alias.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type IInterfaceLikeTypeAlias = {

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.md
@@ -5,7 +5,7 @@
 ## Namespace1.Class3 class
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 class Class3 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.somemethod.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.somemethod.md
@@ -6,7 +6,7 @@
 
 Some method.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someMethod(x: boolean | string): void;
@@ -18,7 +18,7 @@ someMethod(x: boolean | string): void;
 |  --- | --- | --- |
 |  x | boolean \| string |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someoverload.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someoverload.md
@@ -6,7 +6,7 @@
 
 Some overload.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someOverload(x: boolean): void;
@@ -18,7 +18,7 @@ someOverload(x: boolean): void;
 |  --- | --- | --- |
 |  x | boolean |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someoverload_1.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someoverload_1.md
@@ -6,7 +6,7 @@
 
 Some overload.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someOverload(x: string): void;
@@ -18,7 +18,7 @@ someOverload(x: string): void;
 |  --- | --- | --- |
 |  x | string |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someprop.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.class3.someprop.md
@@ -6,7 +6,7 @@
 
 Some prop.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 someProp: number;

--- a/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.md
+++ b/build-tests/api-documenter-scenarios/etc/inheritedMembers/markdown/api-documenter-scenarios.namespace1.md
@@ -5,7 +5,7 @@
 ## Namespace1 namespace
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare namespace Namespace1 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.md
@@ -6,7 +6,7 @@
 
 Some abstract class with abstract members.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare abstract class AbstractClass 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.method.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.method.md
@@ -6,12 +6,12 @@
 
 Some abstract method.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 abstract method(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.property.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.abstractclass.property.md
@@ -6,7 +6,7 @@
 
 Some abstract property.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 protected abstract property: number;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.constraint.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.constraint.md
@@ -6,7 +6,7 @@
 
 Type parameter constraint used by test case below.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface Constraint 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.constvariable.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.constvariable.md
@@ -6,7 +6,7 @@
 
 An exported variable declaration.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 constVariable: number

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.decoratorexample.creationdate.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.decoratorexample.creationdate.md
@@ -6,12 +6,12 @@
 
 The date when the record was created.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 creationDate: Date;
 ```
-<b>Decorators:</b>
+**Decorators:**
 
 `@jsonSerialized`
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.decoratorexample.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.decoratorexample.md
@@ -5,7 +5,7 @@
 ## DecoratorExample class
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class DecoratorExample 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.defaulttype.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.defaulttype.md
@@ -6,7 +6,7 @@
 
 Type parameter default type used by test case below.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface DefaultType 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass._constructor_.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass._constructor_.md
@@ -6,7 +6,7 @@
 
 The simple constructor for `DocBaseClass`
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 constructor();

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass._constructor__1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass._constructor__1.md
@@ -6,7 +6,7 @@
 
 The overloaded constructor for `DocBaseClass`
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 constructor(x: number);

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docbaseclass.md
@@ -7,7 +7,7 @@
 Example base class
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class DocBaseClass 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.deprecatedexample.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.deprecatedexample.md
@@ -9,12 +9,12 @@
 > Use `otherThing()` instead.
 > 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 deprecatedExample(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction.md
@@ -6,7 +6,7 @@
 
 This is an overloaded function.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 exampleFunction(a: string, b: string): string;
@@ -19,7 +19,7 @@ exampleFunction(a: string, b: string): string;
 |  a | string | the first string |
 |  b | string | the second string |
 
-<b>Returns:</b>
+**Returns:**
 
 string
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction_1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.examplefunction_1.md
@@ -6,7 +6,7 @@
 
 This is also an overloaded function.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 exampleFunction(x: number): number;
@@ -18,7 +18,7 @@ exampleFunction(x: number): number;
 |  --- | --- | --- |
 |  x | number | the number |
 
-<b>Returns:</b>
+**Returns:**
 
 number
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.genericwithconstraintanddefault.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.genericwithconstraintanddefault.md
@@ -6,7 +6,7 @@
 
 This is a method with a complex type parameter.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 genericWithConstraintAndDefault<T extends Constraint = DefaultType>(x: T): void;
@@ -18,7 +18,7 @@ genericWithConstraintAndDefault<T extends Constraint = DefaultType>(x: T): void;
 |  --- | --- | --- |
 |  x | T | some generic parameter. |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.interestingedgecases.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.interestingedgecases.md
@@ -8,12 +8,12 @@ Example: "<!-- -->{ \\<!-- -->"maxItemsToShow<!-- -->\\<!-- -->": 123 }<!-- -->"
 
 The regular expression used to validate the constraints is /^\[a-zA-Z0-9<!-- -->\\<!-- -->-\_\]+$/
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 interestingEdgeCases(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.malformedevent.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.malformedevent.md
@@ -6,7 +6,7 @@
 
 This event should have been marked as readonly.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 malformedEvent: SystemEvent;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.md
@@ -6,14 +6,14 @@
 
 This is an example class.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 
 ```
-<b>Extends:</b> [DocBaseClass](./api-documenter-test.docbaseclass.md)
+**Extends:** [DocBaseClass](./api-documenter-test.docbaseclass.md)
 
-<b>Implements:</b> [IDocInterface1](./api-documenter-test.idocinterface1.md)<!-- -->, [IDocInterface2](./api-documenter-test.idocinterface2.md)
+**Implements:** [IDocInterface1](./api-documenter-test.idocinterface1.md)<!-- -->, [IDocInterface2](./api-documenter-test.idocinterface2.md)
 
 ## Remarks
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.modifiedevent.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.modifiedevent.md
@@ -6,7 +6,7 @@
 
 This event is fired whenever the object is modified.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly modifiedEvent: SystemEvent;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.multiplemodifiersproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.multiplemodifiersproperty.md
@@ -6,7 +6,7 @@
 
 Some property with multiple modifiers.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 protected static readonly multipleModifiersProperty: boolean;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.optionalparamfunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.optionalparamfunction.md
@@ -6,7 +6,7 @@
 
 This is a function with an optional parameter.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 optionalParamFunction(x?: number): void;
@@ -16,9 +16,9 @@ optionalParamFunction(x?: number): void;
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  x | number | <i>(Optional)</i> the number |
+|  x | number | _(Optional)_ the number |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.protectedproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.protectedproperty.md
@@ -6,7 +6,7 @@
 
 Some protected property.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 protected protectedProperty: string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.readonlyproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.readonlyproperty.md
@@ -4,7 +4,7 @@
 
 ## DocClass1.readonlyProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 get readonlyProperty(): string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.regularproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.regularproperty.md
@@ -6,7 +6,7 @@
 
 This is a regular property that happens to use the SystemEvent type.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 regularProperty: SystemEvent;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.sumwithexample.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.sumwithexample.md
@@ -6,7 +6,7 @@
 
 Returns the sum of two numbers.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 static sumWithExample(x: number, y: number): number;
@@ -19,7 +19,7 @@ static sumWithExample(x: number, y: number): number;
 |  x | number | the first number to add |
 |  y | number | the second number to add |
 
-<b>Returns:</b>
+**Returns:**
 
 number
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.tableexample.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.tableexample.md
@@ -6,12 +6,12 @@
 
 An example with tables:
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 tableExample(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.writeableproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.writeableproperty.md
@@ -4,7 +4,7 @@
 
 ## DocClass1.writeableProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 get writeableProperty(): string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.writeonlyproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclass1.writeonlyproperty.md
@@ -6,7 +6,7 @@
 
 API Extractor will surface an `ae-missing-getter` finding for this property.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 set writeonlyProperty(value: string);

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclassinterfacemerge.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docclassinterfacemerge.md
@@ -6,7 +6,7 @@
 
 Interface that merges with class
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface DocClassInterfaceMerge 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenum.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenum.md
@@ -7,7 +7,7 @@
 Docs for DocEnum
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare enum DocEnum 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenumnamespacemerge.examplefunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenumnamespacemerge.examplefunction.md
@@ -6,12 +6,12 @@
 
 This is a function inside of a namespace that merges with an enum.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 function exampleFunction(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenumnamespacemerge.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.docenumnamespacemerge.md
@@ -6,7 +6,7 @@
 
 Namespace that merges with enum
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare namespace DocEnumNamespaceMerge 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.ecmasmbols.example.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.ecmasmbols.example.md
@@ -6,7 +6,7 @@
 
 An ECMAScript symbol
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 example: unique symbol

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.ecmasmbols.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.ecmasmbols.md
@@ -6,7 +6,7 @@
 
 A namespace containing an ECMAScript symbol
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare namespace EcmaSmbols 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampleduplicatetypealias.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampleduplicatetypealias.md
@@ -6,10 +6,10 @@
 
 A type alias that has duplicate references.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type ExampleDuplicateTypeAlias = SystemEvent | typeof SystemEvent;
 ```
-<b>References:</b> [SystemEvent](./api-documenter-test.systemevent.md)
+**References:** [SystemEvent](./api-documenter-test.systemevent.md)
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.examplefunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.examplefunction.md
@@ -6,7 +6,7 @@
 
 An exported function with hyperlinked parameters and return value.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare function exampleFunction(x: ExampleTypeAlias, y: number): IDocInterface1;
@@ -19,7 +19,7 @@ export declare function exampleFunction(x: ExampleTypeAlias, y: number): IDocInt
 |  x | [ExampleTypeAlias](./api-documenter-test.exampletypealias.md) | an API item that should get hyperlinked |
 |  y | number | a system type that should NOT get hyperlinked |
 
-<b>Returns:</b>
+**Returns:**
 
 [IDocInterface1](./api-documenter-test.idocinterface1.md)
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampletypealias.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampletypealias.md
@@ -6,7 +6,7 @@
 
 A type alias
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type ExampleTypeAlias = Promise<boolean>;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampleuniontypealias.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.exampleuniontypealias.md
@@ -6,10 +6,10 @@
 
 A type alias that references multiple other types.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type ExampleUnionTypeAlias = IDocInterface1 | IDocInterface3;
 ```
-<b>References:</b> [IDocInterface1](./api-documenter-test.idocinterface1.md)<!-- -->, [IDocInterface3](./api-documenter-test.idocinterface3.md)
+**References:** [IDocInterface1](./api-documenter-test.idocinterface1.md)<!-- -->, [IDocInterface3](./api-documenter-test.idocinterface3.md)
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.generic.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.generic.md
@@ -6,7 +6,7 @@
 
 Generic class.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class Generic<T> 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.generictypealias.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.generictypealias.md
@@ -5,7 +5,7 @@
 ## GenericTypeAlias type
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type GenericTypeAlias<T> = T[];

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface1.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface1.md
@@ -5,7 +5,7 @@
 ## IDocInterface1 interface
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface1 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface1.regularproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface1.regularproperty.md
@@ -6,7 +6,7 @@
 
 Does something
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 regularProperty: SystemEvent;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.deprecatedexample.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.deprecatedexample.md
@@ -9,12 +9,12 @@
 > Use `otherThing()` instead.
 > 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 deprecatedExample(): void;
 ```
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface2.md
@@ -5,12 +5,12 @@
 ## IDocInterface2 interface
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface2 extends IDocInterface1 
 ```
-<b>Extends:</b> [IDocInterface1](./api-documenter-test.idocinterface1.md)
+**Extends:** [IDocInterface1](./api-documenter-test.idocinterface1.md)
 
 ## Methods
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.__not.a.symbol__.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.__not.a.symbol__.md
@@ -6,7 +6,7 @@
 
 An identifier that does need quotes. It misleadingly looks like an ECMAScript symbol.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 "[not.a.symbol]": string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3._ecmasmbols.example_.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3._ecmasmbols.example_.md
@@ -6,7 +6,7 @@
 
 ECMAScript symbol
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 [EcmaSmbols.example]: string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3._new_.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3._new_.md
@@ -6,12 +6,12 @@
 
 Construct signature
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 new (): IDocInterface1;
 ```
-<b>Returns:</b>
+**Returns:**
 
 [IDocInterface1](./api-documenter-test.idocinterface1.md)
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.md
@@ -7,7 +7,7 @@
 Some less common TypeScript declaration kinds.
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface3 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.redundantquotes.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface3.redundantquotes.md
@@ -6,7 +6,7 @@
 
 A quoted identifier with redundant quotes.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 "redundantQuotes": string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.context.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.context.md
@@ -6,7 +6,7 @@
 
 Test newline rendering when code blocks are used in tables
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 Context: ({ children }: {

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.generic.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.generic.md
@@ -6,7 +6,7 @@
 
 make sure html entities are escaped in tables.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 generic: Generic<number>;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.md
@@ -7,7 +7,7 @@
 Type union in an interface.
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface4 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.numberorfunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.numberorfunction.md
@@ -6,7 +6,7 @@
 
 a union type with a function
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 numberOrFunction: number | (() => number);

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.stringornumber.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface4.stringornumber.md
@@ -6,7 +6,7 @@
 
 a union type
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 stringOrNumber: string | number;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface5.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface5.md
@@ -6,7 +6,7 @@
 
 Interface without inline tag to test custom TOC
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface5 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface5.regularproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface5.regularproperty.md
@@ -6,7 +6,7 @@
 
 Property of type string that does something
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 regularProperty: string;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.arrayproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.arrayproperty.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.arrayProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 arrayProperty: IDocInterface1[];

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.genericreferencemethod.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.genericreferencemethod.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.genericReferenceMethod() method
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 genericReferenceMethod<T>(x: T): T;
@@ -16,7 +16,7 @@ genericReferenceMethod<T>(x: T): T;
 |  --- | --- | --- |
 |  x | T |  |
 
-<b>Returns:</b>
+**Returns:**
 
 T
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.intersectionproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.intersectionproperty.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.intersectionProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 intersectionProperty: IDocInterface1 & IDocInterface2;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.md
@@ -6,7 +6,7 @@
 
 Interface without inline tag to test custom TOC with injection
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface6 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.regularproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.regularproperty.md
@@ -6,7 +6,7 @@
 
 Property of type number that does something
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 regularProperty: number;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.tupleproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.tupleproperty.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.tupleProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 tupleProperty: [IDocInterface1, IDocInterface2];

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.typereferenceproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.typereferenceproperty.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.typeReferenceProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 typeReferenceProperty: Generic<IDocInterface1>;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.unionproperty.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface6.unionproperty.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface6.unionProperty property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 unionProperty: IDocInterface1 | IDocInterface2;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.md
@@ -6,7 +6,7 @@
 
 Interface for testing optional properties
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export interface IDocInterface7 
@@ -16,13 +16,13 @@ export interface IDocInterface7
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [optionalField?](./api-documenter-test.idocinterface7.optionalfield.md) |  | boolean | <i>(Optional)</i> Description of optionalField |
-|  [optionalReadonlyField?](./api-documenter-test.idocinterface7.optionalreadonlyfield.md) | <code>readonly</code> | boolean | <i>(Optional)</i> Description of optionalReadonlyField |
-|  [optionalUndocumentedField?](./api-documenter-test.idocinterface7.optionalundocumentedfield.md) |  | boolean | <i>(Optional)</i> |
+|  [optionalField?](./api-documenter-test.idocinterface7.optionalfield.md) |  | boolean | _(Optional)_ Description of optionalField |
+|  [optionalReadonlyField?](./api-documenter-test.idocinterface7.optionalreadonlyfield.md) | <code>readonly</code> | boolean | _(Optional)_ Description of optionalReadonlyField |
+|  [optionalUndocumentedField?](./api-documenter-test.idocinterface7.optionalundocumentedfield.md) |  | boolean | _(Optional)_ |
 
 ## Methods
 
 |  Method | Description |
 |  --- | --- |
-|  [optionalMember()?](./api-documenter-test.idocinterface7.optionalmember.md) | <i>(Optional)</i> Description of optionalMember |
+|  [optionalMember()?](./api-documenter-test.idocinterface7.optionalmember.md) | _(Optional)_ Description of optionalMember |
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalfield.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalfield.md
@@ -6,7 +6,7 @@
 
 Description of optionalField
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 optionalField?: boolean;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalmember.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalmember.md
@@ -6,12 +6,12 @@
 
 Description of optionalMember
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 optionalMember?(): any;
 ```
-<b>Returns:</b>
+**Returns:**
 
 any
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalreadonlyfield.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalreadonlyfield.md
@@ -6,7 +6,7 @@
 
 Description of optionalReadonlyField
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 readonly optionalReadonlyField?: boolean;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalundocumentedfield.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.idocinterface7.optionalundocumentedfield.md
@@ -4,7 +4,7 @@
 
 ## IDocInterface7.optionalUndocumentedField property
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 optionalUndocumentedField?: boolean;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.innernamespace.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.innernamespace.md
@@ -6,7 +6,7 @@
 
 A nested namespace
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 namespace InnerNamespace 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.innernamespace.nestedfunction.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.innernamespace.nestedfunction.md
@@ -6,7 +6,7 @@
 
 A function inside a namespace
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 function nestedFunction(x: number): number;
@@ -18,7 +18,7 @@ function nestedFunction(x: number): number;
 |  --- | --- | --- |
 |  x | number |  |
 
-<b>Returns:</b>
+**Returns:**
 
 number
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.md
@@ -6,7 +6,7 @@
 
 A top-level namespace
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare namespace OuterNamespace 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.nestedvariable.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.outernamespace.nestedvariable.md
@@ -6,7 +6,7 @@
 
 A variable exported from within a namespace.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 nestedVariable: boolean

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.systemevent.addhandler.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.systemevent.addhandler.md
@@ -6,7 +6,7 @@
 
 Adds an handler for the event.
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 addHandler(handler: () => void): void;
@@ -18,7 +18,7 @@ addHandler(handler: () => void): void;
 |  --- | --- | --- |
 |  handler | () =&gt; void |  |
 
-<b>Returns:</b>
+**Returns:**
 
 void
 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.systemevent.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.systemevent.md
@@ -7,7 +7,7 @@
 A class used to exposed events.
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare class SystemEvent 

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.typealias.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.typealias.md
@@ -5,7 +5,7 @@
 ## TypeAlias type
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare type TypeAlias = number;

--- a/build-tests/api-documenter-test/etc/markdown/api-documenter-test.yamlreferenceuniquenesstest.md
+++ b/build-tests/api-documenter-test/etc/markdown/api-documenter-test.yamlreferenceuniquenesstest.md
@@ -5,12 +5,12 @@
 ## yamlReferenceUniquenessTest() function
 
 
-<b>Signature:</b>
+**Signature:**
 
 ```typescript
 export declare function yamlReferenceUniquenessTest(): IDocInterface1;
 ```
-<b>Returns:</b>
+**Returns:**
 
 [IDocInterface1](./api-documenter-test.idocinterface1.md)
 

--- a/common/changes/@microsoft/api-documenter/octogonz-api-documenter-bold-italic_2023-01-28-05-05.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-api-documenter-bold-italic_2023-01-28-05-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Fix an issue where `<b>`/`<i>` tags sometimes interfered with parsing of other Markdown on the same line; italics and boldface are now emitted using `*` and `_`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-api-documenter-bold-italic_2023-01-28-06-13.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-api-documenter-bold-italic_2023-01-28-06-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Motivation

For along time, API Documenter has emitted bold/italic text using HTML markup:

```markdown
Regular text. <b>This is some bold text.</b> <i>Some italics.</i>
```

However in certain implementations/contexts, the presence of any HTML elements will disable Markdown parsing for the rest of the line.  Consider this example:

```markdown
<b>Extends:</b> [IStageContext](./heft.istagecontext.md) &lt;[TestStageHooks](./heft.teststagehooks.md) , [ITestStageProperties](./heft.iteststageproperties.md) &gt;
```

GitHub will render the above text okay:

> <b>Extends:</b> [IStageContext](#) &lt;[TestStageHooks](#) , [ITestStageProperties](#) &gt;


...but Docusaurus will render the above line like this, because the HTML element disables MDX 1.0 markup for the rest of the line:

> <b>Extends:</b> \[IStageContext](./heft.istagecontext.md) &lt;\[TestStageHooks](./heft.teststagehooks.md) , \[ITestStageProperties](./heft.iteststageproperties.md) &gt;

## Details

This PR fixes the problem by emitting Markdown-style bold and italics, like this:

```markdown
Regular text. **This is some bold text.** _Some italics._
```

This was actually the original implementation a long time ago, but I changed it in  8fc4e1ca3c90237d973c48315a2e8ab201762b10.  If I remember correctly, I was concerned about `<p>` tags inside a pipes-and-dashes table, like this:

```markdown
| col 1 | col 2 |
| --- | --- |
| simple text  | <p> paragraph one </p> <p> **paragraph two** </p> |
```

CommonMark has [many contexts](https://spec.commonmark.org/0.30/#example-148) where Markdown syntax can't be mixed with HTML, and `<p> **paragraph two** </p>` is such an example.  (Ironically, the motivating example `<b>Extends:</b>` from above works fine with CommonMark!)  Thus, it had seemed safer to use `<b>` everywhere instead of  trying to work out the edge cases where `*` is safe. 

However, empirical tests show that pipes-and-dashes tables like above are rendered correctly by GitHub, Docusaurus, and Marked. Since `*` is more idiomatic for Markdown, I now think we should emit it by default. If we find some broken edge cases, we can reintroduce `<b>` as a special fix for just those cases.

CC @zelliott 