### PR TITLE
Fix package versions for packages in version policy

### DIFF
--- a/common/changes/@microsoft/rush/user-danade-FixVersions_2023-04-27-16-56.json
+++ b/common/changes/@microsoft/rush/user-danade-FixVersions_2023-04-27-16-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-http-build-cache-plugin/package.json
+++ b/rush-plugins/rush-http-build-cache-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rushstack/rush-http-build-cache-plugin",
-  "version": "5.92.0",
+  "version": "5.97.1",
   "description": "Rush plugin for generic HTTP cloud build cache",
   "repository": {
     "type": "git",

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rushstack/rush-serve-plugin",
-  "version": "0.4.7",
+  "version": "5.97.1",
   "description": "A Rush plugin that hooks into a rush action and serves output folders from all projects in the repository.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

`rush version --bump` was failing due to these package versions being out-of-sync with their newly-applied version policies. This PR updates the versions in package.json manually, so that during the next Rush version policy bump, they will be published with their newly bumped versions.

## How it was tested

Tested locally using `rush version --bump --version-policy noRush`