### PR TITLE
[node-core-library] Add TerminalWritable Adapter

### DIFF
--- a/common/changes/@rushstack/node-core-library/user-danade-TerminalWritableStream_2023-04-28-20-46.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-TerminalWritableStream_2023-04-28-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a Writable stream adapter for ITerminal to allow writing to a terminal as a stream",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -694,11 +694,8 @@ export interface ITerminalProvider {
 
 // @beta
 export interface ITerminalWritableOptions {
-    // (undocumented)
     severity: TerminalProviderSeverity;
-    // (undocumented)
     terminal: ITerminal;
-    // (undocumented)
     writableOptions?: WritableOptions;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -692,14 +692,12 @@ export interface ITerminalProvider {
     write(data: string, severity: TerminalProviderSeverity): void;
 }
 
-// @public
+// @beta
 export interface ITerminalWritableOptions {
-    // Warning: (ae-incompatible-release-tags) The symbol "terminal" is marked as @public, but its signature references "ITerminal" which is marked as @beta
-    //
+    // (undocumented)
+    severity: TerminalProviderSeverity;
     // (undocumented)
     terminal: ITerminal;
-    // (undocumented)
-    type: TerminalOutputType;
     // (undocumented)
     writableOptions?: WritableOptions;
 }
@@ -925,9 +923,6 @@ export class Terminal implements ITerminal {
     writeWarningLine(...messageParts: (string | IColorableSequence)[]): void;
 }
 
-// @public
-export type TerminalOutputType = 'info' | 'error';
-
 // @beta
 export enum TerminalProviderSeverity {
     // (undocumented)
@@ -942,11 +937,11 @@ export enum TerminalProviderSeverity {
     warning = 1
 }
 
-// @public
+// @beta
 export class TerminalWritable extends Writable {
     constructor(options: ITerminalWritableOptions);
     // (undocumented)
-    _write(chunk: string | Buffer | Uint8Array, encoding: string, callback: () => void): void;
+    _write(chunk: string | Buffer | Uint8Array, encoding: string, callback: (error?: Error | null) => void): void;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -8,6 +8,8 @@
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
+import { Writable } from 'stream';
+import { WritableOptions } from 'stream';
 
 // @public
 export enum AlreadyExistsBehavior {
@@ -691,6 +693,18 @@ export interface ITerminalProvider {
 }
 
 // @public
+export interface ITerminalWritableOptions {
+    // Warning: (ae-incompatible-release-tags) The symbol "terminal" is marked as @public, but its signature references "ITerminal" which is marked as @beta
+    //
+    // (undocumented)
+    terminal: ITerminal;
+    // (undocumented)
+    type: TerminalOutputType;
+    // (undocumented)
+    writableOptions?: WritableOptions;
+}
+
+// @public
 export class JsonFile {
     // @internal (undocumented)
     static _formatPathForError: (path: string) => string;
@@ -911,6 +925,9 @@ export class Terminal implements ITerminal {
     writeWarningLine(...messageParts: (string | IColorableSequence)[]): void;
 }
 
+// @public
+export type TerminalOutputType = 'info' | 'error';
+
 // @beta
 export enum TerminalProviderSeverity {
     // (undocumented)
@@ -923,6 +940,13 @@ export enum TerminalProviderSeverity {
     verbose = 3,
     // (undocumented)
     warning = 1
+}
+
+// @public
+export class TerminalWritable extends Writable {
+    constructor(options: ITerminalWritableOptions);
+    // (undocumented)
+    _write(chunk: string | Buffer | Uint8Array, encoding: string, callback: () => void): void;
 }
 
 // @public

--- a/libraries/node-core-library/src/Terminal/TerminalWritable.ts
+++ b/libraries/node-core-library/src/Terminal/TerminalWritable.ts
@@ -8,8 +8,17 @@ import { Writable, type WritableOptions } from 'stream';
  * @beta
  */
 export interface ITerminalWritableOptions {
+  /**
+   * The {@link ITerminal} that the Writable will write to.
+   */
   terminal: ITerminal;
+  /**
+   * The severity of the messages that will be written to the {@link ITerminal}.
+   */
   severity: TerminalProviderSeverity;
+  /**
+   * Options for the underlying Writable.
+   */
   writableOptions?: WritableOptions;
 }
 

--- a/libraries/node-core-library/src/Terminal/TerminalWritable.ts
+++ b/libraries/node-core-library/src/Terminal/TerminalWritable.ts
@@ -1,0 +1,53 @@
+import type { ITerminal } from './ITerminal';
+import { Writable, type WritableOptions } from 'stream';
+
+/**
+ * Supported output types for {@link TerminalWritable}. The selected output type
+ * determines how the data is written to the terminal.
+ *
+ * @public
+ */
+export type TerminalOutputType = 'info' | 'error';
+
+/**
+ * Options for {@link TerminalWritable}.
+ *
+ * @public
+ */
+export interface ITerminalWritableOptions {
+  terminal: ITerminal;
+  type: TerminalOutputType;
+  writableOptions?: WritableOptions;
+}
+
+/**
+ * A adapter to allow writing to a provided terminal using Writable streams.
+ *
+ * @public
+ */
+export class TerminalWritable extends Writable {
+  private _writeMethod: (data: string) => void;
+
+  public constructor(options: ITerminalWritableOptions) {
+    const { terminal, type, writableOptions } = options;
+    super(writableOptions);
+
+    this._writev = undefined;
+    switch (type) {
+      case 'info':
+        this._writeMethod = terminal.write.bind(terminal);
+        break;
+      case 'error':
+        this._writeMethod = terminal.writeError.bind(terminal);
+        break;
+      default:
+        throw new Error(`Unsupported output type: ${type}`);
+    }
+  }
+
+  public _write(chunk: string | Buffer | Uint8Array, encoding: string, callback: () => void): void {
+    const chunkData: string | Buffer = typeof chunk === 'string' ? chunk : Buffer.from(chunk);
+    this._writeMethod(chunkData.toString());
+    callback();
+  }
+}

--- a/libraries/node-core-library/src/Terminal/TerminalWritable.ts
+++ b/libraries/node-core-library/src/Terminal/TerminalWritable.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { ITerminal } from './ITerminal';
 import { TerminalProviderSeverity } from './ITerminalProvider';
 import { Writable, type WritableOptions } from 'stream';

--- a/libraries/node-core-library/src/Terminal/test/TerminalWritable.test.ts
+++ b/libraries/node-core-library/src/Terminal/test/TerminalWritable.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Terminal } from '../Terminal';
+import { StringBufferTerminalProvider } from '../StringBufferTerminalProvider';
+import { TerminalWritable } from '../TerminalWritable';
+import { TerminalProviderSeverity } from '../ITerminalProvider';
+import { Writable } from 'stream';
+
+let terminal: Terminal;
+let provider: StringBufferTerminalProvider;
+
+function verifyProvider(): void {
+  expect({
+    log: provider.getOutput(),
+    warning: provider.getWarningOutput(),
+    error: provider.getErrorOutput(),
+    verbose: provider.getVerbose(),
+    debug: provider.getDebugOutput()
+  }).toMatchSnapshot();
+}
+
+async function writeAsync(writable: Writable, data: string): Promise<void> {
+  await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
+    // eslint-disable-next-line @rushstack/no-new-null
+    writable.write(data, (error?: Error | null) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+describe(TerminalWritable.name, () => {
+  beforeEach(() => {
+    provider = new StringBufferTerminalProvider(true);
+    terminal = new Terminal(provider);
+  });
+
+  test('writes a message', async () => {
+    const writable: TerminalWritable = new TerminalWritable({
+      terminal,
+      severity: TerminalProviderSeverity.log
+    });
+
+    await writeAsync(writable, 'test message');
+    verifyProvider();
+  });
+
+  test('writes a verbose message', async () => {
+    const writable: TerminalWritable = new TerminalWritable({
+      terminal,
+      severity: TerminalProviderSeverity.verbose
+    });
+
+    await writeAsync(writable, 'test message');
+    verifyProvider();
+  });
+
+  test('writes a debug message', async () => {
+    const writable: TerminalWritable = new TerminalWritable({
+      terminal,
+      severity: TerminalProviderSeverity.debug
+    });
+
+    await writeAsync(writable, 'test message');
+    verifyProvider();
+  });
+
+  test('writes a warning message', async () => {
+    const writable: TerminalWritable = new TerminalWritable({
+      terminal,
+      severity: TerminalProviderSeverity.warning
+    });
+
+    await writeAsync(writable, 'test message');
+    verifyProvider();
+  });
+
+  test('writes an error message', async () => {
+    const writable: TerminalWritable = new TerminalWritable({
+      terminal,
+      severity: TerminalProviderSeverity.error
+    });
+
+    await writeAsync(writable, 'test message');
+    verifyProvider();
+  });
+});

--- a/libraries/node-core-library/src/Terminal/test/__snapshots__/TerminalWritable.test.ts.snap
+++ b/libraries/node-core-library/src/Terminal/test/__snapshots__/TerminalWritable.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TerminalWritable writes a debug message 1`] = `
+Object {
+  "debug": "test message",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`TerminalWritable writes a message 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "test message",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`TerminalWritable writes a verbose message 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "test message",
+  "warning": "",
+}
+`;
+
+exports[`TerminalWritable writes a warning message 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "[yellow]test message[default]",
+}
+`;
+
+exports[`TerminalWritable writes an error message 1`] = `
+Object {
+  "debug": "",
+  "error": "[red]test message[default]",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -97,6 +97,7 @@ export { StringBuilder, IStringBuilder } from './StringBuilder';
 export { ISubprocessOptions, SubprocessTerminator } from './SubprocessTerminator';
 export { ITerminal } from './Terminal/ITerminal';
 export { Terminal } from './Terminal/Terminal';
+export { TerminalWritable, ITerminalWritableOptions, TerminalOutputType } from './Terminal/TerminalWritable';
 export { Colors, IColorableSequence, ColorValue, TextAttribute } from './Terminal/Colors';
 export { ITerminalProvider, TerminalProviderSeverity } from './Terminal/ITerminalProvider';
 export { ConsoleTerminalProvider, IConsoleTerminalProviderOptions } from './Terminal/ConsoleTerminalProvider';

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -97,7 +97,6 @@ export { StringBuilder, IStringBuilder } from './StringBuilder';
 export { ISubprocessOptions, SubprocessTerminator } from './SubprocessTerminator';
 export { ITerminal } from './Terminal/ITerminal';
 export { Terminal } from './Terminal/Terminal';
-export { TerminalWritable, ITerminalWritableOptions, TerminalOutputType } from './Terminal/TerminalWritable';
 export { Colors, IColorableSequence, ColorValue, TextAttribute } from './Terminal/Colors';
 export { ITerminalProvider, TerminalProviderSeverity } from './Terminal/ITerminalProvider';
 export { ConsoleTerminalProvider, IConsoleTerminalProviderOptions } from './Terminal/ConsoleTerminalProvider';
@@ -105,4 +104,5 @@ export {
   StringBufferTerminalProvider,
   IStringBufferOutputOptions
 } from './Terminal/StringBufferTerminalProvider';
+export { TerminalWritable, ITerminalWritableOptions } from './Terminal/TerminalWritable';
 export { TypeUuid } from './TypeUuid';


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Adds a new class `TerminalWritable` to `@rushstack/node-core-library` which allows for creating a `Writable` stream that pipes all written chunks out to the provided `ITerminal`.

## How it was tested

Added tests and validated output snapshots. Another implementation of this has been used internally for a while now.

## Impacted documentation

New API added to `@rushstack/node-core-library`