### PR TITLE
Update webpack@5 version to 5.80.0

### DIFF
--- a/build-tests-samples/heft-webpack-basic-tutorial/package.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/package.json
@@ -29,6 +29,6 @@
     "source-map-loader": "~3.0.1",
     "style-loader": "~3.3.1",
     "typescript": "~4.8.4",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/build-tests/hashed-folder-copy-plugin-webpack5-test/package.json
+++ b/build-tests/hashed-folder-copy-plugin-webpack5-test/package.json
@@ -16,6 +16,6 @@
     "html-webpack-plugin": "~4.5.2",
     "typescript": "~4.8.4",
     "webpack-bundle-analyzer": "~4.5.0",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -24,6 +24,6 @@
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~4.8.4",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -4,13 +4,13 @@ importers:
 
   rush-lib-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.97.0.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.97.1.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~4.8.4
     dependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.97.0.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.97.1.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
       '@types/node': 14.18.36
@@ -19,17 +19,17 @@ importers:
 
   rush-sdk-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.97.0.tgz
-      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.97.0.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.97.1.tgz
+      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.97.1.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~4.8.4
     dependencies:
-      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.97.0.tgz_@types+node@14.18.36
+      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.97.1.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.97.0.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.97.1.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       rimraf: 4.1.2
       typescript: 4.8.4
@@ -3653,11 +3653,11 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.97.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.97.0.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.97.0.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.97.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.97.1.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.97.1.tgz
     name: '@microsoft/rush-lib'
-    version: 5.97.0
+    version: 5.97.1
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/link-bins': 5.3.25
@@ -3890,11 +3890,11 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.97.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.97.0.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.97.0.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.97.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.97.1.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.97.1.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.97.0
+    version: 5.97.1
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
       '@types/node-fetch': 2.6.2

--- a/common/changes/@microsoft/rush/main_2023-04-19-18-11.json
+++ b/common/changes/@microsoft/rush/main_2023-04-19-18-11.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Update webpack to v5.80.0",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/common/changes/@microsoft/rush/main_2023-04-19-18-11.json
+++ b/common/changes/@microsoft/rush/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update webpack to v5.80.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/webpack5-load-themed-styles-loader/main_2023-04-19-18-11.json
+++ b/common/changes/@microsoft/webpack5-load-themed-styles-loader/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/webpack5-load-themed-styles-loader",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/webpack5-load-themed-styles-loader"
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-dev-cert-plugin"
+}

--- a/common/changes/@rushstack/heft-web-rig/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/heft-web-rig/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/common/changes/@rushstack/webpack-embedded-dependencies-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/webpack-embedded-dependencies-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-embedded-dependencies-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-embedded-dependencies-plugin"
+}

--- a/common/changes/@rushstack/webpack-plugin-utilities/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/webpack-plugin-utilities/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-plugin-utilities",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-plugin-utilities"
+}

--- a/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin"
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/main_2023-04-19-18-11.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/main_2023-04-19-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "Update webpack to v5.80.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -564,7 +564,7 @@ importers:
       style-loader: ~3.3.1
       tslib: ~2.3.1
       typescript: ~4.8.4
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -578,13 +578,13 @@ importers:
       '@types/react': 16.14.23
       '@types/react-dom': 16.9.14
       '@types/webpack-env': 1.18.0
-      css-loader: 6.6.0_webpack@5.78.0
+      css-loader: 6.6.0_webpack@5.80.0
       eslint: 8.7.0
-      html-webpack-plugin: 5.5.0_webpack@5.78.0
-      source-map-loader: 3.0.2_webpack@5.78.0
-      style-loader: 3.3.1_webpack@5.78.0
+      html-webpack-plugin: 5.5.0_webpack@5.80.0
+      source-map-loader: 3.0.2_webpack@5.80.0
+      style-loader: 3.3.1_webpack@5.80.0
       typescript: 4.8.4
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../build-tests-samples/packlets-tutorial:
     specifiers:
@@ -817,16 +817,16 @@ importers:
       '@types/webpack-env': 1.18.0
       html-webpack-plugin: ~4.5.2
       typescript: ~4.8.4
-      webpack: ~5.78.0
+      webpack: ~5.80.0
       webpack-bundle-analyzer: ~4.5.0
     devDependencies:
       '@rushstack/hashed-folder-copy-plugin': link:../../webpack/hashed-folder-copy-plugin
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
       '@types/webpack-env': 1.18.0
