### PR TITLE
[package-deps-hash] Limit unexpected Git work

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/no-ahead-behind_2023-02-22-22-11.json
+++ b/common/changes/@rushstack/package-deps-hash/no-ahead-behind_2023-02-22-22-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Prevent network calls or maintenance tasks during local Git operations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}


### PR DESCRIPTION
## Summary
Ensures that the call to `git status` does not perform git maintenance tasks or issue network calls.

## Details
Sets the `maintenance.auto` config option to `false` while running the `git status` command to ensure maintenance tasks do not run and passes the `--no-ahead-behind` flag to ensure that it does not query the remote.

## How it was tested
Local rush build with built copy.

## Impacted documentation
None.