### PR TITLE
Fix look by path

### DIFF
--- a/common/changes/@microsoft/rush/fix-look-by-path_2023-04-25-09-41.json
+++ b/common/changes/@microsoft/rush/fix-look-by-path_2023-04-25-09-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Correctly match the prefix with the last single character segment",
+      "comment": "Fix an issue where the last character in a project's path is ignored when determining which files contribute to the project's cache ID.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-look-by-path_2023-04-25-09-41.json
+++ b/common/changes/@microsoft/rush/fix-look-by-path_2023-04-25-09-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Correctly match the prefix with the last single character segment",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/LookupByPath.ts
+++ b/libraries/rush-lib/src/logic/LookupByPath.ts
@@ -111,7 +111,7 @@ export class LookupByPath<TItem> {
     }
 
     // Last segment
-    if (previousIndex + 1 < input.length) {
+    if (previousIndex < input.length) {
       yield {
         prefix: input.slice(previousIndex, input.length),
         index: input.length

--- a/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
+++ b/libraries/rush-lib/src/logic/test/LookupByPath.test.ts
@@ -20,6 +20,10 @@ describe(LookupByPath.iteratePathSegments.name, () => {
     const result = [...LookupByPath.iteratePathSegments('foo/bar/baz')];
     expect(result).toEqual(['foo', 'bar', 'baz']);
   });
+  it('returns correct last single character segment', () => {
+    const result = [...LookupByPath.iteratePathSegments('foo/a')];
+    expect(result).toEqual(['foo', 'a']);
+  });
 });
 
 describe(LookupByPath.prototype.findChildPath.name, () => {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes the logic of prefix match in `LookupByPath` when the last segment of project folder is a single character.

## Details

I am testing build cache in a demo Rush.js monorepo with several projects, the rush.json is like

```json
"projects": [
  {
    "packageName": "a",
    "projectFolder": "projects/a"
  },
  {
    "packageName": "b",
    "projectFolder": "projects/b"
  },
  // ...
]
```

However, when i run `rush build` with build cache enabled. I found there is a issue to calculate the correct cache id. After dive into the code, it seems there is an edge case when prefix matching with each project folders.


Actual behaviour:

When creating the lookup tree with `projects/a`, it now ignores the trailing character a. The path tree would be like

```
{
  value: undefined,
  children: { // It's a map, use object here to show idea.
    "projects": { 
      value: RushConfigurationProject // <-- which is project a.
    }
  }
}
```

The incorrect path tree leads to a issue to match the files under "projects" folder, which means Rush.js now treats `projects/b/package.json`, `projects/c/package.json`, etc.. belongs to project A, and finally the "ProjectBuildCache#_getCacheId" doesn't get the right scope of the project B, C....

Expected:

Create the correct path tree

```
{
  value: undefined,
  children: { // It's a map, use object here to show idea.
    "projects": {
      value: undefined
      children: {
        a: {
          value: RushConfigurationProject // <-- a
        },
        b: {
          value: RushConfigurationProject // <-- b
        },
        ...
      }
    }
  }
}
```

`projects/a/package.json` belongs to `projects/a`
`projects/b/package.json` belongs to `projects/b`

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Add a new test case to cover this edge case.

## Impacted documentation

Nope

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
