### PR TITLE
Bump webpack@5 peerDependency in sync with normal webpack dependency. 

### DIFF
--- a/common/changes/@rushstack/heft-webpack5-plugin/thelarkinn-issue-4053_2023-04-10-18-19.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/thelarkinn-issue-4053_2023-04-10-18-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Fix bug where peerDep of webpack was not properly updated with regular dependency version. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.50.0",
-    "webpack": "~5.75.0"
+    "webpack": "~5.78.0"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",


### PR DESCRIPTION
Fixes #4053 