### PR TITLE
[heft-typescript] Trade perf for correctness in transpile worker

### DIFF
--- a/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
@@ -58,7 +58,12 @@ function runTranspiler(message: ITranspilationRequestMessage): ITranspilationSuc
 
   compilerOptions.suppressOutputPathCheck = true;
   compilerOptions.skipDefaultLibCheck = true;
-  compilerOptions.preserveValueImports = true;
+  // To fully disable the type checker, we have to set `hasNoDefaultLib: true` on every source file.
+  // However, doing so loses the information about which imports are used.
+  // To retain the imports, we use `preserveValueImports`. However, if some imports are only used for types,
+  // this will produce invalid runtime output unless said imports are marked with `type `.
+  // Thus we can only enable this optimization if `verbatimModuleSyntax` is enabled (or equivalent).
+  compilerOptions.preserveValueImports = fullySkipTypeCheck;
 
   const sourceFileByPath: Map<string, TTypescript.SourceFile> = new Map();
 


### PR DESCRIPTION
## Summary
If `verbatimModuleSyntax` is not enabled, the type checker needs to be run to determine which imports are used, or else the transpiler will produce invalid output.

## Details
Updates the set of options used in the case when `verbatimModuleSyntax` is disabled.

## How it was tested
Using the `heft-jest-reporters-test` project with the worker manually enabled and various tsconfig options.

## Impacted documentation
None, other than that it should be noted that `useTranspilerWorker` should really only be enabled if `verbatimModuleSyntax` and `isolatedModules` are both `true`. If the latter is false, it does nothing; if the former is false, it might not save any appreciable amount of time.

On inspection, even without the optimal fast path, it can still be faster to use the worker, just not as fast as it could be.