### PR TITLE
[api-extractor] Fix incorrect documentation for ApiParameterListMixin.overloadIndex

### DIFF
--- a/common/changes/@microsoft/api-extractor-model/octogonz-fix-overloadindex-docs_2023-05-03-18-30.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-fix-overloadindex-docs_2023-05-03-18-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Fix a mistake in the documentation for ApiParameterListMixin.overloadIndex",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/libraries/api-extractor-model/src/mixins/ApiParameterListMixin.ts
+++ b/libraries/api-extractor-model/src/mixins/ApiParameterListMixin.ts
@@ -53,7 +53,7 @@ const _parameters: unique symbol = Symbol('ApiParameterListMixin._parameters');
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ApiParameterListMixin extends ApiItem {
   /**
-   * When a function has multiple overloaded declarations, this zero-based integer index can be used to unqiuely
+   * When a function has multiple overloaded declarations, this one-based integer index can be used to uniquely
    * identify them.
    *
    * @remarks


### PR DESCRIPTION
This problem was identified in https://github.com/microsoft/tsdoc/pull/346

Clarify that `overloadIndex` counts from `1`, as does TSDoc's `DocMemberSelector`.

