### PR TITLE
[WIP] Updated rush-azure-storage-build-cache-plugin to handle multiple Authentication requests to Azure Storage and Key Vault

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -3,6 +3,10 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
   "packages": [
     {
+      "name": "@azure/keyvault-secrets",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@fluentui/react",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -53,6 +53,13 @@
         "watchPhases": ["_phase:build", "_phase:test"]
       }
     },
+    {
+      "name": "test-rush-interactive",
+      "commandKind": "global",
+      "summary": "Testing rush azure interactive",
+      "shellCommand": "node -e \"console.log('Done.');\"",
+      "safeForSimultaneousRushProcesses": true
+    },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2424,6 +2424,7 @@ importers:
   ../../rush-plugins/rush-azure-storage-build-cache-plugin:
     specifiers:
       '@azure/identity': ~2.1.0
+      '@azure/keyvault-secrets': ~4.6.0
       '@azure/storage-blob': ~12.11.0
       '@microsoft/rush-lib': workspace:*
       '@rushstack/eslint-config': workspace:*
@@ -2436,6 +2437,7 @@ importers:
       '@types/node': 14.18.36
     dependencies:
       '@azure/identity': 2.1.0
+      '@azure/keyvault-secrets': 4.6.0
       '@azure/storage-blob': 12.11.0
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@rushstack/rush-sdk': link:../../libraries/rush-sdk
@@ -2975,6 +2977,17 @@ packages:
       - supports-color
     dev: false
 
