### PR TITLE
[ci.yml, rush.json] Add Node 18, drop Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        NodeVersion: [16, 18, 20]
+        NodeVersion: [16, 18]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        NodeVersion: [14, 16]
+        NodeVersion: [16, 18, 20]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.16.0 <19.0.0 || >=20.2.0 <21.0.0",
+  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0 || >=18.16.0 <19.0.0 || >=20.2.0 <21.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.16.0 <19.0.0 || >=20.2.0 <21.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0 || >=18.16.0 <19.0.0 || >=20.2.0 <21.0.0",
+  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0 || >=18.16.0 <19.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION
## Summary
* Add Node 18 to supported and tested versions
* Remove Node 14 since it is EOL
* Node 20 cannot be tested yet, since Node 20 is only supported by `pnpm@>=8.3.1` (https://github.com/pnpm/pnpm/issues/6424), so the rushstack repo would need to upgrade pnpm in `rush.json`

## How it was tested
The CI run for this PR should validate itself.

## Impacted documentation
None