### PR TITLE
[module-minifier] Use terser@^5.9.0

### DIFF
--- a/common/changes/@rushstack/module-minifier/bump-terser_2023-05-04-00-05.json
+++ b/common/changes/@rushstack/module-minifier/bump-terser_2023-05-04-00-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Switch terser dependency to ^5.9.0.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1818,12 +1818,12 @@ importers:
       '@types/serialize-javascript': 5.0.2
       serialize-javascript: 6.0.0
       source-map: ~0.7.3
-      terser: 5.16.1
+      terser: ^5.9.0
     dependencies:
       '@rushstack/worker-pool': link:../worker-pool
       serialize-javascript: 6.0.0
       source-map: 0.7.4
-      terser: 5.16.1
+      terser: 5.17.1
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -14642,7 +14642,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.16.1
+      terser: 5.17.1
 
   /html-tags/3.2.0:
     resolution: {integrity: sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==}
@@ -21285,7 +21285,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 5.0.1
       source-map: 0.6.1
-      terser: 5.16.1
+      terser: 5.17.1
       webpack: 4.44.2
       webpack-sources: 1.4.3
     dev: true
@@ -21310,7 +21310,7 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
-      terser: 5.16.1
+      terser: 5.17.1
       webpack: 5.80.0
     dev: false
 
@@ -21344,16 +21344,6 @@ packages:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
-      source-map-support: 0.5.21
-
-  /terser/5.16.1:
-    resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.2
-      commander: 2.20.3
       source-map-support: 0.5.21
 
   /terser/5.17.1:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "5eaa1d0c382cc4af565c2996d919c7208410d550",
+  "pnpmShrinkwrapHash": "0fa5031eede3d6fb20c17503baabe5b639224501",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/libraries/module-minifier/package.json
+++ b/libraries/module-minifier/package.json
@@ -19,7 +19,7 @@
     "@rushstack/worker-pool": "workspace:*",
     "serialize-javascript": "6.0.0",
     "source-map": "~0.7.3",
-    "terser": "5.16.1"
+    "terser": "^5.9.0"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",


### PR DESCRIPTION
## Summary
Reverts to the previous minimum version of `terser`, `5.9.0` but lets the version float.

## Details

## How it was tested
Existing unit tests validate the current installed version.

## Impacted documentation
None.