### PR TITLE
Fix an issue with the 'File Doc Tickets' pipeline.

### DIFF
--- a/.github/workflows/file-doc-tickets.yml
+++ b/.github/workflows/file-doc-tickets.yml
@@ -40,7 +40,7 @@ jobs:
           const DELIMITER = '## Impacted documentation';
 
           const event = JSON.parse(fs.readFileSync(EVENT_FILE, 'utf8'));
-          const strippedBody = event.pull_request.body.replace(/<!-+(.|\r|\n)+?-+>/g, '');
+          const strippedBody = (event.pull_request.body || '').replace(/<!-+(.|\r|\n)+?-+>/g, '');
           const delimIndex = strippedBody.indexOf(DELIMITER);
 
           if (delimIndex < 0) {


### PR DESCRIPTION
If a PR's description is empty, the `event.pull_request.body` property in the doc pipeline is `null`. See example here: https://github.com/microsoft/rushstack/actions/runs/4494179393/jobs/7906337595

This PR handles that case.