### PR TITLE
[node-core-library][rush] Support weighted async concurrency

### DIFF
--- a/common/changes/@microsoft/rush/weighted-concurrency_2023-05-01-19-41.json
+++ b/common/changes/@microsoft/rush/weighted-concurrency_2023-05-01-19-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow operations to have variable weight for concurrency purposes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/weighted-concurrency_2023-05-01-19-41.json
+++ b/common/changes/@rushstack/node-core-library/weighted-concurrency_2023-05-01-19-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Support variable concurrency based on task weights in `Async.forEachAsync`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -33,7 +33,9 @@ export class AnsiEscape {
 
 // @beta
 export class Async {
-    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
+    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: TEntry extends {
+        weight?: number;
+    } ? IAsyncParallelismOptionsWithWeight : IAsyncParallelismOptions | undefined): Promise<void>;
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
@@ -317,6 +319,11 @@ export interface IAnsiEscapeConvertForTestsOptions {
 // @beta
 export interface IAsyncParallelismOptions {
     concurrency?: number;
+}
+
+// @beta
+export interface IAsyncParallelismOptionsWithWeight extends IAsyncParallelismOptions {
+    useWeight?: boolean;
 }
 
 // @beta (undocumented)

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -9,7 +9,13 @@
 
 export { AlreadyReportedError } from './AlreadyReportedError';
 export { AnsiEscape, IAnsiEscapeConvertForTestsOptions } from './Terminal/AnsiEscape';
-export { Async, AsyncQueue, IAsyncParallelismOptions, IRunWithRetriesOptions } from './Async';
+export {
+  Async,
+  AsyncQueue,
+  IAsyncParallelismOptions,
+  IAsyncParallelismOptionsWithWeight,
+  IRunWithRetriesOptions
+} from './Async';
 export { Brand } from './PrimitiveTypes';
 export { FileConstants, FolderConstants } from './Constants';
 export { Enum } from './Enum';

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -216,9 +216,11 @@ export class OperationExecutionManager {
       executionQueue,
       async (operation: OperationExecutionRecord) => {
         await operation.executeAsync(onOperationComplete);
+        executionQueue.assignOperations();
       },
       {
-        concurrency: maxParallelism
+        concurrency: maxParallelism,
+        useWeight: true
       }
     );
 

--- a/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
@@ -84,6 +84,7 @@ function createOperations(
           result: OperationStatus.Skipped,
           silent: true
         });
+        operation.weight = 0.01;
       } else if (changedProjects.has(project)) {
         operationsWithWork.add(operation);
       }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -95,6 +95,7 @@ function createShellOperations(
           result: OperationStatus.NoOp,
           silent: false
         });
+        operation.weight = 0.01;
       }
     }
   }


### PR DESCRIPTION
## Summary
Updates `Async.forEachAsync` with the ability to have variable concurrency based on task weights.

Updates Rush to use the feature for phased build concurrency.

The motivation for this feature is that when distributing tasks across available CPUs, sometimes a task may only use the target CPU some of the time (e.g. a network request) and therefore contributes a value `<1` to the overall concurrency limit, and conversely sometimes a task may spin up multiple CPU-intensive threads and therefore contributes a value `>1` to the overall concurrency limit.

## Details
Adds a new option `useWeight: true` to `Async.forEachAsync` that is only available when the item type has a property `weight?: number`. If set, this value gets used for comparing available concurrency, instead of the default `1`.

## How it was tested
Added unit test for the scenario.

## Impacted documentation
Just the docs for the method.