### PR TITLE
[heft-next] Fix double invocation of linter

### DIFF
--- a/build-tests/heft-webpack4-everything-test/tsconfig.json
+++ b/build-tests/heft-webpack4-everything-test/tsconfig.json
@@ -15,6 +15,7 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "types": ["heft-jest", "webpack-env"],
+    "incremental": true,
 
     "module": "esnext",
     "moduleResolution": "node",

--- a/common/changes/@rushstack/heft-lint-plugin/heft-rc-fix-double-lint_2023-05-08-21-08.json
+++ b/common/changes/@rushstack/heft-lint-plugin/heft-rc-fix-double-lint_2023-05-08-21-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "Sort rule timings by duration, descending.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/heft-rc-fix-double-lint_2023-05-08-21-08.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/heft-rc-fix-double-lint_2023-05-08-21-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Fix double-execution of `accessor.onChangedFilesHook`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -106,9 +106,14 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
 
   protected lintingFinished(lintFailures: TEslint.ESLint.LintResult[]): void {
     let omittedRuleCount: number = 0;
-    for (const [ruleName, duration] of this._eslintTimings.entries()) {
+    const timings: [string, number][] = Array.from(this._eslintTimings).sort(
+      (x: [string, number], y: [string, number]) => {
+        return y[1] - x[1];
+      }
+    );
+    for (const [ruleName, duration] of timings) {
       if (duration > 0) {
-        this._terminal.writeVerboseLine(`Rule "${ruleName}" duration: ${duration}ms`);
+        this._terminal.writeVerboseLine(`Rule "${ruleName}" duration: ${duration.toFixed(3)} ms`);
       } else {
         omittedRuleCount++;
       }

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -580,7 +580,9 @@ export class TypeScriptBuilder {
     let innerProgram: TTypescript.Program;
 
     if (tsconfig.options.incremental) {
-      builderProgram = this._getCreateBuilderProgram(ts)(
+      // Use ts.createEmitAndSemanticDiagnositcsBuilderProgram directly because the customizations performed by
+      // _getCreateBuilderProgram duplicate those performed in this function for non-incremental build.
+      builderProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
         tsconfig.fileNames,
         tsconfig.options,
         compilerHost,


### PR DESCRIPTION
## Summary
Fixes a bug in which the lint plugin would get invoked twice for a project that sets `"incremental": true` in `tsconfig.json`.

## Details
Removes a duplicate invocation of the `emitChangedFilesCallback` function in the single-project incremental build code path.

Adds coverage of the single-project incremental build code path to the `build-tests` projects via `heft-webpack4-everything-test` (by setting `"incremental": true` in `tsconfig.json`).

Updates the linter logging behavior to sort rule timings by descending duration, rather than the previous behavior of not having any particular pattern.

## How it was tested
Manual invocation of `npm run build -- --verbose` in `heft-webpack4-everything-test` and monitoring the log.

## Impacted documentation
None.