### PR TITLE
[rush] Tiny test fix: removeRepo rush lock file

### DIFF
--- a/common/changes/@microsoft/rush/enelson-fix-lock_2023-04-01-14-57.json
+++ b/common/changes/@microsoft/rush/enelson-fix-lock_2023-04-01-14-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/test/removeRepo/.gitignore
+++ b/libraries/rush-lib/src/cli/actions/test/removeRepo/.gitignore
@@ -1,0 +1,1 @@
+common/temp


### PR DESCRIPTION
## Summary

Running `heft test` locally on Mac/Linux always creates a temp lock file in the removeRepo test folder.

This is because it is missing a gitignore entry for `common/temp`, like the other test repo folders have.

## Details

 - Add `.gitignore` file.

## How it was tested

 - Tested locally, lock file is ignored

