### PR TITLE
[rush] Fix EPERM in AsyncRecycler

### DIFF
--- a/common/changes/@microsoft/rush/recycler-fixes_2023-02-01-22-45.json
+++ b/common/changes/@microsoft/rush/recycler-fixes_2023-02-01-22-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where deleting the `common/temp/node_modules` folder encounters an EPERM error and aborts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
On Windows, when running inside of VSCode, it is common to encounter errors that look like:
```
ERROR: Error: Error: EPERM: operation not permitted, symlink
'D:\test-repo\common\temp\node_modules\.pnpm\my-package@0.0.1\node_modules\my-package\'
->
'D:\test-repo\common\temp\rush-recycler\node_modules_1675288481011\.pnpm\my-package@0.0.1\node_modules\my-package'
Often this is caused by a file lock from a process like the virus scanner.
```

This PR addresses this issue.

## Details
The most unexpected part of the above mentioned error is that the operation being performed is `symlink` in the middle of purging the `common/temp/node_modules` folder. Hooking up a debugger showed that `FileSystem.move`, in its call to `require('fs-extra').moveSync` was internally routing down a code path that performs a copy and delete operation, rather than a cheap rename.

First attempt was to replace the call to `FIleSystem.move` with a direct call to `fs.renameSync`, however, this failed repeatedly and consistently on Windows with `EPERM`.

Recursing into any folder that fails the rename and deleting files / renaming folders solves the `EPERM` issue.

## How it was tested
Built, ran locally against a repro of the issue on Windows.

It appears that the async delete part of `AsyncRecycler` currently isn't doing anything, either.

## Impacted documentation
No current documentation.
