### PR TITLE
[rush] Add ability to silence noops in the logs

### DIFF
--- a/common/changes/@microsoft/rush/silent-noops_2023-05-11-22-50.json
+++ b/common/changes/@microsoft/rush/silent-noops_2023-05-11-22-50.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add a property \"missingScriptBehavior\" to phase definitions tha can be used to silence missing scripts to reduce log noise.",
+      "comment": "(BREAKING API CHANGE) Add a property `missingScriptBehavior` to phase definitions that can be used to silence missing scripts to reduce log noise. This replaces the `ignoreMissingScript` property visible to the plugin API, although the `ignoreMissingScript` property is still supported in the `common/config/rush/command-line.json` config file for backwards compatibility.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/silent-noops_2023-05-11-22-50.json
+++ b/common/changes/@microsoft/rush/silent-noops_2023-05-11-22-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a property \"missingScriptBehavior\" to phase definitions tha can be used to silence missing scripts to reduce log noise.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -467,12 +467,15 @@ export interface IPhase {
         self: Set<IPhase>;
         upstream: Set<IPhase>;
     };
-    ignoreMissingScript: boolean;
     isSynthetic: boolean;
     logFilenameIdentifier: string;
+    missingScriptBehavior: IPhaseBehaviorForMissingScript;
     name: string;
     shellCommand?: string;
 }
+
+// @alpha
+export type IPhaseBehaviorForMissingScript = 'silent' | 'log' | 'error';
 
 // @beta
 export interface IPhasedCommand extends IRushCommand {

--- a/libraries/rush-lib/src/api/CommandLineConfiguration.ts
+++ b/libraries/rush-lib/src/api/CommandLineConfiguration.ts
@@ -29,7 +29,7 @@ export interface IShellCommandTokenContext {
  * The set of valid behaviors for a missing script in a project's package.json scripts for a given phase.
  * @alpha
  */
-export type IPhaseBehaviorForMissingScript = 'silent' | 'log' | 'error';
+export type PhaseBehaviorForMissingScript = 'silent' | 'log' | 'error';
 
 /**
  * Metadata about a phase.
@@ -76,7 +76,7 @@ export interface IPhase {
   /**
    * What should happen if the script is not defined in a project's package.json scripts field. Default is "error".
    */
-  missingScriptBehavior: IPhaseBehaviorForMissingScript;
+  missingScriptBehavior: PhaseBehaviorForMissingScript;
 
   /**
    * (Optional) If the `shellCommand` field is set for a bulk command, Rush will invoke it for each

--- a/libraries/rush-lib/src/api/CommandLineJson.ts
+++ b/libraries/rush-lib/src/api/CommandLineJson.ts
@@ -99,6 +99,10 @@ export interface IPhaseJson {
    */
   ignoreMissingScript?: boolean;
   /**
+   * What should happen if the script is not defined in a project's package.json scripts field. Default is "error". Supersedes \"ignoreMissingScript\".
+   */
+  missingScriptBehavior?: 'silent' | 'log' | 'error';
+  /**
    * By default, Rush returns a nonzero exit code if errors or warnings occur during a command. If this option is set to \"true\", Rush will return a zero exit code if warnings occur during the execution of this phase.
    */
   allowWarningsOnSuccess?: boolean;

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -37,7 +37,10 @@ export {
   IFileSystemBuildCacheProviderOptions
 } from './logic/buildCache/FileSystemBuildCacheProvider';
 
-export { IPhase, IPhaseBehaviorForMissingScript } from './api/CommandLineConfiguration';
+export {
+  IPhase,
+  PhaseBehaviorForMissingScript as IPhaseBehaviorForMissingScript
+} from './api/CommandLineConfiguration';
 
 export {
   EnvironmentConfiguration,

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -37,7 +37,7 @@ export {
   IFileSystemBuildCacheProviderOptions
 } from './logic/buildCache/FileSystemBuildCacheProvider';
 
-export { IPhase } from './api/CommandLineConfiguration';
+export { IPhase, IPhaseBehaviorForMissingScript } from './api/CommandLineConfiguration';
 
 export {
   EnvironmentConfiguration,

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -68,7 +68,7 @@ function createShellOperations(
         phase.shellCommand
       );
 
-      if (commandToRun === undefined && !phase.ignoreMissingScript) {
+      if (commandToRun === undefined && phase.missingScriptBehavior === 'error') {
         throw new Error(
           `The project '${project.packageName}' does not define a '${phase.name}' command in the 'scripts' section of its package.json`
         );
@@ -93,7 +93,7 @@ function createShellOperations(
         operation.runner = new NullOperationRunner({
           name: displayName,
           result: OperationStatus.NoOp,
-          silent: false
+          silent: phase.missingScriptBehavior === 'silent'
         });
       }
     }

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -307,6 +307,13 @@
           "title": "Allow Warnings on Success",
           "description": "By default, Rush returns a nonzero exit code if errors or warnings occur during a command. If this option is set to \"true\", Rush will return a zero exit code if warnings occur during the execution of this phase.",
           "type": "boolean"
+        },
+
+        "missingScriptBehavior": {
+          "title": "Missing Script Behavior",
+          "description": "What should happen if a project's package.json does not have a \"scripts\" entry matching the phase name, or it is an empty string. Supersedes \"ignoreMissingScript\". Defaults to \"error\".",
+          "type": "string",
+          "enum": ["silent", "log", "error"]
         }
       }
     },


### PR DESCRIPTION
## Summary
Adds the ability to silence logging from phases that aren't defined in a given project.

## Details
Adds a new configuration option `missingScriptBehavior` to phase definitions in `command-line.json`.
Current allowed values:
`error` - Throws an error if not defined, as `ignoreMissingScript: false` (which it replaces) (default)
`log` - Logs a no-op if not defined, as `ignoreMissingScript: true` (which it replaces)
`silent` - Does not log at all if not defined. Net new behavior.

## How it was tested
Enabled in the local rushstack repository for `_phase:test` and validated that `rush test -v` no longer logged any no-ops for `_phase:test`.

## Impacted documentation
Docs around command-line.json regarding phase definitions.