### PR TITLE
[heft-sass] Add preserveSCSSExtension option

### DIFF
--- a/build-tests/heft-sass-test/config/sass.json
+++ b/build-tests/heft-sass-test/config/sass.json
@@ -1,4 +1,5 @@
 {
   "cssOutputFolders": ["lib"],
+  "preserveSCSSExtension": true,
   "secondaryGeneratedTsFolders": ["lib"]
 }

--- a/build-tests/heft-sass-test/webpack.config.js
+++ b/build-tests/heft-sass-test/webpack.config.js
@@ -18,7 +18,7 @@ function createWebpackConfig({ production }) {
     module: {
       rules: [
         {
-          test: /\.css$/,
+          test: /\.s?css$/,
           exclude: /node_modules/,
           use: [
             // Creates `style` nodes from JS strings

--- a/common/changes/@rushstack/heft-sass-plugin/preserveSCSSExtension_2023-01-30-20-48.json
+++ b/common/changes/@rushstack/heft-sass-plugin/preserveSCSSExtension_2023-01-30-20-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Add \"preserveSCSSExtension\" flag for backwards compatibility with build flows that cannot be expected to alter import resolution.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -37,6 +37,11 @@ export interface ISassConfiguration {
   cssOutputFolders?: string[] | undefined;
 
   /**
+   * If `true`, when emitting compiled CSS from a file with a ".scss" extension, the emitted CSS will have the extension ".scss" instead of ".scss.css"
+   */
+  preserveSCSSExtension?: boolean | undefined;
+
+  /**
    * Determines whether export values are wrapped in a default property, or not.
    * Defaults to true.
    */
@@ -101,14 +106,22 @@ export class SassProcessor extends StringValuesTypingsGenerator {
 
     const { allFileExtensions, isFileModule } = buildExtensionClassifier(sassConfiguration);
 
-    const { cssOutputFolders } = sassConfiguration;
+    const { cssOutputFolders, preserveSCSSExtension = false } = sassConfiguration;
 
     const getCssPaths: ((relativePath: string) => string[]) | undefined = cssOutputFolders
       ? (relativePath: string): string[] => {
-          return cssOutputFolders.map(
-            (folder: string) =>
-              `${folder}/${relativePath.endsWith('.css') ? relativePath : `${relativePath}.css`}`
-          );
+          const lastDot: number = relativePath.lastIndexOf('.');
+          const oldExtension: string = relativePath.slice(lastDot);
+          const cssRelativePath: string =
+            oldExtension === '.css' || (oldExtension === '.scss' && preserveSCSSExtension)
+              ? relativePath
+              : `${relativePath}.css`;
+
+          const cssPaths: string[] = [];
+          for (const outputFolder of cssOutputFolders) {
+            cssPaths.push(`${outputFolder}/${cssRelativePath}`);
+          }
+          return cssPaths;
         }
       : undefined;
 

--- a/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
@@ -42,11 +42,16 @@
 
     "cssOutputFolders": {
       "type": "array",
-      "description": "If specified, folders where compiled CSS files will be emitted to. They will be named by appending \".css\" to the source file name for ease of reference translation.",
+      "description": "If specified, folders where compiled CSS files will be emitted to. They will be named by appending \".css\" to the source file name for ease of reference translation, unless \"preserveSCSSExtension\" is set.",
       "items": {
         "type": "string",
         "pattern": "[^\\\\]"
       }
+    },
+
+    "preserveSCSSExtension": {
+      "type": "boolean",
+      "description": "If set, when emitting compiled CSS from a file with a \".scss\" extension, the emitted CSS will have the extension \".scss\" instead of \".scss.css\"."
     },
 
     "fileExtensions": {

--- a/heft-plugins/heft-sass-plugin/src/templates/sass.json
+++ b/heft-plugins/heft-sass-plugin/src/templates/sass.json
@@ -38,11 +38,19 @@
 
   /**
    * If specified, folders where compiled CSS files will be emitted to. They will be named by appending
-   * ".css" to the source file name for ease of reference translation.
+   * ".css" to the source file name for ease of reference translation, unless "preserveSCSSExtension" is set.
    *
    * Default value: undefined
    */
   // "cssOutputFolders": [],
+
+  /**
+   * If set, when emitting compiled CSS from a file with a ".scss" extension, the emitted CSS will have
+   * the extension ".scss" instead of ".scss.css".
+   *
+   * Default value: false
+   */
+  // "preserveSCSSExtension": true,
 
   /**
    * Files with these extensions will pass through the Sass transpiler for typings generation.


### PR DESCRIPTION
## Summary
Adds a new option `preserveSCSSExtension` to `@rushstack/heft-sass-plugin` that, if set, will reuse the `.scss` extension when emitting compiled CSS.

## Details
When the option is `false`, the emitted extension for `.scss` source files is `.scss.css`. When the option is true, it is `.scss`. This means that Webpack configurations will need to specify a loader for `.scss`, which may be `sass-loader`, but the input will still be valid CSS without any SCSS features.

The motivation here is to make switching to precompiled CSS backwards compatible with external packages that expect the imports in a given package to resolve to an exact matching filename, without adding any extra extensions.

## How it was tested
Local build test (build-tests/heft-sass-test).
Validated emitted file paths, and that pointing Webpack at the .scss file path, but using an ordinary CSS loader works.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
