### PR TITLE
[rush] Fix an issue with update-autoinstaller.

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-03-22-19-25.json
+++ b/common/changes/@microsoft/rush/main_2023-03-22-19-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with `rush update-autoinstaller` where it may fail with an `Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is not up to date with package.json` error.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -35,8 +35,12 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
       rushConfiguration: this.rushConfiguration,
       rushGlobalFolder: this.rushGlobalFolder
     });
-    await autoinstaller.prepareAsync();
-    autoinstaller.update();
+
+    // Do not run `autoinstaller.prepareAsync` here. It tries to install the autoinstaller with
+    // --frozen-lockfile or equivalent, which will fail if the autoinstaller's dependencies
+    // have been changed.
+
+    await autoinstaller.updateAsync();
 
     console.log('\nSuccess.');
   }

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -157,7 +157,14 @@ export class Autoinstaller {
     }
   }
 
-  public update(): void {
+  public async updateAsync(): Promise<void> {
+    await InstallHelpers.ensureLocalPackageManager(
+      this._rushConfiguration,
+      this._rushGlobalFolder,
+      RushConstants.defaultMaxInstallAttempts,
+      this._restrictConsoleOutput
+    );
+
     const autoinstallerPackageJsonPath: string = path.join(this.folderFullPath, 'package.json');
 
     if (!FileSystem.exists(autoinstallerPackageJsonPath)) {


### PR DESCRIPTION
## Summary

I recently fixed another issue with `rush update-autoinstaller` where it would fail if the package manager wasn't already installed (https://github.com/microsoft/rushstack/pull/4009). This introduced a regression where Rush would attempt to install autoinstallers with `--frozen-lockfile` before updating them, which doesn't work if their dependencies change.

This PR fixes that issue by explicitly installing the package manager during the autoinstaller's update function instead.

## How it was tested

Tested in a repo that was failing to update the autoinstaller before.