### PR TITLE
[rush] Add a "forbidPhantomResolvableNodeModuleFolders" experiment that forbids node_modules folders in the repo root and in parent folders.

### DIFF
--- a/build-tests/install-test-workspace/workspace/rush-sdk-test/src/start.ts
+++ b/build-tests/install-test-workspace/workspace/rush-sdk-test/src/start.ts
@@ -13,5 +13,5 @@ console.log(config.commonFolder);
 console.log('Calling an internal API...');
 
 // Use a path-based import to access an internal API (do so at your own risk!)
-import { GitEmailPolicy } from '@rushstack/rush-sdk/lib/logic/policy/GitEmailPolicy';
+import * as GitEmailPolicy from '@rushstack/rush-sdk/lib/logic/policy/GitEmailPolicy';
 console.log(GitEmailPolicy.getEmailExampleLines(config));

--- a/common/changes/@microsoft/rush/check-for-phantom-node-modules-folders_2023-05-01-22-07.json
+++ b/common/changes/@microsoft/rush/check-for-phantom-node-modules-folders_2023-05-01-22-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"forbidPhantomResolvableNodeModuleFolders\" experiment that forbids node_modules folders in the repo root and in parent folders.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -303,6 +303,7 @@ export interface IExecutionResult {
 export interface IExperimentsJson {
     buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
     cleanInstallAfterNpmrcChanges?: boolean;
+    forbidPhantomResolvableNodeModuleFolders?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     phasedCommands?: boolean;
@@ -967,6 +968,7 @@ export class RushConstants {
     static readonly buildCacheVersion: number;
     static readonly buildCommandName: string;
     static readonly bulkCommandKind: 'bulk';
+    static readonly bypassPolicyFlagLongName: '--bypass-policy';
     static readonly changeFilesFolderName: string;
     static readonly commandLineFilename: string;
     static readonly commonFolderName: string;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -51,5 +51,10 @@
   /**
    * If true, print the outputs of shell commands defined in event hooks to the console.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "printEventHooksOutputToConsole": true
+  /*[LINE "HYPOTHETICAL"]*/ "printEventHooksOutputToConsole": true,
+
+  /**
+   * If true, Rush will not allow node_modules in the repo folder or in parent folders.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "forbidPhantomResolvableNodeModuleFolders": true
 }

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -58,6 +58,11 @@ export interface IExperimentsJson {
    * If true, print the outputs of shell commands defined in event hooks to the console.
    */
   printEventHooksOutputToConsole?: boolean;
+
+  /**
+   * If true, Rush will not allow node_modules in the repo folder or in parent folders.
+   */
+  forbidPhantomResolvableNodeModuleFolders?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -49,7 +49,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
       description: 'Perform "rush purge" before starting the installation'
     });
     this._bypassPolicyParameter = this.defineFlagParameter({
-      parameterLongName: '--bypass-policy',
+      parameterLongName: RushConstants.bypassPolicyFlagLongName,
       description: 'Overrides enforcement of the "gitPolicy" rules from rush.json (use honorably!)'
     });
     this._noLinkParameter = this.defineFlagParameter({

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -49,6 +49,7 @@ export class InstallAction extends BaseInstallAction {
     return {
       debug: this.parser.isDebug,
       allowShrinkwrapUpdates: false,
+      bypassPolicyAllowed: true,
       bypassPolicy: this._bypassPolicyParameter.value!,
       noLink: this._noLinkParameter.value!,
       fullUpgrade: false,

--- a/libraries/rush-lib/src/cli/actions/PublishAction.ts
+++ b/libraries/rush-lib/src/cli/actions/PublishAction.ts
@@ -21,7 +21,7 @@ import { PrereleaseToken } from '../../logic/PrereleaseToken';
 import { ChangeManager } from '../../logic/ChangeManager';
 import { BaseRushAction } from './BaseRushAction';
 import { PublishGit } from '../../logic/PublishGit';
-import { PolicyValidator } from '../../logic/policy/PolicyValidator';
+import * as PolicyValidator from '../../logic/policy/PolicyValidator';
 import { VersionPolicy } from '../../api/VersionPolicy';
 import { DEFAULT_PACKAGE_UPDATE_MESSAGE } from './VersionAction';
 import { Utilities } from '../../utilities/Utilities';
@@ -211,7 +211,7 @@ export class PublishAction extends BaseRushAction {
    * Executes the publish action, which will read change request files, apply changes to package.jsons,
    */
   protected async runAsync(): Promise<void> {
-    PolicyValidator.validatePolicy(this.rushConfiguration, { bypassPolicy: false });
+    await PolicyValidator.validatePolicyAsync(this.rushConfiguration, { bypassPolicy: false });
 
     // Example: "common\temp\publish-home"
     this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');

--- a/libraries/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAction.ts
@@ -66,6 +66,7 @@ export class UpdateAction extends BaseInstallAction {
     return {
       debug: this.parser.isDebug,
       allowShrinkwrapUpdates: true,
+      bypassPolicyAllowed: true,
       bypassPolicy: this._bypassPolicyParameter.value!,
       noLink: this._noLinkParameter.value!,
       fullUpgrade: this._fullParameter.value!,

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -10,10 +10,11 @@ import { VersionPolicyConfiguration } from '../../api/VersionPolicyConfiguration
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismatchFinder';
 import { RushCommandLineParser } from '../RushCommandLineParser';
-import { PolicyValidator } from '../../logic/policy/PolicyValidator';
+import * as PolicyValidator from '../../logic/policy/PolicyValidator';
 import { BaseRushAction } from './BaseRushAction';
 import { PublishGit } from '../../logic/PublishGit';
 import { Git } from '../../logic/Git';
+import { RushConstants } from '../../logic/RushConstants';
 
 import type * as VersionManagerType from '../../logic/VersionManager';
 
@@ -61,7 +62,7 @@ export class VersionAction extends BaseRushAction {
       description: 'Bumps package version based on version policies.'
     });
     this._bypassPolicy = this.defineFlagParameter({
-      parameterLongName: '--bypass-policy',
+      parameterLongName: RushConstants.bypassPolicyFlagLongName,
       description: 'Overrides "gitPolicy" enforcement (use honorably!)'
     });
     this._versionPolicy = this.defineStringParameter({
@@ -94,7 +95,10 @@ export class VersionAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    PolicyValidator.validatePolicy(this.rushConfiguration, { bypassPolicy: this._bypassPolicy.value });
+    await PolicyValidator.validatePolicyAsync(this.rushConfiguration, {
+      bypassPolicyAllowed: true,
+      bypassPolicy: this._bypassPolicy.value
+    });
     const git: Git = new Git(this.rushConfiguration);
     const userEmail: string = git.getGitEmail();
 

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -11,7 +11,7 @@ import { Executable, AlreadyReportedError, Path, ITerminal } from '@rushstack/no
 import { ensureGitMinimumVersion } from '@rushstack/package-deps-hash';
 
 import { Utilities } from '../utilities/Utilities';
-import { GitEmailPolicy } from './policy/GitEmailPolicy';
+import * as GitEmailPolicy from './policy/GitEmailPolicy';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { EnvironmentConfiguration } from '../api/EnvironmentConfiguration';
 import { IChangedGitStatusEntry, IGitStatusEntry, parseGitStatus } from './GitStatusParser';

--- a/libraries/rush-lib/src/logic/RushConstants.ts
+++ b/libraries/rush-lib/src/logic/RushConstants.ts
@@ -264,4 +264,9 @@ export class RushConstants {
    * file system event occurs in this interval, the timeout will reset.
    */
   public static readonly defaultWatchDebounceMs: number = 1000;
+
+  /**
+   * The name of the parameter that can be used to bypass policies.
+   */
+  public static readonly bypassPolicyFlagLongName: '--bypass-policy' = '--bypass-policy';
 }

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -36,7 +36,7 @@ import { RushConstants } from '../RushConstants';
 import { ShrinkwrapFileFactory } from '../ShrinkwrapFileFactory';
 import { Utilities } from '../../utilities/Utilities';
 import { InstallHelpers } from '../installManager/InstallHelpers';
-import { PolicyValidator } from '../policy/PolicyValidator';
+import * as PolicyValidator from '../policy/PolicyValidator';
 import { WebClient, WebClientResponse } from '../../utilities/WebClient';
 import { SetupPackageRegistry } from '../setup/SetupPackageRegistry';
 import { PnpmfileConfiguration } from '../pnpm/PnpmfileConfiguration';
@@ -256,7 +256,7 @@ export abstract class BaseInstallManager {
     npmrcHash: string | undefined;
   }> {
     // Check the policies
-    PolicyValidator.validatePolicy(this.rushConfiguration, this.options);
+    await PolicyValidator.validatePolicyAsync(this.rushConfiguration, this.options);
 
     this._installGitHooks();
 
@@ -438,7 +438,8 @@ export abstract class BaseInstallManager {
           console.error(
             color(
               [
-                '(Or, to temporarily ignore this problem, invoke Rush with the "--bypass-policy" option.)',
+                '(Or, to temporarily ignore this problem, invoke Rush with the ' +
+                  `"${RushConstants.bypassPolicyFlagLongName}" option.)`,
                 ' '
               ].join('\n')
             )
@@ -747,7 +748,8 @@ export abstract class BaseInstallManager {
         console.error();
         console.error(
           colors.bold(
-            '==> Please run "rush setup" to update your NPM token.  (Or append "--bypass-policy" to proceed anyway.)'
+            '==> Please run "rush setup" to update your NPM token. ' +
+              `(Or append "${RushConstants.bypassPolicyFlagLongName}" to proceed anyway.)`
           )
         );
         throw new AlreadyReportedError();

--- a/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
@@ -19,6 +19,11 @@ export interface IInstallManagerOptions {
   checkOnly: boolean;
 
   /**
+   * Whether a "--bypass-policy" flag can be specified.
+   */
+  bypassPolicyAllowed?: boolean;
+
+  /**
    * Whether to skip policy checks.
    */
   bypassPolicy: boolean;

--- a/libraries/rush-lib/src/logic/policy/EnvironmentPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/EnvironmentPolicy.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { AlreadyReportedError, Async, FileSystem } from '@rushstack/node-core-library';
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { IPolicyValidatorOptions } from './PolicyValidator';
+import { RushConstants } from '../RushConstants';
+
+/**
+ * Ensures the environment where the Rush repo exists is valid
+ */
+export async function validateAsync(
+  rushConfiguration: RushConfiguration,
+  options: IPolicyValidatorOptions
+): Promise<void> {
+  if (rushConfiguration.experimentsConfiguration.configuration.forbidPhantomResolvableNodeModuleFolders) {
+    const pathParts: string[] = rushConfiguration.rushJsonFolder.split(/[\/\\]/);
+    const existingNodeModulesPaths: string[] = [];
+    await Async.forEachAsync(
+      pathParts,
+      async (pathPart: string, index: number) => {
+        const potentialNodeModulesPath: string = `${pathParts.slice(0, index + 1).join('/')}/node_modules`;
+        const pathExists: boolean = await FileSystem.existsAsync(potentialNodeModulesPath);
+        if (pathExists) {
+          existingNodeModulesPaths.push(potentialNodeModulesPath);
+        }
+      },
+      { concurrency: 5 }
+    );
+
+    if (existingNodeModulesPaths.length > 0) {
+      const paths: string = existingNodeModulesPaths.join(', ');
+      let errorMessage: string =
+        `The following node_modules folders exist in the path to the Rush repo: ${paths}. ` +
+        `This is not supported, and may cause issues.`;
+      if (options.bypassPolicyAllowed) {
+        errorMessage += ` To ignore, use the "${RushConstants.bypassPolicyFlagLongName}" flag.`;
+      }
+
+      console.error(errorMessage);
+      throw new AlreadyReportedError();
+    }
+  }
+}

--- a/libraries/rush-lib/src/logic/policy/EnvironmentPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/EnvironmentPolicy.ts
@@ -30,7 +30,7 @@ export async function validateAsync(
     );
 
     if (existingNodeModulesPaths.length > 0) {
-      const paths: string = existingNodeModulesPaths.join(', ');
+      const paths: string = existingNodeModulesPaths.sort().join(', ');
       let errorMessage: string =
         `The following node_modules folders exist in the path to the Rush repo: ${paths}. ` +
         `This is not supported, and may cause issues.`;

--- a/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -4,130 +4,138 @@
 import colors from 'colors/safe';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 
-import { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushConfiguration } from '../../api/RushConfiguration';
 import { Utilities } from '../../utilities/Utilities';
 import { Git } from '../Git';
+import { RushConstants } from '../RushConstants';
+import type { IPolicyValidatorOptions } from './PolicyValidator';
 
-export class GitEmailPolicy {
-  public static validate(rushConfiguration: RushConfiguration): void {
-    const git: Git = new Git(rushConfiguration);
+export function validate(rushConfiguration: RushConfiguration, options: IPolicyValidatorOptions): void {
+  const git: Git = new Git(rushConfiguration);
 
-    if (!git.isGitPresent()) {
-      // If Git isn't installed, or this Rush project is not under a Git working folder,
-      // then we don't care about the Git email
-      console.log(
-        colors.cyan('Ignoring Git validation because the Git binary was not found in the shell path.') + '\n'
-      );
-      return;
-    }
-
-    if (!git.isPathUnderGitWorkingTree()) {
-      // If Git isn't installed, or this Rush project is not under a Git working folder,
-      // then we don't care about the Git email
-      console.log(colors.cyan('Ignoring Git validation because this is not a Git working folder.') + '\n');
-      return;
-    }
-
-    // If there isn't a Git policy, then we don't care whether the person configured
-    // a Git email address at all.  This helps people who don't
-    if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
-      if (git.tryGetGitEmail() === undefined) {
-        return;
-      }
-
-      // Otherwise, if an email *is* configured at all, then we still perform the basic
-      // sanity checks (e.g. no spaces in the address).
-    }
-
-    let userEmail: string;
-    try {
-      userEmail = git.getGitEmail();
-
-      // sanity check; a valid email should not contain any whitespace
-      // if this fails, then we have another issue to report
-      if (!userEmail.match(/^\S+$/g)) {
-        console.log(
-          [
-            colors.red('Your Git email address is invalid: ' + JSON.stringify(userEmail)),
-            '',
-            `To configure your Git email address, try something like this:`,
-            '',
-            ...GitEmailPolicy.getEmailExampleLines(rushConfiguration),
-            ''
-          ].join('\n')
-        );
-        throw new AlreadyReportedError();
-      }
-    } catch (e) {
-      if (e instanceof AlreadyReportedError) {
-        console.log(
-          colors.red('Aborting, so you can go fix your settings.  (Or use --bypass-policy to skip.)')
-        );
-        throw e;
-      } else {
-        throw e;
-      }
-    }
-
-    if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
-      // If there is no policy, then we're good
-      return;
-    }
-
-    console.log('Checking Git policy for this repository.\n');
-
-    // If there is a policy, at least one of the RegExp's must match
-    for (const pattern of rushConfiguration.gitAllowedEmailRegExps) {
-      const regex: RegExp = new RegExp(`^${pattern}$`, 'i');
-      if (userEmail.match(regex)) {
-        return;
-      }
-    }
-
-    // Show the user's name as well.
-    // Ex. "Example Name <name@example.com>"
-    let fancyEmail: string = colors.cyan(userEmail);
-    try {
-      const userName: string = Utilities.executeCommandAndCaptureOutput(
-        git.gitPath!,
-        ['config', 'user.name'],
-        '.'
-      ).trim();
-      if (userName) {
-        fancyEmail = `${userName} <${fancyEmail}>`;
-      }
-    } catch (e) {
-      // but if it fails, this isn't critical, so don't bother them about it
-    }
-
+  if (!git.isGitPresent()) {
+    // If Git isn't installed, or this Rush project is not under a Git working folder,
+    // then we don't care about the Git email
     console.log(
-      [
-        'Hey there!  To keep things tidy, this repo asks you to submit your Git commits using an email like ' +
-          (rushConfiguration.gitAllowedEmailRegExps.length > 1 ? 'one of these patterns:' : 'this pattern:'),
-        '',
-        ...rushConfiguration.gitAllowedEmailRegExps.map((pattern) => '    ' + colors.cyan(pattern)),
-        '',
-        '...but yours is configured like this:',
-        '',
-        `    ${fancyEmail}`,
-        '',
-        'To fix it, you can use commands like this:',
-        '',
-        ...GitEmailPolicy.getEmailExampleLines(rushConfiguration),
-        ''
-      ].join('\n')
+      colors.cyan('Ignoring Git validation because the Git binary was not found in the shell path.') + '\n'
     );
-
-    console.log(colors.red('Aborting, so you can go fix your settings.  (Or use --bypass-policy to skip.)'));
-    throw new AlreadyReportedError();
+    return;
   }
 
-  public static getEmailExampleLines(rushConfiguration: RushConfiguration): string[] {
-    return [
-      colors.cyan('    git config --local user.name "Example Name"'),
-      colors.cyan(
-        `    git config --local user.email "${rushConfiguration.gitSampleEmail || 'name@example.com'}"`
-      )
-    ];
+  if (!git.isPathUnderGitWorkingTree()) {
+    // If Git isn't installed, or this Rush project is not under a Git working folder,
+    // then we don't care about the Git email
+    console.log(colors.cyan('Ignoring Git validation because this is not a Git working folder.') + '\n');
+    return;
   }
+
+  // If there isn't a Git policy, then we don't care whether the person configured
+  // a Git email address at all.  This helps people who don't
+  if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
+    if (git.tryGetGitEmail() === undefined) {
+      return;
+    }
+
+    // Otherwise, if an email *is* configured at all, then we still perform the basic
+    // sanity checks (e.g. no spaces in the address).
+  }
+
+  let userEmail: string;
+  try {
+    userEmail = git.getGitEmail();
+
+    // sanity check; a valid email should not contain any whitespace
+    // if this fails, then we have another issue to report
+    if (!userEmail.match(/^\S+$/g)) {
+      console.log(
+        [
+          colors.red('Your Git email address is invalid: ' + JSON.stringify(userEmail)),
+          '',
+          `To configure your Git email address, try something like this:`,
+          '',
+          ...getEmailExampleLines(rushConfiguration),
+          ''
+        ].join('\n')
+      );
+      throw new AlreadyReportedError();
+    }
+  } catch (e) {
+    if (e instanceof AlreadyReportedError) {
+      let errorMessage: string = 'Aborting, so you can go fix your settings.';
+      if (options.bypassPolicyAllowed) {
+        errorMessage += ` (Or use "${RushConstants.bypassPolicyFlagLongName}" to skip.)`;
+      }
+
+      console.log(colors.red(errorMessage));
+      throw e;
+    } else {
+      throw e;
+    }
+  }
+
+  if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
+    // If there is no policy, then we're good
+    return;
+  }
+
+  console.log('Checking Git policy for this repository.\n');
+
+  // If there is a policy, at least one of the RegExp's must match
+  for (const pattern of rushConfiguration.gitAllowedEmailRegExps) {
+    const regex: RegExp = new RegExp(`^${pattern}$`, 'i');
+    if (userEmail.match(regex)) {
+      return;
+    }
+  }
+
+  // Show the user's name as well.
+  // Ex. "Example Name <name@example.com>"
+  let fancyEmail: string = colors.cyan(userEmail);
+  try {
+    const userName: string = Utilities.executeCommandAndCaptureOutput(
+      git.gitPath!,
+      ['config', 'user.name'],
+      '.'
+    ).trim();
+    if (userName) {
+      fancyEmail = `${userName} <${fancyEmail}>`;
+    }
+  } catch (e) {
+    // but if it fails, this isn't critical, so don't bother them about it
+  }
+
+  console.log(
+    [
+      'Hey there!  To keep things tidy, this repo asks you to submit your Git commits using an email like ' +
+        (rushConfiguration.gitAllowedEmailRegExps.length > 1 ? 'one of these patterns:' : 'this pattern:'),
+      '',
+      ...rushConfiguration.gitAllowedEmailRegExps.map((pattern) => '    ' + colors.cyan(pattern)),
+      '',
+      '...but yours is configured like this:',
+      '',
+      `    ${fancyEmail}`,
+      '',
+      'To fix it, you can use commands like this:',
+      '',
+      ...getEmailExampleLines(rushConfiguration),
+      ''
+    ].join('\n')
+  );
+
+  let errorMessage: string = 'Aborting, so you can go fix your settings.';
+  if (options.bypassPolicyAllowed) {
+    errorMessage += ` (Or use "${RushConstants.bypassPolicyFlagLongName}" to skip.)`;
+  }
+
+  console.log(colors.red(errorMessage));
+  throw new AlreadyReportedError();
+}
+
+export function getEmailExampleLines(rushConfiguration: RushConfiguration): string[] {
+  return [
+    colors.cyan('    git config --local user.name "Example Name"'),
+    colors.cyan(
+      `    git config --local user.email "${rushConfiguration.gitSampleEmail || 'name@example.com'}"`
+    )
+  ];
 }

--- a/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
+++ b/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
@@ -1,23 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { RushConfiguration } from '../../api/RushConfiguration';
-import { GitEmailPolicy } from './GitEmailPolicy';
-import { ShrinkwrapFilePolicy } from './ShrinkwrapFilePolicy';
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import * as GitEmailPolicy from './GitEmailPolicy';
+import * as ShrinkwrapFilePolicy from './ShrinkwrapFilePolicy';
+import * as EnvironmentPolicy from './EnvironmentPolicy';
 
 export interface IPolicyValidatorOptions {
+  bypassPolicyAllowed?: boolean;
   bypassPolicy?: boolean;
   allowShrinkwrapUpdates?: boolean;
   shrinkwrapVariant?: string;
 }
 
-export class PolicyValidator {
-  public static validatePolicy(rushConfiguration: RushConfiguration, options: IPolicyValidatorOptions): void {
-    if (options.bypassPolicy) {
-      return;
-    }
-
-    GitEmailPolicy.validate(rushConfiguration);
+export async function validatePolicyAsync(
+  rushConfiguration: RushConfiguration,
+  options: IPolicyValidatorOptions
+): Promise<void> {
+  if (!options.bypassPolicy) {
+    GitEmailPolicy.validate(rushConfiguration, options);
+    await EnvironmentPolicy.validateAsync(rushConfiguration, options);
     if (!options.allowShrinkwrapUpdates) {
       // Don't validate the shrinkwrap if updates are allowed, as it's likely to change
       // It also may have merge conflict markers, which PNPM can gracefully handle, but the validator cannot

--- a/libraries/rush-lib/src/logic/policy/RushPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/RushPolicy.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
-// See LICENSE in the project root for license information.
-
-import { RushConfiguration } from '../../api/RushConfiguration';
-
-export abstract class RushPolicy {
-  public abstract validate(rushConfiguration: RushConfiguration): void;
-}

--- a/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { RushConfiguration } from '../../api/RushConfiguration';
-import { IPolicyValidatorOptions } from './PolicyValidator';
-import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { IPolicyValidatorOptions } from './PolicyValidator';
+import type { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 import { ShrinkwrapFileFactory } from '../ShrinkwrapFileFactory';
-import { RepoStateFile } from '../RepoStateFile';
+import type { RepoStateFile } from '../RepoStateFile';
 
 export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorOptions {
   repoState: RepoStateFile;
@@ -14,28 +14,26 @@ export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorO
 /**
  *  A policy that validates shrinkwrap files used by package managers.
  */
-export class ShrinkwrapFilePolicy {
-  public static validate(rushConfiguration: RushConfiguration, options: IPolicyValidatorOptions): void {
-    console.log('Validating package manager shrinkwrap file.\n');
-    const shrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
-      rushConfiguration.packageManager,
-      rushConfiguration.packageManagerOptions,
-      rushConfiguration.getCommittedShrinkwrapFilename(options.shrinkwrapVariant)
-    );
+export function validate(rushConfiguration: RushConfiguration, options: IPolicyValidatorOptions): void {
+  console.log('Validating package manager shrinkwrap file.\n');
+  const shrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
+    rushConfiguration.packageManager,
+    rushConfiguration.packageManagerOptions,
+    rushConfiguration.getCommittedShrinkwrapFilename(options.shrinkwrapVariant)
+  );
 
-    if (!shrinkwrapFile) {
-      console.log('Shrinkwrap file could not be found, skipping validation.\n');
-      return;
-    }
-
-    // Run shrinkwrap-specific validation
-    shrinkwrapFile.validate(
-      rushConfiguration.packageManagerOptions,
-      {
-        ...options,
-        repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant)
-      },
-      rushConfiguration.experimentsConfiguration.configuration
-    );
+  if (!shrinkwrapFile) {
+    console.log('Shrinkwrap file could not be found, skipping validation.\n');
+    return;
   }
+
+  // Run shrinkwrap-specific validation
+  shrinkwrapFile.validate(
+    rushConfiguration.packageManagerOptions,
+    {
+      ...options,
+      repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant)
+    },
+    rushConfiguration.experimentsConfiguration.configuration
+  );
 }

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -41,6 +41,10 @@
     "printEventHooksOutputToConsole": {
       "description": "If true, print the outputs of shell commands defined in event hooks to the console.",
       "type": "boolean"
+    },
+    "forbidPhantomResolvableNodeModuleFolders": {
+      "description": "If true, Rush will not allow node_modules in the repo folder or in parent folders.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds a policy that checks for phantom `node_modules` folders that are resolvable from inside the repo. This does not check inside folders between project folders and the repo root.

## How it was tested

Created the issue and confirmed that it creates an error.

## Impacted documentation

Will need to be added to experiments configuration docs.