### PR TITLE
[rush] Add support for Node.js 18.x LTS

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-nodejs-lts-18_2023-01-30-21-18.json
+++ b/common/changes/@microsoft/rush/octogonz-nodejs-lts-18_2023-01-30-21-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update \"rush init\" and version checks to reflect that Node.js 18.x is now the Long Term Support (LTS) release series",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -11,6 +11,8 @@ jobs:
           NodeVersion: 14
         'NodeJs 16':
           NodeVersion: 16
+        'NodeJs 18':
+          NodeVersion: 18
 
     steps:
       - checkout: self

--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -2,7 +2,7 @@ pool:
   vmImage: 'ubuntu-latest'
 variables:
   - name: NodeVersion
-    value: 14
+    value: 18
   - name: FORCE_COLOR
     value: 1
   - name: SourceBranch

--- a/common/config/azure-pipelines/npm-publish.yaml
+++ b/common/config/azure-pipelines/npm-publish.yaml
@@ -2,7 +2,7 @@ pool:
   vmImage: 'ubuntu-latest'
 variables:
   - name: NodeVersion
-    value: 14
+    value: 18
   - name: FORCE_COLOR
     value: 1
   - name: SourceBranch

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0 || >=18.12.1 <19.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current

--- a/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -49,7 +49,7 @@ export class NodeJsCompatibility {
     // IMPORTANT: If this test fails, the Rush CLI front-end process will terminate with an error.
     // Only increment it when our code base is known to use newer features (e.g. "async"/"await") that
     // have no hope of working with older Node.js.
-    if (semver.satisfies(nodeVersion, '< 8.9.0')) {
+    if (semver.satisfies(nodeVersion, '< 10.23.3')) {
       console.error(
         colors.red(
           `Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush. ` +

--- a/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -9,13 +9,13 @@ import * as semver from 'semver';
 import type { RushConfiguration } from '../api/RushConfiguration';
 
 /**
- * This constant is the major version of the next LTS node Node.js release. This constant should be updated when
- * a new LTS version is added to Rush's support matrix.
+ * This constant is the major version of the currently active LTS node Node.js release series.
+ * This constant should be updated whenever a new LTS version is added to Rush's support matrix.
  *
  * LTS schedule: https://nodejs.org/en/about/releases/
- * LTS versions: https://nodejs.org/en/download/releases/
+ * LTS versions: https://nodejs.org/en/download/releases/  (searchable)
  */
-const UPCOMING_NODE_LTS_VERSION: number = 18;
+const LATEST_NODE_LTS_VERSION: number = 18;
 const nodeVersion: string = process.versions.node;
 const nodeMajorVersion: number = semver.major(nodeVersion);
 
@@ -82,7 +82,15 @@ export class NodeJsCompatibility {
    * Warn about a Node.js version that has not been tested yet with Rush.
    */
   public static warnAboutVersionTooNew(options: IWarnAboutVersionTooNewOptions): boolean {
-    if (nodeMajorVersion >= UPCOMING_NODE_LTS_VERSION + 1) {
+    // For example, suppose that LATEST_NODE_LTS_VERSION=18, then the schedule might look like this:
+    //
+    //                            14.x: Maintenance
+    //                            16.x: Maintenance
+    // LATEST_NODE_LTS_VERSION    18.x: Active LTS
+    //                            19.x: Current experimental odd-numbered release series
+    //                            20.x: "Pending" release series (that will later become LTS)
+    // LATEST_NODE_LTS_VERSION+3  21.x: . . .
+    if (nodeMajorVersion >= LATEST_NODE_LTS_VERSION + 3) {
       if (!options.alreadyReportedNodeTooNewError) {
         // We are on a much newer release than we have tested and support
         if (options.isRushLib) {

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.12.1 <19.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION


## Summary

@xuewan-seven pointed out that our repo doesn't support Node.js 18 in https://github.com/microsoft/rush-example/issues/17 

Node.js 18.x is now LTS as of 2022-10-25.

Node.js 14.x will reach end of line on 2023-04-30.



## Details
- Upgrade CI pipelines
- Upgrade `rush init` template
- Update logic in NodeJsCompatibility.ts
- I replaced the confusing `UPCOMING_NODE_LTS_VERSION` constant with `LATEST_NODE_LTS_VERSION`

## How it was tested

Tested locally. I also tested `reportAncientIncompatibleVersion()` by installing Node.js 8.9.0 and trying to build our repo. Rush crashed due to an unsupported RegExp, so I bumped the ancient version to 10.x

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->
 
Fixes https://github.com/microsoft/rush-example/issues/17