### PR TITLE
[rush] Fix rush version `workspace:*` perf

### DIFF
--- a/common/changes/@microsoft/rush/rush-version-workspace-perf_2023-04-20-22-52.json
+++ b/common/changes/@microsoft/rush/rush-version-workspace-perf_2023-04-20-22-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a performance bug in `rush version` when using `workspace:` protocol.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -779,14 +779,16 @@ export class PublishUtilities {
       const isWorkspaceWildcardVersion: boolean =
         requiredVersion.specifierType === DependencySpecifierType.Workspace &&
         requiredVersion.versionSpecifier === '*';
-      const alwaysUpdate: boolean =
-        (!!prereleaseToken &&
-          prereleaseToken.hasValue &&
-          !allChanges.packageChanges.has(parentPackageName)) ||
-        isWorkspaceWildcardVersion;
+
+      const isPrerelease: boolean =
+        !!prereleaseToken && prereleaseToken.hasValue && !allChanges.packageChanges.has(parentPackageName);
 
       // If the version range exists and has not yet been updated to this version, update it.
-      if (requiredVersion.versionSpecifier !== change.newRangeDependency || alwaysUpdate) {
+      if (
+        isPrerelease ||
+        isWorkspaceWildcardVersion ||
+        requiredVersion.versionSpecifier !== change.newRangeDependency
+      ) {
         let changeType: ChangeType | undefined;
         // Propagate hotfix changes to dependencies
         if (change.changeType === ChangeType.hotfix) {
@@ -815,7 +817,7 @@ export class PublishUtilities {
           projectsToExclude
         });
 
-        if (hasChanges || alwaysUpdate) {
+        if (hasChanges || isPrerelease) {
           // Only re-evaluate downstream dependencies if updating the parent package's dependency
           // caused a version bump.
           hasChanges =


### PR DESCRIPTION
## Summary
Fixes a performance bug in `rush version` when projects use the `workspace:*` dependency version specifier. Reduces time spent in `_updateDownstreamDependency` to a negligible portion of the total runtime.

Fixes #4067

## Details
Doesn't actually change the overall algorithm, but allows the early return to work as expected.

## How it was tested
Reduced the number of times the `_updateDownstreamDependency` branch that would call `semver.satisfies` is called from 80450952 to 8589 in a test run.

## Impacted documentation
None.