### PR TITLE
[api-documenter] OfficeYamlDocumenter: Simplify example labelling and remove unnecessary asterisk protection

### DIFF
--- a/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import yaml = require('js-yaml');
 
 import { ApiModel } from '@microsoft/api-extractor-model';
-import { Text, FileSystem } from '@rushstack/node-core-library';
+import { FileSystem } from '@rushstack/node-core-library';
 
 import { IYamlTocItem } from '../yaml/IYamlTocFile';
 import { IYamlItem } from '../yaml/IYamlApiFile';
@@ -78,18 +78,9 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     const nameWithoutPackage: string = yamlItem.uid.replace(/^[^.]+\!/, '');
     if (yamlItem.summary) {
       yamlItem.summary = this._fixupApiSet(yamlItem.summary, yamlItem.uid);
-      yamlItem.summary = this._fixBoldAndItalics(yamlItem.summary);
     }
     if (yamlItem.remarks) {
       yamlItem.remarks = this._fixupApiSet(yamlItem.remarks, yamlItem.uid);
-      yamlItem.remarks = this._fixBoldAndItalics(yamlItem.remarks);
-    }
-    if (yamlItem.syntax && yamlItem.syntax.parameters) {
-      yamlItem.syntax.parameters.forEach((part) => {
-        if (part.description) {
-          part.description = this._fixBoldAndItalics(part.description);
-        }
-      });
     }
 
     const snippets: string[] | undefined = this._snippetsAll[nameWithoutPackage];
@@ -130,21 +121,10 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     return this._apiSetUrlDefault; // match not found.
   }
 
-  private _fixBoldAndItalics(text: string): string {
-    return Text.replaceAll(text, '\\*', '*');
-  }
-
   private _generateExampleSnippetText(snippets: string[]): string {
     const text: string[] = ['\n\n#### Examples\n'];
     for (const snippet of snippets) {
-      if (snippet.search(/await/) === -1) {
-        text.push('```javascript');
-      } else {
-        text.push('```typescript');
-      }
-
-      text.push(snippet);
-      text.push('```');
+      text.push(`\`\`\`TypeScript\n${snippet}\n\`\`\``);
     }
     return text.join('\n');
   }

--- a/common/changes/@microsoft/api-documenter/AlexJ-TSJS_2023-04-17-23-03.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-TSJS_2023-04-17-23-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Update OfficeYamlDocumenter to label all samples as TypeScript and no longer escape asterisks.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
PR #3932 allowed for markdown bold and italics to be emitted. The overrides in the Office-specific implementation are not longer necessary. Additionally, the distinction the Office-specific documenter was drawing for TS versus JS examples isn't relevant with ES6 JavaScript, so all examples are now labelled as TypeScript. This matches the DocFX API signature labeling as well 
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Local build tests and in the [Office Scripts reference repo](https://github.com/OfficeDev/office-scripts-docs-reference/compare/main...AlexJ-RSTest).
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation
None
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
