### PR TITLE
[heft-typescript@next] Add "useTranspilerWorker" option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,24 @@
 			"internalConsoleOptions": "neverOpen"
 		},
 		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Build in Selected Project (Heft)",
+			"cwd": "${fileDirname}",
+			"runtimeArgs": [
+				"--nolazy",
+				"--inspect-brk",
+				"${workspaceFolder}/apps/heft/lib/start.js",
+				"--debug",
+				"build"
+			],
+			"skipFiles": ["<node_internals>/**"],
+			"outFiles": [],
+			"sourceMaps": true,
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		},
+		{
 			"name": "Attach",
 			"type": "node",
 			"request": "attach",

--- a/build-tests/heft-typescript-composite-test/src/indexA.ts
+++ b/build-tests/heft-typescript-composite-test/src/indexA.ts
@@ -8,3 +8,5 @@ import(/* webpackChunkName: 'chunk' */ './chunks/ChunkClass')
   .catch((e) => {
     console.log('Error: ' + e.message);
   });
+
+export {};

--- a/build-tests/heft-typescript-composite-test/src/indexB.ts
+++ b/build-tests/heft-typescript-composite-test/src/indexB.ts
@@ -1,1 +1,3 @@
 console.log('dostuff');
+
+export {};

--- a/build-tests/heft-typescript-composite-test/tsconfig-base.json
+++ b/build-tests/heft-typescript-composite-test/tsconfig-base.json
@@ -16,6 +16,9 @@
     "noUnusedLocals": true,
     "types": ["heft-jest", "webpack-env"],
 
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error",
+
     "module": "esnext",
     "moduleResolution": "node",
     "target": "es5",

--- a/build-tests/heft-webpack4-everything-test/config/typescript.json
+++ b/build-tests/heft-webpack4-everything-test/config/typescript.json
@@ -55,5 +55,7 @@
     // "excludeGlobs": [
     //   "some/path/*.css"
     // ]
-  }
+  },
+
+  "useTranspilerWorker": true
 }

--- a/build-tests/heft-webpack4-everything-test/package.json
+++ b/build-tests/heft-webpack4-everything-test/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "heft build --clean",
-    "start": "heft start",
+    "start": "heft build-watch --serve",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },

--- a/build-tests/heft-webpack4-everything-test/src/indexA.ts
+++ b/build-tests/heft-webpack4-everything-test/src/indexA.ts
@@ -8,3 +8,5 @@ import(/* webpackChunkName: 'chunk' */ './chunks/ChunkClass')
   .catch((e) => {
     console.log('Error: ' + e.message);
   });
+
+export {};

--- a/build-tests/heft-webpack4-everything-test/src/indexB.ts
+++ b/build-tests/heft-webpack4-everything-test/src/indexB.ts
@@ -1,1 +1,3 @@
 console.log('dostuff');
+
+export {};

--- a/build-tests/heft-webpack4-everything-test/tsconfig.json
+++ b/build-tests/heft-webpack4-everything-test/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedLocals": true,
     "types": ["heft-jest", "webpack-env"],
     "incremental": true,
+    "isolatedModules": true,
 
     "module": "esnext",
     "moduleResolution": "node",

--- a/common/reviews/api/heft-typescript-plugin.api.md
+++ b/common/reviews/api/heft-typescript-plugin.api.md
@@ -59,6 +59,7 @@ export interface ITypeScriptConfigurationJson {
     // (undocumented)
     project?: string;
     staticAssetsToCopy?: IStaticAssetsCopyConfiguration;
+    useTranspilerWorker?: boolean;
 }
 
 // @beta (undocumented)

--- a/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
@@ -1,6 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 import { parentPort, workerData } from 'node:worker_threads';
 
