### PR TITLE
[node-core-library] Add an option to the PrefixProxyTerminalProvider to create a dynamic prefix.

### DIFF
--- a/common/changes/@rushstack/node-core-library/dynamic-prefix_2023-05-11-21-15.json
+++ b/common/changes/@rushstack/node-core-library/dynamic-prefix_2023-05-11-21-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add an option to the `PrefixProxyTerminalProvider` to create a dynamic prefix, which can be used for something like prefixing logging lines with a timestamp.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -339,6 +339,11 @@ export interface IConsoleTerminalProviderOptions {
     verboseEnabled: boolean;
 }
 
+// @beta
+export interface IDynamicPrefixProxyTerminalProviderOptions extends IPrefixProxyTerminalProviderOptionsBase {
+    getPrefix: () => string;
+}
+
 // @public
 export interface IEnvironmentEntry {
     name: string;
@@ -636,9 +641,11 @@ export interface IPeerDependenciesMetaTable {
     };
 }
 
-// @beta
-export interface IPrefixProxyTerminalProviderOptions {
-    prefix: string;
+// @beta (undocumented)
+export type IPrefixProxyTerminalProviderOptions = IStaticPrefixProxyTerminalProviderOptions | IDynamicPrefixProxyTerminalProviderOptions;
+
+// @beta (undocumented)
+export interface IPrefixProxyTerminalProviderOptionsBase {
     terminalProvider: ITerminalProvider;
 }
 
@@ -657,6 +664,11 @@ export interface IRunWithRetriesOptions<TResult> {
     maxRetries: number;
     // (undocumented)
     retryDelayMs?: number;
+}
+
+// @beta
+export interface IStaticPrefixProxyTerminalProviderOptions extends IPrefixProxyTerminalProviderOptionsBase {
+    prefix: string;
 }
 
 // @beta (undocumented)

--- a/libraries/node-core-library/src/Terminal/PrefixProxyTerminalProvider.ts
+++ b/libraries/node-core-library/src/Terminal/PrefixProxyTerminalProvider.ts
@@ -93,34 +93,24 @@ export class PrefixProxyTerminalProvider implements ITerminalProvider {
     let currentIndex: number = 0;
     // eslint-disable-next-line @rushstack/no-new-null
     let newlineMatch: RegExpExecArray | null;
-    let isFirstLoop: boolean = true;
-    const startedOnNewLine: boolean = this._isOnNewline;
-    let currentPrefix: string = this._isOnNewline ? this._getPrefix() : '';
 
     while ((newlineMatch = this._newlineRegex.exec(data))) {
-      if (!isFirstLoop && !startedOnNewLine) {
-        currentPrefix = this._getPrefix();
-      }
-
       // Extract the line, add the prefix, and write it out with the newline
       const newlineIndex: number = newlineMatch.index;
       const newIndex: number = newlineIndex + newlineMatch[0].length;
-      const dataToWrite: string = `${currentPrefix}${data.substring(currentIndex, newIndex)}`;
+      const prefix: string = this._isOnNewline ? this._getPrefix() : '';
+      const dataToWrite: string = `${prefix}${data.substring(currentIndex, newIndex)}`;
       this._parentTerminalProvider.write(dataToWrite, severity);
       // Update the currentIndex to start the search from the char after the newline
       currentIndex = newIndex;
-      isFirstLoop = false;
       this._isOnNewline = true;
-    }
-
-    if (!isFirstLoop && !startedOnNewLine) {
-      currentPrefix = this._getPrefix();
     }
 
     // The remaining data is not postfixed by a newline, so write out the data and set _isNewline to false
     const remainingData: string = data.substring(currentIndex);
     if (remainingData.length) {
-      this._parentTerminalProvider.write(`${currentPrefix}${remainingData}`, severity);
+      const prefix: string = this._isOnNewline ? this._getPrefix() : '';
+      this._parentTerminalProvider.write(`${prefix}${remainingData}`, severity);
       this._isOnNewline = false;
     }
   }

--- a/libraries/node-core-library/src/Terminal/test/__snapshots__/PrefixProxyTerminalProvider.test.ts.snap
+++ b/libraries/node-core-library/src/Terminal/test/__snapshots__/PrefixProxyTerminalProvider.test.ts.snap
@@ -14,7 +14,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a messag
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (2)] message 3",
   "verbose": "",
   "warning": "",
 }
