### PR TITLE
[rush-lib] Support --peer flag for rush add command

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-02-23-17-02.json
+++ b/common/changes/@microsoft/rush/main_2023-02-23-17-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add `--peer` flag to `rush add` command to add peerDependencies",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/AddAction.ts
+++ b/libraries/rush-lib/src/cli/actions/AddAction.ts
@@ -20,6 +20,7 @@ export class AddAction extends BaseAddAndRemoveAction {
   private readonly _exactFlag: CommandLineFlagParameter;
   private readonly _caretFlag: CommandLineFlagParameter;
   private readonly _devDependencyFlag: CommandLineFlagParameter;
+  private readonly _peerDependencyFlag: CommandLineFlagParameter;
   private readonly _makeConsistentFlag: CommandLineFlagParameter;
 
   public constructor(parser: RushCommandLineParser) {
@@ -67,6 +68,11 @@ export class AddAction extends BaseAddAndRemoveAction {
       parameterLongName: '--dev',
       description:
         'If specified, the package will be added to the "devDependencies" section of the package.json'
+    });
+    this._peerDependencyFlag = this.defineFlagParameter({
+      parameterLongName: '--peer',
+      description:
+        'If specified, the package will be added to the "peerDependencies" section of the package.json'
     });
     this._makeConsistentFlag = this.defineFlagParameter({
       parameterLongName: '--make-consistent',
@@ -147,6 +153,7 @@ export class AddAction extends BaseAddAndRemoveAction {
       projects: projects,
       packagesToUpdate: packagesToAdd,
       devDependency: this._devDependencyFlag.value,
+      peerDependency: this._peerDependencyFlag.value,
       updateOtherPackages: this._makeConsistentFlag.value,
       skipUpdate: this._skipUpdateFlag.value,
       debugInstall: this.parser.isDebug,

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -77,7 +77,9 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: add 1`] = `
-"usage: rush add [-h] [-s] -p PACKAGE [--exact] [--caret] [--dev] [-m] [--all]
+"usage: rush add [-h] [-s] -p PACKAGE [--exact] [--caret] [--dev] [--peer] [-m]
+                [--all]
+                
 
 Adds specified package(s) to the dependencies of the current project (as 
 determined by the current working directory) and then runs \\"rush update\\". If 
@@ -111,6 +113,8 @@ Optional arguments:
                         specifier (\\"^\\").
   --dev                 If specified, the package will be added to the 
                         \\"devDependencies\\" section of the package.json
+  --peer                If specified, the package will be added to the 
+                        \\"peerDependencies\\" section of the package.json
   -m, --make-consistent
                         If specified, other packages with this dependency 
                         will have their package.json files updated to use the 

--- a/libraries/rush-lib/src/logic/PackageJsonUpdaterTypes.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdaterTypes.ts
@@ -68,6 +68,10 @@ export interface IPackageJsonUpdaterRushAddOptions extends IPackageJsonUpdaterRu
    */
   devDependency: boolean;
   /**
+   * Whether or not this dependency should be added as a peerDependency or a regular dependency.
+   */
+  peerDependency: boolean;
+  /**
    * If specified, other packages that use this dependency will also have their package.json's updated.
    */
   updateOtherPackages: boolean;

--- a/libraries/rush-lib/src/npm-check-typings.d.ts
+++ b/libraries/rush-lib/src/npm-check-typings.d.ts
@@ -31,6 +31,7 @@ declare module 'npm-check' {
     packageWanted: string; // Requested version from the package.json.
     packageJson: string; // Version or range requested in the parent package.json.
     devDependency: boolean; // Is this a devDependency?
+    peerDependency: boolean; // Is this a peerDependency?
     usedInScripts: undefined | string[]; // Array of `scripts` in package.json that use this module.
     mismatch: boolean; // Does the version installed not match the range in package.json?
     semverValid: string; // Is the installed version valid semver?


### PR DESCRIPTION
## Summary
Add `--peer` flag to `rush add` command to add peerDepependencies to package.json

Fixes #1456

## How it was tested

Invoked `rush add` with `--peer <packageName>` and confirmed that package was added successfully to package.json.
Also tested successfully with additional parameter `--exact` after the first command.

## Impacted documentation
https://rushjs.io/pages/commands/rush_add/


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
