### PR TITLE
[debug-cert] Add env, fix IP address

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/cert-fixes_2023-05-08-22-16.json
+++ b/common/changes/@rushstack/debug-certificate-manager/cert-fixes_2023-05-08-22-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Add environment variable to force disable certificate generation. Correctly encode 127.0.0.1 as an IP Address in subjectAltNames field during certificate generation.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/reviews/api/debug-certificate-manager.api.md
+++ b/common/reviews/api/debug-certificate-manager.api.md
@@ -40,6 +40,7 @@ export interface ICertificate {
 // @public
 export interface ICertificateGenerationOptions {
     subjectAltNames?: ReadonlyArray<string>;
+    subjectIpAddresses?: ReadonlyArray<string>;
     validityInDays?: number;
 }
 

--- a/common/reviews/api/debug-certificate-manager.api.md
+++ b/common/reviews/api/debug-certificate-manager.api.md
@@ -40,7 +40,7 @@ export interface ICertificate {
 // @public
 export interface ICertificateGenerationOptions {
     subjectAltNames?: ReadonlyArray<string>;
-    subjectIpAddresses?: ReadonlyArray<string>;
+    subjectIPAddresses?: ReadonlyArray<string>;
     validityInDays?: number;
 }
 

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -29,6 +29,9 @@ export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string> = ['localh
  */
 export const DEFAULT_CERTIFICATE_SUBJECT_IP_ADDRESSES: ReadonlyArray<string> = ['127.0.0.1'];
 
+const DISABLE_CERT_GENERATION_VARIABLE_NAME: 'RUSHSTACK_DISABLE_DEV_CERT_GENERATION' =
+  'RUSHSTACK_DISABLE_DEV_CERT_GENERATION';
+
 /**
  * The interface for a debug certificate instance
  *
@@ -137,10 +140,10 @@ export class CertificateManager {
 
     const { certificateData: existingCert, keyData: existingKey } = this._certificateStore;
 
-    if (process.env.RUSHSTACK_DISABLE_DEV_CERT_GENERATION === '1') {
+    if (process.env[DISABLE_CERT_GENERATION_VARIABLE_NAME] === '1') {
       // Allow the environment (e.g. GitHub codespaces) to forcibly disable dev cert generation
       terminal.writeLine(
-        `Found environment variable RUSHSTACK_DISABLE_DEV_CERT_GENERATION=1, disabling certificate generation.`
+        `Found environment variable ${DISABLE_CERT_GENERATION_VARIABLE_NAME}=1, disabling certificate generation.`
       );
       canGenerateNewCertificate = false;
     }

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -84,6 +84,7 @@ interface IDnsAltName {
 }
 /**
  * Fields for a Subject Alternative Name of type IP Address
+ * `node-forge` requires the field name to be "ip" instead of "value", likely due to subtle encoding differences.
  */
 interface IIPAddressAltName {
   type: 7;
@@ -103,7 +104,7 @@ export interface ICertificateGenerationOptions {
   /**
    * The IP Address Subject names to issue the certificate for. Defaults to ['127.0.0.1'].
    */
-  subjectIpAddresses?: ReadonlyArray<string>;
+  subjectIPAddresses?: ReadonlyArray<string>;
   /**
    * How many days the certificate should be valid for.
    */
@@ -420,7 +421,7 @@ export class CertificateManager {
     certificate.publicKey = keys.publicKey;
     certificate.serialNumber = TLS_SERIAL_NUMBER;
 
-    const { subjectAltNames: subjectNames, subjectIpAddresses, validityInDays } = options;
+    const { subjectAltNames: subjectNames, subjectIPAddresses: subjectIpAddresses, validityInDays } = options;
 
     const { certificate: caCertificate, privateKey: caPrivateKey } = await this._createCACertificateAsync(
       validityInDays,
@@ -783,10 +784,10 @@ function applyDefaultOptions(
   options: ICertificateGenerationOptions | undefined
 ): Required<ICertificateGenerationOptions> {
   const subjectNames: ReadonlyArray<string> | undefined = options?.subjectAltNames;
-  const subjectIpAddresses: ReadonlyArray<string> | undefined = options?.subjectIpAddresses;
+  const subjectIpAddresses: ReadonlyArray<string> | undefined = options?.subjectIPAddresses;
   return {
     subjectAltNames: subjectNames?.length ? subjectNames : DEFAULT_CERTIFICATE_SUBJECT_NAMES,
-    subjectIpAddresses: subjectIpAddresses?.length
+    subjectIPAddresses: subjectIpAddresses?.length
       ? subjectIpAddresses
       : DEFAULT_CERTIFICATE_SUBJECT_IP_ADDRESSES,
     validityInDays: Math.min(


### PR DESCRIPTION
## Summary
Adds an environment variable `DISABLE_DEV_CERT_GENERATION` that can be set to `1` on the machine to cause all calls to generate a new dev certificate to be an error. This is most relevant to GitHub codespaces, where the certificate needs to be kept in sync with a certificate on the client machine to successfully connect.

## Details
Removes `rushstack.localhost` from this list of required `subjectAltNames` again to avoid forcing certificate regeneration.

Switches `127.0.0.1` to be properly flagged in the X.509 certificate as an IP Address, rather than a DNS name.

## How it was tested
Local run.
Validated that `https://127.0.0.1:8080` now has a secure connection to `npm start` in `heft-webpack5-everything-test`.

## Impacted documentation
None, currently.