-      html-webpack-plugin: 4.5.2_webpack@5.78.0
+      html-webpack-plugin: 4.5.2_webpack@5.80.0
       typescript: 4.8.4
-      webpack: 5.78.0
+      webpack: 5.80.0
       webpack-bundle-analyzer: 4.5.0
 
   ../../build-tests/heft-action-plugin:
@@ -1178,7 +1178,7 @@ importers:
       tslint: ~5.20.1
       tslint-microsoft-contrib: ~6.2.0
       typescript: ~4.8.4
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -1190,11 +1190,11 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/webpack-env': 1.18.0
       eslint: 8.7.0
-      html-webpack-plugin: 5.5.0_webpack@5.78.0
+      html-webpack-plugin: 5.5.0_webpack@5.80.0
       tslint: 5.20.1_typescript@4.8.4
       tslint-microsoft-contrib: 6.2.0_is64cncltak2c2767drphpzcku
       typescript: 4.8.4
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../build-tests/install-test-workspace:
     specifiers:
@@ -1521,7 +1521,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       eslint: ~8.7.0
-      webpack: ~5.78.0
+      webpack: ~5.80.0
       webpack-dev-server: ~4.9.3
     dependencies:
       '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
@@ -1534,8 +1534,8 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       eslint: 8.7.0
-      webpack: 5.78.0
-      webpack-dev-server: 4.9.3_webpack@5.78.0
+      webpack: 5.80.0
+      webpack-dev-server: 4.9.3_webpack@5.80.0
 
   ../../heft-plugins/heft-jest-plugin:
     specifiers:
@@ -1673,17 +1673,17 @@ importers:
       '@rushstack/heft-node-rig': workspace:*
       '@rushstack/node-core-library': workspace:*
       '@types/node': 14.18.36
-      webpack: ~5.78.0
+      webpack: ~5.80.0
       webpack-dev-server: ~4.9.3
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
-      webpack-dev-server: 4.9.3_webpack@5.78.0
+      webpack-dev-server: 4.9.3_webpack@5.80.0
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/node': 14.18.36
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../libraries/api-extractor-model:
     specifiers:
@@ -1953,7 +1953,7 @@ importers:
       tapable: 2.2.1
       tar: ~6.1.11
       true-case-path: ~2.2.1
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/heft-config-file': link:../heft-config-file
@@ -2016,7 +2016,7 @@ importers:
       '@types/strict-uri-encode': 2.0.0
       '@types/tar': 6.1.1
       '@types/webpack-env': 1.18.0
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../libraries/rush-sdk:
     specifiers:
@@ -2315,7 +2315,7 @@ importers:
       terser-webpack-plugin: ~5.3.1
       typescript: ~4.8.4
       url-loader: ~4.1.1
-      webpack: ~5.78.0
+      webpack: ~5.80.0
       webpack-bundle-analyzer: ~4.5.0
       webpack-merge: ~5.8.0
     dependencies:
@@ -2324,22 +2324,22 @@ importers:
       '@rushstack/heft-sass-plugin': link:../../heft-plugins/heft-sass-plugin
       '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
       autoprefixer: 10.4.13_postcss@8.4.21
-      css-loader: 6.6.0_webpack@5.78.0
-      css-minimizer-webpack-plugin: 3.4.1_webpack@5.78.0
+      css-loader: 6.6.0_webpack@5.80.0
+      css-minimizer-webpack-plugin: 3.4.1_webpack@5.80.0
       eslint: 8.7.0
-      html-webpack-plugin: 5.5.0_webpack@5.78.0
+      html-webpack-plugin: 5.5.0_webpack@5.80.0
       jest-environment-jsdom: 29.5.0
-      mini-css-extract-plugin: 2.5.3_webpack@5.78.0
+      mini-css-extract-plugin: 2.5.3_webpack@5.80.0
       postcss: 8.4.21
-      postcss-loader: 6.2.1_2izhiogyhzv3k6gmxpzxzwhblu
+      postcss-loader: 6.2.1_s3hlmk3dolibrgzfaoz6qln5l4
       sass: 1.49.11
