### PR TITLE
[rush-lib] Extend LookupByPath to return index of remaining path

### DIFF
--- a/common/changes/@microsoft/rush/extend-lookup-by-path_2023-03-14-17-57.json
+++ b/common/changes/@microsoft/rush/extend-lookup-by-path_2023-03-14-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Extend LookupByPath to also be able to obtain the index of the remainder of the matched path.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -494,7 +494,7 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     useWorkspaces?: boolean;
 }
 
-// @public (undocumented)
+// @beta
 export interface IPrefixMatch<TItem> {
     // (undocumented)
     index: number;
@@ -617,8 +617,8 @@ export class LookupByPath<TItem> {
     constructor(entries?: Iterable<[string, TItem]>, delimiter?: string);
     readonly delimiter: string;
     findChildPath(childPath: string): TItem | undefined;
-    findChildPathAndIndex(childPath: string): IPrefixMatch<TItem> | undefined;
     findChildPathFromSegments(childPathSegments: Iterable<string>): TItem | undefined;
+    findLongestPrefixMatch(query: string): IPrefixMatch<TItem> | undefined;
     static iteratePathSegments(serializedPath: string, delimiter?: string): Iterable<string>;
     setItem(serializedPath: string, value: TItem): this;
     setItemFromSegments(pathSegments: Iterable<string>, value: TItem): this;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -494,6 +494,14 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     useWorkspaces?: boolean;
 }
 
+// @public (undocumented)
+export interface IPrefixMatch<TItem> {
+    // (undocumented)
+    index: number;
+    // (undocumented)
+    value: TItem;
+}
+
 // @beta
 export interface IRushCommand {
     readonly actionName: string;
@@ -609,6 +617,7 @@ export class LookupByPath<TItem> {
     constructor(entries?: Iterable<[string, TItem]>, delimiter?: string);
     readonly delimiter: string;
     findChildPath(childPath: string): TItem | undefined;
+    findChildPathAndIndex(childPath: string): IPrefixMatch<TItem> | undefined;
     findChildPathFromSegments(childPathSegments: Iterable<string>): TItem | undefined;
     static iteratePathSegments(serializedPath: string, delimiter?: string): Iterable<string>;
     setItem(serializedPath: string, value: TItem): this;

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -63,7 +63,7 @@ export { PackageJsonEditor, PackageJsonDependency, DependencyType } from './api/
 
 export { RepoStateFile } from './logic/RepoStateFile';
 
-export { LookupByPath } from './logic/LookupByPath';
+export { LookupByPath, IPrefixMatch } from './logic/LookupByPath';
 export { EventHooks, Event } from './api/EventHooks';
 
 export { ChangeManager } from './api/ChangeManager';

--- a/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
+++ b/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
@@ -101,3 +101,36 @@ describe(LookupByPath.prototype.findChildPath.name, () => {
     expect(tree.findChildPathFromSegments(['foo', 'bar', 'baz'])).toEqual(1);
   });
 });
+
+describe(LookupByPath.prototype.findChildPathAndIndex.name, () => {
+  it('returns empty for an empty tree', () => {
+    expect(new LookupByPath().findChildPathAndIndex('foo')).toEqual(undefined);
+  });
+  it('returns the matching node for a trivial tree', () => {
+    expect(new LookupByPath([['foo', 1]]).findChildPathAndIndex('foo')).toEqual({ value: 1, index: 3 });
+  });
+  it('returns the matching node for a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.findChildPathAndIndex('foo')).toEqual({ value: 1, index: 3 });
+    expect(tree.findChildPathAndIndex('bar')).toEqual({ value: 2, index: 3 });
+    expect(tree.findChildPathAndIndex('baz')).toEqual({ value: 3, index: 3 });
+    expect(tree.findChildPathAndIndex('buzz')).toEqual(undefined);
+  });
+  it('returns the matching parent for multi-layer queries', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.findChildPathAndIndex('foo/bar')).toEqual({ value: 1, index: 3 });
+    expect(tree.findChildPathAndIndex('bar/baz')).toEqual({ value: 2, index: 3 });
+    expect(tree.findChildPathAndIndex('baz/foo')).toEqual({ value: 3, index: 3 });
+    expect(tree.findChildPathAndIndex('foo/foo')).toEqual({ value: 1, index: 3 });
+  });
+});

