### PR TITLE
[rush-lib] enable event hook scripts output by default

### DIFF
--- a/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-21-07-43.json
+++ b/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-21-07-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "enable event hook scripts output by default",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-21-07-43.json
+++ b/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-21-07-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "enable event hook scripts output by default",
+      "comment": "Update event hook scripts to print their output to the console.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-23-06-10.json
+++ b/common/changes/@microsoft/rush/feature-rush-event-hook-output_2023-03-23-06-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Update event hook scripts to print their output to the console.",
+      "comment": "Add experiment `printEventHooksOutputToConsole` to allow printing outputs from event hooks to the console.",
       "type": "none"
     }
   ],

--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -46,5 +46,10 @@
    * If true, perform a clean install after when running `rush install` or `rush update` if the
    * `.npmrc` file has changed since the last install.
    */
-  // "cleanInstallAfterNpmrcChanges": true
+  // "cleanInstallAfterNpmrcChanges": true,
+
+  /**
+   * If true, print the outputs of shell commands defined in event hooks to the console.
+   */
+  // "printEventHooksOutputToConsole": true
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -307,6 +307,7 @@ export interface IExperimentsJson {
     phasedCommands?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
+    printEventHooksOutputToConsole?: boolean;
 }
 
 // @beta

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -305,9 +305,9 @@ export interface IExperimentsJson {
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     phasedCommands?: boolean;
+    printEventHooksOutputToConsole?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
-    printEventHooksOutputToConsole?: boolean;
 }
 
 // @beta

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -46,5 +46,10 @@
    * If true, perform a clean install after when running `rush install` or `rush update` if the
    * `.npmrc` file has changed since the last install.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "cleanInstallAfterNpmrcChanges": true
+  /*[LINE "HYPOTHETICAL"]*/ "cleanInstallAfterNpmrcChanges": true,
+
+  /**
+   * If true, print the outputs of shell commands defined in event hooks to the console.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "printEventHooksOutputToConsole": true
 }

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -53,6 +53,11 @@ export interface IExperimentsJson {
    * `.npmrc` file has changed since the last install.
    */
   cleanInstallAfterNpmrcChanges?: boolean;
+
+  /**
+   * If true, print the outputs of shell commands defined in event hooks to the console.
+   */
+  printEventHooksOutputToConsole?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/EventHooksManager.ts
+++ b/libraries/rush-lib/src/logic/EventHooksManager.ts
@@ -34,13 +34,17 @@ export class EventHooksManager {
 
       const stopwatch: Stopwatch = Stopwatch.start();
       console.log('\n' + colors.green(`Executing event hooks for ${Event[event]}`));
+
+      const printEventHooksOutputToConsole =
+        isDebug ||
+        this._rushConfiguration.experimentsConfiguration.configuration.printEventHooksOutputToConsole;
       scripts.forEach((script) => {
         try {
           Utilities.executeLifecycleCommand(script, {
             rushConfiguration: this._rushConfiguration,
             workingDirectory: this._rushConfiguration.rushJsonFolder,
             initCwd: this._commonTempFolder,
-            handleOutput: false,
+            handleOutput: !printEventHooksOutputToConsole,
             environmentPathOptions: {
               includeRepoBin: true
             }

--- a/libraries/rush-lib/src/logic/EventHooksManager.ts
+++ b/libraries/rush-lib/src/logic/EventHooksManager.ts
@@ -35,7 +35,7 @@ export class EventHooksManager {
       const stopwatch: Stopwatch = Stopwatch.start();
       console.log('\n' + colors.green(`Executing event hooks for ${Event[event]}`));
 
-      const printEventHooksOutputToConsole =
+      const printEventHooksOutputToConsole: boolean | undefined =
         isDebug ||
         this._rushConfiguration.experimentsConfiguration.configuration.printEventHooksOutputToConsole;
       scripts.forEach((script) => {

--- a/libraries/rush-lib/src/logic/EventHooksManager.ts
+++ b/libraries/rush-lib/src/logic/EventHooksManager.ts
@@ -40,7 +40,7 @@ export class EventHooksManager {
             rushConfiguration: this._rushConfiguration,
             workingDirectory: this._rushConfiguration.rushJsonFolder,
             initCwd: this._commonTempFolder,
-            handleOutput: !isDebug,
+            handleOutput: false,
             environmentPathOptions: {
               includeRepoBin: true
             }

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -37,6 +37,10 @@
     "cleanInstallAfterNpmrcChanges": {
       "description": "If true, perform a clean install after when running `rush install` or `rush update` if the `.npmrc` file has changed since the last install.",
       "type": "boolean"
+    },
+    "printEventHooksOutputToConsole": {
+      "description": "If true, print the outputs of shell commands defined in event hooks to the console.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

The problem: currently, rush does not show any output from scripts defined within hooks like `postRushInstall ` by default. This is an issue because it prevents users from seeing any meaningful logs or progress from their scripts. This is more of a pain point when the scripts are long-running and may create the illusion of hanging.

The fix: we should enable event hook scripts outputs by default, since they are fully controlled by users, and they shouldn't be hidden behind `verbose` or `debug` flag, as it would create unwanted noise from other steps when enabled and hinder the flexibility of user extension points. 

The only change is to let user script to handle output for event hooks.

Fixes #553

## How it was tested

- test default experiments.json file
  - `rush init`
  - verify common/config/rush/experiments.json has `printEventHooksOutputToConsole` flag
- configure event hooks such as 'postRushInstall' with inline command and shell script invocation
- test default behaviour
  - run `rush update`
  - expect no output from event hooks
- test debug feature
  - run `rush --debug update`
  - expect outputs from event hooks printed to console
- test experiment feature: 
  - enable `printEventHooksOutputToConsole` flag in common/config/rush/experiments.json
  - run `rush update`
  - expect outputs from event hooks printed to console


