### PR TITLE
[rush-lib] Disable automatic depcheck when running `upgrade-interactive`

### DIFF
--- a/common/changes/@microsoft/rush/feature-skip-unused-checks_2023-02-03-22-49.json
+++ b/common/changes/@microsoft/rush/feature-skip-unused-checks_2023-02-03-22-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable unused depcheck feature for upgrade-interactive.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
+++ b/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
@@ -72,7 +72,10 @@ export class InteractiveUpgrader {
   ): Promise<NpmCheck.INpmCheckPackage[]> {
     const { projectFolder } = rushProject;
 
-    const currentState: NpmCheck.INpmCheckCurrentState = await npmCheck({ cwd: projectFolder });
+    const currentState: NpmCheck.INpmCheckCurrentState = await npmCheck({
+      cwd: projectFolder,
+      skipUnused: true
+    });
 
     return currentState.get('packages');
   }


### PR DESCRIPTION
This PR removes the automatic `depcheck` feature from npm-check when calling `upgrade-interactive`. 

Currently today this provides some poor UI visualizations while npm-check is fetching registry data for a long list of packages. 

![image](https://user-images.githubusercontent.com/3408176/216713022-77c611a0-f9c2-4369-9a3c-107ec99d8e89.png)

Now only a spinner will appear with "Checking for package updates" appears. 