### PR TITLE
[rush-azure-storage-plugin] Remove rush-sdk dependency from AzureStorageAuthentication

### DIFF
--- a/common/changes/@microsoft/rush/azure-auth-remove-sdk_2023-02-09-21-41.json
+++ b/common/changes/@microsoft/rush/azure-auth-remove-sdk_2023-02-09-21-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove runtime dependency on @rushstack/rush-sdk from the AzureStorageAuthentication class in @rushstack/rush-azure-storage-build-cache-plugin so that it can be used in isolation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -22,7 +22,7 @@ export abstract class AzureAuthenticationBase {
     // (undocumented)
     protected abstract readonly _credentialNameForCache: string;
     // (undocumented)
-    protected abstract readonly _credentialUpdateCommandForLogging: string | undefined;
+    protected readonly _credentialUpdateCommandForLogging: string | undefined;
     // (undocumented)
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
     protected abstract _getCacheIdParts(): string[];
@@ -48,8 +48,6 @@ export class AzureStorageAuthentication extends AzureAuthenticationBase {
     // (undocumented)
     protected readonly _credentialNameForCache: string;
     // (undocumented)
-    protected readonly _credentialUpdateCommandForLogging: string;
-    // (undocumented)
     protected _getCacheIdParts(): string[];
     // (undocumented)
     protected _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
@@ -70,6 +68,8 @@ export type ExpiredCredentialBehavior = 'logWarning' | 'throwError' | 'ignore';
 export interface IAzureAuthenticationBaseOptions {
     // (undocumented)
     azureEnvironment?: AzureEnvironmentName;
+    // (undocumented)
+    credentialUpdateCommandForLogging?: string | undefined;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -72,6 +72,7 @@ export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
  */
 export interface IAzureAuthenticationBaseOptions {
   azureEnvironment?: AzureEnvironmentName;
+  credentialUpdateCommandForLogging?: string | undefined;
 }
 
 /**
@@ -88,7 +89,7 @@ export interface IAzureAuthenticationBaseOptions {
 export abstract class AzureAuthenticationBase {
   protected abstract readonly _credentialNameForCache: string;
   protected abstract readonly _credentialKindForLogging: string;
-  protected abstract readonly _credentialUpdateCommandForLogging: string | undefined;
+  protected readonly _credentialUpdateCommandForLogging: string | undefined;
 
   protected readonly _azureEnvironment: AzureEnvironmentName;
 
@@ -109,6 +110,7 @@ export abstract class AzureAuthenticationBase {
 
   public constructor(options: IAzureAuthenticationBaseOptions) {
     this._azureEnvironment = options.azureEnvironment || 'AzurePublicCloud';
+    this._credentialUpdateCommandForLogging = options.credentialUpdateCommandForLogging;
   }
 
   public async updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void> {

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -10,7 +10,6 @@ import {
   type ServiceGetUserDelegationKeyResponse
 } from '@azure/storage-blob';
 import type { ITerminal } from '@rushstack/node-core-library';
-import { RushConstants } from '@rushstack/rush-sdk';
 import {
   AzureAuthenticationBase,
   type ICredentialResult,
@@ -34,7 +33,6 @@ const SAS_TTL_MILLISECONDS: number = 7 * 24 * 60 * 60 * 1000; // Seven days
 export class AzureStorageAuthentication extends AzureAuthenticationBase {
   protected readonly _credentialNameForCache: string = 'azure-blob-storage';
   protected readonly _credentialKindForLogging: string = 'Storage';
-  protected readonly _credentialUpdateCommandForLogging: string = `rush ${RushConstants.updateCloudCredentialsCommandName}`;
 
   protected readonly _storageAccountName: string;
   protected readonly _storageContainerName: string;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
@@ -43,7 +43,10 @@ export class AzureStorageBuildCacheProvider
   private _containerClient: ContainerClient | undefined;
 
   public constructor(options: IAzureStorageBuildCacheProviderOptions) {
-    super(options);
+    super({
+      credentialUpdateCommandForLogging: `rush ${RushConstants.updateCloudCredentialsCommandName}`,
+      ...options
+    });
 
     this._blobPrefix = options.blobPrefix;
     this._environmentCredential = EnvironmentConfiguration.buildCacheCredential;


### PR DESCRIPTION
## Summary
Removes the runtime dependency on @rushstack/rush-sdk from the AzureStorageAuthentication class so that it can be loaded in isolation.

## Details
Moved the `credentialUpdateCommandForLogging` field to be a constructor parameter instead of an abstract field, and stopped providing a default value in `AzureStorageAuthentication`, so that it no longer imports `@rushstack/rush-sdk`.

## How it was tested
Local build + unit test.

## Impacted documentation
None.