### PR TITLE
[package-extractor] Expose extractor-metadata.json file type and include `projectName` in output

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-ExportMetadataFileType_2023-05-04-22-11.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-ExportMetadataFileType_2023-05-04-22-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Export typings for the extractor-metadata.json file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -9,15 +9,8 @@ import { ITerminal } from '@rushstack/node-core-library';
 
 // @public
 export interface IExtractorMetadataJson {
-    // Warning: (ae-forgotten-export) The symbol "ILinkInfo" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     links: ILinkInfo[];
-    // (undocumented)
     mainProjectName: string;
-    // Warning: (ae-forgotten-export) The symbol "IProjectInfoJson" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     projects: IProjectInfoJson[];
 }
 
@@ -45,6 +38,19 @@ export interface IExtractorProjectConfiguration {
     additionalProjectsToInclude?: string[];
     dependenciesToExclude?: string[];
     projectFolder: string;
+    projectName: string;
+}
+
+// @public
+export interface ILinkInfo {
+    kind: 'fileLink' | 'folderLink';
+    linkPath: string;
+    targetPath: string;
+}
+
+// @public
+export interface IProjectInfoJson {
+    path: string;
     projectName: string;
 }
 

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -8,6 +8,20 @@ import { IPackageJson } from '@rushstack/node-core-library';
 import { ITerminal } from '@rushstack/node-core-library';
 
 // @public
+export interface IExtractorMetadataJson {
+    // Warning: (ae-forgotten-export) The symbol "ILinkInfo" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    links: ILinkInfo[];
+    // (undocumented)
+    mainProjectName: string;
+    // Warning: (ae-forgotten-export) The symbol "IProjectInfoJson" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    projects: IProjectInfoJson[];
+}
+
+// @public
 export interface IExtractorOptions {
     createArchiveFilePath?: string;
     createArchiveOnly?: boolean;

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -37,20 +37,37 @@ declare module 'npm-packlist' {
 
 /**
  * Part of the extractor-matadata.json file format. Represents an extracted project.
+ *
+ * @public
  */
-interface IProjectInfoJson {
+export interface IProjectInfoJson {
   /**
-   * This path is relative to the extractor target folder.
+   * The name of the project as specified in its package.json file.
+   */
+  projectName: string;
+  /**
+   * This path is relative to the root of the extractor output folder
    */
   path: string;
 }
 
 /**
  * The extractor-metadata.json file format.
+ *
+ * @public
  */
 export interface IExtractorMetadataJson {
+  /**
+   * The name of the main project the extraction was performed for.
+   */
   mainProjectName: string;
+  /**
+   * A list of all projects that were extracted.
+   */
   projects: IProjectInfoJson[];
+  /**
+   * A list of all links that are part of the extracted project.
+   */
   links: ILinkInfo[];
 }
 
@@ -779,9 +796,10 @@ export class PackageExtractor {
       links: []
     };
 
-    for (const projectFolder of projectConfigurationsByPath.keys()) {
+    for (const { projectFolder, projectName } of projectConfigurationsByPath.values()) {
       if (state.foldersToCopy.has(projectFolder)) {
         extractorMetadataJson.projects.push({
+          projectName,
           path: this._remapPathForExtractorMetadata(projectFolder, options)
         });
       }

--- a/libraries/package-extractor/src/SymlinkAnalyzer.ts
+++ b/libraries/package-extractor/src/SymlinkAnalyzer.ts
@@ -40,13 +40,18 @@ export interface ILinkNode extends IPathNodeBase {
 export type PathNode = IFileNode | IFolderNode | ILinkNode;
 
 /**
- * Represents a symbolic link reported by {@link SymlinkAnalyzer.reportSymlinks}.
+ * Represents a symbolic link.
+ *
+ * @public
  */
 export interface ILinkInfo {
+  /**
+   * The type of link that was encountered.
+   */
   kind: 'fileLink' | 'folderLink';
 
   /**
-   * The path of the symbolic link.
+   * The path to the link, relative to the root of the extractor output folder.
    */
   linkPath: string;
 

--- a/libraries/package-extractor/src/index.ts
+++ b/libraries/package-extractor/src/index.ts
@@ -5,5 +5,8 @@ export {
   PackageExtractor,
   type IExtractorOptions,
   type IExtractorProjectConfiguration,
-  type IExtractorMetadataJson
+  type IExtractorMetadataJson,
+  type IProjectInfoJson
 } from './PackageExtractor';
+
+export type { ILinkInfo } from './SymlinkAnalyzer';

--- a/libraries/package-extractor/src/index.ts
+++ b/libraries/package-extractor/src/index.ts
@@ -4,5 +4,6 @@
 export {
   PackageExtractor,
   type IExtractorOptions,
-  type IExtractorProjectConfiguration
+  type IExtractorProjectConfiguration,
+  type IExtractorMetadataJson
 } from './PackageExtractor';


### PR DESCRIPTION
## Summary

Exports typings for the `extractor-metadata.json` file that is produced when exporting a package. Additionally, this change will add a new field `projectName` to the generated `extractor-metadata.json` file.