### PR TITLE
[rush] Support direct to FS Cloud Cache

### DIFF
--- a/common/changes/@microsoft/rush/build-cache-file_2023-02-22-21-30.json
+++ b/common/changes/@microsoft/rush/build-cache-file_2023-02-22-21-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support cloud build cache providers performing reads and writes directly to the file system, rather than forcing an in-memory copy of the archive. This is intended to reduce memory usage of the Rush process.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -237,8 +237,10 @@ export interface ICloudBuildCacheProvider {
     readonly isCacheWriteAllowed: boolean;
     // (undocumented)
     tryGetCacheEntryBufferByIdAsync(terminal: ITerminal, cacheId: string): Promise<Buffer | undefined>;
+    tryGetCacheEntryFileByIdAsync?(terminal: ITerminal, cacheId: string, filePath: string): Promise<boolean>;
     // (undocumented)
     trySetCacheEntryBufferAsync(terminal: ITerminal, cacheId: string, entryBuffer: Buffer): Promise<boolean>;
+    trySetCacheEntryFileAsync?(terminal: ITerminal, cacheId: string, filePath: string): Promise<boolean>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
     // (undocumented)

--- a/libraries/rush-lib/src/logic/buildCache/ICloudBuildCacheProvider.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ICloudBuildCacheProvider.ts
@@ -9,6 +9,17 @@ import { ITerminal } from '@rushstack/node-core-library';
 export interface ICloudBuildCacheProvider {
   readonly isCacheWriteAllowed: boolean;
 
+  /**
+   * Gets a cache entry from the provider and stores it at `filePath`.
+   * @returns true if the file was written, false otherwise
+   */
+  tryGetCacheEntryFileByIdAsync?(terminal: ITerminal, cacheId: string, filePath: string): Promise<boolean>;
+  /**
+   * Sets the cache entry located at `filePath` in this provider.
+   * @returns true if the cache entry was persisted, false otherwise
+   */
+  trySetCacheEntryFileAsync?(terminal: ITerminal, cacheId: string, filePath: string): Promise<boolean>;
+
   tryGetCacheEntryBufferByIdAsync(terminal: ITerminal, cacheId: string): Promise<Buffer | undefined>;
   trySetCacheEntryBufferAsync(terminal: ITerminal, cacheId: string, entryBuffer: Buffer): Promise<boolean>;
   updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -147,32 +147,69 @@ export class ProjectBuildCache {
 
     let localCacheEntryPath: string | undefined =
       await this._localBuildCacheProvider.tryGetCacheEntryPathByIdAsync(terminal, cacheId);
-    let cacheEntryBuffer: Buffer | undefined;
     let updateLocalCacheSuccess: boolean | undefined;
     if (!localCacheEntryPath && this._cloudBuildCacheProvider) {
       terminal.writeVerboseLine(
         'This project was not found in the local build cache. Querying the cloud build cache.'
       );
 
-      cacheEntryBuffer = await this._cloudBuildCacheProvider.tryGetCacheEntryBufferByIdAsync(
-        terminal,
-        cacheId
-      );
-      if (cacheEntryBuffer) {
-        try {
-          localCacheEntryPath = await this._localBuildCacheProvider.trySetCacheEntryBufferAsync(
-            terminal,
-            cacheId,
-            cacheEntryBuffer
-          );
-          updateLocalCacheSuccess = true;
-        } catch (e) {
-          updateLocalCacheSuccess = false;
+      if (this._cloudBuildCacheProvider.tryGetCacheEntryFileByIdAsync) {
+        const finalLocalCacheEntryPath: string = this._localBuildCacheProvider.getCacheEntryPath(cacheId);
+
+        // Derive the temp file from the destination path to ensure they are on the same volume
+        // In the case of a shared network drive containing the build cache, we also need to make
+        // sure the the temp path won't be shared by two parallel rush builds.
+        const randomSuffix: string = crypto.randomBytes(8).toString('hex');
+        const tempLocalCacheEntryPath: string = `${finalLocalCacheEntryPath}-${randomSuffix}.temp`;
+
+        updateLocalCacheSuccess = await this._cloudBuildCacheProvider.tryGetCacheEntryFileByIdAsync(
+          terminal,
+          cacheId,
+          tempLocalCacheEntryPath
+        );
+
+        if (updateLocalCacheSuccess) {
+          // Move after the download is finished so that if the process is interrupted we aren't left with an invalid file
+          try {
+            await Async.runWithRetriesAsync({
+              action: () =>
+                FileSystem.moveAsync({
+                  sourcePath: tempLocalCacheEntryPath,
+                  destinationPath: finalLocalCacheEntryPath,
+                  overwrite: true
+                }),
+              maxRetries: 2,
+              retryDelayMs: 500
+            });
+          } catch (moveError) {
+            try {
+              await FileSystem.deleteFileAsync(tempLocalCacheEntryPath);
+            } catch (deleteError) {
+              // Ignored
+            }
+            throw moveError;
+          }
+          localCacheEntryPath = finalLocalCacheEntryPath;
+        }
+      } else {
+        const cacheEntryBuffer: Buffer | undefined =
+          await this._cloudBuildCacheProvider.tryGetCacheEntryBufferByIdAsync(terminal, cacheId);
+        if (cacheEntryBuffer) {
+          try {
+            localCacheEntryPath = await this._localBuildCacheProvider.trySetCacheEntryBufferAsync(
+              terminal,
+              cacheId,
+              cacheEntryBuffer
+            );
+            updateLocalCacheSuccess = true;
+          } catch (e) {
+            updateLocalCacheSuccess = false;
+          }
         }
       }
     }
 
-    if (!localCacheEntryPath && !cacheEntryBuffer) {
+    if (!localCacheEntryPath) {
       terminal.writeVerboseLine('This project was not found in the build cache.');
       return false;
     }
@@ -291,8 +328,6 @@ export class ProjectBuildCache {
       return false;
     }
 
-    let cacheEntryBuffer: Buffer | undefined;
-
     let setCloudCacheEntryPromise: Promise<boolean> | undefined;
 
     // Note that "writeAllowed" settings (whether in config or environment) always apply to
@@ -301,19 +336,30 @@ export class ProjectBuildCache {
 
     if (this._cloudBuildCacheProvider?.isCacheWriteAllowed) {
       if (localCacheEntryPath) {
-        cacheEntryBuffer = await FileSystem.readFileToBufferAsync(localCacheEntryPath);
+        if (this._cloudBuildCacheProvider.trySetCacheEntryFileAsync) {
+          // Upload directly from the file. Preferred to keep memory usage down in the face of large projects.
+          setCloudCacheEntryPromise = this._cloudBuildCacheProvider.trySetCacheEntryFileAsync(
+            terminal,
+            cacheId,
+            localCacheEntryPath
+          );
+        } else {
+          const cacheEntryBuffer: Buffer = await FileSystem.readFileToBufferAsync(localCacheEntryPath);
+
+          setCloudCacheEntryPromise = this._cloudBuildCacheProvider?.trySetCacheEntryBufferAsync(
+            terminal,
+            cacheId,
+            cacheEntryBuffer
+          );
+        }
       } else {
         throw new InternalError('Expected the local cache entry path to be set.');
       }
-
-      setCloudCacheEntryPromise = this._cloudBuildCacheProvider?.trySetCacheEntryBufferAsync(
-        terminal,
-        cacheId,
-        cacheEntryBuffer
-      );
     }
 
-    const updateCloudCacheSuccess: boolean | undefined = (await setCloudCacheEntryPromise) ?? true;
+    const updateCloudCacheSuccess: boolean | undefined = setCloudCacheEntryPromise
+      ? await setCloudCacheEntryPromise
+      : true;
 
     const success: boolean = updateCloudCacheSuccess && !!localCacheEntryPath;
     if (success) {

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageBuildCacheProvider.ts
@@ -29,6 +29,8 @@ interface IBlobError extends Error {
   };
 }
 
+type BlobUploadCommonResponse = Awaited<ReturnType<BlockBlobClient['uploadFile']>>;
+
 export class AzureStorageBuildCacheProvider
   extends AzureStorageAuthentication
   implements ICloudBuildCacheProvider
@@ -66,56 +68,73 @@ export class AzureStorageBuildCacheProvider
     const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId, terminal);
 
     try {
-      const blobExists: boolean = await blobClient.exists();
-      if (blobExists) {
-        return await blobClient.downloadToBuffer();
-      } else {
-        return undefined;
-      }
+      return await blobClient.downloadToBuffer();
     } catch (err) {
-      const e: IBlobError = err as IBlobError;
-      const errorMessage: string =
-        'Error getting cache entry from Azure Storage: ' +
-        [e.name, e.message, e.response?.status, e.response?.parsedHeaders?.errorCode]
-          .filter((piece: string | undefined) => piece)
-          .join(' ');
+      this._handleAzureError(err as IBlobError, terminal);
+    }
+  }
 
-      if (e.response?.parsedHeaders?.errorCode === 'PublicAccessNotPermitted') {
-        // This error means we tried to read the cache with no credentials, but credentials are required.
-        // We'll assume that the configuration of the cache is correct and the user has to take action.
-        terminal.writeWarningLine(
-          `${errorMessage}\n\n` +
-            `You need to configure Azure Storage SAS credentials to access the build cache.\n` +
-            `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", \n` +
-            `or provide a SAS in the ` +
-            `${EnvironmentVariableNames.RUSH_BUILD_CACHE_CREDENTIAL} environment variable.`
-        );
-      } else if (e.response?.parsedHeaders?.errorCode === 'AuthenticationFailed') {
-        // This error means the user's credentials are incorrect, but not expired normally. They might have
-        // gotten corrupted somehow, or revoked manually in Azure Portal.
-        terminal.writeWarningLine(
-          `${errorMessage}\n\n` +
-            `Your Azure Storage SAS credentials are not valid.\n` +
-            `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", \n` +
-            `or provide a SAS in the ` +
-            `${EnvironmentVariableNames.RUSH_BUILD_CACHE_CREDENTIAL} environment variable.`
-        );
-      } else if (e.response?.parsedHeaders?.errorCode === 'AuthorizationPermissionMismatch') {
-        // This error is not solvable by the user, so we'll assume it is a configuration error, and revert
-        // to providing likely next steps on configuration. (Hopefully this error is rare for a regular
-        // developer, more likely this error will appear while someone is configuring the cache for the
-        // first time.)
-        terminal.writeWarningLine(
-          `${errorMessage}\n\n` +
-            `Your Azure Storage SAS credentials are valid, but do not have permission to read the build cache.\n` +
-            `Make sure you have added the role 'Storage Blob Data Reader' to the appropriate user(s) or group(s)\n` +
-            `on your storage account in the Azure Portal.`
-        );
-      } else {
-        // We don't know what went wrong, hopefully we'll print something useful.
-        terminal.writeWarningLine(errorMessage);
-      }
-      return undefined;
+  public async tryGetCacheEntryFileByIdAsync(
+    terminal: ITerminal,
+    cacheId: string,
+    filePath: string
+  ): Promise<boolean> {
+    const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId, terminal);
+
+    try {
+      await blobClient.downloadToFile(filePath, undefined, undefined, {
+        maxRetryRequests: 10
+      });
+      return true;
+    } catch (err) {
+      this._handleAzureError(err as IBlobError, terminal);
+      return false;
+    }
+  }
+
+  private _handleAzureError(err: IBlobError, terminal: ITerminal): void {
+    const errorMessage: string =
+      'Error getting cache entry from Azure Storage: ' +
+      [err.name, err.message, err.response?.status, err.response?.parsedHeaders?.errorCode]
+        .filter((piece: string | undefined) => piece)
+        .join(' ');
+
+    if (err.response?.parsedHeaders?.errorCode === 'PublicAccessNotPermitted') {
+      // This error means we tried to read the cache with no credentials, but credentials are required.
+      // We'll assume that the configuration of the cache is correct and the user has to take action.
+      terminal.writeWarningLine(
+        `${errorMessage}\n\n` +
+          `You need to configure Azure Storage SAS credentials to access the build cache.\n` +
+          `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", \n` +
+          `or provide a SAS in the ` +
+          `${EnvironmentVariableNames.RUSH_BUILD_CACHE_CREDENTIAL} environment variable.`
+      );
+    } else if (err.response?.parsedHeaders?.errorCode === 'AuthenticationFailed') {
+      // This error means the user's credentials are incorrect, but not expired normally. They might have
+      // gotten corrupted somehow, or revoked manually in Azure Portal.
+      terminal.writeWarningLine(
+        `${errorMessage}\n\n` +
+          `Your Azure Storage SAS credentials are not valid.\n` +
+          `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}", \n` +
+          `or provide a SAS in the ` +
+          `${EnvironmentVariableNames.RUSH_BUILD_CACHE_CREDENTIAL} environment variable.`
+      );
+    } else if (err.response?.parsedHeaders?.errorCode === 'AuthorizationPermissionMismatch') {
+      // This error is not solvable by the user, so we'll assume it is a configuration error, and revert
+      // to providing likely next steps on configuration. (Hopefully this error is rare for a regular
+      // developer, more likely this error will appear while someone is configuring the cache for the
+      // first time.)
+      terminal.writeWarningLine(
+        `${errorMessage}\n\n` +
+          `Your Azure Storage SAS credentials are valid, but do not have permission to read the build cache.\n` +
+          `Make sure you have added the role 'Storage Blob Data Reader' to the appropriate user(s) or group(s)\n` +
+          `on your storage account in the Azure Portal.`
+      );
+    } else if (err.statusCode === 404) {
+      // Expected
+    } else {
+      // We don't know what went wrong, hopefully we'll print something useful.
+      terminal.writeWarningLine(errorMessage);
     }
   }
 
@@ -123,6 +142,34 @@ export class AzureStorageBuildCacheProvider
     terminal: ITerminal,
     cacheId: string,
     entryStream: Buffer
+  ): Promise<boolean> {
+    return this._trySetCacheEntryAsync(terminal, cacheId, (blockBlobClient: BlockBlobClient) => {
+      return blockBlobClient.uploadData(entryStream, {
+        conditions: {
+          ifNoneMatch: '*'
+        }
+      });
+    });
+  }
+
+  public async trySetCacheEntryFileAsync(
+    terminal: ITerminal,
+    cacheId: string,
+    cacheFilePath: string
+  ): Promise<boolean> {
+    return this._trySetCacheEntryAsync(terminal, cacheId, (blockBlobClient: BlockBlobClient) => {
+      return blockBlobClient.uploadFile(cacheFilePath, {
+        conditions: {
+          ifNoneMatch: '*'
+        }
+      });
+    });
+  }
+
+  public async _trySetCacheEntryAsync(
+    terminal: ITerminal,
+    cacheId: string,
+    uploadFunction: (blockBlobClient: BlockBlobClient) => Promise<BlobUploadCommonResponse>
   ): Promise<boolean> {
     if (!this.isCacheWriteAllowed) {
       terminal.writeErrorLine(
@@ -133,47 +180,24 @@ export class AzureStorageBuildCacheProvider
 
     const blobClient: BlobClient = await this._getBlobClientForCacheIdAsync(cacheId, terminal);
     const blockBlobClient: BlockBlobClient = blobClient.getBlockBlobClient();
-    let blobAlreadyExists: boolean = false;
 
     try {
-      blobAlreadyExists = await blockBlobClient.exists();
-    } catch (err) {
-      const e: IBlobError = err as IBlobError;
-
-      // If RUSH_BUILD_CACHE_CREDENTIAL is set but is corrupted or has been rotated
-      // in Azure Portal, or the user's own cached credentials have been corrupted or
-      // invalidated, we'll print the error and continue (this way we don't fail the
-      // actual rush build).
-      const errorMessage: string =
-        'Error checking if cache entry exists in Azure Storage: ' +
-        [e.name, e.message, e.response?.status, e.response?.parsedHeaders?.errorCode]
-          .filter((piece: string | undefined) => piece)
-          .join(' ');
-
-      terminal.writeWarningLine(errorMessage);
-    }
-
-    if (blobAlreadyExists) {
-      terminal.writeVerboseLine('Build cache entry blob already exists.');
-      return true;
-    } else {
-      try {
-        await blockBlobClient.upload(entryStream, entryStream.length);
+      const response: BlobUploadCommonResponse = await uploadFunction(blockBlobClient);
+      const status: number = response._response.status;
+      return (status >= 200 && status < 300) || status === 409;
+    } catch (e) {
+      if ((e as IBlobError).statusCode === 409 /* conflict */) {
+        // If something else has written to the blob at the same time,
+        // it's probably a concurrent process that is attempting to write
+        // the same cache entry. That is an effective success.
+        terminal.writeVerboseLine(
+          'Azure Storage returned status 409 (conflict). The cache entry has ' +
+            `probably already been set by another builder. Code: "${(e as IBlobError).code}".`
+        );
         return true;
-      } catch (e) {
-        if ((e as IBlobError).statusCode === 409 /* conflict */) {
-          // If something else has written to the blob at the same time,
-          // it's probably a concurrent process that is attempting to write
-          // the same cache entry. That is an effective success.
-          terminal.writeVerboseLine(
-            'Azure Storage returned status 409 (conflict). The cache entry has ' +
-              `probably already been set by another builder. Code: "${(e as IBlobError).code}".`
-          );
-          return true;
-        } else {
-          terminal.writeWarningLine(`Error uploading cache entry to Azure Storage: ${e}`);
-          return false;
-        }
+      } else {
+        terminal.writeWarningLine(`Error uploading cache entry to Azure Storage: ${e}`);
+        return false;
       }
     }
   }


### PR DESCRIPTION
## Summary
Provides the option for Cloud Cache providers to directly read the existing local cache entry when writing and write to a local file that will be ingested into the local cache when reading, rather than routing through an intermediary `Buffer`. This change is intended to reduce the memory footprint of the Rush process.

## Details
Adds new optional APIs to `ICloudBuildCacheProvider` that read and write from a local file instead of taking a `Buffer`.

Since we use the native `tar` binary for packing and unpacking of archives, there is no benefit to maintaining the entire archive in memory.

## How it was tested
Pending.

## Impacted documentation
Documentation for implementing Cloud Build Cache Providers for Rush.