### PR TITLE
[debug-cert-manager] Add more default subjects

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/cert-subjects_2023-04-13-22-22.json
+++ b/common/changes/@rushstack/debug-certificate-manager/cert-subjects_2023-04-13-22-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Include \"rushstack.localhost\" and \"127.0.0.1\" in the default certificate subjects.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -21,7 +21,11 @@ const ONE_DAY_IN_MILLISECONDS: number = 24 * 60 * 60 * 1000;
  * The set of names the certificate should be generated for, by default.
  * @public
  */
-export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string> = ['localhost'];
+export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string> = [
+  'localhost',
+  'rushstack.localhost',
+  '127.0.0.1'
+];
 
 /**
  * The interface for a debug certificate instance
@@ -129,6 +133,17 @@ export class CertificateManager {
           'The existing development certificate is missing the subjectAltName ' +
             'property and will not work with the latest versions of some browsers.'
         );
+      } else {
+        const missingSubjectNames: Set<string> = new Set(optionsWithDefaults.subjectAltNames);
+        for (const { value } of altNamesExtension.altNames) {
+          missingSubjectNames.delete(value);
+        }
+        if (missingSubjectNames.size) {
+          messages.push(
+            `The existing development certificate does not include the following expected subjectAltName values: ` +
+              Array.from(missingSubjectNames, (name: string) => `"${name}"`).join(', ')
+          );
+        }
       }
 
       const { notBefore, notAfter } = certificate.validity;


### PR DESCRIPTION
## Summary
For some reason, clicking on links to `https://localhost:1123` (or whatever port), opens `https://127.0.0.1:1123` in the browser, which then fails the certificate check. This PR updates the default certificate subjects to include `127.0.0.1` as one of the entries, alongside the `rushstack.localhost` option.

## Details
Updates the default list of certificate subjectAltNames. Modifies the certificate validator to consider a certificate missing requested names as invalid.

## How it was tested
Local run.

## Impacted documentation
None that I know of, currently.