-      sass-loader: 12.4.0_nhnw2mbyotoesjxyh2t7o6kqbq
-      source-map-loader: 3.0.2_webpack@5.78.0
-      style-loader: 3.3.1_webpack@5.78.0
-      terser-webpack-plugin: 5.3.6_webpack@5.78.0
+      sass-loader: 12.4.0_eyzo4krppp6jzbzhebz7eme2km
+      source-map-loader: 3.0.2_webpack@5.80.0
+      style-loader: 3.3.1_webpack@5.80.0
+      terser-webpack-plugin: 5.3.6_webpack@5.80.0
       typescript: 4.8.4
-      url-loader: 4.1.1_webpack@5.78.0
-      webpack: 5.78.0
+      url-loader: 4.1.1_webpack@5.80.0
+      webpack: 5.80.0
       webpack-bundle-analyzer: 4.5.0
       webpack-merge: 5.8.0
     devDependencies:
@@ -2554,14 +2554,14 @@ importers:
       '@rushstack/heft-node-rig': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/set-webpack-public-path-plugin:
     specifiers:
@@ -2594,7 +2594,7 @@ importers:
       '@rushstack/node-core-library': workspace:*
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
@@ -2603,7 +2603,7 @@ importers:
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/webpack-embedded-dependencies-plugin:
     specifiers:
@@ -2615,7 +2615,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       memfs: 3.4.3
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
     devDependencies:
@@ -2626,7 +2626,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       memfs: 3.4.3
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/webpack-plugin-utilities:
     specifiers:
@@ -2637,7 +2637,7 @@ importers:
       '@types/node': 14.18.36
       '@types/tapable': 1.0.6
       memfs: 3.4.3
-      webpack: ~5.78.0
+      webpack: ~5.80.0
       webpack-merge: ~5.8.0
     dependencies:
       memfs: 3.4.3
@@ -2649,7 +2649,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       '@types/tapable': 1.0.6
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/webpack4-localization-plugin:
     specifiers:
@@ -2730,7 +2730,7 @@ importers:
       '@types/node': 14.18.36
       css-loader: ~6.6.0
       memfs: 3.4.3
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     devDependencies:
       '@microsoft/load-themed-styles': link:../../libraries/load-themed-styles
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -2739,9 +2739,9 @@ importers:
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
-      css-loader: 6.6.0_webpack@5.78.0
+      css-loader: 6.6.0_webpack@5.80.0
       memfs: 3.4.3
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/webpack5-localization-plugin:
     specifiers:
@@ -2753,7 +2753,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       memfs: 3.4.3
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       '@rushstack/localization-utilities': link:../../libraries/localization-utilities
       '@rushstack/node-core-library': link:../../libraries/node-core-library
@@ -2764,7 +2764,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       memfs: 3.4.3
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   ../../webpack/webpack5-module-minifier-plugin:
     specifiers:
@@ -2779,7 +2779,7 @@ importers:
       '@types/tapable': 1.0.6
       memfs: 3.4.3
       tapable: 2.2.1
-      webpack: ~5.78.0
+      webpack: ~5.80.0
     dependencies:
       '@rushstack/worker-pool': link:../../libraries/worker-pool
       '@types/estree': 0.0.50
@@ -2793,7 +2793,7 @@ importers:
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
       memfs: 3.4.3
-      webpack: 5.78.0
+      webpack: 5.80.0
 
 packages:
 
@@ -5964,7 +5964,7 @@ packages:
       html-entities: 2.3.3
       loader-utils: 2.0.4
       react-refresh: 0.11.0
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       source-map: 0.7.4
       webpack: 4.44.2
     dev: true
@@ -8556,8 +8556,8 @@ packages:
   /@types/estree/0.0.50:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
 
-  /@types/estree/0.0.51:
-    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+  /@types/estree/1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
 
   /@types/events/3.0.0:
     resolution: {integrity: sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==}
@@ -9258,11 +9258,11 @@ packages:
     resolution: {integrity: sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==}
     dev: false
 
-  /@webassemblyjs/ast/1.11.1:
-    resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
+  /@webassemblyjs/ast/1.11.5:
+    resolution: {integrity: sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==}
     dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/helper-numbers': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -9271,20 +9271,20 @@ packages:
       '@webassemblyjs/helper-wasm-bytecode': 1.9.0
       '@webassemblyjs/wast-parser': 1.9.0
 
