### PR TITLE
[rush-lib/deploy] Improve rush deploy error message for symlinks outside of the source path

### DIFF
--- a/common/changes/@microsoft/rush/fix_error_message_2023-04-21-22-41.json
+++ b/common/changes/@microsoft/rush/fix_error_message_2023-04-21-22-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve rush deploy error message for symlinks outside of the source path.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/deploy/DeployManager.ts
+++ b/libraries/rush-lib/src/logic/deploy/DeployManager.ts
@@ -583,6 +583,11 @@ export class DeployManager {
 
     // Remap the links to be relative to target folder
     for (const absoluteLinkInfo of deployState.symlinkAnalyzer.reportSymlinks()) {
+      if (!Path.isUnderOrEqual(absoluteLinkInfo.targetPath, deployState.sourceRootFolder)) {
+        throw new Error(
+          `Symlink targets must be under ${deployState.sourceRootFolder}\n${absoluteLinkInfo.linkPath} -> ${absoluteLinkInfo.targetPath}`
+        );
+      }
       const relativeInfo: ILinkInfo = {
         kind: absoluteLinkInfo.kind,
         linkPath: this._remapPathForDeployMetadata(absoluteLinkInfo.linkPath, deployState),


### PR DESCRIPTION
## Summary

Fixes #3774

Gives a better error message in the scenario in which there are symlinks pointing outward.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Manually tested in one of my own projects

Before
![image](https://user-images.githubusercontent.com/1300387/233744727-4723f04e-6166-4fca-acbe-3d7249a88048.png)


After
![image](https://user-images.githubusercontent.com/1300387/233744703-48b15c5e-ae3a-4c2e-9fe7-efe3222c2795.png)


## Impacted documentation

I don't believe so. Behind the scenes / error messaging