### PR TITLE
Add a test case for --allowArbitraryExtensions.

### DIFF
--- a/apps/api-extractor/src/api/ExtractorMessageId.ts
+++ b/apps/api-extractor/src/api/ExtractorMessageId.ts
@@ -100,6 +100,8 @@ export const enum ExtractorMessageId {
   /**
    * "Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension.
    * Troubleshooting tips: `https://api-extractor.com/link/dts-error`"
+   *
+   * Note that this is suppressed by the allowArbitraryExtensions TSConfig option
    */
   WrongInputFileType = 'ae-wrong-input-file-type'
 }

--- a/build-tests/api-extractor-test-04/build.js
+++ b/build-tests/api-extractor-test-04/build.js
@@ -19,6 +19,10 @@ fsx.emptyDirSync('temp');
 // Run the TypeScript compiler
 executeCommand('node node_modules/typescript/lib/tsc');
 
+// Copy the arbitraryExtensionModule.d.xyz.ts declaration file to lib
+console.log(`==> Copying arbitraryExtensionModule.d.xyz.ts to lib`);
+fsx.copySync('src/arbitraryExtensionModule.d.xyz.ts', 'lib/arbitraryExtensionModule.d.xyz.ts');
+
 // Run the API Extractor command-line
 if (process.argv.indexOf('--production') >= 0) {
   executeCommand('node node_modules/@microsoft/api-extractor/lib/start run');

--- a/build-tests/api-extractor-test-04/dist/api-extractor-test-04-alpha.d.ts
+++ b/build-tests/api-extractor-test-04/dist/api-extractor-test-04-alpha.d.ts
@@ -173,4 +173,9 @@ export declare enum RegularEnum {
  */
 export declare const variableDeclaration: string;
 
+/**
+ * @public
+ */
+export declare const variableFromArbitraryExtensionModule: string;
+
 export { }

--- a/build-tests/api-extractor-test-04/dist/api-extractor-test-04-beta.d.ts
+++ b/build-tests/api-extractor-test-04/dist/api-extractor-test-04-beta.d.ts
@@ -128,4 +128,9 @@ export declare enum RegularEnum {
  */
 export declare const variableDeclaration: string;
 
+/**
+ * @public
+ */
+export declare const variableFromArbitraryExtensionModule: string;
+
 export { }

--- a/build-tests/api-extractor-test-04/dist/api-extractor-test-04-public.d.ts
+++ b/build-tests/api-extractor-test-04/dist/api-extractor-test-04-public.d.ts
@@ -53,4 +53,9 @@ export declare class PublicClass {
 
 /* Excluded from this release type: variableDeclaration */
 
+/**
+ * @public
+ */
+export declare const variableFromArbitraryExtensionModule: string;
+
 export { }

--- a/build-tests/api-extractor-test-04/dist/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/api-extractor-test-04.d.ts
@@ -233,4 +233,9 @@ export declare enum RegularEnum {
  */
 export declare const variableDeclaration: string;
 
+/**
+ * @public
+ */
+export declare const variableFromArbitraryExtensionModule: string;
+
 export { }

--- a/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
+++ b/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
@@ -110,5 +110,7 @@ export enum RegularEnum {
 // @beta
 export const variableDeclaration: string;
 
+// @public (undocumented)
+export const variableFromArbitraryExtensionModule: string;
 
 ```

--- a/build-tests/api-extractor-test-04/src/arbitraryExtensionModule.d.xyz.ts
+++ b/build-tests/api-extractor-test-04/src/arbitraryExtensionModule.d.xyz.ts
@@ -1,0 +1,4 @@
+/**
+ * @public
+ */
+export declare const variableFromArbitraryExtensionModule: string;

--- a/build-tests/api-extractor-test-04/src/index.ts
+++ b/build-tests/api-extractor-test-04/src/index.ts
@@ -35,4 +35,6 @@ export type ExportedAlias = AlphaClass;
 
 export { IPublicComplexInterface } from './IPublicComplexInterface';
 
+export { variableFromArbitraryExtensionModule } from './arbitraryExtensionModule.xyz';
+
 export { Lib1Interface } from 'api-extractor-lib1-test';

--- a/build-tests/api-extractor-test-04/tsconfig.json
+++ b/build-tests/api-extractor-test-04/tsconfig.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "types": [],
     "lib": ["es5", "scripthost", "es2015.collection", "es2015.promise", "es2015.iterable", "dom"],
-    "outDir": "lib"
+    "outDir": "lib",
+    "allowArbitraryExtensions": true
   },
-  "include": ["src/**/*.ts", "typings/tsd.d.ts"]
+  "include": ["src/**/*.ts", "typings/tsd.d.ts", "src/AlphaClass.tsz"]
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/rushstack/pull/4103, testing https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#supporting-multiple-configuration-files-in-extends.

This feature is currently broken, and need to be fixed in API Extractor.