-import * as TTypescript from 'typescript';
+import type * as TTypescript from 'typescript';
 import type {
   ITranspilationErrorMessage,
   ITranspilationRequestMessage,

--- a/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
@@ -1,0 +1,83 @@
+import { parentPort, workerData } from 'node:worker_threads';
+
+import * as TTypescript from 'typescript';
+import type {
+  ITranspilationRequestMessage,
+  ITranspilationResponseMessage,
+  ITypescriptWorkerData
+} from './types';
+import type { ExtendedTypeScript } from './internalTypings/TypeScriptInternals';
+import { configureProgramForMultiEmit } from './configureProgramForMultiEmit';
+
+const typedWorkerData: ITypescriptWorkerData = workerData;
+
+const ts: ExtendedTypeScript = require(typedWorkerData.typeScriptToolPath);
+
+function handleMessage(message: ITranspilationRequestMessage | false): void {
+  if (!message) {
+    process.exit(0);
+  }
+
+  const { requestId, compilerOptions, moduleKindsToEmit, fileNames } = message;
+
+  const fullySkipTypeCheck: boolean =
+    compilerOptions.importsNotUsedAsValues === ts.ImportsNotUsedAsValues.Error;
+
+  for (const [option, value] of Object.entries(ts.getDefaultCompilerOptions())) {
+    if (compilerOptions[option] === undefined) {
+      compilerOptions[option] = value;
+    }
+  }
+
+  const { target: rawTarget } = compilerOptions;
+
+  for (const option of ts.transpileOptionValueCompilerOptions) {
+    compilerOptions[option.name] = option.transpileOptionValue;
+  }
+
+  compilerOptions.suppressOutputPathCheck = true;
+  compilerOptions.skipDefaultLibCheck = true;
+  compilerOptions.preserveValueImports = true;
+
+  const sourceFileByPath: Map<string, TTypescript.SourceFile> = new Map();
+
+  for (const fileName of fileNames) {
+    const sourceText: string | undefined = ts.sys.readFile(fileName);
+    if (sourceText) {
+      const sourceFile: TTypescript.SourceFile = ts.createSourceFile(fileName, sourceText, rawTarget!);
+      sourceFile.hasNoDefaultLib = fullySkipTypeCheck;
+      sourceFileByPath.set(fileName, sourceFile);
+    }
+  }
+
+  const newLine: string = ts.getNewLineCharacter(compilerOptions);
+
+  const compilerHost: TTypescript.CompilerHost = {
+    getSourceFile: (fileName: string) => sourceFileByPath.get(fileName),
+    writeFile: ts.sys.writeFile,
+    getDefaultLibFileName: () => 'lib.d.ts',
+    useCaseSensitiveFileNames: () => true,
+    getCanonicalFileName: (fileName: string) => fileName,
+    getCurrentDirectory: () => '',
+    getNewLine: () => newLine,
+    fileExists: (fileName: string) => sourceFileByPath.has(fileName),
+    readFile: () => '',
+    directoryExists: () => true,
+    getDirectories: () => []
+  };
+
+  const program: TTypescript.Program = ts.createProgram(fileNames, compilerOptions, compilerHost);
+
+  configureProgramForMultiEmit(program, ts, moduleKindsToEmit, 'transpile');
+
+  const result: TTypescript.EmitResult = program.emit(undefined, undefined, undefined, undefined, undefined);
+
+  const response: ITranspilationResponseMessage = {
+    requestId,
+    result
+  };
+
+  parentPort!.postMessage(response);
+}
+
+parentPort!.on('message', handleMessage);

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -3,8 +3,10 @@
 
 import * as crypto from 'crypto';
 import * as path from 'path';
+import { Worker } from 'worker_threads';
+
 import * as semver from 'semver';
-import * as TTypescript from 'typescript';
+import type * as TTypescript from 'typescript';
 import {
   type ITerminal,
   JsonFile,
@@ -26,7 +28,6 @@ import type {
   ITypescriptWorkerData
 } from './types';
 import { configureProgramForMultiEmit } from './configureProgramForMultiEmit';
-import { Worker } from 'worker_threads';
 
 export interface ITypeScriptBuilderConfiguration extends ITypeScriptConfigurationJson {
   /**

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -4,15 +4,14 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
 import * as semver from 'semver';
-import type * as TTypescript from 'typescript';
+import * as TTypescript from 'typescript';
 import {
   type ITerminal,
   JsonFile,
   type IPackageJson,
   Path,
   Async,
-  FileError,
-  InternalError
+  FileError
 } from '@rushstack/node-core-library';
 import type { IScopedLogger } from '@rushstack/heft';
 
@@ -20,24 +19,14 @@ import type { ExtendedTypeScript, IExtendedSolutionBuilder } from './internalTyp
 import { TypeScriptCachedFileSystem } from './fileSystem/TypeScriptCachedFileSystem';
 import type { ITypeScriptConfigurationJson } from './TypeScriptPlugin';
 import type { PerformanceMeasurer, PerformanceMeasurerAsync } from './Performance';
-
-interface ICachedEmitModuleKind {
-  moduleKind: TTypescript.ModuleKind;
-
-  outFolderPath: string;
-
-  /**
-   * File extension to use instead of '.js' for emitted ECMAScript files.
-   * For example, '.cjs' to indicate commonjs content, or '.mjs' to indicate ECMAScript modules.
-   */
-  jsExtensionOverride: string | undefined;
-
-  /**
-   * Set to true if this is the emit kind that is specified in the tsconfig.json.
-   * Declarations are only emitted for the primary module kind.
-   */
-  isPrimary: boolean;
-}
+import type {
+  ICachedEmitModuleKind,
+  ITranspilationRequestMessage,
+  ITranspilationResponseMessage,
+  ITypescriptWorkerData
+} from './types';
+import { configureProgramForMultiEmit } from './configureProgramForMultiEmit';
+import { Worker } from 'worker_threads';
 
 export interface ITypeScriptBuilderConfiguration extends ITypeScriptConfigurationJson {
   /**
@@ -131,10 +120,6 @@ const OLDEST_SUPPORTED_TS_MINOR_VERSION: number = 9;
 const NEWEST_SUPPORTED_TS_MAJOR_VERSION: number = 5;
 const NEWEST_SUPPORTED_TS_MINOR_VERSION: number = 0;
 
-// symbols for attaching hidden metadata to ts.Program instances.
-const INNER_GET_COMPILER_OPTIONS_SYMBOL: unique symbol = Symbol('getCompilerOptions');
-const INNER_EMIT_SYMBOL: unique symbol = Symbol('emit');
-
 interface ITypeScriptTool {
   ts: ExtendedTypeScript;
   measureSync: PerformanceMeasurer;
@@ -150,6 +135,10 @@ interface ITypeScriptTool {
   pendingOperations: Set<IPendingWork>;
 
   executing: boolean;
+
+  worker: Worker | undefined;
+  pendingTranspilePromises: Map<number, Promise<TTypescript.EmitResult>>;
+  pendingTranspileResolves: Map<number, (result: TTypescript.EmitResult) => void>;
 
   reportDiagnostic: TTypescript.DiagnosticReporter;
   clearTimeout: (timeout: IPendingWork) => void;
@@ -174,6 +163,8 @@ export class TypeScriptBuilder {
   private _cachedFileSystem: TypeScriptCachedFileSystem = new TypeScriptCachedFileSystem();
 
   private _tool: ITypeScriptTool | undefined = undefined;
+
+  private _nextRequestId: number = 0;
 
   private get _tsCacheFilePath(): string {
     if (!this.__tsCacheFilePath) {
@@ -361,7 +352,12 @@ export class TypeScriptBuilder {
             onChangeDetected();
           }
           return timeout;
-        }
+        },
+
+        worker: undefined,
+
+        pendingTranspilePromises: new Map(),
+        pendingTranspileResolves: new Map()
       };
     }
 
@@ -371,147 +367,22 @@ export class TypeScriptBuilder {
     performance.enable();
 
     if (onChangeDetected !== undefined) {
-      this._runWatch(this._tool);
+      await this._runWatchAsync(this._tool);
     } else if (this._useSolutionBuilder) {
-      this._runSolutionBuild(this._tool);
+      await this._runSolutionBuildAsync(this._tool);
     } else {
       await this._runBuildAsync(this._tool);
     }
   }
 
-  private _configureProgramForMultiEmit(
-    innerProgram: TTypescript.Program,
-    ts: ExtendedTypeScript
-  ): { changedFiles: Set<TTypescript.SourceFile> } {
-    interface IProgramWithMultiEmit extends TTypescript.Program {
-      // Attach the originals to the Program instance to avoid modifying the same Program twice.
-      // Don't use WeakMap because this Program could theoretically get a { ... } applied to it.
-      [INNER_GET_COMPILER_OPTIONS_SYMBOL]?: TTypescript.Program['getCompilerOptions'];
-      [INNER_EMIT_SYMBOL]?: TTypescript.Program['emit'];
-    }
-
-    const program: IProgramWithMultiEmit = innerProgram;
-
-    // Check to see if this Program has already been modified.
-    let { [INNER_EMIT_SYMBOL]: innerEmit, [INNER_GET_COMPILER_OPTIONS_SYMBOL]: innerGetCompilerOptions } =
-      program;
-
-    if (!innerGetCompilerOptions) {
-      program[INNER_GET_COMPILER_OPTIONS_SYMBOL] = innerGetCompilerOptions = program.getCompilerOptions;
-    }
-
-    if (!innerEmit) {
-      program[INNER_EMIT_SYMBOL] = innerEmit = program.emit;
-    }
-
-    let foundPrimary: boolean = false;
-    let defaultModuleKind: TTypescript.ModuleKind;
-
-    const multiEmitMap: Map<ICachedEmitModuleKind, TTypescript.CompilerOptions> = new Map();
-    for (const moduleKindToEmit of this._moduleKindsToEmit) {
-      const kindCompilerOptions: TTypescript.CompilerOptions = moduleKindToEmit.isPrimary
-        ? {
-            ...innerGetCompilerOptions()
-          }
-        : {
-            ...innerGetCompilerOptions(),
-            module: moduleKindToEmit.moduleKind,
-            outDir: moduleKindToEmit.outFolderPath,
-
-            // Don't emit declarations for secondary module kinds
-            declaration: false,
-            declarationMap: false
-          };
-      if (!kindCompilerOptions.outDir) {
-        throw new InternalError('Expected compilerOptions.outDir to be assigned');
-      }
-      multiEmitMap.set(moduleKindToEmit, kindCompilerOptions);
-
-      if (moduleKindToEmit.isPrimary) {
-        if (foundPrimary) {
-          throw new Error('Multiple primary module emit kinds encountered.');
-        } else {
-          foundPrimary = true;
-        }
-
-        defaultModuleKind = moduleKindToEmit.moduleKind;
-      }
-    }
-
-    const changedFiles: Set<TTypescript.SourceFile> = new Set();
-
-    program.emit = (
-      targetSourceFile?: TTypescript.SourceFile,
-      writeFile?: TTypescript.WriteFileCallback,
-      cancellationToken?: TTypescript.CancellationToken,
-      emitOnlyDtsFiles?: boolean,
-      customTransformers?: TTypescript.CustomTransformers
-    ) => {
-      if (emitOnlyDtsFiles) {
-        return program[INNER_EMIT_SYMBOL]!(
-          targetSourceFile,
-          writeFile,
-          cancellationToken,
-          emitOnlyDtsFiles,
-          customTransformers
-        );
-      }
-
-      if (targetSourceFile && changedFiles) {
-        changedFiles.add(targetSourceFile);
-      }
-
-      const originalCompilerOptions: TTypescript.CompilerOptions =
-        program[INNER_GET_COMPILER_OPTIONS_SYMBOL]!();
-
-      let defaultModuleKindResult: TTypescript.EmitResult;
-      const diagnostics: TTypescript.Diagnostic[] = [];
-      let emitSkipped: boolean = false;
-      try {
-        for (const [moduleKindToEmit, kindCompilerOptions] of multiEmitMap) {
-          program.getCompilerOptions = () => kindCompilerOptions;
-          // Need to mutate the compiler options for the `module` field specifically, because emitWorker() captures
-          // options in the closure and passes it to `ts.getTransformers()`
-          originalCompilerOptions.module = moduleKindToEmit.moduleKind;
-          const flavorResult: TTypescript.EmitResult = program[INNER_EMIT_SYMBOL]!(
-            targetSourceFile,
-            writeFile && wrapWriteFile(writeFile, moduleKindToEmit.jsExtensionOverride),
-            cancellationToken,
-            emitOnlyDtsFiles,
-            customTransformers
-          );
-
-          emitSkipped = emitSkipped || flavorResult.emitSkipped;
-          // Need to aggregate diagnostics because some are impacted by the target module type
-          for (const diagnostic of flavorResult.diagnostics) {
-            diagnostics.push(diagnostic);
-          }
-
-          if (moduleKindToEmit.moduleKind === defaultModuleKind) {
-            defaultModuleKindResult = flavorResult;
-          }
-        }
-
-        const mergedDiagnostics: readonly TTypescript.Diagnostic[] =
-          ts.sortAndDeduplicateDiagnostics(diagnostics);
-
-        return {
-          ...defaultModuleKindResult!,
-          changedSourceFiles: changedFiles,
-          diagnostics: mergedDiagnostics,
-          emitSkipped
-        };
-      } finally {
-        // Restore the original compiler options and module kind for future calls
-        program.getCompilerOptions = program[INNER_GET_COMPILER_OPTIONS_SYMBOL]!;
-        originalCompilerOptions.module = defaultModuleKind;
-      }
-    };
-    return { changedFiles };
-  }
-
-  public _runWatch(tool: ITypeScriptTool): void {
-    const { ts, measureSync: measureTsPerformance, pendingOperations, rawDiagnostics } = tool;
+  public async _runWatchAsync(tool: ITypeScriptTool): Promise<void> {
+    const {
+      ts,
+      measureSync: measureTsPerformance,
+      pendingOperations,
+      rawDiagnostics,
+      pendingTranspilePromises
+    } = tool;
 
     if (!tool.solutionBuilder && !tool.watchProgram) {
       //#region CONFIGURE
@@ -547,13 +418,27 @@ export class TypeScriptBuilder {
         pendingOperations.delete(operation);
         operation();
       }
+      if (pendingTranspilePromises.size) {
+        const emitResults: TTypescript.EmitResult[] = await Promise.all(pendingTranspilePromises.values());
+        for (const { diagnostics } of emitResults) {
+          for (const diagnostic of diagnostics) {
+            rawDiagnostics.push(diagnostic);
+          }
+        }
+      }
+      // eslint-disable-next-line require-atomic-updates
       tool.executing = false;
     }
     this._logDiagnostics(ts, rawDiagnostics);
   }
 
   public async _runBuildAsync(tool: ITypeScriptTool): Promise<void> {
-    const { ts, measureSync: measureTsPerformance, measureAsync: measureTsPerformanceAsync } = tool;
+    const {
+      ts,
+      measureSync: measureTsPerformance,
+      measureAsync: measureTsPerformanceAsync,
+      pendingTranspilePromises
+    } = tool;
 
     //#region CONFIGURE
     const {
@@ -579,17 +464,26 @@ export class TypeScriptBuilder {
     let builderProgram: TTypescript.BuilderProgram | undefined = undefined;
     let innerProgram: TTypescript.Program;
 
+    const isolatedModules: boolean =
+      !!this._configuration.useTranspilerWorker && !!tsconfig.options.isolatedModules;
+    const mode: 'both' | 'declaration' = isolatedModules ? 'declaration' : 'both';
+
+    let fileNames: string[] | undefined;
+
     if (tsconfig.options.incremental) {
       // Use ts.createEmitAndSemanticDiagnositcsBuilderProgram directly because the customizations performed by
       // _getCreateBuilderProgram duplicate those performed in this function for non-incremental build.
+      const oldProgram: TTypescript.EmitAndSemanticDiagnosticsBuilderProgram | undefined =
+        ts.readBuilderProgram(tsconfig.options, compilerHost);
       builderProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
         tsconfig.fileNames,
         tsconfig.options,
         compilerHost,
-        ts.readBuilderProgram(tsconfig.options, compilerHost),
+        oldProgram,
         ts.getConfigFileParsingDiagnostics(tsconfig),
         tsconfig.projectReferences
       );
+      fileNames = getFilesToTranspileFromBuilderProgram(builderProgram);
       innerProgram = builderProgram.getProgram();
     } else {
       innerProgram = ts.createProgram({
@@ -600,6 +494,7 @@ export class TypeScriptBuilder {
         oldProgram: undefined,
         configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(tsconfig)
       });
+      fileNames = getFilesToTranspileFromProgram(innerProgram);
     }
 
     // Prefer the builder program, since it is what gives us incremental builds
@@ -607,6 +502,11 @@ export class TypeScriptBuilder {
 
     this._logReadPerformance(ts);
     //#endregion
+
+    if (isolatedModules) {
+      // Kick the transpilation worker.
+      this._queueTranspileInWorker(tool, genericProgram.getCompilerOptions(), fileNames);
+    }
 
     //#region ANALYSIS
     const { duration: diagnosticsDurationMs, diagnostics: preDiagnostics } = measureTsPerformance(
@@ -632,7 +532,7 @@ export class TypeScriptBuilder {
       filesToWrite.push({ filePath, data });
     };
 
-    const { changedFiles } = this._configureProgramForMultiEmit(innerProgram, ts);
+    const { changedFiles } = configureProgramForMultiEmit(innerProgram, ts, this._moduleKindsToEmit, mode);
 
     const emitResult: TTypescript.EmitResult = genericProgram.emit(undefined, writeFileCallback);
     //#endregion
@@ -657,6 +557,17 @@ export class TypeScriptBuilder {
     );
     //#endregion
 
+    this._configuration.emitChangedFilesCallback(innerProgram, changedFiles);
+
+    if (pendingTranspilePromises.size) {
+      const emitResults: TTypescript.EmitResult[] = await Promise.all(pendingTranspilePromises.values());
+      for (const { diagnostics } of emitResults) {
+        for (const diagnostic of diagnostics) {
+          rawDiagnostics.push(diagnostic);
+        }
+      }
+    }
+
     const { duration: writeDuration } = await writePromise;
     this._typescriptTerminal.writeVerboseLine(`I/O Write: ${writeDuration}ms (${filesToWrite.length} files)`);
 
@@ -664,13 +575,14 @@ export class TypeScriptBuilder {
     // Reset performance counters in case any are used in the callback
     ts.performance.disable();
     ts.performance.enable();
-    this._configuration.emitChangedFilesCallback(innerProgram, changedFiles);
+
+    await this._cleanupWorkerAsync();
   }
 
-  public _runSolutionBuild(tool: ITypeScriptTool): void {
+  public async _runSolutionBuildAsync(tool: ITypeScriptTool): Promise<void> {
     this._typescriptTerminal.writeVerboseLine(`Using solution mode`);
 
-    const { ts, measureSync, rawDiagnostics } = tool;
+    const { ts, measureSync, rawDiagnostics, pendingTranspilePromises } = tool;
     rawDiagnostics.length = 0;
 
     if (!tool.solutionBuilder) {
@@ -705,7 +617,18 @@ export class TypeScriptBuilder {
     tool.solutionBuilder.build();
     //#endregion
 
+    if (pendingTranspilePromises.size) {
+      const emitResults: TTypescript.EmitResult[] = await Promise.all(pendingTranspilePromises.values());
+      for (const { diagnostics } of emitResults) {
+        for (const diagnostic of diagnostics) {
+          rawDiagnostics.push(diagnostic);
+        }
+      }
+    }
+
     this._logDiagnostics(ts, rawDiagnostics);
+
+    await this._cleanupWorkerAsync();
   }
 
   private _logDiagnostics(ts: ExtendedTypeScript, rawDiagnostics: TTypescript.Diagnostic[]): void {
@@ -1084,6 +1007,16 @@ export class TypeScriptBuilder {
 
       this._logReadPerformance(ts);
 
+      const isolatedModules: boolean =
+        !!this._configuration.useTranspilerWorker && !!compilerOptions!.isolatedModules;
+      const mode: 'both' | 'declaration' = isolatedModules ? 'declaration' : 'both';
+
+      if (isolatedModules) {
+        // Kick the transpilation worker.
+        const fileNamesToTranspile: string[] = getFilesToTranspileFromBuilderProgram(newProgram);
+        this._queueTranspileInWorker(this._tool!, compilerOptions!, fileNamesToTranspile);
+      }
+
       const { emit: originalEmit } = newProgram;
 
       const emit: TTypescript.Program['emit'] = (
@@ -1097,7 +1030,12 @@ export class TypeScriptBuilder {
 
         const innerCompilerOptions: TTypescript.CompilerOptions = innerProgram.getCompilerOptions();
 
-        const { changedFiles } = this._configureProgramForMultiEmit(innerProgram, ts);
+        const { changedFiles } = configureProgramForMultiEmit(
+          innerProgram,
+          ts,
+          this._moduleKindsToEmit,
+          mode
+        );
 
         const result: TTypescript.EmitResult = originalEmit.call(
           newProgram,
@@ -1293,32 +1231,92 @@ export class TypeScriptBuilder {
         throw new Error(`"${moduleKindName}" is not a valid module kind name.`);
     }
   }
-}
 
-const JS_EXTENSION_REGEX: RegExp = /\.js(\.map)?$/;
+  private _queueTranspileInWorker(
+    tool: ITypeScriptTool,
+    compilerOptions: TTypescript.CompilerOptions,
+    fileNames: string[]
+  ): void {
+    const { pendingTranspilePromises, pendingTranspileResolves } = tool;
+    let maybeWorker: Worker | undefined = tool.worker;
+    if (!maybeWorker) {
+      const workerData: ITypescriptWorkerData = {
+        typeScriptToolPath: this._configuration.typeScriptToolPath
+      };
+      tool.worker = maybeWorker = new Worker(require.resolve('./TranspilerWorker.js'), {
+        workerData: workerData
+      });
 
-function wrapWriteFile(
-  baseWriteFile: TTypescript.WriteFileCallback,
-  jsExtensionOverride: string | undefined
-): TTypescript.WriteFileCallback {
-  if (!jsExtensionOverride) {
-    return baseWriteFile;
+      maybeWorker.on('message', (response: ITranspilationResponseMessage) => {
+        const { requestId: resolvingRequestId, result } = response;
+        const resolve: ((result: TTypescript.EmitResult) => void) | undefined =
+          pendingTranspileResolves.get(resolvingRequestId);
+        if (resolve) {
+          resolve(result);
+        } else {
+          this._typescriptTerminal.writeErrorLine(
+            `Unexpected worker resolution for request with id ${resolvingRequestId}`
+          );
+        }
+      });
+    }
+
+    // make linter happy
+    const worker: Worker = maybeWorker;
+
+    const requestId: number = ++this._nextRequestId;
+    const transpilePromise: Promise<TTypescript.EmitResult> = new Promise(
+      (resolve: (result: TTypescript.EmitResult) => void, reject: (err: Error) => void) => {
+        pendingTranspileResolves.set(requestId, resolve);
+
+        this._typescriptTerminal.writeLine(`Asynchronously transpiling ${compilerOptions.configFilePath}`);
+        const request: ITranspilationRequestMessage = {
+          compilerOptions,
+          fileNames,
+          moduleKindsToEmit: this._moduleKindsToEmit,
+          requestId
+        };
+
+        worker.postMessage(request);
+      }
+    );
+
+    pendingTranspilePromises.set(requestId, transpilePromise);
   }
 
-  const replacementExtension: string = `${jsExtensionOverride}$1`;
-  return (
-    fileName: string,
-    data: string,
-    writeBOM: boolean,
-    onError?: ((message: string) => void) | undefined,
-    sourceFiles?: readonly TTypescript.SourceFile[] | undefined
-  ) => {
-    return baseWriteFile(
-      fileName.replace(JS_EXTENSION_REGEX, replacementExtension),
-      data,
-      writeBOM,
-      onError,
-      sourceFiles
-    );
-  };
+  private async _cleanupWorkerAsync(): Promise<void> {
+    const worker: Worker | undefined = this._tool?.worker;
+    if (worker) {
+      this._typescriptTerminal.writeLine(`Waiting for worker to exit`);
+      await new Promise<void>((resolve: () => void, reject: (err: Error) => void) => {
+        worker.on('exit', resolve);
+        this._tool!.worker = undefined;
+        worker.postMessage(false);
+      });
+    }
+  }
+}
+
+function getFilesToTranspileFromBuilderProgram(builderProgram: TTypescript.BuilderProgram): string[] {
+  const changedFilesSet: Set<string> = (
+    builderProgram as unknown as { getState(): { changedFilesSet: Set<string> } }
+  ).getState().changedFilesSet;
+  const fileNames: string[] = [];
+  for (const fileName of changedFilesSet) {
+    const sourceFile: TTypescript.SourceFile | undefined = builderProgram.getSourceFile(fileName);
+    if (sourceFile && !sourceFile.isDeclarationFile) {
+      fileNames.push(fileName);
+    }
+  }
+  return fileNames;
+}
+
+function getFilesToTranspileFromProgram(program: TTypescript.Program): string[] {
+  const fileNames: string[] = [];
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.isDeclarationFile) {
+      fileNames.push(sourceFile.fileName);
+    }
+  }
+  return fileNames;
 }

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -70,6 +70,11 @@ export interface ITypeScriptConfigurationJson {
    */
   buildProjectReferences?: boolean;
 
+  /**
+   * If true, and the tsconfig has \"isolatedModules\": true, then transpilation will happen in parallel in a worker thread.
+   */
+  useTranspilerWorker?: boolean;
+
   /*
    * Specifies the tsconfig.json file that will be used for compilation. Equivalent to the "project" argument for the 'tsc' and 'tslint' command line tools.
    *
@@ -362,6 +367,8 @@ export default class TypeScriptPlugin implements IHeftTaskPlugin {
       typeScriptToolPath: typeScriptToolPath,
 
       buildProjectReferences: typeScriptConfigurationJson?.buildProjectReferences,
+
+      useTranspilerWorker: typeScriptConfigurationJson?.useTranspilerWorker,
 
       tsconfigPath: getTsconfigFilePath(heftConfiguration, typeScriptConfigurationJson),
       additionalModuleKindsToEmit: typeScriptConfigurationJson?.additionalModuleKindsToEmit,

--- a/heft-plugins/heft-typescript-plugin/src/configureProgramForMultiEmit.ts
+++ b/heft-plugins/heft-typescript-plugin/src/configureProgramForMultiEmit.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 import type * as TTypescript from 'typescript';
 import { InternalError } from '@rushstack/node-core-library';
 

--- a/heft-plugins/heft-typescript-plugin/src/configureProgramForMultiEmit.ts
+++ b/heft-plugins/heft-typescript-plugin/src/configureProgramForMultiEmit.ts
@@ -1,0 +1,181 @@
+import type * as TTypescript from 'typescript';
+import { InternalError } from '@rushstack/node-core-library';
+
+import type { ExtendedTypeScript } from './internalTypings/TypeScriptInternals';
+import type { ICachedEmitModuleKind } from './types';
+
+// symbols for attaching hidden metadata to ts.Program instances.
+const INNER_GET_COMPILER_OPTIONS_SYMBOL: unique symbol = Symbol('getCompilerOptions');
+const INNER_EMIT_SYMBOL: unique symbol = Symbol('emit');
+
+const JS_EXTENSION_REGEX: RegExp = /\.js(\.map)?$/;
+
+function wrapWriteFile(
+  this: void,
+  baseWriteFile: TTypescript.WriteFileCallback,
+  jsExtensionOverride: string | undefined
+): TTypescript.WriteFileCallback {
+  if (!jsExtensionOverride) {
+    return baseWriteFile;
+  }
+
+  const replacementExtension: string = `${jsExtensionOverride}$1`;
+  return (
+    fileName: string,
+    data: string,
+    writeBOM: boolean,
+    onError?: ((message: string) => void) | undefined,
+    sourceFiles?: readonly TTypescript.SourceFile[] | undefined
+  ) => {
+    return baseWriteFile(
+      fileName.replace(JS_EXTENSION_REGEX, replacementExtension),
+      data,
+      writeBOM,
+      onError,
+      sourceFiles
+    );
+  };
+}
+
+export function configureProgramForMultiEmit(
+  this: void,
+  innerProgram: TTypescript.Program,
+  ts: ExtendedTypeScript,
+  moduleKindsToEmit: ICachedEmitModuleKind[],
+  mode: 'transpile' | 'declaration' | 'both'
+): { changedFiles: Set<TTypescript.SourceFile> } {
+  interface IProgramWithMultiEmit extends TTypescript.Program {
+    // Attach the originals to the Program instance to avoid modifying the same Program twice.
+    // Don't use WeakMap because this Program could theoretically get a { ... } applied to it.
+    [INNER_GET_COMPILER_OPTIONS_SYMBOL]?: TTypescript.Program['getCompilerOptions'];
+    [INNER_EMIT_SYMBOL]?: TTypescript.Program['emit'];
+  }
+
+  const program: IProgramWithMultiEmit = innerProgram;
+
+  // Check to see if this Program has already been modified.
+  let { [INNER_EMIT_SYMBOL]: innerEmit, [INNER_GET_COMPILER_OPTIONS_SYMBOL]: innerGetCompilerOptions } =
+    program;
+
+  if (!innerGetCompilerOptions) {
+    program[INNER_GET_COMPILER_OPTIONS_SYMBOL] = innerGetCompilerOptions = program.getCompilerOptions;
+  }
+
+  if (!innerEmit) {
+    program[INNER_EMIT_SYMBOL] = innerEmit = program.emit;
+  }
+
+  let foundPrimary: boolean = false;
+  let defaultModuleKind: TTypescript.ModuleKind;
+
+  const multiEmitMap: Map<ICachedEmitModuleKind, TTypescript.CompilerOptions> = new Map();
+  for (const moduleKindToEmit of moduleKindsToEmit) {
+    const kindCompilerOptions: TTypescript.CompilerOptions = moduleKindToEmit.isPrimary
+      ? {
+          ...innerGetCompilerOptions()
+        }
+      : {
+          ...innerGetCompilerOptions(),
+          module: moduleKindToEmit.moduleKind,
+          outDir: moduleKindToEmit.outFolderPath,
+
+          // Don't emit declarations for secondary module kinds
+          declaration: false,
+          declarationMap: false
+        };
+    if (!kindCompilerOptions.outDir) {
+      throw new InternalError('Expected compilerOptions.outDir to be assigned');
+    }
+    if (mode === 'transpile') {
+      kindCompilerOptions.declaration = false;
+      kindCompilerOptions.declarationMap = false;
+    } else if (mode === 'declaration') {
+      kindCompilerOptions.emitDeclarationOnly = true;
+    }
+
+    if (moduleKindToEmit.isPrimary || mode !== 'declaration') {
+      multiEmitMap.set(moduleKindToEmit, kindCompilerOptions);
+    }
+
+    if (moduleKindToEmit.isPrimary) {
+      if (foundPrimary) {
+        throw new Error('Multiple primary module emit kinds encountered.');
+      } else {
+        foundPrimary = true;
+      }
+
+      defaultModuleKind = moduleKindToEmit.moduleKind;
+    }
+  }
+
+  const changedFiles: Set<TTypescript.SourceFile> = new Set();
+
+  program.emit = (
+    targetSourceFile?: TTypescript.SourceFile,
+    writeFile?: TTypescript.WriteFileCallback,
+    cancellationToken?: TTypescript.CancellationToken,
+    emitOnlyDtsFiles?: boolean,
+    customTransformers?: TTypescript.CustomTransformers
+  ) => {
+    if (emitOnlyDtsFiles) {
+      return program[INNER_EMIT_SYMBOL]!(
+        targetSourceFile,
+        writeFile,
+        cancellationToken,
+        emitOnlyDtsFiles,
+        customTransformers
+      );
+    }
+
+    if (targetSourceFile && changedFiles) {
+      changedFiles.add(targetSourceFile);
+    }
+
+    const originalCompilerOptions: TTypescript.CompilerOptions =
+      program[INNER_GET_COMPILER_OPTIONS_SYMBOL]!();
+
+    let defaultModuleKindResult: TTypescript.EmitResult;
+    const diagnostics: TTypescript.Diagnostic[] = [];
+    let emitSkipped: boolean = false;
+    try {
+      for (const [moduleKindToEmit, kindCompilerOptions] of multiEmitMap) {
+        program.getCompilerOptions = () => kindCompilerOptions;
+        // Need to mutate the compiler options for the `module` field specifically, because emitWorker() captures
+        // options in the closure and passes it to `ts.getTransformers()`
+        originalCompilerOptions.module = moduleKindToEmit.moduleKind;
+        const flavorResult: TTypescript.EmitResult = program[INNER_EMIT_SYMBOL]!(
+          targetSourceFile,
+          writeFile && wrapWriteFile(writeFile, moduleKindToEmit.jsExtensionOverride),
+          cancellationToken,
+          emitOnlyDtsFiles,
+          customTransformers
+        );
+
+        emitSkipped = emitSkipped || flavorResult.emitSkipped;
+        // Need to aggregate diagnostics because some are impacted by the target module type
+        for (const diagnostic of flavorResult.diagnostics) {
+          diagnostics.push(diagnostic);
+        }
+
+        if (moduleKindToEmit.moduleKind === defaultModuleKind) {
+          defaultModuleKindResult = flavorResult;
+        }
+      }
+
+      const mergedDiagnostics: readonly TTypescript.Diagnostic[] =
+        ts.sortAndDeduplicateDiagnostics(diagnostics);
+
+      return {
+        ...defaultModuleKindResult!,
+        changedSourceFiles: changedFiles,
+        diagnostics: mergedDiagnostics,
+        emitSkipped
+      };
+    } finally {
+      // Restore the original compiler options and module kind for future calls
+      program.getCompilerOptions = program[INNER_GET_COMPILER_OPTIONS_SYMBOL]!;
+      originalCompilerOptions.module = defaultModuleKind;
+    }
+  };
+  return { changedFiles };
+}

--- a/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
+++ b/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
@@ -45,6 +45,14 @@ export interface IExtendedTypeScript {
     getCount(measureName: string): number;
   };
 
+  transpileOptionValueCompilerOptions: {
+    name: keyof TTypescript.CompilerOptions;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    transpileOptionValue: any;
+  }[];
+
+  getNewLineCharacter(compilerOptions: TTypescript.CompilerOptions): string;
+
   /**
    * https://github.com/microsoft/TypeScript/blob/782c09d783e006a697b4ba6d1e7ec2f718ce8393/src/compiler/utilities.ts#L6540
    */

--- a/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
+++ b/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
@@ -52,6 +52,11 @@
       "type": "boolean"
     },
 
+    "useTranspilerWorker": {
+      "description": "If true, and the tsconfig has \"isolatedModules\": true, then transpilation will happen in parallel in a worker thread.",
+      "type": "boolean"
+    },
+
     "project": {
       "description": "Specifies the tsconfig.json file that will be used for compilation. Equivalent to the \"project\" argument for the 'tsc' and 'tslint' command line tools. The default value is \"./tsconfig.json\".",
       "type": "string"

--- a/heft-plugins/heft-typescript-plugin/src/types.ts
+++ b/heft-plugins/heft-typescript-plugin/src/types.ts
@@ -1,0 +1,50 @@
+import type * as TTypescript from 'typescript';
+
+export interface ITypescriptWorkerData {
+  /**
+   * Path to the version of TypeScript to use.
+   */
+  typeScriptToolPath: string;
+}
+
+export interface ITranspilationRequestMessage {
+  /**
+   * Unique identifier for this request.
+   */
+  requestId: number;
+  /**
+   * The tsconfig compiler options to use for the request.
+   */
+  compilerOptions: TTypescript.CompilerOptions;
+  /**
+   * The variants to emit.
+   */
+  moduleKindsToEmit: ICachedEmitModuleKind[];
+  /**
+   * The set of files to build.
+   */
+  fileNames: string[];
+}
+
+export interface ITranspilationResponseMessage {
+  requestId: number;
+  result: TTypescript.EmitResult;
+}
+
+export interface ICachedEmitModuleKind {
+  moduleKind: TTypescript.ModuleKind;
+
+  outFolderPath: string;
+
+  /**
+   * File extension to use instead of '.js' for emitted ECMAScript files.
+   * For example, '.cjs' to indicate commonjs content, or '.mjs' to indicate ECMAScript modules.
+   */
+  jsExtensionOverride: string | undefined;
+
+  /**
+   * Set to true if this is the emit kind that is specified in the tsconfig.json.
+   * Declarations are only emitted for the primary module kind.
+   */
+  isPrimary: boolean;
+}

--- a/heft-plugins/heft-typescript-plugin/src/types.ts
+++ b/heft-plugins/heft-typescript-plugin/src/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 import type * as TTypescript from 'typescript';
 
 export interface ITypescriptWorkerData {

--- a/heft-plugins/heft-typescript-plugin/src/types.ts
+++ b/heft-plugins/heft-typescript-plugin/src/types.ts
@@ -26,10 +26,22 @@ export interface ITranspilationRequestMessage {
   fileNames: string[];
 }
 
-export interface ITranspilationResponseMessage {
+export interface ITranspilationSuccessMessage {
   requestId: number;
+  type: 'success';
   result: TTypescript.EmitResult;
 }
+
+export interface ITranspilationErrorMessage {
+  requestId: number;
+  type: 'error';
+  result: {
+    message: string;
+    [key: string]: unknown;
+  };
+}
+
+export type ITranspilationResponseMessage = ITranspilationSuccessMessage | ITranspilationErrorMessage;
 
 export interface ICachedEmitModuleKind {
   moduleKind: TTypescript.ModuleKind;

--- a/heft-plugins/heft-typescript-plugin/tsconfig.json
+++ b/heft-plugins/heft-typescript-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "lib": ["ES2019"]
   }
 }


### PR DESCRIPTION
## Summary
Adds a new option in `typescript.json`, `useTranspilerWorker`, that if `true`, and the tsconfig has `isolatedModules: true`, will split transpilation into a worker thread and run it in parallel with the type checker.

## Details
If opted in and the tsconfig is compatible, will start a worker thread and hand it the list of changed source files and the emit options. Multi-emit then occurs only in the worker, since declaration files are only emitted for the primary module kind.

## How it was tested
Local runs on projects in various configurations. Still needs more testing against large projects with `isolatedModules: true` to determine if the performance is significantly improved.
Verified in both watch and non-watch mode.
Verified using project references.

## Impacted documentation
Documentation for `typescript.json`.