### PR TITLE
[heft] Fix watchGlobAsync

### DIFF
--- a/apps/heft/src/plugins/FileGlobSpecifier.ts
+++ b/apps/heft/src/plugins/FileGlobSpecifier.ts
@@ -106,8 +106,8 @@ export async function watchGlobAsync(
   options: IWatchGlobOptions
 ): Promise<Map<string, IWatchedFileState>> {
   const { fs, cwd, absolute } = options;
-  if (!cwd && !absolute) {
-    throw new Error(`"cwd" must be set in the options passed to "watchGlobAsync" if "absolute" is not set`);
+  if (!cwd) {
+    throw new Error(`"cwd" must be set in the options passed to "watchGlobAsync"`);
   }
 
   const rawFiles: string[] = await glob(pattern, options);
@@ -116,7 +116,9 @@ export async function watchGlobAsync(
   await Async.forEachAsync(
     rawFiles,
     async (file: string) => {
-      const state: IWatchedFileState = await fs.getStateAndTrackAsync(path.normalize(file));
+      const state: IWatchedFileState = await fs.getStateAndTrackAsync(
+        absolute ? path.normalize(file) : path.resolve(cwd, file)
+      );
       results.set(file, state);
     },
     {


### PR DESCRIPTION
## Summary
Fix regression in `watchGlobAsync` introduced while switching for synchronous `for ... of` to `Async.forEachAsync`

## Details
Code was mistranscribed while converting from synchronous `for ... of` to `Async.forEachAsync`, such that it no longer normalized to absolute paths before recording file accesses.

## How it was tested
Local run in watch mode, verified that only touched files are selected on watch rerun.

## Impacted documentation
None