### PR TITLE
[rush] Fix an issue with running 'rush update-autoinstaller'.

### DIFF
--- a/common/changes/@microsoft/rush/fix-update-autoinstaller_2023-03-14-02-58.json
+++ b/common/changes/@microsoft/rush/fix-update-autoinstaller_2023-03-14-02-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where running `rush update-autoinstaller` without having run `rush install` or `rush update` first would cause a crash with an unhelpful error message.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -136,7 +136,8 @@ export class RushCommandLineParser extends CommandLineParser {
       rushConfiguration: this.rushConfiguration,
       terminal: this._terminal,
       builtInPluginConfigurations: this._rushOptions.builtInPluginConfigurations,
-      restrictConsoleOutput: this._restrictConsoleOutput
+      restrictConsoleOutput: this._restrictConsoleOutput,
+      rushGlobalFolder: this.rushGlobalFolder
     });
 
     this._populateActions();

--- a/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -38,7 +38,8 @@ export class InitAutoinstallerAction extends BaseRushAction {
 
     const autoinstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName,
-      rushConfiguration: this.rushConfiguration
+      rushConfiguration: this.rushConfiguration,
+      rushGlobalFolder: this.rushGlobalFolder
     });
 
     if (FileSystem.exists(autoinstaller.folderFullPath)) {

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -32,8 +32,10 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
 
     const autoinstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName,
-      rushConfiguration: this.rushConfiguration
+      rushConfiguration: this.rushConfiguration,
+      rushGlobalFolder: this.rushGlobalFolder
     });
+    await autoinstaller.prepareAsync();
     autoinstaller.update();
 
     console.log('\nSuccess.');

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -88,7 +88,8 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
   private async _prepareAutoinstallerName(): Promise<void> {
     const autoInstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName: this._autoinstallerName,
-      rushConfiguration: this.rushConfiguration
+      rushConfiguration: this.rushConfiguration,
+      rushGlobalFolder: this.rushGlobalFolder
     });
 
     await autoInstaller.prepareAsync();

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -11,7 +11,7 @@ import { PackageName, IParsedPackageNameOrError } from '@rushstack/node-core-lib
 import { RushConfiguration } from '../api/RushConfiguration';
 import { PackageJsonEditor } from '../api/PackageJsonEditor';
 import { InstallHelpers } from './installManager/InstallHelpers';
-import { RushGlobalFolder } from '../api/RushGlobalFolder';
+import type { RushGlobalFolder } from '../api/RushGlobalFolder';
 import { RushConstants } from './RushConstants';
 import { LastInstallFlag } from '../api/LastInstallFlag';
 import { RushCommandLineParser } from '../cli/RushCommandLineParser';
@@ -19,6 +19,7 @@ import { RushCommandLineParser } from '../cli/RushCommandLineParser';
 interface IAutoinstallerOptions {
   autoinstallerName: string;
   rushConfiguration: RushConfiguration;
+  rushGlobalFolder: RushGlobalFolder;
   restrictConsoleOutput?: boolean;
 }
 
@@ -26,11 +27,13 @@ export class Autoinstaller {
   public readonly name: string;
 
   private readonly _rushConfiguration: RushConfiguration;
+  private readonly _rushGlobalFolder: RushGlobalFolder;
   private readonly _restrictConsoleOutput: boolean;
 
   public constructor(options: IAutoinstallerOptions) {
     this.name = options.autoinstallerName;
     this._rushConfiguration = options.rushConfiguration;
+    this._rushGlobalFolder = options.rushGlobalFolder;
     this._restrictConsoleOutput =
       options.restrictConsoleOutput ?? RushCommandLineParser.shouldRestrictConsoleOutput();
 
@@ -75,10 +78,9 @@ export class Autoinstaller {
       );
     }
 
-    const rushGlobalFolder: RushGlobalFolder = new RushGlobalFolder();
     await InstallHelpers.ensureLocalPackageManager(
       this._rushConfiguration,
-      rushGlobalFolder,
+      this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts,
       this._restrictConsoleOutput
     );

--- a/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
@@ -13,9 +13,11 @@ import {
   IRushPluginManifestJson,
   PluginLoaderBase
 } from './PluginLoaderBase';
+import type { RushGlobalFolder } from '../../api/RushGlobalFolder';
 
 interface IAutoinstallerPluginLoaderOptions extends IPluginLoaderOptions<IRushPluginConfiguration> {
   restrictConsoleOutput: boolean;
+  rushGlobalFolder: RushGlobalFolder;
 }
 
 /**
@@ -31,7 +33,8 @@ export class AutoinstallerPluginLoader extends PluginLoaderBase<IRushPluginConfi
     this.autoinstaller = new Autoinstaller({
       autoinstallerName: options.pluginConfiguration.autoinstallerName,
       rushConfiguration: this._rushConfiguration,
-      restrictConsoleOutput: options.restrictConsoleOutput
+      restrictConsoleOutput: options.restrictConsoleOutput,
+      rushGlobalFolder: options.rushGlobalFolder
     });
 
     this.packageFolder = path.join(this.autoinstaller.folderFullPath, 'node_modules', this.packageName);

--- a/libraries/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginManager.ts
@@ -11,6 +11,7 @@ import { AutoinstallerPluginLoader } from './PluginLoader/AutoinstallerPluginLoa
 import { RushSession } from './RushSession';
 import { PluginLoaderBase } from './PluginLoader/PluginLoaderBase';
 import { Rush } from '../api/Rush';
+import type { RushGlobalFolder } from '../api/RushGlobalFolder';
 
 export interface IPluginManagerOptions {
   terminal: ITerminal;
@@ -18,6 +19,7 @@ export interface IPluginManagerOptions {
   rushSession: RushSession;
   builtInPluginConfigurations: IBuiltInPluginConfiguration[];
   restrictConsoleOutput: boolean;
+  rushGlobalFolder: RushGlobalFolder;
 }
 
 export interface ICustomCommandLineConfigurationInfo {
@@ -34,6 +36,7 @@ export class PluginManager {
   private readonly _autoinstallerPluginLoaders: AutoinstallerPluginLoader[];
   private readonly _installedAutoinstallerNames: Set<string>;
   private readonly _loadedPluginNames: Set<string> = new Set<string>();
+  private readonly _rushGlobalFolder: RushGlobalFolder;
 
   private _error: Error | undefined;
 
@@ -42,6 +45,7 @@ export class PluginManager {
     this._rushConfiguration = options.rushConfiguration;
     this._rushSession = options.rushSession;
     this._restrictConsoleOutput = options.restrictConsoleOutput;
+    this._rushGlobalFolder = options.rushGlobalFolder;
 
     this._installedAutoinstallerNames = new Set<string>();
 
@@ -98,7 +102,8 @@ export class PluginManager {
         pluginConfiguration,
         rushConfiguration: this._rushConfiguration,
         terminal: this._terminal,
-        restrictConsoleOutput: this._restrictConsoleOutput
+        restrictConsoleOutput: this._restrictConsoleOutput,
+        rushGlobalFolder: this._rushGlobalFolder
       });
     });
   }


### PR DESCRIPTION
## Summary

There is an issue with `rush update-autoinstaller` where it doesn't ensure the package manager is installed before trying to invoke it in the autoinstaller's folder. This PR fixes that and ensure that the autoinstaller updater uses the same `RushGlobalFolder` as other installers.

## How it was tested

Ran `rush purge` and then `rush update-autoinstaller` in a test repo with a change to an autoinstalled package.