### PR TITLE
[debug-certificate-manager] Fix cert expiration

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/fix-certificate-expiration_2023-03-02-23-52.json
+++ b/common/changes/@rushstack/debug-certificate-manager/fix-certificate-expiration_2023-03-02-23-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/debug-certificate-manager",
-      "comment": "Fix certificate expiration calculation.",
+      "comment": "Fix an issue where certificate expiration was calculated incorrectly and certificates were set to expire too late.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/debug-certificate-manager/fix-certificate-expiration_2023-03-02-23-52.json
+++ b/common/changes/@rushstack/debug-certificate-manager/fix-certificate-expiration_2023-03-02-23-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix certificate expiration calculation.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -279,9 +279,11 @@ export class CertificateManager {
 
     certificate.serialNumber = CA_SERIAL_NUMBER;
 
-    const now: Date = new Date();
-    certificate.validity.notBefore = now;
-    certificate.validity.notAfter.setUTCDate(certificate.validity.notBefore.getUTCDate() + validityInDays);
+    const notBefore: Date = new Date();
+    const notAfter: Date = new Date(notBefore);
+    notAfter.setUTCDate(notBefore.getUTCDate() + validityInDays);
+    certificate.validity.notBefore = notBefore;
+    certificate.validity.notAfter = notAfter;
 
     const attrs: pki.CertificateField[] = [
       {
@@ -359,9 +361,11 @@ export class CertificateManager {
       forge
     );
 
-    const now: Date = new Date();
-    certificate.validity.notBefore = now;
-    certificate.validity.notAfter.setUTCDate(certificate.validity.notBefore.getUTCDate() + validityInDays);
+    const notBefore: Date = new Date();
+    const notAfter: Date = new Date(notBefore);
+    notAfter.setUTCDate(notBefore.getUTCDate() + validityInDays);
+    certificate.validity.notBefore = notBefore;
+    certificate.validity.notAfter = notAfter;
 
     const subjectAttrs: pki.CertificateField[] = [
       {

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -85,6 +85,8 @@ export interface ICertificateGenerationOptions {
   validityInDays?: number;
 }
 
+const MAX_CERTIFICATE_VALIDITY_DAYS: 365 = 365;
+
 /**
  * A utility class to handle generating, trusting, and untrustring a debug certificate.
  * Contains two public methods to `ensureCertificate` and `untrustCertificate`.
@@ -139,6 +141,14 @@ export class CertificateManager {
       if (now > notAfter) {
         messages.push(
           `The existing development certificate's validity period ended ${notAfter}. It is currently ${now}.`
+        );
+      }
+
+      now.setUTCDate(now.getUTCDate() + optionsWithDefaults.validityInDays);
+      if (notAfter > now) {
+        messages.push(
+          `The existing development certificate's expiration date ${notAfter} exceeds the allowed limit ${now}. ` +
+            `This will be rejected by many browsers.`
         );
       }
 
@@ -713,6 +723,9 @@ function applyDefaultOptions(
   const subjectNames: ReadonlyArray<string> | undefined = options?.subjectAltNames;
   return {
     subjectAltNames: subjectNames?.length ? subjectNames : DEFAULT_CERTIFICATE_SUBJECT_NAMES,
-    validityInDays: options?.validityInDays ?? 365
+    validityInDays: Math.min(
+      MAX_CERTIFICATE_VALIDITY_DAYS,
+      options?.validityInDays ?? MAX_CERTIFICATE_VALIDITY_DAYS
+    )
   };
 }


### PR DESCRIPTION
## Summary
Fixes a bug in which certificates were being generated with a longer-than-expected validity period and therefore failing browsers' maximum validity period checks.

## Details
Ensures that the `notAfter` date is completely specified, rather than using whatever default value was provided by `node-forge` and altering the UTCDate field.
Adds a validation step on the expiration date to ensure that the certifiate doesn't exceed the maximum validity allowed by common browsers.

## How it was tested
Manual execution of heft-webpack5-everything-test after deleting local certificate:
```
Subject: localhost
Issuer: rushstack-certificate-manager.localhost
Expires on: Mar 1, 2024
Current date: Mar 2, 2023
```

## Impacted documentation
None