### PR TITLE
[heft-next] Documentation / Config polish

### DIFF
--- a/apps/heft/UPGRADING.md
+++ b/apps/heft/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrade notes for @rushstack/heft
 
-### Heft 0.50.0-rc.4
+### Heft 0.51.0
 
 Multi-phase Heft is a complete re-write of the `@rushstack/heft` project with the intention of being more closely compatible with multi-phase Rush builds. In addition, this update brings greater customizability and improved parallel process handling to Heft.
 
@@ -89,7 +89,7 @@ Lifecycle plugins are specified in the top-level `heftPlugins` array. Plugins ca
 ##### Phase, Task, and Task Plugin Specification
 All phases are defined within the top-level `phasesByName` property. Each phase may specify `phaseDependencies` to define the order of phase execution when running a selection of Heft phases. Phases may also provide the `cleanFiles` option, which accepts an array of deletion operations to perform when running with the `--clean` flag.
 
-Within the phase specification, `tasksByName` defines all tasks that run while executing a phase. Each task may specify `taskDependencies` to define the order of task execution. All tasks defined in `taskDependencies` must exist within the same phase. For CLI-availability reasons, phase names, task names, plugin names, and parameter scopes, must be `kabob-cased`.
+Within the phase specification, `tasksByName` defines all tasks that run while executing a phase. Each task may specify `taskDependencies` to define the order of task execution. All tasks defined in `taskDependencies` must exist within the same phase. For CLI-availability reasons, phase names, task names, plugin names, and parameter scopes, must be `kebab-cased`.
 
 The following is an example "heft.json" file defining both a "build" and a "test" phase:
 ```json
@@ -322,30 +322,26 @@ In updating to the new version of Heft, plugins will also need to be updated for
 - Path-related variables have been renamed to clarify they are paths (ex. `HeftConfiguration.buildFolder` is now `HeftConfiguration.buildFolderPath`)
 - The `runIncremental` hook can now be utilized to add ensure that watch mode rebuilds occur in proper dependency order
 - The `clean` hook was removed in favor of the `cleanFiles` option in "heft.json" in order to make it obvious what files are being cleaned and when
-- The `folderNameForTests` and `extensionForTests` properties are now specified in the `@rushstack/heft-jest-plugin` options in "heft.json" instead of in "typescript.json"
+- The `folderNameForTests` and `extensionForTests` properties have been removed and should instead be addressed via the `testMatch` property in `jest.config.json`
 
 #### Testing on Your Own Project
 The new version of Heft and all related plugins are available in the following prerelease packages:
-- `@rushstack/heft@0.49.0-rc.1`
-- `@rushstack/heft-typescript-plugin@0.1.0-rc.1`
-- `@rushstack/heft-lint-plugin@0.1.0-rc.1`
-- `@rushstack/heft-api-extractor-plugin@0.1.0-rc.1`
-- `@rushstack/heft-jest-plugin@0.4.0-rc.1`
-- `@rushstack/heft-sass-plugin@0.8.0-rc.1`
-- `@rushstack/heft-storybook-plugin@0.2.0-rc.1`
-- `@rushstack/heft-webpack4-plugin@0.6.0-rc.1`
-- `@rushstack/heft-webpack5-plugin@0.6.0-rc.1`
-- `@rushstack/heft-dev-cert-plugin@0.3.0-rc.1`
+- `@rushstack/heft@0.51.0-rc.6`
+- `@rushstack/heft-typescript-plugin@0.2.0-rc.6`
+- `@rushstack/heft-lint-plugin@0.2.0-rc.6`
+- `@rushstack/heft-api-extractor-plugin@0.2.0-rc.6`
+- `@rushstack/heft-jest-plugin@0.6.0-rc.6`
+- `@rushstack/heft-sass-plugin@0.10.0-rc.6`
+- `@rushstack/heft-storybook-plugin@0.3.0-rc.6`
+- `@rushstack/heft-webpack4-plugin@0.6.0-rc.6`
+- `@rushstack/heft-webpack5-plugin@0.7.0-rc.6`
+- `@rushstack/heft-dev-cert-plugin@0.3.0-rc.6`
 
 Additionally, Rushstack-provided rigs have been updated to be compatible with the new version of Heft:
-- `@rushstack/heft-node-rig@1.12.0-rc.0`
-- `@rushstack/heft-web-rig@0.13.0-rc.0`
+- `@rushstack/heft-node-rig@1.14.0-rc.6`
+- `@rushstack/heft-web-rig@0.16.0-rc.6`
 
 If you have any issues with the prerelease packages or the new changes to Heft, please [file an issue](https://github.com/microsoft/rushstack/issues/new?assignees=&labels=&template=heft.md&title=%5Bheft%2Frc%2f0%5D+).
-
-#### Known Issues
-- TypeScript solution mode is not supported in watch mode
-- TypeScript plugin copies all static assets when in watch mode
 
 ### Heft 0.35.0
 

--- a/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
@@ -46,10 +46,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests-samples/heft-storybook-react-tutorial/config/typescript.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/typescript.json
@@ -27,12 +27,6 @@
   ],
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {

--- a/build-tests-samples/heft-webpack-basic-tutorial/config/heft.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/config/heft.json
@@ -34,10 +34,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests-samples/heft-webpack-basic-tutorial/config/typescript.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/config/typescript.json
@@ -27,12 +27,6 @@
   ],
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {

--- a/build-tests/heft-jest-preset-test/config/jest.config.json
+++ b/build-tests/heft-jest-preset-test/config/jest.config.json
@@ -62,7 +62,7 @@
 
   // The modulePathIgnorePatterns below accepts these sorts of paths:
   //   - <rootDir>/lib
-  //   - <rootDir>/lib/file.ts
+  //   - <rootDir>/lib/file.js
   // ...and ignores anything else under <rootDir>
   "modulePathIgnorePatterns": [],
 

--- a/build-tests/heft-jest-preset-test/config/typescript.json
+++ b/build-tests/heft-jest-preset-test/config/typescript.json
@@ -23,7 +23,7 @@
   ],
 
   /**
-   * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   * If true, emit CommonJS module output to the folder specified in the tsconfig "outDir" compiler option with the .cjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   "emitCjsExtensionForCommonJS": true,
 
@@ -31,12 +31,6 @@
    * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   // "emitMjsExtensionForESModule": true,
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
 
   /**
    * Describes the way files should be statically coped from src to TS output folders

--- a/build-tests/heft-jest-reporters-test/config/typescript.json
+++ b/build-tests/heft-jest-reporters-test/config/typescript.json
@@ -23,7 +23,7 @@
   ],
 
   /**
-   * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
+   * If true, emit CommonJS module output to the folder specified in the tsconfig "outDir" compiler option with the .cjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   "emitCjsExtensionForCommonJS": true,
 
@@ -31,12 +31,6 @@
    * If true, emit ESNext module output to the folder specified in the tsconfig "outDir" compiler option with the .mjs extension alongside (or instead of, if TSConfig specifies ESNext) the default compilation output.
    */
   // "emitMjsExtensionForESModule": true,
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
 
   /**
    * Describes the way files should be statically coped from src to TS output folders

--- a/build-tests/heft-minimal-rig-test/profiles/default/config/heft.json
+++ b/build-tests/heft-minimal-rig-test/profiles/default/config/heft.json
@@ -31,10 +31,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests/heft-minimal-rig-test/profiles/default/config/typescript.json
+++ b/build-tests/heft-minimal-rig-test/profiles/default/config/typescript.json
@@ -14,10 +14,4 @@
       "outFolderName": "lib-commonjs"
     }
   ]
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-node-everything-esm-module-test/config/typescript.json
+++ b/build-tests/heft-node-everything-esm-module-test/config/typescript.json
@@ -22,10 +22,4 @@
   "staticAssetsToCopy": {
     "fileExtensions": [".txt"]
   }
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-node-everything-test/config/typescript.json
+++ b/build-tests/heft-node-everything-test/config/typescript.json
@@ -22,10 +22,4 @@
   "staticAssetsToCopy": {
     "fileExtensions": [".txt"]
   }
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-sass-test/config/heft.json
+++ b/build-tests/heft-sass-test/config/heft.json
@@ -40,10 +40,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests/heft-sass-test/config/typescript.json
+++ b/build-tests/heft-sass-test/config/typescript.json
@@ -27,12 +27,6 @@
   ],
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {

--- a/build-tests/heft-typescript-composite-test/config/heft.json
+++ b/build-tests/heft-typescript-composite-test/config/heft.json
@@ -28,10 +28,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "extensionForTests": ".cjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests/heft-typescript-composite-test/config/typescript.json
+++ b/build-tests/heft-typescript-composite-test/config/typescript.json
@@ -17,12 +17,6 @@
   "project": "./tsconfig.json",
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {

--- a/build-tests/heft-typescript-v2-test/config/typescript.json
+++ b/build-tests/heft-typescript-v2-test/config/typescript.json
@@ -18,10 +18,4 @@
       "outFolderName": "lib-umd"
     }
   ]
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-typescript-v3-test/config/typescript.json
+++ b/build-tests/heft-typescript-v3-test/config/typescript.json
@@ -18,10 +18,4 @@
       "outFolderName": "lib-umd"
     }
   ]
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-typescript-v4-test/config/typescript.json
+++ b/build-tests/heft-typescript-v4-test/config/typescript.json
@@ -18,10 +18,4 @@
       "outFolderName": "lib-umd"
     }
   ]
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/build-tests/heft-webpack4-everything-test/config/heft.json
+++ b/build-tests/heft-webpack4-everything-test/config/heft.json
@@ -34,10 +34,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests/heft-webpack4-everything-test/config/typescript.json
+++ b/build-tests/heft-webpack4-everything-test/config/typescript.json
@@ -27,12 +27,6 @@
   ],
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {
@@ -57,5 +51,8 @@
     // ]
   },
 
+  /**
+   * If true and "isolatedModules" is configured in tsconfig.json, use a worker thread to run transpilation concurrently with type checking and declaration emit.
+   */
   "useTranspilerWorker": true
 }

--- a/build-tests/heft-webpack5-everything-test/config/heft.json
+++ b/build-tests/heft-webpack5-everything-test/config/heft.json
@@ -34,10 +34,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/build-tests/heft-webpack5-everything-test/config/typescript.json
+++ b/build-tests/heft-webpack5-everything-test/config/typescript.json
@@ -27,12 +27,6 @@
   ],
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50,
-
-  /**
    * Describes the way files should be statically coped from src to TS output folders
    */
   "staticAssetsToCopy": {

--- a/common/reviews/api/heft-typescript-plugin.api.md
+++ b/common/reviews/api/heft-typescript-plugin.api.md
@@ -55,7 +55,6 @@ export interface ITypeScriptConfigurationJson {
     buildProjectReferences?: boolean;
     emitCjsExtensionForCommonJS?: boolean | undefined;
     emitMjsExtensionForESModule?: boolean | undefined;
-    maxWriteParallelism?: number;
     // (undocumented)
     project?: string;
     staticAssetsToCopy?: IStaticAssetsCopyConfiguration;

--- a/heft-plugins/heft-jest-plugin/UPGRADING.md
+++ b/heft-plugins/heft-jest-plugin/UPGRADING.md
@@ -1,6 +1,8 @@
 # Upgrade notes for @rushstack/heft-jest-plugin
 
-### Version 0.6.0-rc.4
+### Version 0.6.0
+BREAKING CHANGE: The `testFiles` option in `config/jest.config.json` should now specify the path to compiled CommonJS files, *not* TypeScript source files. Snapshot resolution depends on the presence of source maps in the output folder.
+
 This release of `heft-jest-plugin` switched from using Jest's transformer infrastructure and pointing at TypeScript source files to instead directly point Jest at the compiled output files, relying on source maps to redirect snapshot files back to the committed source folder. If no source maps are present, the plugin will assume that the project is authored in raw ECMAScript and expect to find snapshots in a `__snapshots__` folder directly alongside the test files.
 
 ### Version 0.3.0

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -100,10 +100,7 @@ export interface IJestPluginOptions {
   detectOpenHandles?: boolean;
   disableCodeCoverage?: boolean;
   disableConfigurationModuleResolution?: boolean;
-  extensionForTests?: '.js' | '.cjs' | '.mjs';
   findRelatedTests?: string[];
-  folderNameForTests?: string;
-  folderNameForSnapshots?: string;
   maxWorkers?: string;
   passWithNoTests?: boolean;
   silent?: boolean;

--- a/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
+++ b/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
@@ -11,25 +11,6 @@
       "title": "Disable Configuration Module Resolution",
       "description": "If set to true, modules specified in the Jest configuration will be resolved using Jest default (rootDir-relative) resolution. Otherwise, modules will be resolved using Node module resolution.",
       "type": "boolean"
-    },
-
-    "extensionForTests": {
-      "title": "File Extension For Tests",
-      "description": "Specifies the file extension for tests located in the \"folderNameForTests\".  Because Jest uses the Node.js runtime to execute tests, the module format contained must be CommonJS. The default value is \".js\".",
-      "pattern": "^\\.(c|m)?js$",
-      "type": "string"
-    },
-
-    "folderNameForTests": {
-      "title": "Folder Name For Tests",
-      "description": "Specifies the intermediary folder that tests will use.  Because Jest uses the Node.js runtime to execute tests, the module format must be CommonJS. The default value is \"lib\".",
-      "type": "string"
-    },
-
-    "folderNameForSnapshots": {
-      "title": "Folder Name For Snapshots",
-      "description": "Specifies the source folder where snapshots are committed to. This is used along with \"folderNameForTests\" when watching for changes to identify the relevant test for a snapshot. The default value is \"src\".",
-      "type": "string"
     }
   }
 }

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -45,12 +45,6 @@ export interface ITypeScriptBuilderConfiguration extends ITypeScriptConfiguratio
   tsconfigPath: string;
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  maxWriteParallelism: number;
-
-  /**
    * The scoped logger that the builder will log to.
    */
   scopedLogger: IScopedLogger;

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -87,12 +87,6 @@ export interface ITypeScriptConfigurationJson {
    * so that these files can be resolved by import statements.
    */
   staticAssetsToCopy?: IStaticAssetsCopyConfiguration;
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  maxWriteParallelism?: number;
 }
 
 /**
@@ -374,8 +368,6 @@ export default class TypeScriptPlugin implements IHeftTaskPlugin {
       additionalModuleKindsToEmit: typeScriptConfigurationJson?.additionalModuleKindsToEmit,
       emitCjsExtensionForCommonJS: !!typeScriptConfigurationJson?.emitCjsExtensionForCommonJS,
       emitMjsExtensionForESModule: !!typeScriptConfigurationJson?.emitMjsExtensionForESModule,
-      // watchMode: watchMode,
-      maxWriteParallelism: typeScriptConfigurationJson?.maxWriteParallelism || 50,
       scopedLogger: taskSession.logger,
       emitChangedFilesCallback: (
         program: TTypescript.Program,

--- a/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
+++ b/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
@@ -62,11 +62,6 @@
       "type": "string"
     },
 
-    "maxWriteParallelism": {
-      "description": "Set this to change the maximum write parallelism. The default is 50.",
-      "type": "number"
-    },
-
     "staticAssetsToCopy": {
       "description": "Configures additional file types that should be copied into the TypeScript compiler's emit folders, for example so that these files can be resolved by import statements.",
       "type": "object",

--- a/libraries/load-themed-styles/config/typescript.json
+++ b/libraries/load-themed-styles/config/typescript.json
@@ -30,10 +30,4 @@
       "outFolderName": "lib-es6"
     }
   ]
-
-  /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
-   */
-  // "maxWriteParallelism": 50
 }

--- a/libraries/rush-lib/config/heft.json
+++ b/libraries/rush-lib/config/heft.json
@@ -51,18 +51,6 @@
           }
         }
       }
-    },
-
-    "test": {
-      "tasksByName": {
-        "jest": {
-          "taskPlugin": {
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/rigs/heft-node-rig/profiles/default/config/typescript.json
+++ b/rigs/heft-node-rig/profiles/default/config/typescript.json
@@ -39,10 +39,9 @@
   // "emitMjsExtensionForESModule": true,
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
+   * If true and "isolatedModules" is configured in tsconfig.json, use a worker thread to run transpilation concurrently with type checking and declaration emit.
    */
-  // "maxWriteParallelism": 50,
+  // "useTranspilerWorker": true
 
   /**
    * Configures additional file types that should be copied into the TypeScript compiler's emit folders, for example

--- a/rigs/heft-web-rig/profiles/app/config/heft.json
+++ b/rigs/heft-web-rig/profiles/app/config/heft.json
@@ -58,10 +58,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/rigs/heft-web-rig/profiles/app/config/typescript.json
+++ b/rigs/heft-web-rig/profiles/app/config/typescript.json
@@ -44,10 +44,9 @@
   // "emitMjsExtensionForESModule": true,
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
+   * If true and "isolatedModules" is configured in tsconfig.json, use a worker thread to run transpilation concurrently with type checking and declaration emit.
    */
-  // "maxWriteParallelism": 50,
+  // "useTranspilerWorker": true
 
   /**
    * Configures additional file types that should be copied into the TypeScript compiler's emit folders, for example

--- a/rigs/heft-web-rig/profiles/library/config/heft.json
+++ b/rigs/heft-web-rig/profiles/library/config/heft.json
@@ -58,10 +58,7 @@
       "tasksByName": {
         "jest": {
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-jest-plugin",
-            "options": {
-              "folderNameForTests": "lib-commonjs"
-            }
+            "pluginPackage": "@rushstack/heft-jest-plugin"
           }
         }
       }

--- a/rigs/heft-web-rig/profiles/library/config/typescript.json
+++ b/rigs/heft-web-rig/profiles/library/config/typescript.json
@@ -44,10 +44,9 @@
   // "emitMjsExtensionForESModule": true,
 
   /**
-   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
-   * The default is 50.
+   * If true and "isolatedModules" is configured in tsconfig.json, use a worker thread to run transpilation concurrently with type checking and declaration emit.
    */
-  // "maxWriteParallelism": 50,
+  // "useTranspilerWorker": true
 
   /**
    * Configures additional file types that should be copied into the TypeScript compiler's emit folders, for example


### PR DESCRIPTION
## Summary
Removes various config options that are no longer used for anything from both the plugins and all existing config files.
Updates migration docs.

## Details
`heft-jest-plugin` - Removes the `folderNameForTests`, `folderNameForSnapshots`, and `extensionForTests` options. Updates upgrading.md to be clearer about what changed.
`heft-typescript-plugin` - Removes the `maxWriteParallelism` field, since writes are back to being synchronous. Added some information about the new `useTranspilerWorker` field.

## How it was tested
Built/tested to confirm that no additional changes occurred.

## Impacted documentation
Heft plugin documentation.
