### PR TITLE
[rush] Allow ProjectChangeAnalyzer to acccept an ignore glob

### DIFF
--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -327,6 +327,7 @@ export interface IGenerateCacheEntryIdOptions {
 // @beta (undocumented)
 export interface IGetChangedProjectsOptions {
     enableFiltering: boolean;
+    ignoreGlobs?: string[];
     includeExternalDependencies: boolean;
     // (undocumented)
     shouldFetch?: boolean;
@@ -795,7 +796,7 @@ export class ProjectChangeAnalyzer {
     // @internal (undocumented)
     _ensureInitializedAsync(terminal: ITerminal): Promise<IRawRepoState | undefined>;
     // (undocumented)
-    _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, terminal: ITerminal): Promise<Map<string, T>>;
+    _filterProjectDataAsync<T>(project: RushConfigurationProject, unfilteredProjectData: Map<string, T>, rootDir: string, additionalIgnoreGlobs: string[], terminal: ITerminal): Promise<Map<string, T>>;
     getChangedProjectsAsync(options: IGetChangedProjectsOptions): Promise<Set<RushConfigurationProject>>;
     // @internal
     _tryGetProjectDependenciesAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<Map<string, string> | undefined>;


### PR DESCRIPTION
## Summary

When writing tools that use ProjectChangeAnalyzer, it would be very convenient to be able to pass a custom list of ignore globs that can augment (or override) the existing project-specific ignore globs.

Add an option that can be used by monorepo tooling (but isn't exposed in any way to the rush command-line) to support this.

## Details

Here's the scenario that spawned this PR: in pull requests, we want to run `terraform plan` on all projects that have impacted infrastructure. However, due to the way terraforming has been designed across the organization, we need to do so by using a reusable workflow that we don't control. This means it's _really important_ to us not to run plan unless we think there's a _good chance_ that infrastructure has been impacted.

Our criteria for this is as follows:

 - List all projects that have git diffs (compared to same target e.g. `main`)
 - Filter this list to _only_ projects that have touched files in the relative folder `infra/terraform`
 - From this list, calculate "impacted by" (project and all recursive dependents)
 - From this list, filter to only projects tagged `terraform`.

(We use the inherit Rush project structure to list infrastructure components as "dependencies" of consuming projects; this allows us to find all projects that might need to plan infrastructure changes, if any project they depend on has changes in the folder where infrastructure lives.)

## How it was tested

