### PR TITLE
[rush] Add basic retry logic to http build cache plugin

### DIFF
--- a/common/changes/@microsoft/rush/enelson-http-cache-2_2023-04-19-17-43.json
+++ b/common/changes/@microsoft/rush/enelson-http-cache-2_2023-04-19-17-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "The HTTP build cache plugin will retry up to 3 times",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Add basic HTTP retry logic to the http build cache plugin.

## Details

It might be nice to have configurable retry attempts and timeout values, but a basic implementation with a few retries is a must-have just to weather inevitable transient 503s (for example, from a backing S3 storage or similar service).

This PR adds built-in retries, up to 3 attempts with ~2.5 second delay, to the http build cache plugin.

