### PR TITLE
[rush-serve-plugin] Add workspace-level routing

### DIFF
--- a/common/changes/@rushstack/rush-serve-plugin/serve-global-dir_2023-02-02-23-52.json
+++ b/common/changes/@rushstack/rush-serve-plugin/serve-global-dir_2023-02-02-23-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "comment": "Support workspace-level routing rules in the plugin config, to serve files that are not associated with any specific project.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-serve-plugin"
+}

--- a/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
@@ -54,9 +54,10 @@ export class RushServeConfiguration {
 
   public async loadProjectConfigsAsync(
     projects: Iterable<RushConfigurationProject>,
-    terminal: ITerminal
+    terminal: ITerminal,
+    workspaceRoutingRules: Iterable<IRoutingRule>
   ): Promise<Iterable<IRoutingRule>> {
-    const rules: IRoutingRule[] = [];
+    const rules: IRoutingRule[] = Array.from(workspaceRoutingRules);
 
     await Async.forEachAsync(
       projects,

--- a/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
@@ -1,8 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
+
 import type { IRushPlugin, RushSession, RushConfiguration, IPhasedCommand } from '@rushstack/rush-sdk';
 import { PLUGIN_NAME } from './constants';
+
+import type { IBaseRoutingRuleJson, IRoutingRule } from './RushProjectServeConfigFile';
+
+export interface IGlobalRoutingFolderRuleJson extends IBaseRoutingRuleJson {
+  workspaceRelativeFile: undefined;
+  workspaceRelativeFolder: string;
+}
+
+export interface IGlobalRoutingFileRuleJson extends IBaseRoutingRuleJson {
+  workspaceRelativeFile: string;
+  workspaceRelativeFolder: undefined;
+}
+
+export type IGlobalRoutingRuleJson = IGlobalRoutingFileRuleJson | IGlobalRoutingFolderRuleJson;
 
 export interface IRushServePluginOptions {
   /**
@@ -14,6 +30,8 @@ export interface IRushServePluginOptions {
    * If specified, the plugin will ensure the value is synchronized with the port used for its server.
    */
   portParameterLongName?: string | undefined;
+
+  globalRouting?: IGlobalRoutingRuleJson[];
 }
 
 /**
@@ -24,14 +42,29 @@ export class RushServePlugin implements IRushPlugin {
 
   private readonly _phasedCommands: Set<string>;
   private readonly _portParameterLongName: string | undefined;
+  private readonly _globalRoutingRules: IGlobalRoutingRuleJson[];
 
   public constructor(options: IRushServePluginOptions) {
     this._phasedCommands = new Set(options.phasedCommands);
     this._portParameterLongName = options.portParameterLongName;
+    this._globalRoutingRules = options.globalRouting ?? [];
   }
 
   public apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void {
     const handler: (command: IPhasedCommand) => Promise<void> = async (command: IPhasedCommand) => {
+      const globalRoutingRules: IRoutingRule[] = this._globalRoutingRules.map(
+        (rule: IGlobalRoutingRuleJson) => {
+          const { workspaceRelativeFile, workspaceRelativeFolder } = rule;
+          const diskPath: string = workspaceRelativeFolder ?? workspaceRelativeFile;
+          return {
+            type: workspaceRelativeFile ? 'file' : 'folder',
+            diskPath: path.resolve(rushConfiguration.rushJsonFolder, diskPath),
+            servePath: rule.servePath,
+            immutable: !!rule.immutable
+          };
+        }
+      );
+
       // Defer importing the implementation until this plugin is actually invoked.
       await (
         await import('./phasedCommandHandler')
@@ -39,7 +72,8 @@ export class RushServePlugin implements IRushPlugin {
         rushSession,
         rushConfiguration,
         command,
-        portParameterLongName: this._portParameterLongName
+        portParameterLongName: this._portParameterLongName,
+        globalRoutingRules
       });
     };
 

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -27,10 +27,11 @@ export interface IPhasedCommandHandlerOptions {
   rushConfiguration: RushConfiguration;
   command: IPhasedCommand;
   portParameterLongName: string | undefined;
+  globalRoutingRules: IRoutingRule[];
 }
 
 export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions): Promise<void> {
-  const { rushSession, command, portParameterLongName } = options;
+  const { rushSession, command, portParameterLongName, globalRoutingRules } = options;
 
   const logger: ILogger = rushSession.getLogger(PLUGIN_NAME);
 
@@ -99,7 +100,8 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
 
       const routingRules: Iterable<IRoutingRule> = await serveConfig.loadProjectConfigsAsync(
         selectedProjects,
-        logger.terminal
+        logger.terminal,
+        globalRoutingRules
       );
 
       const fileRoutingRules: Map<string, IRoutingRule> = new Map();
@@ -108,6 +110,7 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
       function setHeaders(response: express.Response, path?: string, stat?: unknown): void {
         response.set('Access-Control-Allow-Origin', '*');
         response.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+
         // TODO: Generalize headers and MIME types with an external database or JSON file.
         if (path && wbnRegex.test(path)) {
           response.set('X-Content-Type-Options', 'nosniff');

--- a/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
+++ b/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
@@ -25,6 +25,57 @@
       "type": "string",
       "description": "The name of a custom parameter in command-line.json that provides a port number for the server. If the parameter is defined and not passed on the command line, it will be populated with the auto-assigned port number after the server starts.",
       "pattern": "^--(?:[a-z0-9]+)(?:-[a-z0-9]+)*$"
+    },
+
+    "globalRouting": {
+      "type": "array",
+      "description": "Routing rules for files that are associated with the entire workspace, rather than a single project (e.g. files output by Rush plugins).",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["workspaceRelativeFolder", "servePath"],
+            "properties": {
+              "workspaceRelativeFolder": {
+                "type": "string",
+                "description": "The folder from which to read assets, relative to the root of the Rush workspace."
+              },
+
+              "servePath": {
+                "type": "string",
+                "description": "The server path at which to serve the assets in \"workspaceRelativeFolder\"."
+              },
+
+              "immutable": {
+                "type": "boolean",
+                "description": "Enables or disables the `immutable` directive in the `Cache-Control` resoponse header. See (https://expressjs.com/en/4x/api.html#express.static)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["workspaceRelativeFile", "servePath"],
+            "properties": {
+              "workspaceRelativeFile": {
+                "type": "string",
+                "description": "The file to serve, relative to the root of the Rush workspace"
+              },
+
+              "servePath": {
+                "type": "string",
+                "description": "The server path at which to serve \"workspaceRelativeFile\"."
+              },
+
+              "immutable": {
+                "type": "boolean",
+                "description": "Enables or disables the `immutable` directive in the `Cache-Control` resoponse header. See (https://expressjs.com/en/4x/api.html#express.static)."
+              }
+            }
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds a field `globalRouting` to the plugin config for `rush-serve-plugin`, to enable Rush workspaces to serve assets that are owned by the entire workspace (or plugins) rather than specific projects within said workspace.

## Details
Workspace level routing rules come from the plugin's options file, rather than files in individual projects. Expected use case is if a Rush plugin writes files that it wants served, that the plugin config can be used to specify a location, regardless of what projects are in scope of the Rush command.

## How it was tested
Copied into another repository and tested in place with a workspace config.

## Impacted documentation
Documented in the schema. Will need an init template added eventually.