--- a/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
+++ b/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
@@ -102,35 +102,36 @@ describe(LookupByPath.prototype.findChildPath.name, () => {
   });
 });
 
-describe(LookupByPath.prototype.findChildPathAndIndex.name, () => {
+describe(LookupByPath.prototype.findLongestPrefixMatch.name, () => {
   it('returns empty for an empty tree', () => {
-    expect(new LookupByPath().findChildPathAndIndex('foo')).toEqual(undefined);
+    expect(new LookupByPath().findLongestPrefixMatch('foo')).toEqual(undefined);
   });
   it('returns the matching node for a trivial tree', () => {
-    expect(new LookupByPath([['foo', 1]]).findChildPathAndIndex('foo')).toEqual({ value: 1, index: 3 });
+    expect(new LookupByPath([['foo', 1]]).findLongestPrefixMatch('foo')).toEqual({ value: 1, index: 3 });
   });
   it('returns the matching node for a single-layer tree', () => {
     const tree: LookupByPath<number> = new LookupByPath([
       ['foo', 1],
-      ['bar', 2],
+      ['barbar', 2],
       ['baz', 3]
     ]);
 
-    expect(tree.findChildPathAndIndex('foo')).toEqual({ value: 1, index: 3 });
-    expect(tree.findChildPathAndIndex('bar')).toEqual({ value: 2, index: 3 });
-    expect(tree.findChildPathAndIndex('baz')).toEqual({ value: 3, index: 3 });
-    expect(tree.findChildPathAndIndex('buzz')).toEqual(undefined);
+    expect(tree.findLongestPrefixMatch('foo')).toEqual({ value: 1, index: 3 });
+    expect(tree.findLongestPrefixMatch('barbar')).toEqual({ value: 2, index: 6 });
+    expect(tree.findLongestPrefixMatch('baz')).toEqual({ value: 3, index: 3 });
+    expect(tree.findLongestPrefixMatch('buzz')).toEqual(undefined);
   });
   it('returns the matching parent for multi-layer queries', () => {
     const tree: LookupByPath<number> = new LookupByPath([
       ['foo', 1],
-      ['bar', 2],
-      ['baz', 3]
+      ['barbar', 2],
+      ['baz', 3],
+      ['foo/bar', 4]
     ]);
 
-    expect(tree.findChildPathAndIndex('foo/bar')).toEqual({ value: 1, index: 3 });
-    expect(tree.findChildPathAndIndex('bar/baz')).toEqual({ value: 2, index: 3 });
-    expect(tree.findChildPathAndIndex('baz/foo')).toEqual({ value: 3, index: 3 });
-    expect(tree.findChildPathAndIndex('foo/foo')).toEqual({ value: 1, index: 3 });
+    expect(tree.findLongestPrefixMatch('foo/bar')).toEqual({ value: 4, index: 7 });
+    expect(tree.findLongestPrefixMatch('barbar/baz')).toEqual({ value: 2, index: 6 });
+    expect(tree.findLongestPrefixMatch('baz/foo')).toEqual({ value: 3, index: 3 });
+    expect(tree.findLongestPrefixMatch('foo/foo')).toEqual({ value: 1, index: 3 });
   });
 });


### PR DESCRIPTION
## Summary
Enhances the `LookupByPath` helper class with a method `findChildPathAndIndex` that returns both the matched entry and the index at which the remainder of the query path starts.

## Details
Useful for `ProjectChangeAnalyzer` when routing files to projects, to get the remaining path relative to the project.

## How it was tested
Added unit tests.

## Impacted documentation
None