### PR TITLE
[rush-lib] Expose beforeLog hook to augment/modify telemetry logs

### DIFF
--- a/common/changes/@microsoft/rush/feature-custom-hooks-log-telemetry_2023-05-23-19-53.json
+++ b/common/changes/@microsoft/rush/feature-custom-hooks-log-telemetry_2023-05-23-19-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Expose beforeLog hook",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -755,6 +755,7 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
 export class PhasedCommandHooks {
     readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]>;
     readonly beforeExecuteOperations: AsyncSeriesHook<[Map<Operation, IOperationExecutionResult>]>;
+    readonly beforeLog: SyncHook<ITelemetryData, void>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
     readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]>;
     readonly waitingForChanges: SyncHook<void>;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -36,7 +36,7 @@ import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
 import { OperationStatus } from '../../logic/operations/OperationStatus';
 import { IExecutionResult } from '../../logic/operations/IOperationExecutionResult';
 import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
-import type { ITelemetryOperationResult } from '../../logic/Telemetry';
+import type { ITelemetryData, ITelemetryOperationResult } from '../../logic/Telemetry';
 import { parseParallelism } from '../parsing/ParseParallelism';
 
 /**
@@ -633,13 +633,17 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         }
       }
 
-      this.parser.telemetry.log({
+      const logEntry: ITelemetryData = {
         name: this.actionName,
         durationInSeconds: stopwatch.duration,
         result: success ? 'Succeeded' : 'Failed',
         extraData,
         operationResults
-      });
+      };
+
+      this.hooks.beforeLog.call(logEntry);
+
+      this.parser.telemetry.log(logEntry);
 
       this.parser.flushTelemetry();
     }

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -11,6 +11,7 @@ import type { RushConfigurationProject } from '../api/RushConfigurationProject';
 
 import type { Operation } from '../logic/operations/Operation';
 import type { ProjectChangeAnalyzer } from '../logic/ProjectChangeAnalyzer';
+import { ITelemetryData } from '../logic/Telemetry';
 import { IExecutionResult, IOperationExecutionResult } from '../logic/operations/IOperationExecutionResult';
 
 /**
@@ -114,4 +115,10 @@ export class PhasedCommandHooks {
    * Only relevant when running in watch mode.
    */
   public readonly waitingForChanges: SyncHook<void> = new SyncHook(undefined, 'waitingForChanges');
+
+  /**
+   * Hook invoked after executing operations and before waitingForChanges. Allows the caller
+   * to augment or modify the log entry about to be written.
+   */
+  public readonly beforeLog: SyncHook<ITelemetryData, void> = new SyncHook(['telemetryData'], 'beforeLog');
 }


### PR DESCRIPTION
## Summary
Exposes a _beforeLog_ hook that can be used to modify the telemetry object before it gets written in the temporary telemetry folder. This allows plugin writers to add custom fields in the telemetry.

## How it was tested
Manual tests where a custom Rush plugin was created and attached to the _beforeLog_ hook to add more data to the telemetry payload.
