### PR TITLE
[rush] Stop shipping everything except for index.js under lib-shim in rush-sdk.

### DIFF
--- a/common/changes/@microsoft/rush/clean-up-rush-sdk-shipped-files_2023-03-30-18-55.json
+++ b/common/changes/@microsoft/rush/clean-up-rush-sdk-shipped-files_2023-03-30-18-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-sdk/.npmignore
+++ b/libraries/rush-sdk/.npmignore
@@ -27,4 +27,7 @@
 # DO NOT MODIFY THE TEMPLATE ABOVE THIS LINE
 #--------------------------------------------
 
+/lib-shim/**
+!/lib-shim/index.js
+
 # (Add your project-specific overrides here)


### PR DESCRIPTION
rush-sdk currently ships typings, sourcemaps, and the shim generator script under its `lib-shim` folder. These aren't useful to a consumer of the package.