### PR TITLE
[rush-lib] check `ensureConsistentVersions` when running `rush version`

### DIFF
--- a/common/changes/@microsoft/rush/aruniverse-respect_ensureConsistentVersions_2023-04-13-22-13.json
+++ b/common/changes/@microsoft/rush/aruniverse-respect_ensureConsistentVersions_2023-04-13-22-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "`rush version` will now respect the `ensureConsistentVersions` field in `rush.json`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -204,6 +204,11 @@ export class VersionAction extends BaseRushAction {
       this.rushConfiguration.rushJsonFile
     );
 
+    // Respect the `ensureConsistentVersions` field in rush.json
+    if (!rushConfig.ensureConsistentVersions) {
+      return;
+    }
+
     const mismatchFinder: VersionMismatchFinder = VersionMismatchFinder.getMismatches(rushConfig);
     if (mismatchFinder.numberOfMismatches) {
       throw new Error(


### PR DESCRIPTION
## Summary

Ran into an issue where I had set `ensureConsistentVersions` to false in my rush repo, but when running `rush version --bump`, it correctly bumped the versions as expected, but threw an error _"ERROR: Unable to finish version bump because inconsistencies were encountered. Run "rush check" to find more details."_.

## Details

Check the `ensureConsistentVersions` field, and break out earlier if not true
