### PR TITLE
[api-extractor] support .d.mts and .d.cts files

### DIFF
--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -210,7 +210,7 @@ export class ExtractorConfig {
     path.join(__dirname, '../schemas/api-extractor-defaults.json')
   );
 
-  private static readonly _declarationFileExtensionRegExp: RegExp = /\.d\.ts$/i;
+  private static readonly _declarationFileExtensionRegExp: RegExp = /\.d\.(c|m)?ts$/i;
 
   /** {@inheritDoc IConfigFile.projectFolder} */
   public readonly projectFolder: string;

--- a/common/changes/@microsoft/api-extractor/main_2023-03-20-14-36.json
+++ b/common/changes/@microsoft/api-extractor/main_2023-03-20-14-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add api-extractor support for .d.mts and .d.cts files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Summary

TypeScript supports emitting and loading typings with `.d.cts` and `.d.mts` file extensions. We published a package which uses these extensions for its typings file, but it broke our api-extractor usage so we applied this patch.

## Details

This was the only place I found that specifically hard-coded the `.d.ts` requirement.

## How it was tested

Sorry I don't have time to dig into how you're doing testing in this repo.

## Impacted documentation

I don't think this affects any docs, or needs to be explicitly document itself.



<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
