### PR TITLE
[heft-typescript@next] Forward watch options

### DIFF
--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -1200,7 +1200,8 @@ export class TypeScriptBuilder {
       this._getCreateBuilderProgram(ts),
       tool.reportDiagnostic,
       reportWatchStatus,
-      tsconfig.projectReferences
+      tsconfig.projectReferences,
+      tsconfig.watchOptions
     );
 
     compilerHost.clearTimeout = tool.clearTimeout;


### PR DESCRIPTION
## Summary
Ensures that the watchOptions section of tsconfig gets forwarded to the watchCompilerHost.

## How it was tested
Running under debugger with a project configured with `watchOptions` in tsconfig.

## Impacted documentation
None
