### PR TITLE
[rush] Update the RushSession.registerCloudBuildCacheProviderFactory API to allow a cache provider's factory function to return a promise.

### DIFF
--- a/common/changes/@microsoft/rush/cleaner-cache-support_2023-04-30-13-02.json
+++ b/common/changes/@microsoft/rush/cleaner-cache-support_2023-04-30-13-02.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Update the `RushSession.registerCloudBuildCacheProviderFactory` API to allow a cache provider's factory function to return a function.",
+      "comment": "Update the `RushSession.registerCloudBuildCacheProviderFactory` API to allow a cache provider's factory function to return a promise.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/cleaner-cache-support_2023-04-30-13-02.json
+++ b/common/changes/@microsoft/rush/cleaner-cache-support_2023-04-30-13-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the `RushSession.registerCloudBuildCacheProviderFactory` API to allow a cache provider's factory function to return a function.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -93,7 +93,7 @@ export class ChangeManager {
 // Warning: (ae-forgotten-export) The symbol "IBuildCacheJson" needs to be exported by the entry point index.d.ts
 //
 // @beta (undocumented)
-export type CloudBuildCacheProviderFactory = (buildCacheJson: IBuildCacheJson) => ICloudBuildCacheProvider;
+export type CloudBuildCacheProviderFactory = (buildCacheJson: IBuildCacheJson) => ICloudBuildCacheProvider | Promise<ICloudBuildCacheProvider>;
 
 // @public
 export class CommonVersionsConfiguration {

--- a/libraries/rush-lib/src/pluginFramework/RushSession.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.ts
@@ -18,7 +18,9 @@ export interface IRushSessionOptions {
 /**
  * @beta
  */
-export type CloudBuildCacheProviderFactory = (buildCacheJson: IBuildCacheJson) => ICloudBuildCacheProvider;
+export type CloudBuildCacheProviderFactory = (
+  buildCacheJson: IBuildCacheJson
+) => ICloudBuildCacheProvider | Promise<ICloudBuildCacheProvider>;
 
 /**
  * @beta
@@ -60,6 +62,7 @@ export class RushSession {
     if (this._cloudBuildCacheProviderFactories.has(cacheProviderName)) {
       throw new Error(`A build cache provider factory for ${cacheProviderName} has already been registered`);
     }
+
     this._cloudBuildCacheProviderFactories.set(cacheProviderName, factory);
   }
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Import } from '@rushstack/node-core-library';
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
 import type { AzureEnvironmentName } from './AzureAuthenticationBase';
-
-const AzureStorageBuildCacheProviderModule: typeof import('./AzureStorageBuildCacheProvider') = Import.lazy(
-  './AzureStorageBuildCacheProvider',
-  require
-);
 
 const PLUGIN_NAME: string = 'AzureStorageBuildCachePlugin';
 
@@ -50,12 +44,13 @@ export class RushAzureStorageBuildCachePlugin implements IRushPlugin {
 
   public apply(rushSession: RushSession, rushConfig: RushConfiguration): void {
     rushSession.hooks.initialize.tap(PLUGIN_NAME, () => {
-      rushSession.registerCloudBuildCacheProviderFactory('azure-blob-storage', (buildCacheConfig) => {
+      rushSession.registerCloudBuildCacheProviderFactory('azure-blob-storage', async (buildCacheConfig) => {
         type IBuildCache = typeof buildCacheConfig & {
           azureBlobStorageConfiguration: IAzureBlobStorageConfigurationJson;
         };
         const { azureBlobStorageConfiguration } = buildCacheConfig as IBuildCache;
-        return new AzureStorageBuildCacheProviderModule.AzureStorageBuildCacheProvider({
+        const { AzureStorageBuildCacheProvider } = await import('./AzureStorageBuildCacheProvider');
+        return new AzureStorageBuildCacheProvider({
           storageAccountName: azureBlobStorageConfiguration.storageAccountName,
           storageContainerName: azureBlobStorageConfiguration.storageContainerName,
           azureEnvironment: azureBlobStorageConfiguration.azureEnvironment,

--- a/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
@@ -1,11 +1,8 @@
-import { Import } from '@rushstack/node-core-library';
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
 import type { HttpBuildCacheProvider, IHttpBuildCacheProviderOptions } from './HttpBuildCacheProvider';
-
-const HttpBuildCacheProviderModule: typeof import('./HttpBuildCacheProvider') = Import.lazy(
-  './HttpBuildCacheProvider',
-  require
-);
 
 const PLUGIN_NAME: string = 'HttpBuildCachePlugin';
 
@@ -56,31 +53,29 @@ export class RushHttpBuildCachePlugin implements IRushPlugin {
 
   public apply(rushSession: RushSession, rushConfig: RushConfiguration): void {
     rushSession.hooks.initialize.tap(this.pluginName, () => {
-      rushSession.registerCloudBuildCacheProviderFactory(
-        'http',
-        (buildCacheConfig): HttpBuildCacheProvider => {
-          const config: IRushHttpBuildCachePluginConfig = (
-            buildCacheConfig as typeof buildCacheConfig & {
-              httpConfiguration: IRushHttpBuildCachePluginConfig;
-            }
-          ).httpConfiguration;
+      rushSession.registerCloudBuildCacheProviderFactory('http', async (buildCacheConfig) => {
+        const config: IRushHttpBuildCachePluginConfig = (
+          buildCacheConfig as typeof buildCacheConfig & {
+            httpConfiguration: IRushHttpBuildCachePluginConfig;
+          }
+        ).httpConfiguration;
 
-          const { url, uploadMethod, headers, tokenHandler, cacheKeyPrefix, isCacheWriteAllowed } = config;
+        const { url, uploadMethod, headers, tokenHandler, cacheKeyPrefix, isCacheWriteAllowed } = config;
 
-          const options: IHttpBuildCacheProviderOptions = {
-            pluginName: this.pluginName,
-            rushProjectRoot: rushConfig.rushJsonFolder,
-            url: url,
-            uploadMethod: uploadMethod,
-            headers: headers,
-            tokenHandler: tokenHandler,
-            cacheKeyPrefix: cacheKeyPrefix,
-            isCacheWriteAllowed: !!isCacheWriteAllowed
-          };
+        const options: IHttpBuildCacheProviderOptions = {
+          pluginName: this.pluginName,
+          rushProjectRoot: rushConfig.rushJsonFolder,
+          url: url,
+          uploadMethod: uploadMethod,
+          headers: headers,
+          tokenHandler: tokenHandler,
+          cacheKeyPrefix: cacheKeyPrefix,
+          isCacheWriteAllowed: !!isCacheWriteAllowed
+        };
 
-          return new HttpBuildCacheProviderModule.HttpBuildCacheProvider(options, rushSession);
-        }
-      );
+        const { HttpBuildCacheProvider } = await import('./HttpBuildCacheProvider');
+        return new HttpBuildCacheProvider(options, rushSession);
+      });
     });
   }
 }

--- a/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
@@ -1,11 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 jest.mock('node-fetch', function () {
   return Object.assign(jest.fn(), jest.requireActual('node-fetch'));
 });
 
 import fetch, { Response } from 'node-fetch';
-import { HttpBuildCacheProvider } from './HttpBuildCacheProvider';
 import { RushSession, EnvironmentConfiguration } from '@rushstack/rush-sdk';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
+
+import { HttpBuildCacheProvider } from '../HttpBuildCacheProvider';
 
 const EXAMPLE_OPTIONS = {
   url: 'https://buildcache.example.acme.com',


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/microsoft/rushstack/pull/3976.

## How it was tested

Tested by running a build in a repo that uses the Azure Storage cache provider.

## Impacted documentation

The custom cache provider docs may need to be updated.