### PR TITLE
Clean up docs for packages that appear on the API website

### DIFF
--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * Heft is a config-driven toolchain that invokes other popular tools such
+ * as TypeScript, ESLint, Jest, Webpack, and API Extractor. You can use it to build
+ * web applications, Node.js services, command-line tools, libraries, and more.
+ *
+ * @packageDocumentation
+ */
+
 export { IHeftPlugin } from './pluginFramework/IHeftPlugin';
 export {
   HeftConfiguration,

--- a/common/changes/@rushstack/debug-certificate-manager/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/debug-certificate-manager/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/heft-config-file/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/heft/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/localization-utilities/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/localization-utilities/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/changes/@rushstack/module-minifier/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/module-minifier/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/rush-serve-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/rush-serve-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/common/changes/@rushstack/typings-generator/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/typings-generator/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator"
+}

--- a/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-localization-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/worker-pool/octogonz-clean-up-api-docs_2023-01-28-06-58.json
+++ b/common/changes/@rushstack/worker-pool/octogonz-clean-up-api-docs_2023-01-28-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/worker-pool",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/worker-pool"
+}

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -117,6 +117,4 @@ export enum PathResolutionMethod {
 // @beta (undocumented)
 export type PropertyInheritanceCustomFunction<TObject> = (currentObject: TObject, parentObject: TObject) => TObject;
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -461,6 +461,4 @@ export class TestStageHooks extends StageHooksBase<ITestStageProperties> {
     readonly run: AsyncParallelHook;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/common/reviews/api/localization-utilities.api.md
+++ b/common/reviews/api/localization-utilities.api.md
@@ -110,6 +110,4 @@ export class TypingsGenerator extends StringValuesTypingsGenerator {
     constructor(options: ITypingsGeneratorOptions);
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/common/reviews/api/module-minifier.api.md
+++ b/common/reviews/api/module-minifier.api.md
@@ -118,6 +118,4 @@ export class WorkerPoolMinifier implements IModuleMinifier {
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -73,6 +73,4 @@ export class TypingsGenerator {
     readonly sourceFolderPath: string;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/common/reviews/api/worker-pool.api.md
+++ b/common/reviews/api/worker-pool.api.md
@@ -43,6 +43,4 @@ export class WorkerPool {
     reset(): void;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/libraries/debug-certificate-manager/src/index.ts
+++ b/libraries/debug-certificate-manager/src/index.ts
@@ -3,15 +3,16 @@
 
 /**
  * This package is used to manage debug certificates for development servers.
- * It is used by
- * [\@microsoft/gulp-core-build-serve](https://www.npmjs.com/package/\@microsoft/gulp-core-build-serve)
- * to generate and trust a certificate when HTTPS is turned on.
  *
  * This package provides the following utilities:
+ *
  * - `CertificateStore` to handle retrieving and saving a debug certificate.
+ *
  * - `CertificateManager` is a utility class containing the following public methods:
- * | - `ensureCertificate` will find or optionally create a debug certificate and trust it.
- * | - `untrustCertificate` will untrust a debug certificate.
+ *
+ * - `ensureCertificate` will find or optionally create a debug certificate and trust it.
+ *
+ * - `untrustCertificate` will untrust a debug certificate.
  *
  * @packageDocumentation
  */

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * A library for loading config files for use with the
+ * {@link https://rushstack.io/pages/heft/overview/ | Heft} build system.
+ *
+ * @packageDocumentation
+ */
+
 export {
   ConfigurationFile,
   IConfigurationFileOptionsBase,

--- a/libraries/localization-utilities/src/index.ts
+++ b/libraries/localization-utilities/src/index.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * Some utilities for working with Rush Stack localization files.
+ *
+ * @packageDocumentation
+ */
+
 export type {
   ILocalizationFile,
   ILocalizedString,

--- a/libraries/module-minifier/src/index.ts
+++ b/libraries/module-minifier/src/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * This library wraps terser in convenient handles for parallelization.
+ * It powers `@rushstack/webpack4-module-minifier-plugin` and `@rushstack/webpack5-module-minifier-plugin`
+ * but has no coupling with webpack.
+ *
+ * @packageDocumentation
+ */
+
 export type { MinifyOptions } from 'terser';
 
 export type { ILocalMinifierOptions } from './LocalMinifier';

--- a/libraries/typings-generator/src/index.ts
+++ b/libraries/typings-generator/src/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * An engine for generating TypeScript .d.ts files that provide type signatures
+ * for non-TypeScript modules such as generated JavaScript or CSS. It can operate
+ * in either a single-run mode or a watch mode.
+ *
+ * @packageDocumentation
+ */
+
 export { ITypingsGeneratorBaseOptions, ITypingsGeneratorOptions, TypingsGenerator } from './TypingsGenerator';
 
 export {

--- a/libraries/worker-pool/src/index.ts
+++ b/libraries/worker-pool/src/index.ts
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * A lightweight worker pool implementation using the NodeJS `worker_threads` API.
+ *
+ * @packageDocumentation
+ */
+
 export type { IWorkerPoolOptions } from './WorkerPool';
 export { WORKER_ID_SYMBOL, WorkerPool } from './WorkerPool';

--- a/rush-plugins/rush-serve-plugin/config/api-extractor.json
+++ b/rush-plugins/rush-serve-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/hashed-folder-copy-plugin/config/api-extractor.json
+++ b/webpack/hashed-folder-copy-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/preserve-dynamic-require-plugin/config/api-extractor.json
+++ b/webpack/preserve-dynamic-require-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/webpack-deep-imports-plugin/config/api-extractor.json
+++ b/webpack/webpack-deep-imports-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/webpack4-localization-plugin/config/api-extractor.json
+++ b/webpack/webpack4-localization-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/webpack4-module-minifier-plugin/config/api-extractor.json
+++ b/webpack/webpack4-module-minifier-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/webpack5-localization-plugin/config/api-extractor.json
+++ b/webpack/webpack5-localization-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 

--- a/webpack/webpack5-module-minifier-plugin/config/api-extractor.json
+++ b/webpack/webpack5-module-minifier-plugin/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
 
   "docModel": {
-    "enabled": true,
+    "enabled": false,
     "apiJsonFilePath": "../../../common/temp/api/<unscopedPackageName>.api.json"
   },
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

- Disable .api.json generation for packages that don't have useful API docs
- Add missing `@packageDocumentation` tags


The output is deployed live here: https://api.rushstack.io