### PR TITLE
[rush] Exposing executionRecords in PhasedScriptsAction allows users to observe the execution process

### DIFF
--- a/common/changes/@microsoft/rush/feat-periodically-send-operation-state_2023-03-17-02-07.json
+++ b/common/changes/@microsoft/rush/feat-periodically-send-operation-state_2023-03-17-02-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "add hooks to PhasedCommandHooks to give user the operation records",
+      "comment": "Include some more hooks to allow plugins to monitor phased command execution in real-time.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/feat-periodically-send-operation-state_2023-03-17-02-07.json
+++ b/common/changes/@microsoft/rush/feat-periodically-send-operation-state_2023-03-17-02-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "add hooks to PhasedCommandHooks to give user the operation records",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -744,7 +744,9 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
 // @alpha
 export class PhasedCommandHooks {
     readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]>;
+    readonly beforeExecuteOperations: AsyncSeriesHook<[Map<Operation, IOperationExecutionResult>]>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
+    readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]>;
     readonly waitingForChanges: SyncHook<void>;
 }
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -28,6 +28,7 @@ import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 import type { IPhase, IPhasedCommandConfig } from '../../api/CommandLineConfiguration';
 import { Operation } from '../../logic/operations/Operation';
+import { OperationExecutionRecord } from '../../logic/operations/OperationExecutionRecord';
 import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlugin';
 import { ShellOperationRunnerPlugin } from '../../logic/operations/ShellOperationRunnerPlugin';
 import { Event } from '../../api/EventHooks';
@@ -340,7 +341,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       quietMode: isQuietMode,
       debugMode: this.parser.isDebug,
       parallelism,
-      changedProjectsOnly
+      changedProjectsOnly,
+      beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
+        await this.hooks.beforeExecuteOperations.promise(records);
+      },
+      onOperationStatusChanged: (record: OperationExecutionRecord) => {
+        this.hooks.onOperationStatusChanged.call(record);
+      }
     };
 
     const internalOptions: IRunPhasesOptions = {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -13,6 +13,7 @@ import { OperationMetadataManager } from './OperationMetadataManager';
 
 export interface IOperationExecutionRecordContext {
   streamCollator: StreamCollator;
+  onOperationStatusChanged?: (record: OperationExecutionRecord) => void;
 
   debugMode: boolean;
   quietMode: boolean;
@@ -135,6 +136,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
   public async executeAsync(onResult: (record: OperationExecutionRecord) => void): Promise<void> {
     this.status = OperationStatus.Executing;
     this.stopwatch.start();
+    this._context.onOperationStatusChanged?.(this);
 
     try {
       this.status = await this.runner.executeAsync(this);
@@ -149,6 +151,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
       this._collatedWriter?.close();
       this.stdioSummarizer.close();
       this.stopwatch.stop();
+      this._context.onOperationStatusChanged?.(this);
     }
   }
 }

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -11,7 +11,7 @@ import type { RushConfigurationProject } from '../api/RushConfigurationProject';
 
 import type { Operation } from '../logic/operations/Operation';
 import type { ProjectChangeAnalyzer } from '../logic/ProjectChangeAnalyzer';
-import { IExecutionResult } from '../logic/operations/IOperationExecutionResult';
+import { IExecutionResult, IOperationExecutionResult } from '../logic/operations/IOperationExecutionResult';
 
 /**
  * A plugin that interacts with a phased commands.
@@ -86,6 +86,19 @@ export class PhasedCommandHooks {
    */
   public readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]> =
     new AsyncSeriesWaterfallHook(['operations', 'context'], 'createOperations');
+
+  /**
+   * Hook invoked before operation start
+   * Hook is series for stable output.
+   */
+  public readonly beforeExecuteOperations: AsyncSeriesHook<[Map<Operation, IOperationExecutionResult>]> =
+    new AsyncSeriesHook(['records']);
+
+  /**
+   * Hook invoked when operation statue changed
+   * Hook is series for stable output.
+   */
+  public readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]> = new SyncHook(['record']);
 
   /**
    * Hook invoked after executing a set of operations.

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -95,7 +95,7 @@ export class PhasedCommandHooks {
     new AsyncSeriesHook(['records']);
 
   /**
-   * Hook invoked when operation statue changed
+   * Hook invoked when operation status changed
    * Hook is series for stable output.
    */
   public readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]> = new SyncHook(['record']);


### PR DESCRIPTION
## Summary
Exposing executionRecords in PhasedScriptsAction allows users to observe the execution process

## Details
As a member of the monorepo infrastructure team, there will be many compilations in progress at the same time, 
 I hope to be able to collect the real-time status of the rush execution command. If I can get the real-time status in the hooks of rushLifeCycle, I can observe the start and end times of all project compilation in a task, and then send it to the data server to build a dashboard that can view the execution status in real time

## How to use
```
rushSession.hooks.runAnyPhasedCommand.tap(PLUGIN_NAME, (phase: ReadonlyMap<Operation, IOperationExecutionResult>) => {
    phase.hooks.beforeExecuteOperations.tapPromise(PLUGIN_NAME, async (records) => {
        // all operation records
    });
    phase.hooks.onOperationStatusChanged.tap(PLUGIN_NAME, (record: IOperationExecutionResult) => {
        // statue changed operation record
    });
});
```
### Demo use local data
![image](https://user-images.githubusercontent.com/11866967/224955490-70141526-b1a5-4288-b925-1ed4ec1e72da.png)