@@ -24,7 +24,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a messag
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (2)] message 3",
   "verbose": "",
   "warning": "",
 }
@@ -34,7 +34,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a mix of
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1message 2[n][prefix (1)] message 3[n][prefix (3)] message 4message 5[n][prefix (4)] message 6",
+  "log": "[prefix (0)] message 1message 2[n][prefix (1)] message 3[n][prefix (2)] message 4message 5[n][prefix (3)] message 6",
   "verbose": "",
   "warning": "",
 }
@@ -64,7 +64,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a me
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3[n]",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (2)] message 3[n]",
   "verbose": "",
   "warning": "",
 }
@@ -74,7 +74,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a me
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3[n]",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (2)] message 3[n]",
   "verbose": "",
   "warning": "",
 }
@@ -84,7 +84,7 @@ exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a mi
 Object {
   "debug": "",
   "error": "",
-  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (1)] message 3[n][prefix (1)] [n][prefix (2)] message 4[n][prefix (3)] message 5[n][prefix (3)] message 6[n]",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (2)] message 3[n][prefix (3)] [n][prefix (4)] message 4[n][prefix (5)] message 5[n][prefix (6)] message 6[n]",
   "verbose": "",
   "warning": "",
 }

--- a/libraries/node-core-library/src/Terminal/test/__snapshots__/PrefixProxyTerminalProvider.test.ts.snap
+++ b/libraries/node-core-library/src/Terminal/test/__snapshots__/PrefixProxyTerminalProvider.test.ts.snap
@@ -1,6 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PrefixProxyTerminalProvider write writes a message 1`] = `
+exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a message 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] test message",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a message with newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a message with provider newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes a mix of messages with and without newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1message 2[n][prefix (1)] message 3[n][prefix (3)] message 4message 5[n][prefix (4)] message 6",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix write writes messages without newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1message 2message 3",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a message line 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] test message[n]",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a message line with newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3[n]",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a message line with provider newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1[n][prefix (0)] message 2[n][prefix (0)] message 3[n]",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a dynamic prefix writeLine writes a mix of message lines with and without newlines 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "[prefix (0)] message 1[n][prefix (1)] message 2[n][prefix (1)] message 3[n][prefix (1)] [n][prefix (2)] message 4[n][prefix (3)] message 5[n][prefix (3)] message 6[n]",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`PrefixProxyTerminalProvider With a static prefix write writes a message 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -10,7 +100,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider write writes a message with newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix write writes a message with newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -20,7 +110,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider write writes a message with provider newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix write writes a message with provider newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -30,7 +120,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider write writes a mix of messages with and without newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix write writes a mix of messages with and without newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -40,7 +130,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider write writes messages without newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix write writes messages without newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -50,7 +140,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider writeLine writes a message line 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix writeLine writes a message line 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -60,7 +150,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider writeLine writes a message line with newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix writeLine writes a message line with newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -70,7 +160,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider writeLine writes a message line with provider newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix writeLine writes a message line with provider newlines 1`] = `
 Object {
   "debug": "",
   "error": "",
@@ -80,7 +170,7 @@ Object {
 }
 `;
 
-exports[`PrefixProxyTerminalProvider writeLine writes a mix of message lines with and without newlines 1`] = `
+exports[`PrefixProxyTerminalProvider With a static prefix writeLine writes a mix of message lines with and without newlines 1`] = `
 Object {
   "debug": "",
   "error": "",

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -106,7 +106,10 @@ export {
 } from './Terminal/StringBufferTerminalProvider';
 export {
   PrefixProxyTerminalProvider,
-  IPrefixProxyTerminalProviderOptions
+  IPrefixProxyTerminalProviderOptions,
+  IDynamicPrefixProxyTerminalProviderOptions,
+  IPrefixProxyTerminalProviderOptionsBase,
+  IStaticPrefixProxyTerminalProviderOptions
 } from './Terminal/PrefixProxyTerminalProvider';
 export { TerminalWritable, ITerminalWritableOptions } from './Terminal/TerminalWritable';
 export { TypeUuid } from './TypeUuid';


### PR DESCRIPTION
## Summary

This PR adds an option to `PrefixProxyTerminalProvider` called `getPrefix` which takes a function that returns a string to dynamically generate the prefix. This can be used for prefixing logging lines with timestamps.

## How it was tested

Included a unit test.