### PR TITLE
[debug-certificate-manager] Force certificates with a validity period longer than 365 days to be refreshed.

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/refresh-too-long-lived-certs_2023-03-03-03-27.json
+++ b/common/changes/@rushstack/debug-certificate-manager/refresh-too-long-lived-certs_2023-03-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Force certificates with a validity period longer than the expected validity period to be refreshed.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -15,6 +15,7 @@ const FRIENDLY_NAME: string = 'debug-certificate-manager Development Certificate
 const MAC_KEYCHAIN: string = '/Library/Keychains/System.keychain';
 const CERTUTIL_EXE_NAME: string = 'certutil';
 const CA_ALT_NAME: string = 'rushstack-certificate-manager.localhost';
+const ONE_DAY_IN_MILLISECONDS: number = 24 * 60 * 60 * 1000;
 
 /**
  * The set of names the certificate should be generated for, by default.
@@ -149,6 +150,16 @@ export class CertificateManager {
         messages.push(
           `The existing development certificate's expiration date ${notAfter} exceeds the allowed limit ${now}. ` +
             `This will be rejected by many browsers.`
+        );
+      }
+
+      if (
+        notBefore.getTime() - notAfter.getTime() >
+        optionsWithDefaults.validityInDays * ONE_DAY_IN_MILLISECONDS
+      ) {
+        messages.push(
+          "The existing development certificate's validity period is longer " +
+            `than ${optionsWithDefaults.validityInDays} days.`
         );
       }
 


### PR DESCRIPTION
Related to https://github.com/microsoft/rushstack/pull/3997, this PR will force certificates with a validity period longer than the allowed period to be refreshed.