### PR TITLE
[heft-typescript@next] Tune transpiler worker

### DIFF
--- a/heft-plugins/heft-typescript-plugin/src/types.ts
+++ b/heft-plugins/heft-typescript-plugin/src/types.ts
@@ -25,7 +25,7 @@ export interface ITranspilationRequestMessage {
   /**
    * The set of files to build.
    */
-  fileNames: string[];
+  filesToTranspile: Map<string, string>;
 }
 
 export interface ITranspilationSuccessMessage {


### PR DESCRIPTION
## Summary
Slight performance tuning of the transpiler worker (enabled by `useTranspilerWorker: true` in `typescript.json` when `isolatedModules: true` in `tsconfig`).

## Details
Passes the already-loaded source file text via postMessage instead of re-reading from disk.

## How it was tested
Running the built compiler against a fairly large internal project that has these options enabled and collecting CPU profiles.

## Impacted documentation
None, currently.