### PR TITLE
Change the peer dependency selector on @types/node to a wildcard.

### DIFF
--- a/common/changes/@rushstack/module-minifier/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/module-minifier/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/module-minifier"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/node-core-library/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/terminal/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/terminal/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/terminal"
+    }
+  ],
+  "packageName": "@rushstack/terminal",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/typings-generator/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/typings-generator/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/typings-generator"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/webpack4-localization-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/webpack4-module-minifier-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/webpack5-localization-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/webpack5-module-minifier-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/worker-pool/node-peerdep-wildcard_2023-02-04-23-42.json
+++ b/common/changes/@rushstack/worker-pool/node-peerdep-wildcard_2023-02-04-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change the peer dependency selector on `@types/node` to a wildcard (`*`).",
+      "type": "patch",
+      "packageName": "@rushstack/worker-pool"
+    }
+  ],
+  "packageName": "@rushstack/worker-pool",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/module-minifier/package.json
+++ b/libraries/module-minifier/package.json
@@ -30,7 +30,7 @@
     "@types/serialize-javascript": "5.0.2"
   },
   "peerDependencies": {
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -36,7 +36,7 @@
     "@types/semver": "7.3.5"
   },
   "peerDependencies": {
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -29,7 +29,7 @@
     "colors": "~1.2.1"
   },
   "peerDependencies": {
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/libraries/typings-generator/package.json
+++ b/libraries/typings-generator/package.json
@@ -32,7 +32,7 @@
     "@types/node": "14.18.36"
   },
   "peerDependencies": {
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/libraries/worker-pool/package.json
+++ b/libraries/worker-pool/package.json
@@ -23,7 +23,7 @@
     "@types/node": "14.18.36"
   },
   "peerDependencies": {
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/webpack/webpack4-localization-plugin/package.json
+++ b/webpack/webpack4-localization-plugin/package.json
@@ -18,7 +18,7 @@
     "@rushstack/set-webpack-public-path-plugin": "^3.3.89",
     "@types/webpack": "^4.39.0",
     "webpack": "^4.31.0",
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@rushstack/set-webpack-public-path-plugin": {

--- a/webpack/webpack4-module-minifier-plugin/package.json
+++ b/webpack/webpack4-module-minifier-plugin/package.json
@@ -23,7 +23,7 @@
     "@types/webpack-sources": "*",
     "webpack": "^4.31.0",
     "webpack-sources": "~1.4.3",
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "peerDependenciesMeta": {
     "@types/webpack": {

--- a/webpack/webpack5-localization-plugin/package.json
+++ b/webpack/webpack5-localization-plugin/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "webpack": "^5.68.0",
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "dependencies": {
     "@rushstack/localization-utilities": "workspace:*",

--- a/webpack/webpack5-module-minifier-plugin/package.json
+++ b/webpack/webpack5-module-minifier-plugin/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@rushstack/module-minifier": "*",
     "webpack": "^5.68.0",
-    "@types/node": "^14.18.36"
+    "@types/node": "*"
   },
   "dependencies": {
     "@rushstack/worker-pool": "workspace:*",


### PR DESCRIPTION
This is in response to issues many people have been reporting after we moved `@types/node` from a regular dependency to a peer dependency.

Design discussion here: [Zulip: Unmet peer dependencies in @rushstack/node-core-library](https://rushstack.zulipchat.com/#narrow/stream/262513-general/topic/Unmet.20peer.20dependencies.20in.20.40rushstack.2Fnode-core-library/near/325049326)

Fixes #3946