### PR TITLE
[rush] Rush version can generate version manifest

### DIFF
--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -14,6 +14,7 @@ import { PolicyValidator } from '../../logic/policy/PolicyValidator';
 import { BaseRushAction } from './BaseRushAction';
 import { PublishGit } from '../../logic/PublishGit';
 import { Git } from '../../logic/Git';
+import { VersionManifest } from '../../logic/VersionManifest';
 
 import type * as VersionManagerType from '../../logic/VersionManager';
 
@@ -30,6 +31,7 @@ export class VersionAction extends BaseRushAction {
   private readonly _overwriteBump: CommandLineStringParameter;
   private readonly _prereleaseIdentifier: CommandLineStringParameter;
   private readonly _ignoreGitHooksParameter: CommandLineFlagParameter;
+  private readonly _manifestFileParameter: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -91,6 +93,11 @@ export class VersionAction extends BaseRushAction {
       parameterLongName: '--ignore-git-hooks',
       description: `Skips execution of all git hooks. Make sure you know what you are skipping.`
     });
+    this._manifestFileParameter = this.defineStringParameter({
+      parameterLongName: '--manifest-file',
+      argumentName: 'FILEPATH',
+      description: 'Create a version manifest file containing the results of this versioning event.'
+    });
   }
 
   protected async runAsync(): Promise<void> {
@@ -125,12 +132,16 @@ export class VersionAction extends BaseRushAction {
       }
     } else if (this._bumpVersion.value) {
       const tempBranch: string = 'version/bump-' + new Date().getTime();
-      await versionManager.bumpAsync(
+      const updatedPackages: Map<string, IPackageJson> | undefined = await versionManager.bumpAsync(
         this._versionPolicy.value,
         this._overwriteBump.value ? Enum.getValueByKey(BumpType, this._overwriteBump.value) : undefined,
         this._prereleaseIdentifier.value,
         true
       );
+      if (updatedPackages && this._manifestFileParameter.value) {
+        const manifest: VersionManifest = VersionManifest.fromUpdatedProjects(updatedPackages);
+        await manifest.save(this._manifestFileParameter.value);
+      }
       this._gitProcess(tempBranch, this._targetBranch.value);
     }
   }

--- a/libraries/rush-lib/src/logic/VersionManifest.ts
+++ b/libraries/rush-lib/src/logic/VersionManifest.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { FileSystem, JsonFile, JsonSchema, IPackageJson } from '@rushstack/node-core-library';
+
+import schemaJson from '../schemas/version-manifest.schema.json';
+
+interface IVersionManifestJson {
+  projects: IVersionManifestProjectJson[];
+}
+
+interface IVersionManifestProjectJson {
+  name: string;
+  relativeFolderPath: string;
+  version: string;
+  previousVersion?: string;
+}
+
+/**
+ * A "version manifest" is a small JSON file that describes the results of a versioning
+ * event (for example, running "rush version --bump").
+ */
+export class VersionManifest {
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
+
+  private _data: IVersionManifestJson;
+
+  private constructor(data: IVersionManifestJson) {
+    this._data = data;
+  }
+
+  public async save(filePath: string): Promise<void> {
+    await FileSystem.writeFileAsync(filePath, JSON.stringify(this._data, undefined, 2));
+  }
+
+  public static fromUpdatedProjects(updatedProjects: Map<string, IPackageJson>): VersionManifest {
+    const data: IVersionManifestJson = { projects: [] };
+
+    for (const [name, packageJson] of updatedProjects.entries()) {
+      data.projects.push({
+        name: name,
+        relativeFolderPath: '.',
+        version: packageJson.version
+      });
+    }
+
+    return new VersionManifest(data);
+  }
+
+  public static async load(filePath: string): Promise<VersionManifest> {
+    const data: IVersionManifestJson = JsonFile.loadAndValidate(filePath, VersionManifest._jsonSchema);
+    return new VersionManifest(data);
+  }
+}

--- a/libraries/rush-lib/src/schemas/version-manifest.schema.json
+++ b/libraries/rush-lib/src/schemas/version-manifest.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Version manifest output file format",
+  "description": "A version manifest is an output file produced by the 'rush version' command in Rush, describing the set of projects that have new versions and should be published and/or deployed.",
+  "type": "object",
+  "required": ["projects"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+    "projects": {
+      "description": "A list of versioned projects.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "relativeFolderPath", "version"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The name of the versioned project.",
+            "type": "string"
+          },
+          "relativeFolderPath": {
+            "description": "The relative path to the folder containing this project.",
+            "type": "string"
+          },
+          "version": {
+            "description": "The new version of the project to be published and/or deployed.",
+            "type": "string"
+          },
+          "previousVersion": {
+            "description": "(Optional) The previous version of this project.",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Allow the `rush version` command to optionally produce a new "version manifest" file, which describes the results of a _versioning event_ (in this case, version bumping of any projects during rush version).

This PR fixes #3957.

## Details

Create a schema for the _version manifest_, as well as a simple file save / file load class.

I've wired up just enough to show off the `rush version` command producing the report, but not all the details are there -- I can fill in the additional wiring if people feel the overall schema and naming make sense.

> Notes: there's a lot of possible names for this thing: it's a version _report_, it's a publishing _plan_, etc. I think "version manifest" might be the best option because it is, essentially, just a list of the projects we've versioned, without putting any spin on what you might do with it next (for example: convert it into a nice markdown report; use it as an input for rush publishing; use it as a github actions matrix for an infrastructure deployment workflow; etc.).

## How it was tested

 - In local monorepo, run: `(rush) version --bump --manifest-file=common/temp/manifest.json` produces the expected manifest.

## Impacted documentation

 - Add "version manifest" to the list of JSON schemas