+  /@azure/core-http-compat/1.3.0:
+    resolution: {integrity: sha512-ZN9avruqbQ5TxopzG3ih3KRy52n8OAbitX3fnZT5go4hzu0J+KVPSzkL+Wt3hpJpdG8WIfg1sBD1tWkgUdEpBA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-client': 1.7.0
+      '@azure/core-rest-pipeline': 1.10.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@azure/core-http/2.3.1:
     resolution: {integrity: sha512-cur03BUwV0Tbv81bQBOLafFB02B6G++K6F2O3IMl8pSE2QlXm3cu11bfyBNlDUKi5U+xnB3GC63ae3athhkx6Q==}
     engines: {node: '>=14.0.0'}
@@ -3075,6 +3088,25 @@ packages:
       stoppable: 1.1.0
       tslib: 2.3.1
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@azure/keyvault-secrets/4.6.0:
+    resolution: {integrity: sha512-MDqsyODCGC2srqLKmO6MFw9WdgLrbPsfCNxgbekHXEd6XKM6KKyBlup5joj96EmdfZnXDFriecAIpj0Dtu81RQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-client': 1.7.0
+      '@azure/core-http-compat': 1.3.0
+      '@azure/core-lro': 2.5.0
+      '@azure/core-paging': 1.4.0
+      '@azure/core-rest-pipeline': 1.10.1
+      '@azure/core-tracing': 1.0.1
+      '@azure/core-util': 1.1.1
+      '@azure/logger': 1.0.3
+      tslib: 2.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0fa5031eede3d6fb20c17503baabe5b639224501",
+  "pnpmShrinkwrapHash": "e77f1f23bfa2f16dd5a2a3fe3f52ebf65381df9b",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -25,6 +25,8 @@ export abstract class AzureAuthenticationBase {
     protected readonly _credentialUpdateCommandForLogging: string | undefined;
     // (undocumented)
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
+    // (undocumented)
+    protected readonly _deviceCodeCredential: DeviceCodeCredential | undefined;
     protected abstract _getCacheIdParts(): string[];
     // (undocumented)
     protected abstract _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
@@ -70,6 +72,8 @@ export interface IAzureAuthenticationBaseOptions {
     azureEnvironment?: AzureEnvironmentName;
     // (undocumented)
     credentialUpdateCommandForLogging?: string | undefined;
+    // (undocumented)
+    deviceCodeCredentails?: DeviceCodeCredential;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@azure/identity": "~2.1.0",
+    "@azure/keyvault-secrets": "~4.6.0",
     "@azure/storage-blob": "~12.11.0",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rush-sdk": "workspace:*",

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -73,6 +73,7 @@ export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
 export interface IAzureAuthenticationBaseOptions {
   azureEnvironment?: AzureEnvironmentName;
   credentialUpdateCommandForLogging?: string | undefined;
+  deviceCodeCredentails?: DeviceCodeCredential;
 }
 
 /**
@@ -90,7 +91,7 @@ export abstract class AzureAuthenticationBase {
   protected abstract readonly _credentialNameForCache: string;
   protected abstract readonly _credentialKindForLogging: string;
   protected readonly _credentialUpdateCommandForLogging: string | undefined;
-
+  protected readonly _deviceCodeCredential: DeviceCodeCredential | undefined;
   protected readonly _azureEnvironment: AzureEnvironmentName;
 
   private __credentialCacheId: string | undefined;
@@ -111,6 +112,7 @@ export abstract class AzureAuthenticationBase {
   public constructor(options: IAzureAuthenticationBaseOptions) {
     this._azureEnvironment = options.azureEnvironment || 'AzurePublicCloud';
     this._credentialUpdateCommandForLogging = options.credentialUpdateCommandForLogging;
+    this._deviceCodeCredential = options.deviceCodeCredentails || undefined;
   }
 
   public async updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void> {
@@ -236,6 +238,10 @@ export abstract class AzureAuthenticationBase {
     const authorityHost: string | undefined = AzureAuthorityHosts[this._azureEnvironment];
     if (!authorityHost) {
       throw new Error(`Unexpected Azure environment: ${this._azureEnvironment}`);
+    }
+
+    if (this._deviceCodeCredential) {
+      return await this._getCredentialFromDeviceCodeAsync(terminal, this._deviceCodeCredential);
     }
 
     const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential({

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/KeyVaultAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/KeyVaultAuthentication.ts
@@ -1,0 +1,92 @@
+import type { DeviceCodeCredential } from '@azure/identity';
+import { type KeyVaultSecret, SecretClient } from '@azure/keyvault-secrets';
+import type { ITerminal } from '@rushstack/node-core-library';
+import type { ICredentialResult, IAzureAuthenticationBaseOptions } from './AzureAuthenticationBase';
+// Importing this from the index triggers a runtime import of `@rushstack/rush-sdk`.
+import { AzureAuthenticationBase } from './AzureAuthenticationBase';
+import type { ICredentialCacheEntry } from '@rushstack/rush-sdk';
+
+/**
+ * @public
+ */
+export interface IKeyVaultAuthenticationOptions extends IAzureAuthenticationBaseOptions {
+  updateCredentialCommand?: string;
+  vaultName: string;
+  secretName: string;
+  /**
+   * If this value is sooner than the expiration from KeyVault, use this time instead.
+   *
+   * @remarks
+   * If the expiration from KeyVault is sooner, that time is used instead.
+   */
+  overrideExpiration?: Date;
+}
+
+interface IKeyVaultCredentialMetadata {
+  credentialVersion: string | undefined;
+}
+
+/**
+ * @public
+ */
+export class KeyVaultAuthentication extends AzureAuthenticationBase {
+  protected readonly _credentialNameForCache: string = 'azure-key-vault';
+  protected readonly _credentialKindForLogging: string = 'Key Vault';
+  protected readonly _credentialUpdateCommandForLogging: string | undefined;
+  private readonly _vaultName: string;
+  private readonly _secretName: string;
+  private readonly _overrideExpiration: Date | undefined;
+
+  public static isCredentialVersionInList(
+    credential: ICredentialCacheEntry,
+    versionSet: Set<string | undefined>
+  ): boolean {
+    const credentialMetadata: IKeyVaultCredentialMetadata | undefined = credential.credentialMetadata as
+      | IKeyVaultCredentialMetadata
+      | undefined;
+    const credentialVersion: string | undefined = credentialMetadata?.credentialVersion;
+    return versionSet.has(credentialVersion);
+  }
+
+  public constructor(options: IKeyVaultAuthenticationOptions) {
+    super(options);
+    this._credentialUpdateCommandForLogging = options.updateCredentialCommand;
+    this._vaultName = options.vaultName;
+    this._secretName = options.secretName;
+  }
+
+  protected _getCacheIdParts(): string[] {
+    return [this._vaultName, this._secretName];
+  }
+
+  protected async _getCredentialFromDeviceCodeAsync(
+    terminal: ITerminal,
+    deviceCodeCredential: DeviceCodeCredential
+  ): Promise<ICredentialResult> {
+    const keyVaultUrl: string = `https://${this._vaultName}.vault.azure.net`;
+    const secretClient: SecretClient = new SecretClient(keyVaultUrl, deviceCodeCredential);
+    const secret: KeyVaultSecret = await secretClient.getSecret(this._secretName);
+    if (secret.value === undefined) {
+      throw new Error('Unable to get secret value');
+    }
+
+    let expiresOn: Date | undefined = secret.properties.expiresOn;
+    if (!expiresOn) {
+      expiresOn = this._overrideExpiration;
+    } else {
+      if (this._overrideExpiration && expiresOn > this._overrideExpiration) {
+        expiresOn = this._overrideExpiration;
+      }
+    }
+
+    const credentialMetadata: IKeyVaultCredentialMetadata = {
+      credentialVersion: secret.properties.version
+    };
+
+    return {
+      credentialString: secret.value,
+      expiresOn,
+      credentialMetadata
+    };
+  }
+}

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
@@ -9,16 +9,6 @@
   "required": ["storageAccountName", "storageContainerName"],
 
   "properties": {
-    "storageAccountName": {
-      "type": "string",
-      "description": "(Required) The name of the the Azure storage account to authenticate to."
-    },
-
-    "storageContainerName": {
-      "type": "string",
-      "description": "(Required) The name of the container in the Azure storage account to authenticate to."
-    },
-
     "azureEnvironment": {
       "type": "string",
       "description": "The Azure environment the storage account exists in. Defaults to AzurePublicCloud.",
@@ -43,6 +33,14 @@
       "description": "The set of phased rush commands before which this plugin should update credentials.",
       "items": {
         "type": "string"
+      }
+    },
+
+    "authList": {
+      "type": "array",
+      "description": "An array with the credential details to be retrieved from each Azure Storage location",
+      "items": {
+        "type": "object"
       }
     }
   }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

    I implemented an feature that modifies the `rush-azure-storage-build-cache-plugin` so that it can handle multiple authentication requests to Azure and Key Vault Storage with only one credential validation. The schema input has been changed to handle this feature and users will need to update their rush-azure-storage-build-cache-plugin schemas in order for rush-azure-storage-build-cache-plugin to continue working on their end.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     I solved the problem by passing in the same DeviceCodeCredential to multiple authentication requests instead of each authentication request needing its own credential. 
     Did you completely solve the problem, or are some cases not handled yet?
Problem fully solved
     Does this change break backwards compatibility?
Yes, current users of the plugin will need to update their input schema to use the updated plugin.
     Could any aspects of your change impact performance?
No. 
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."
     
     I tested by running the plugin locally with inputs to multiple different authentications. The Authentication credentials were successfully retrieved with only one user login. 

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
