### PR TITLE
[rush] Scope watchers to avoid noise in .git

### DIFF
--- a/common/changes/@microsoft/rush/rush-watch-perf_2023-03-30-00-47.json
+++ b/common/changes/@microsoft/rush/rush-watch-perf_2023-03-30-00-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix file watching on Windows in the presence of Git's fsmonitor by not watching the .git folder.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Instead of applying a single recursive watcher to the root of the rush repository when recursive watching is supported, creates one non-recursive watcher in the root (to watch config files), and one recursive watcher in each selected project folder.

Fixes #4031

## Details
Also ignores changes to any folders/files called `.git` or `node_modules`.

There may be concern about watcher counts if watching a monorepo with several hundred projects.

## How it was tested
Local run watching in rushstack repository on Windows.

## Impacted documentation
None