-  /@webassemblyjs/floating-point-hex-parser/1.11.1:
-    resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+  /@webassemblyjs/floating-point-hex-parser/1.11.5:
+    resolution: {integrity: sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ==}
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
 
-  /@webassemblyjs/helper-api-error/1.11.1:
-    resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+  /@webassemblyjs/helper-api-error/1.11.5:
+    resolution: {integrity: sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA==}
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
 
-  /@webassemblyjs/helper-buffer/1.11.1:
-    resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+  /@webassemblyjs/helper-buffer/1.11.5:
+    resolution: {integrity: sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg==}
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -9302,26 +9302,26 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
 
-  /@webassemblyjs/helper-numbers/1.11.1:
-    resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
+  /@webassemblyjs/helper-numbers/1.11.5:
+    resolution: {integrity: sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==}
     dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
+      '@webassemblyjs/floating-point-hex-parser': 1.11.5
+      '@webassemblyjs/helper-api-error': 1.11.5
       '@xtuc/long': 4.2.2
 
-  /@webassemblyjs/helper-wasm-bytecode/1.11.1:
-    resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+  /@webassemblyjs/helper-wasm-bytecode/1.11.5:
+    resolution: {integrity: sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
 
-  /@webassemblyjs/helper-wasm-section/1.11.1:
-    resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
+  /@webassemblyjs/helper-wasm-section/1.11.5:
+    resolution: {integrity: sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -9331,8 +9331,8 @@ packages:
       '@webassemblyjs/helper-wasm-bytecode': 1.9.0
       '@webassemblyjs/wasm-gen': 1.9.0
 
-  /@webassemblyjs/ieee754/1.11.1:
-    resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
+  /@webassemblyjs/ieee754/1.11.5:
+    resolution: {integrity: sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
 
@@ -9341,8 +9341,8 @@ packages:
     dependencies:
       '@xtuc/ieee754': 1.2.0
 
-  /@webassemblyjs/leb128/1.11.1:
-    resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
+  /@webassemblyjs/leb128/1.11.5:
+    resolution: {integrity: sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==}
     dependencies:
       '@xtuc/long': 4.2.2
 
@@ -9351,23 +9351,23 @@ packages:
     dependencies:
       '@xtuc/long': 4.2.2
 
-  /@webassemblyjs/utf8/1.11.1:
-    resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+  /@webassemblyjs/utf8/1.11.5:
+    resolution: {integrity: sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ==}
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
 
-  /@webassemblyjs/wasm-edit/1.11.1:
-    resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
+  /@webassemblyjs/wasm-edit/1.11.5:
+    resolution: {integrity: sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/helper-wasm-section': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-opt': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      '@webassemblyjs/wast-printer': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/helper-wasm-section': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
+      '@webassemblyjs/wasm-opt': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
+      '@webassemblyjs/wast-printer': 1.11.5
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -9381,14 +9381,14 @@ packages:
       '@webassemblyjs/wasm-parser': 1.9.0
       '@webassemblyjs/wast-printer': 1.9.0
 
-  /@webassemblyjs/wasm-gen/1.11.1:
-    resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
+  /@webassemblyjs/wasm-gen/1.11.5:
+    resolution: {integrity: sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/ieee754': 1.11.5
+      '@webassemblyjs/leb128': 1.11.5
+      '@webassemblyjs/utf8': 1.11.5
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -9399,13 +9399,13 @@ packages:
       '@webassemblyjs/leb128': 1.9.0
       '@webassemblyjs/utf8': 1.9.0
 
-  /@webassemblyjs/wasm-opt/1.11.1:
-    resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
+  /@webassemblyjs/wasm-opt/1.11.5:
+    resolution: {integrity: sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-buffer': 1.11.5
+      '@webassemblyjs/wasm-gen': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -9415,15 +9415,15 @@ packages:
       '@webassemblyjs/wasm-gen': 1.9.0
       '@webassemblyjs/wasm-parser': 1.9.0
 
-  /@webassemblyjs/wasm-parser/1.11.1:
-    resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
+  /@webassemblyjs/wasm-parser/1.11.5:
+    resolution: {integrity: sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/helper-api-error': 1.11.5
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.5
+      '@webassemblyjs/ieee754': 1.11.5
+      '@webassemblyjs/leb128': 1.11.5
+      '@webassemblyjs/utf8': 1.11.5
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -9445,10 +9445,10 @@ packages:
       '@webassemblyjs/helper-fsm': 1.9.0
       '@xtuc/long': 4.2.2
 
-  /@webassemblyjs/wast-printer/1.11.1:
-    resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
+  /@webassemblyjs/wast-printer/1.11.5:
+    resolution: {integrity: sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==}
     dependencies:
-      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/ast': 1.11.5
       '@xtuc/long': 4.2.2
 
   /@webassemblyjs/wast-printer/1.9.0:
@@ -11637,7 +11637,7 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /css-loader/6.6.0_webpack@5.78.0:
+  /css-loader/6.6.0_webpack@5.80.0:
     resolution: {integrity: sha512-FK7H2lisOixPT406s5gZM1S3l8GrfhEBT3ZiL2UX1Ng1XWs0y2GPllz/OTyvbaHe12VgQrIXIzuEGVlbUhodqg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -11651,9 +11651,9 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.21
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.78.0
+      webpack: 5.80.0
 
-  /css-minimizer-webpack-plugin/3.4.1_webpack@5.78.0:
+  /css-minimizer-webpack-plugin/3.4.1_webpack@5.80.0:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -11678,7 +11678,7 @@ packages:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
       source-map: 0.6.1
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: false
 
   /css-modules-loader-core/1.1.0:
@@ -12412,8 +12412,8 @@ packages:
       memory-fs: 0.5.0
       tapable: 1.1.3
 
-  /enhanced-resolve/5.12.0:
-    resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
+  /enhanced-resolve/5.13.0:
+    resolution: {integrity: sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
@@ -12520,8 +12520,8 @@ packages:
       stop-iteration-iterator: 1.0.0
     dev: true
 
-  /es-module-lexer/0.9.3:
-    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+  /es-module-lexer/1.2.1:
+    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
 
   /es-set-tostringtag/2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -13592,7 +13592,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       webpack: 4.44.2
     dev: true
 
@@ -14623,7 +14623,7 @@ packages:
       util.promisify: 1.0.0
       webpack: 4.44.2
 
-  /html-webpack-plugin/4.5.2_webpack@5.78.0:
+  /html-webpack-plugin/4.5.2_webpack@5.80.0:
     resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
     engines: {node: '>=6.9'}
     peerDependencies:
@@ -14638,10 +14638,10 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: true
 
-  /html-webpack-plugin/5.5.0_webpack@5.78.0:
+  /html-webpack-plugin/5.5.0_webpack@5.80.0:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -14652,7 +14652,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   /htmlparser2/6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -17346,14 +17346,14 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  /mini-css-extract-plugin/2.5.3_webpack@5.78.0:
+  /mini-css-extract-plugin/2.5.3_webpack@5.80.0:
     resolution: {integrity: sha512-YseMB8cs8U/KCaAGQoqYmfUuhhGW0a9p9XvWXrxVOkE3/IiISTLw4ALNt7JR5B2eYauFM+PQGSbXMDmVbR7Tfw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: false
 
   /minimalistic-assert/1.0.1:
@@ -18534,12 +18534,12 @@ packages:
       klona: 2.0.6
       loader-utils: 2.0.4
       postcss: 7.0.39
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       semver: 7.3.8
       webpack: 4.44.2
     dev: true
 
-  /postcss-loader/6.2.1_2izhiogyhzv3k6gmxpzxzwhblu:
+  /postcss-loader/6.2.1_s3hlmk3dolibrgzfaoz6qln5l4:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -18550,7 +18550,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.21
       semver: 7.3.8
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: false
 
   /postcss-merge-longhand/5.1.7_postcss@8.4.21:
@@ -19263,7 +19263,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       webpack: 4.44.2
     dev: true
 
@@ -20152,7 +20152,7 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /sass-loader/12.4.0_nhnw2mbyotoesjxyh2t7o6kqbq:
+  /sass-loader/12.4.0_eyzo4krppp6jzbzhebz7eme2km:
     resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -20171,7 +20171,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.49.11
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: false
 
   /sass/1.3.2:
@@ -20245,6 +20245,14 @@ packages:
 
   /schema-utils/3.1.1:
     resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.11
+      ajv: 6.12.6
+      ajv-keywords: 3.5.2_ajv@6.12.6
+
+  /schema-utils/3.1.2:
+    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
@@ -20341,6 +20349,12 @@ packages:
 
   /serialize-javascript/6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: false
+
+  /serialize-javascript/6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
 
@@ -20587,7 +20601,7 @@ packages:
       whatwg-mimetype: 2.3.0
     dev: true
 
-  /source-map-loader/3.0.2_webpack@5.78.0:
+  /source-map-loader/3.0.2_webpack@5.80.0:
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -20596,7 +20610,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   /source-map-resolve/0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -20993,13 +21007,13 @@ packages:
       webpack: 4.44.2
     dev: true
 
-  /style-loader/3.3.1_webpack@5.78.0:
+  /style-loader/3.3.1_webpack@5.80.0:
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   /style-to-object/0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
@@ -21221,7 +21235,7 @@ packages:
       find-cache-dir: 3.3.2
       jest-worker: 26.6.2
       p-limit: 3.1.0
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.16.1
@@ -21229,7 +21243,7 @@ packages:
       webpack-sources: 1.4.3
     dev: true
 
-  /terser-webpack-plugin/5.3.6_webpack@5.78.0:
+  /terser-webpack-plugin/5.3.6_webpack@5.80.0:
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21250,7 +21264,31 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.16.1
-      webpack: 5.78.0
+      webpack: 5.80.0
+    dev: false
+
+  /terser-webpack-plugin/5.3.7_webpack@5.80.0:
+    resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      jest-worker: 27.5.1
+      schema-utils: 3.1.2
+      serialize-javascript: 6.0.1
+      terser: 5.17.1
+      webpack: 5.80.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -21263,6 +21301,16 @@ packages:
 
   /terser/5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.2
+      acorn: 8.8.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  /terser/5.17.1:
+    resolution: {integrity: sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -21848,7 +21896,7 @@ packages:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
 
-  /url-loader/4.1.1_webpack@5.78.0:
+  /url-loader/4.1.1_webpack@5.80.0:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21861,7 +21909,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 5.78.0
+      webpack: 5.80.0
     dev: false
 
   /url-loader/4.1.1_zmzwotvrfu62vdeozbyveyswza:
@@ -22260,7 +22308,7 @@ packages:
       webpack: 4.44.2_webpack-cli@3.3.12
     dev: false
 
-  /webpack-dev-middleware/5.3.3_webpack@5.78.0:
+  /webpack-dev-middleware/5.3.3_webpack@5.80.0:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -22275,7 +22323,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.78.0
+      webpack: 5.80.0
 
   /webpack-dev-server/4.9.3_2jhnw6fokymnjfoumvhvkjoyjq:
     resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
@@ -22385,7 +22433,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /webpack-dev-server/4.9.3_webpack@5.78.0:
+  /webpack-dev-server/4.9.3_webpack@5.80.0:
     resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -22428,8 +22476,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.78.0
-      webpack-dev-middleware: 5.3.3_webpack@5.78.0
+      webpack: 5.80.0
+      webpack-dev-middleware: 5.3.3_webpack@5.80.0
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -22562,8 +22610,8 @@ packages:
       webpack-sources: 1.4.3
     dev: false
 
-  /webpack/5.78.0:
-    resolution: {integrity: sha512-gT5DP72KInmE/3azEaQrISjTvLYlSM0j1Ezhht/KLVkrqtv10JoP/RXhwmX/frrutOPuSq3o5Vq0ehR/4Vmd1g==}
+  /webpack/5.80.0:
+    resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -22573,16 +22621,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 0.0.51
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/wasm-edit': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
       acorn: 8.8.2
       acorn-import-assertions: 1.8.0_acorn@8.8.2
       browserslist: 4.21.4
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.12.0
-      es-module-lexer: 0.9.3
+      enhanced-resolve: 5.13.0
+      es-module-lexer: 1.2.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -22591,9 +22639,9 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6_webpack@5.78.0
+      terser-webpack-plugin: 5.3.7_webpack@5.80.0
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6ccbade8b892e34c52192c92b8dcba06ec1d9b48",
+  "pnpmShrinkwrapHash": "a1681a4c0e1d3c156fa5e501a94688a520955940",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/heft-plugins/heft-dev-cert-plugin/package.json
+++ b/heft-plugins/heft-dev-cert-plugin/package.json
@@ -33,6 +33,6 @@
     "@types/node": "14.18.36",
     "eslint": "~8.7.0",
     "webpack-dev-server": "~4.9.3",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.50.0",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
@@ -30,6 +30,6 @@
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/node": "14.18.36",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -84,7 +84,7 @@
     "@types/strict-uri-encode": "2.0.0",
     "@types/tar": "6.1.1",
     "@types/webpack-env": "1.18.0",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "publishOnlyDependencies": {
     "@rushstack/rush-amazon-s3-build-cache-plugin": "workspace:*",

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -38,7 +38,7 @@
     "url-loader": "~4.1.1",
     "webpack-bundle-analyzer": "~4.5.0",
     "webpack-merge": "~5.8.0",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/webpack/preserve-dynamic-require-plugin/package.json
+++ b/webpack/preserve-dynamic-require-plugin/package.json
@@ -24,7 +24,7 @@
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "sideEffects": false
 }

--- a/webpack/webpack-deep-imports-plugin/package.json
+++ b/webpack/webpack-deep-imports-plugin/package.json
@@ -27,7 +27,7 @@
     "@rushstack/heft": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "sideEffects": false,
   "dependencies": {

--- a/webpack/webpack-embedded-dependencies-plugin/package.json
+++ b/webpack/webpack-embedded-dependencies-plugin/package.json
@@ -34,7 +34,7 @@
     "@rushstack/heft-node-rig": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
-    "webpack": "~5.78.0",
+    "webpack": "~5.80.0",
     "memfs": "3.4.3"
   }
 }

--- a/webpack/webpack-plugin-utilities/package.json
+++ b/webpack/webpack-plugin-utilities/package.json
@@ -37,6 +37,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
     "@types/tapable": "1.0.6",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   }
 }

--- a/webpack/webpack5-load-themed-styles-loader/package.json
+++ b/webpack/webpack5-load-themed-styles-loader/package.json
@@ -32,7 +32,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
-    "webpack": "~5.78.0",
+    "webpack": "~5.80.0",
     "memfs": "3.4.3",
     "css-loader": "~6.6.0"
   }

--- a/webpack/webpack5-load-themed-styles-loader/src/test/__snapshots__/LoadThemedStylesLoader.test.ts.snap
+++ b/webpack/webpack5-load-themed-styles-loader/src/test/__snapshots__/LoadThemedStylesLoader.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`webpack5-load-themed-style-loader generates desired loader output snapshot: LoaderContent 1`] = `
-"var content = require(\\"!!../../../../../common/temp/node_modules/.pnpm/css-loader@6.6.0_webpack@5.78.0/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!./MockStyle1.css\\");
+"var content = require(\\"!!../../../../../common/temp/node_modules/.pnpm/css-loader@6.6.0_webpack@5.80.0/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!./MockStyle1.css\\");
 var loader = require(\\"../../../lib/test/testData/LoadThemedStylesMock\\");
 
 if(typeof content === \\"string\\") content = [[module.id, content]];
@@ -13,7 +13,7 @@ if(content.locals) module.exports = content.locals;"
 `;
 
 exports[`webpack5-load-themed-style-loader generates desired output for esModule option set to "true" as a snapshot: LoaderContent ESModule 1`] = `
-"import content from \\"!!../../../../../common/temp/node_modules/.pnpm/css-loader@6.6.0_webpack@5.78.0/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!./MockStyle1.css\\";
+"import content from \\"!!../../../../../common/temp/node_modules/.pnpm/css-loader@6.6.0_webpack@5.80.0/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!./MockStyle1.css\\";
 import { loadStyles } from \\"../../../lib/test/testData/LoadThemedStylesMock\\";
 
 if(typeof content === \\"string\\") content = [[module.id, content]];

--- a/webpack/webpack5-localization-plugin/package.json
+++ b/webpack/webpack5-localization-plugin/package.json
@@ -30,7 +30,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
     "memfs": "3.4.3",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/webpack/webpack5-module-minifier-plugin/package.json
+++ b/webpack/webpack5-module-minifier-plugin/package.json
@@ -37,7 +37,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36",
     "memfs": "3.4.3",
-    "webpack": "~5.78.0"
+    "webpack": "~5.80.0"
   },
   "sideEffects": false,
   "peerDependenciesMeta": {


### PR DESCRIPTION
Bumps all deps using webpack 5 to latest webpack 5.80.0.

webpack 5.80.0 release notes: https://github.com/webpack/webpack/releases/tag/v5.80.0