### PR TITLE
[heft-sass] Switch to sass-embedded

### DIFF
--- a/common/changes/@rushstack/heft-sass-plugin/sass-embedded_2023-05-10-20-37.json
+++ b/common/changes/@rushstack/heft-sass-plugin/sass-embedded_2023-05-10-20-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Switch from sass to sass-embedded for better performance.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -639,6 +639,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "sass-embedded",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "sass-loader",
       "allowedCategories": [ "libraries", "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1616,14 +1616,14 @@ importers:
       eslint: ~8.7.0
       postcss: ~8.4.6
       postcss-modules: ~1.5.0
-      sass: ~1.49.7
+      sass-embedded: ~1.49.7
     dependencies:
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
       '@rushstack/node-core-library': link:../../libraries/node-core-library
       '@rushstack/typings-generator': link:../../libraries/typings-generator
       postcss: 8.4.21
       postcss-modules: 1.5.0
-      sass: 1.49.11
+      sass-embedded: 1.49.11
     devDependencies:
       '@microsoft/api-extractor': link:../../apps/api-extractor
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -9014,6 +9014,14 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 14.18.36
+    dev: false
+    optional: true
+
   /@typescript-eslint/eslint-plugin/5.38.1_dgdlt47nc666rkw3n5usybcqsa:
     resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10698,9 +10706,12 @@ packages:
     dependencies:
       node-int64: 0.4.0
 
+  /buffer-builder/0.2.0:
+    resolution: {integrity: sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==}
+    dev: false
+
   /buffer-crc32/0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-    dev: true
 
   /buffer-equal-constant-time/1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -11930,6 +11941,19 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /debug/4.3.4_supports-color@8.1.1:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 8.1.1
+    dev: false
 
   /debuglog/1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -13483,6 +13507,20 @@ packages:
       yauzl: 2.10.0
     dev: true
 
+  /extract-zip/2.0.1_supports-color@8.1.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+    dependencies:
+      debug: 4.3.4_supports-color@8.1.1
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /fast-decode-uri-component/1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
     dev: false
@@ -13603,7 +13641,6 @@ packages:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
-    dev: true
 
   /figgy-pudding/3.5.2:
     resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
@@ -14305,6 +14342,10 @@ packages:
       pify: 4.0.1
       slash: 2.0.0
     dev: true
+
+  /google-protobuf/3.21.2:
+    resolution: {integrity: sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==}
+    dev: false
 
   /gopd/1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -18369,7 +18410,6 @@ packages:
 
   /pend/1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-    dev: true
 
   /picocolors/0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
@@ -19725,7 +19765,6 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.1
-    dev: true
 
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -20126,6 +20165,12 @@ packages:
     dependencies:
       tslib: 1.14.1
 
+  /rxjs/7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
   /safe-buffer/5.1.1:
     resolution: {integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==}
     dev: true
@@ -20173,6 +20218,25 @@ packages:
       minimist: 1.2.7
       walker: 1.0.8
     dev: true
+
+  /sass-embedded/1.49.11:
+    resolution: {integrity: sha512-X0I+z0Iao7VeRk/bfEVWx/Kux/ztBk29SHZ3HfVmiNs2+8wAJCm7AKkruqWZBB8C8scFLGEsX0Vhf1wgV+vzEw==}
+    engines: {node: '>=14.0.0'}
+    requiresBuild: true
+    dependencies:
+      buffer-builder: 0.2.0
+      extract-zip: 2.0.1_supports-color@8.1.1
+      google-protobuf: 3.21.2
+      immutable: 4.2.2
+      node-fetch: 2.6.7
+      rxjs: 7.8.1
+      semver: 7.3.8
+      shelljs: 0.8.5
+      supports-color: 8.1.1
+      tar: 6.1.13
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /sass-loader/10.0.5_sass@1.3.2+webpack@4.44.2:
     resolution: {integrity: sha512-2LqoNPtKkZq/XbXNQ4C64GFEleSEHKv6NPSI+bMC/l+jpEXGJhiRYkAQToO24MR7NU4JRY2RpLpJ/gjo2Uf13w==}
@@ -20512,7 +20576,6 @@ packages:
       glob: 7.0.6
       interpret: 1.4.0
       rechoir: 0.6.2
-    dev: true
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -23085,7 +23148,6 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
-    dev: true
 
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0fa5031eede3d6fb20c17503baabe5b639224501",
+  "pnpmShrinkwrapHash": "2c8482b603eee50e3c5c8e053d1f8084e197a0e6",
   "preferredVersionsHash": "5222ca779ae69ebfd201e39c17f48ce9eaf8c3c2"
 }

--- a/heft-plugins/heft-sass-plugin/README.md
+++ b/heft-plugins/heft-sass-plugin/README.md
@@ -1,6 +1,7 @@
 # @rushstack/heft-sass-plugin
 
-This is a Heft plugin for using node-sass during the "build" stage.
+This is a Heft plugin for using sass-embedded during the "build" stage.
+If `sass-embedded` is not supported on your platform, you can override the dependency via npm alias to use the `sass` package instead.
 
 ## Links
 

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -24,7 +24,7 @@
     "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/typings-generator": "workspace:*",
-    "sass": "~1.49.7",
+    "sass-embedded": "~1.49.7",
     "postcss": "~8.4.6",
     "postcss-modules": "~1.5.0"
   },

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -4,7 +4,7 @@
 
 import * as path from 'path';
 import { URL, pathToFileURL, fileURLToPath } from 'url';
-import { CompileResult, Syntax, Exception, compileString } from 'sass';
+import { CompileResult, Syntax, Exception, compileStringAsync } from 'sass-embedded';
 import * as postcss from 'postcss';
 import cssModules from 'postcss-modules';
 import { FileSystem, Sort } from '@rushstack/node-core-library';
@@ -212,7 +212,7 @@ export class SassProcessor extends StringValuesTypingsGenerator {
     let result: CompileResult;
     const nodeModulesUrl: URL = pathToFileURL(`${buildFolder}/node_modules/`);
     try {
-      result = compileString(fileContents, {
+      result = await compileStringAsync(fileContents, {
         importers: [
           {
             findFileUrl: (url: string): URL | null => {


### PR DESCRIPTION
## Summary
Switch from `sass` to `sass-embedded` for improved SASS compiler performance.

## Details
The `sass` package is the Dart implementation of the SASS compiler transpiled to JavaScript
The `sass-embedded` package is the Dart implementation of the SASS compiler packaged as a native executable communicating via IPC.

The JavaScript transpilation contains various constructs that perform extremely poorly in JavaScript.

## How it was tested
Full retest run.

## Impacted documentation
Readme for heft-sass-plugin.