### PR TITLE
[heft-rc] Fix build scripts

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -2,6 +2,9 @@ lockfileVersion: 5.4
 
 importers:
 
+  .:
+    specifiers: {}
+
   rush-lib-test:
     specifiers:
       '@microsoft/rush-lib': file:microsoft-rush-lib-5.97.1.tgz
@@ -37,17 +40,17 @@ importers:
   typescript-newest-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.2.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.50.0.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.0-rc.4.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz
+      '@rushstack/heft': file:rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.0-rc.5.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.2.0.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.50.0.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -55,17 +58,17 @@ importers:
   typescript-v3-test:
     specifiers:
       '@rushstack/eslint-config': file:rushstack-eslint-config-3.2.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.50.0.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.0-rc.4.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz
+      '@rushstack/heft': file:rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.0-rc.5.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.8.4
     devDependencies:
       '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.2.0.tgz_esueefhpt5ql6xiqdj4wcgwfzi
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.50.0.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.8.4
       typescript: 4.8.4
@@ -3710,12 +3713,13 @@ packages:
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz_@types+node@14.18.36
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.11.tgz_@types+node@14.18.36
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.12.tgz_@types+node@14.18.36
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.1.0.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.18.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.229.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.4.tgz_@types+node@14.18.36
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.230.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.5.tgz_@types+node@14.18.36
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.2.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
@@ -3831,15 +3835,15 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.50.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.50.0.tgz}
+  file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz}
     name: '@rushstack/heft'
-    version: 0.50.0
+    version: 0.51.0-rc.5
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.18.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.2.tgz
       '@types/tapable': 1.0.6
@@ -3855,58 +3859,58 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.11.9
+    version: 0.11.10
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.18.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz}
-    id: file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz
+  file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz}
+    id: file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz
     name: '@rushstack/heft-config-file'
-    version: 0.11.9
+    version: 0.11.10
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.18.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.4.tgz}
-    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.4.tgz
+  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.5.tgz}
+    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.0-rc.5.tgz
     name: '@rushstack/heft-lint-plugin'
-    version: 0.1.0-rc.4
+    version: 0.1.0-rc.5
     peerDependencies:
-      '@rushstack/heft': 0.50.0
+      '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.50.0.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz
       semver: 7.3.8
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz_@rushstack+heft@0.50.0:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz}
-    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.4.tgz
+  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz_qaxlinjmol5ttptayw7uvzxpzu:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz}
+    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.0-rc.5.tgz
     name: '@rushstack/heft-typescript-plugin'
-    version: 0.1.0-rc.4
+    version: 0.1.0-rc.5
     peerDependencies:
-      '@rushstack/heft': 0.50.0
+      '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.50.0.tgz
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.9.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0-rc.5.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.11.10.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz
       '@types/tapable': 1.0.6
       semver: 7.3.8
       tapable: 1.1.3
@@ -3914,10 +3918,10 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.55.2
+    version: 3.56.0
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -3933,11 +3937,11 @@ packages:
       z-schema: 5.0.3
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz}
-    id: file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz
+  file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz}
+    id: file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz
     name: '@rushstack/node-core-library'
-    version: 3.55.2
+    version: 3.56.0
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -3953,13 +3957,28 @@ packages:
       semver: 7.3.8
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.0.11.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.11.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.11.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.0.12.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.12.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.12.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.0.11
+    version: 4.0.12
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
+    transitivePeerDependencies:
+      - '@types/node'
+
+  file:../temp/tarballs/rushstack-package-extractor-0.1.0.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.1.0.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.1.0.tgz
+    name: '@rushstack/package-extractor'
+    version: 0.1.0
+    dependencies:
+      '@pnpm/link-bins': 5.3.25
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.5.tgz_@types+node@14.18.36
+      ignore: 5.1.9
+      jszip: 3.8.0
+      npm-packlist: 2.1.5
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3977,36 +3996,36 @@ packages:
     name: '@rushstack/rush-sdk'
     version: 5.97.1
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
       '@types/node-fetch': 2.6.2
       tapable: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.0.229.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.229.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.0.229.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.0.230.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.230.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.0.230.tgz
     name: '@rushstack/stream-collator'
-    version: 4.0.229
+    version: 4.0.230
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.4.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.5.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.5.4.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.4.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.5.4.tgz
+  file:../temp/tarballs/rushstack-terminal-0.5.5.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.5.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.5.5.tgz
     name: '@rushstack/terminal'
-    version: 0.5.4
+    version: 0.5.5
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.55.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.56.0.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       wordwrap: 1.0.0
 

--- a/build-tests/install-test-workspace/workspace/package.json
+++ b/build-tests/install-test-workspace/workspace/package.json
@@ -1,0 +1,9 @@
+{
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowAny": [
+        "@rushstack/heft"
+      ]
+    }
+  }
+}

--- a/libraries/package-extractor/package.json
+++ b/libraries/package-extractor/package.json
@@ -11,9 +11,9 @@
   },
   "scripts": {
     "build": "heft build --clean",
-    "test": "heft test --no-build",
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build"
+    "test": "heft test --clean",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
Fixes the build script for `@rushstack/package-extractor` to be compatible with `heft@next`.
Fixes the `install-test-workspace` project.

## Details

## How it was tested
Local build.