### PR TITLE
[rush] Fix support for multi-worktree environments

### DIFF
--- a/common/changes/@microsoft/rush/fix-worktrees_2023-02-08-02-59.json
+++ b/common/changes/@microsoft/rush/fix-worktrees_2023-02-08-02-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix determination of the root of the current Git worktree when in a multi-worktree setup.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -405,9 +405,10 @@ export class ProjectChangeAnalyzer {
   private async _getRepoDepsAsync(terminal: ITerminal): Promise<IGitState | undefined> {
     try {
       const gitPath: string = this._git.getGitPathOrThrow();
-      const rootDir: string | undefined = this._git.getGitInfo()?.root;
 
-      if (rootDir) {
+      if (this._git.isPathUnderGitWorkingTree()) {
+        // Do not use getGitInfo().root; it is the root of the *primary* worktree, not the *current* one.
+        const rootDir: string = getRepoRoot(this._rushConfiguration.rushJsonFolder, gitPath);
         // Load the package deps hash for the whole repository
         // Include project shrinkwrap files as part of the computation
         const additionalFilesToHash: string[] = [];


### PR DESCRIPTION
## Summary
Fixes #3962 

## Details
Regression was introduced by #3756.

## How it was tested
Validation that `git rev-parse --showtoplevel` returns the correct working tree root in a multi-worktree environment.
Comparison with a prior Rush version.

## Impacted documentation
None.