### PR TITLE
[rush] Fix an issue where rush-sdk sometimes fails to load if the globally installed Rush package is too old

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-sdk-loading-issue_2023-03-30-19-19.json
+++ b/common/changes/@microsoft/rush/fix-rush-sdk-loading-issue_2023-03-30-19-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where rush-sdk would fail to load if it was invoked from insdie a Rush process where the version selector's version doesn't match the currently-executing rush-lib version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-rush-sdk-loading-issue_2023-03-30-19-19.json
+++ b/common/changes/@microsoft/rush/fix-rush-sdk-loading-issue_2023-03-30-19-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an issue where rush-sdk would fail to load if it was invoked from insdie a Rush process where the version selector's version doesn't match the currently-executing rush-lib version.",
+      "comment": "Fix an issue where rush-sdk sometimes failed to load if the globally installed Rush version was older than rushVersion in rush.json (GitHub #4039)",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/utilities/SetRushLibPath.ts
+++ b/libraries/rush-lib/src/utilities/SetRushLibPath.ts
@@ -2,11 +2,9 @@ import { PackageJsonLookup } from '@rushstack/node-core-library';
 
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 
-if (!process.env[EnvironmentVariableNames.RUSH_LIB_PATH]) {
-  const rootDir: string | undefined = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname);
-  if (rootDir) {
-    // Route to the 'main' field of package.json
-    const rushLibIndex: string = require.resolve(rootDir, { paths: [] });
-    process.env[EnvironmentVariableNames.RUSH_LIB_PATH] = rushLibIndex;
-  }
+const rootDir: string | undefined = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname);
+if (rootDir) {
+  // Route to the 'main' field of package.json
+  const rushLibIndex: string = require.resolve(rootDir, { paths: [] });
+  process.env[EnvironmentVariableNames.RUSH_LIB_PATH] = rushLibIndex;
 }


### PR DESCRIPTION
Fix an issue where rush-sdk would fail to load if it was invoked from inside a Rush process where the version selector's version doesn't match the currently-executing rush-lib version.

## Summary

The `@microsoft/rush` package loads the version of `@microsoft/rush-lib` that it was shipped with, which sets the `_RUSH_LIB_PATH` env variable to the entrypoint of that copy (and version) of `rush-lib`. If the version selector logic in `@microsoft/rush` then determines that the repo that it's executing in wants a different version of `rush-lib`, and loads that, the `_RUSH_LIB_PATH` is currently not updated to point to the correct version of `rush-lib`.

If something executing inside that Rush process (like a build tool) then loads `rush-sdk`, it will get the wrong version of `rush-lib` and potentially not be able to parse that repo's `rush.json` file.

This PR fixes that issue by always having `rush-lib` set the `_RUSH_LIB_PATH` env variable, under the thesis that the most recently loaded copy of `rush-lib` is the correct version for the repo.

## How it was tested

Tested this fix under a repro of the issue outlined above - where the globally-installed copy of `@microsoft/rush` (and, therefore, `@microsoft/rush-lib`) was a version behind what a project's build tool expected, causing that project to fail when built by `rush build`.