### PR TITLE
Setup default dev container for rushstack with Rust and Node (v16) toolchains.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "npm install -g @microsoft/rush @rushstack/heft && rush update --bypass-policy",
+  "onCreateCommand": "/bin/bash ./.devcontainer/setup.sh",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/rust:1": {},
+    "devwasm.azurecr.io/dev-wasm/dev-wasm-feature/rust-wasi:0": {}
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "onCreateCommand": "npm install -g @microsoft/rush @rushstack/heft && rush update --bypass-policy",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "bungcip.better-toml",
+        "ms-vscode.cpptools",
+        "GitHub.copilot",
+        "dustypomerleau.rust-syntax",
+        "serayuzgur.crates",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "mutantdino.resourcemonitor",
+        "DavidAnson.vscode-markdownlint"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/setGitConfigUserName.js
+++ b/.devcontainer/setGitConfigUserName.js
@@ -1,0 +1,44 @@
+const child_process = require('child_process');
+const https = require('https');
+
+const buildRequestOptionsForGetUser = (username) => {
+  if (!username) {
+    throw new Error('Username is required');
+  }
+
+  const requestOptions = {
+    host: 'api.github.com',
+    path: `/users/${username}`,
+    headers: {
+      'User-Agent': '@microsoft/rushstack Codespaces Setup Script'
+    }
+  };
+
+  return requestOptions;
+};
+
+const main = (username) => {
+  const requestOptions = buildRequestOptionsForGetUser(username);
+  const request = https.request(requestOptions, (response) => {
+    let data = '';
+    response.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    response.on('end', () => {
+      const user = JSON.parse(data);
+      const { name } = user;
+
+      // Execute git config command
+      console.log(`git config --local user.email "${username}@users.noreply.github.com"`);
+      child_process.execSync(`git config --local user.email "${username}@users.noreply.github.com"`);
+
+      console.log(`git config --local user.name "${name}"`);
+      child_process.execSync(`git config --local user.name "${name}"`);
+    });
+  });
+
+  request.end();
+};
+
+main(process.argv[2]);

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+echo "🚀 Setting up Rushstack codespace..."
+
+echo "🔑 Setting up GitHub user config..."
+node ./.devcontainer/setGitConfigUserName.js ${GITHUB_USER}
+
+# Install Rush and Heft Dependencies
+echo "📦 Installing Rush, Heft, & Prettier dependencies..."
+npm install -g @microsoft/rush @rushstack/heft prettier
+
+# Install Rush Dependencies
+echo "📦 Installing monorepo dependencies..."
+rush install
+
+echo "🚀 Codespace setup complete! "
+echo "🙏 Thank you for contributing to Rushstack! "

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.49.5.tgz
+      '@rushstack/heft': file:rushstack-heft-0.49.6.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.5.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.6.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -34,13 +34,13 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.1.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.49.5.tgz
+      '@rushstack/heft': file:rushstack-heft-0.49.6.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.1.1.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.5.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.49.6.tgz
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -2258,7 +2258,7 @@ packages:
     dev: false
 
   /json-buffer/3.0.0:
-    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
     dev: false
 
   /json-parse-even-better-errors/2.3.1:
@@ -3989,12 +3989,12 @@ packages:
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz_@types+node@14.18.36
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.6.tgz_@types+node@14.18.36
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.7.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.225.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.0.tgz_@types+node@14.18.36
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.226.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.1.tgz_@types+node@14.18.36
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
@@ -4111,15 +4111,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.49.5.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.49.5.tgz}
+  file:../temp/tarballs/rushstack-heft-0.49.6.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.49.6.tgz}
     name: '@rushstack/heft'
-    version: 0.49.5
+    version: 0.49.6
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.1.tgz
       '@types/tapable': 1.0.6
@@ -4136,37 +4136,37 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.11.7
+    version: 0.11.8
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz}
-    id: file:../temp/tarballs/rushstack-heft-config-file-0.11.7.tgz
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz}
+    id: file:../temp/tarballs/rushstack-heft-config-file-0.11.8.tgz
     name: '@rushstack/heft-config-file'
-    version: 0.11.7
+    version: 0.11.8
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.17.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.55.0
+    version: 3.55.1
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4182,11 +4182,11 @@ packages:
       z-schema: 5.0.3
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz}
-    id: file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz
+  file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz}
+    id: file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz
     name: '@rushstack/node-core-library'
-    version: 3.55.0
+    version: 3.55.1
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4203,13 +4203,13 @@ packages:
       z-schema: 5.0.3
     dev: false
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.0.6.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.6.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.6.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.0.7.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.7.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.7.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.0.6
+    version: 4.0.7
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
     dev: false
@@ -4222,30 +4222,30 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-stream-collator-4.0.225.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.225.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.0.225.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.0.226.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.226.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.0.226.tgz
     name: '@rushstack/stream-collator'
-    version: 4.0.225
+    version: 4.0.226
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.0.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.1.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-terminal-0.5.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.0.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.5.0.tgz
+  file:../temp/tarballs/rushstack-terminal-0.5.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.1.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.5.1.tgz
     name: '@rushstack/terminal'
-    version: 0.5.0
+    version: 0.5.1
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.0.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.1.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       wordwrap: 1.0.0
     dev: false


### PR DESCRIPTION
Add customized default .devcontainer with rust and node toolchains only. This should considerably speed up the setup of a codespace as the default from github dev container was also including python, ruby, go, java, etc. 

Partially addresses many of the boxes in #3965 

Additionally in this PR the build-test folder lockfile got bumped running a full test build, so I'll also commit that change here since it is a small and inconsequential change.