### PR TITLE
[rush] Single-line watch status

### DIFF
--- a/common/changes/@microsoft/rush/tweak-log-verbosity_2023-05-09-21-24.json
+++ b/common/changes/@microsoft/rush/tweak-log-verbosity_2023-05-09-21-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Flatten watch status into a single line with TTY rewrites.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Reduce watch status updates to a single line with interactive clearing and rewriting.

## Details
![image](https://github.com/microsoft/rushstack/assets/26827560/dbb7c162-e41d-45a0-8c77-8a4b1b5f8c13)

## How it was tested
Local run of `apps/rush/lib/start-dev.js start`.

## Impacted documentation
None