### PR TITLE
[module-minifier-plugin] Fix import compression

### DIFF
--- a/build-tests/localization-plugin-test-02/src/indexA.ts
+++ b/build-tests/localization-plugin-test-02/src/indexA.ts
@@ -28,6 +28,11 @@ import(/* webpackChunkName: 'chunk-without-strings' */ './chunks/chunkWithoutStr
   }
 );
 
+// @ts-expect-error
+import('non-existent').then(() => {
+  // Do nothing.
+});
+
 console.log(strings5.string1);
 console.log(strings5.stringWithQuotes);
 console.log(strings5.stringWithTabsAndNewlines);

--- a/build-tests/localization-plugin-test-02/webpack.config.js
+++ b/build-tests/localization-plugin-test-02/webpack.config.js
@@ -54,6 +54,9 @@ function generateConfiguration(mode, outputFolderName) {
     devtool: 'source-map',
     plugins: [
       new webpack.optimize.ModuleConcatenationPlugin(),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^non-existent$/
+      }),
       new LocalizationPlugin({
         localizedData: {
           defaultLocale: {

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/fix-async-import-compression_2023-05-03-18-25.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/fix-async-import-compression_2023-05-03-18-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "Fix async import compressor erroring when encountering unresolved dependencies.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}


### PR DESCRIPTION
## Summary
Fixes an crash in `@rushstack/webpack4-module-minifier-plugin` when `compressAsyncImports: true` and some imports target modules that have been excluded from the compilation.

## Details
Updates code that rewrites async imports to verify that the target of the import is part of the module graph first.

## How it was tested
Updated `build-tests/localization-plugin-test-02` to include an import of an ignored module.

## Impacted documentation
None.