### PR TITLE
[node-core-library] Remove extra JsonFile encode

### DIFF
--- a/common/changes/@rushstack/node-core-library/json-file-redundant-encode_2023-05-26-23-54.json
+++ b/common/changes/@rushstack/node-core-library/json-file-redundant-encode_2023-05-26-23-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Remove extraneous string encode/decode of final output during `JsonFile.save`/`JsonFile.saveAsync`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -422,7 +422,7 @@ export class JsonFile {
       }
     }
 
-    FileSystem.writeFile(jsonFilename, newBuffer.toString(DEFAULT_ENCODING), {
+    FileSystem.writeFile(jsonFilename, newBuffer, {
       ensureFolderExists: options.ensureFolderExists
     });
 
@@ -480,7 +480,7 @@ export class JsonFile {
       }
     }
 
-    await FileSystem.writeFileAsync(jsonFilename, newBuffer.toString(DEFAULT_ENCODING), {
+    await FileSystem.writeFileAsync(jsonFilename, newBuffer, {
       ensureFolderExists: options.ensureFolderExists
     });
 


### PR DESCRIPTION
## Summary
Removes a useless `Buffer -> String -> Buffer` conversion during `JsonFile.save` and `JsonFile.saveAsync`.

## Details
For large JSON files this can save a decent chunk of time during serialization.

## How it was tested
Locally used JsonFile.save and JsonFile.saveAsync to write files and validated the output is correctly encoded.

## Impacted documentation
None