### PR TITLE
[rush] Use JSON.parse for package.json

### DIFF
--- a/common/changes/@microsoft/rush/rush-boot-parse-perf_2023-05-30-17-40.json
+++ b/common/changes/@microsoft/rush/rush-boot-parse-perf_2023-05-30-17-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use `JSON.parse` instead of `jju` to parse `package.json` files for faster performance.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import * as semver from 'semver';
-import { JsonFile, IPackageJson, FileSystem, FileConstants, JsonSyntax } from '@rushstack/node-core-library';
+import { IPackageJson, FileSystem, FileConstants } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { VersionPolicy, LockStepVersionPolicy } from './VersionPolicy';
@@ -212,7 +212,9 @@ export class RushConfigurationProject {
     const packageJsonFilename: string = path.join(this.projectFolder, FileConstants.PackageJson);
 
     try {
-      this._packageJson = JsonFile.load(packageJsonFilename, { jsonSyntax: JsonSyntax.Strict });
+      const packageJsonText: string = FileSystem.readFile(packageJsonFilename);
+      // JSON.parse is native and runs in less than 1/2 the time of jju.parse. package.json is required to be strict JSON by NodeJS.
+      this._packageJson = JSON.parse(packageJsonText);
     } catch (error) {
       if (FileSystem.isNotExistError(error as Error)) {
         throw new Error(


### PR DESCRIPTION
## Summary
Since `package.json` files are required by NodeJS to be strict JSON, switches parsing in `RushConfigurationProject` from `jju.parse` to `JSON.parse` to improve performance.

## Details

## How it was tested
Compared CPU profiles of with and without the change when running `rush list`. With the change reduced the time spent initializing `RushConfigurationProject` instances by roughly 50%.

## Impacted documentation
Not a behavior change, so none.