### PR TITLE
[package-extractor] Fix `typings` field in @rushstack/package-extractor package.json

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-FixExtractorTypings_2023-04-28-18-56.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-FixExtractorTypings_2023-04-28-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Fix typings reference in package.json",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/libraries/package-extractor/package.json
+++ b/libraries/package-extractor/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "description": "A library for bundling selected files and dependencies into a deployable package.",
   "main": "lib/index.js",
-  "typings": "dist/deploy-manager.d.ts",
+  "typings": "dist/package-extractor.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",
-    "directory": "libraries/deploy-manager"
+    "directory": "libraries/package-extractor"
   },
   "scripts": {
     "build": "heft build --clean",


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fix package extractor typings. The current package.json references the legacy name of the package. Updated package.json to reference the correct typings.

