### PR TITLE
[rush-lib] Improve performance of 'rush version --bump'

### DIFF
--- a/common/changes/@microsoft/rush/rush-version-performance_2023-04-20-20-57.json
+++ b/common/changes/@microsoft/rush/rush-version-performance_2023-04-20-20-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve performance of 'rush version' when using 'workspace:' protocol.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -788,21 +788,19 @@ export class PublishUtilities {
       // If the version range exists and has not yet been updated to this version, update it.
       if (requiredVersion.versionSpecifier !== change.newRangeDependency || alwaysUpdate) {
         let changeType: ChangeType | undefined;
-        if (changeType === undefined) {
-          // Propagate hotfix changes to dependencies
-          if (change.changeType === ChangeType.hotfix) {
-            changeType = ChangeType.hotfix;
-          } else {
-            // Either it already satisfies the new version, or doesn't.
-            // If not, the downstream dep needs to be republished.
-            // The downstream dep will also need to be republished if using `workspace:*` as this will publish
-            // as the exact version.
-            changeType =
-              semver.satisfies(change.newVersion!, requiredVersion.versionSpecifier) &&
-              !isWorkspaceWildcardVersion
-                ? ChangeType.dependency
-                : ChangeType.patch;
-          }
+        // Propagate hotfix changes to dependencies
+        if (change.changeType === ChangeType.hotfix) {
+          changeType = ChangeType.hotfix;
+        } else {
+          // Either it already satisfies the new version, or doesn't.
+          // If not, the downstream dep needs to be republished.
+          // The downstream dep will also need to be republished if using `workspace:*` as this will publish
+          // as the exact version.
+          changeType =
+            !isWorkspaceWildcardVersion &&
+            semver.satisfies(change.newVersion!, requiredVersion.versionSpecifier)
+              ? ChangeType.dependency
+              : ChangeType.patch;
         }
 
         hasChanges = PublishUtilities._addChange({


### PR DESCRIPTION
## Summary
Improves the performance of `rush version --bump` for monorepos that use the `workspace:` protocol to specify local dependencies by around 50% by preventing unused `semver.satisfies` checks from executing.

## Details
Flips the order of a conditional so that the cheap condition evaluates first.

Before:
![image](https://user-images.githubusercontent.com/26827560/233488568-2cc3f512-9c5e-4a62-80a7-1472e9449ebe.png)

After:
![image](https://user-images.githubusercontent.com/26827560/233488668-5e22abed-8d84-4b4b-ab47-95f1f35df443.png)


## How it was tested
Running `rush version --bump` on a repository with a large number of pending changes.

## Impacted documentation
Not a behavior change, so none.