### PR TITLE
[hashed-folder-copy-plugin] Respect output.hashSalt

### DIFF
--- a/build-tests/hashed-folder-copy-plugin-webpack4-test/webpack.config.js
+++ b/build-tests/hashed-folder-copy-plugin-webpack4-test/webpack.config.js
@@ -18,7 +18,8 @@ function generateConfiguration(mode, outputFolderName) {
     output: {
       path: path.join(__dirname, outputFolderName),
       filename: '[name]_[contenthash].js',
-      chunkFilename: '[id].[name]_[contenthash].js'
+      chunkFilename: '[id].[name]_[contenthash].js',
+      hashSalt: '2'
     },
     optimization: {
       minimizer: [

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/hashed-copy-salt_2023-02-01-02-58.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/hashed-copy-salt_2023-02-01-02-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "Apply webpack's \"output.hashSalt\" configuration property (if present) to the folder hash.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/webpack/hashed-folder-copy-plugin/src/HashedFolderCopyPlugin.ts
+++ b/webpack/hashed-folder-copy-plugin/src/HashedFolderCopyPlugin.ts
@@ -286,6 +286,12 @@ export class HashedFolderCopyPlugin implements webpack.Plugin {
     }
 
     const hash: crypto.Hash = crypto.createHash('md5');
+    // If the webpack config specified a salt, apply it here
+    const hashSalt: string | undefined = compilation.outputOptions?.hashSalt;
+    if (hashSalt) {
+      hash.update(hashSalt);
+    }
+
     // Sort the paths to maximize hash stability
     for (const assetPath of Array.from(assetsToAdd.keys()).sort()) {
       hash.update(assetPath);


### PR DESCRIPTION
## Summary
Includes the value of the webpack configuration option `output.hashSalt` in the computed hash for the copied folder.

## Details
The value of the `hashSalt`, if defined, is applied to the hash before hashing folder content.

## How it was tested
Applied the property with different values in `build-tests/hashed-folder-copy-plugin-webpack4-test` and `build-tests/hashed-folder-copy-plugin-webpack5-test` and validated that the output hash was impacted in a stable manner.

## Impacted documentation
None, currently.