### PR TITLE
[rush-amazon-s3-build-cache-plugin] Read credentials from common AWS_* env vars

### DIFF
--- a/common/changes/@microsoft/rush/s3-build-cache-read-aws-creds_2023-06-02-00-43.json
+++ b/common/changes/@microsoft/rush/s3-build-cache-read-aws-creds_2023-06-02-00-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "[rush-amazon-s3-build-cache-plugin] Read credentials from common AWS_* env vars.",
+      "comment": "Add functionality for the Amazon S3 Build Cache Plugin to read credentials from common AWS_* environment variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/s3-build-cache-read-aws-creds_2023-06-02-00-43.json
+++ b/common/changes/@microsoft/rush/s3-build-cache-read-aws-creds_2023-06-02-00-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-amazon-s3-build-cache-plugin] Read credentials from common AWS_* env vars.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3BuildCacheProvider.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3BuildCacheProvider.ts
@@ -98,7 +98,7 @@ export class AmazonS3BuildCacheProvider implements ICloudBuildCacheProvider {
 
   private async _getS3ClientAsync(terminal: ITerminal): Promise<AmazonS3Client> {
     if (!this.__s3Client) {
-      let credentials: IAmazonS3Credentials | undefined = fromAmazonEnv() ?? fromRushEnv();
+      let credentials: IAmazonS3Credentials | undefined = fromRushEnv() ?? fromAmazonEnv();
 
       if (!credentials) {
         terminal.writeDebugLine('No credentials found in env. Trying cloud credentials.');
@@ -121,7 +121,7 @@ export class AmazonS3BuildCacheProvider implements ICloudBuildCacheProvider {
                 `Update the credentials by running "rush ${RushConstants.updateCloudCredentialsCommandName}".`
             );
           } else {
-            credentials = fromAmazonEnv() ?? fromRushEnv(cacheEntry?.credential);
+            credentials = fromRushEnv(cacheEntry?.credential);
           }
         } else if (this._isCacheWriteAllowedByConfiguration) {
           throw new Error(

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3BuildCacheProvider.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3BuildCacheProvider.ts
@@ -14,7 +14,7 @@ import {
 
 import { AmazonS3Client } from './AmazonS3Client';
 import { WebClient } from './WebClient';
-import { IAmazonS3Credentials, fromAmazonEnv, fromRushEnv } from './AmazonS3Credentials';
+import { type IAmazonS3Credentials, fromAmazonEnv, fromRushEnv } from './AmazonS3Credentials';
 
 /**
  * @public

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
@@ -7,7 +7,7 @@ import * as fetch from 'node-fetch';
 
 import { IAmazonS3BuildCacheProviderOptionsAdvanced } from './AmazonS3BuildCacheProvider';
 import { IGetFetchOptions, IPutFetchOptions, WebClient } from './WebClient';
-import { IAmazonS3Credentials, fromRushEnv } from './AmazonS3Credentials';
+import { type IAmazonS3Credentials, fromRushEnv } from './AmazonS3Credentials';
 
 const CONTENT_HASH_HEADER_NAME: 'x-amz-content-sha256' = 'x-amz-content-sha256';
 const DATE_HEADER_NAME: 'x-amz-date' = 'x-amz-date';

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
@@ -7,22 +7,12 @@ import * as fetch from 'node-fetch';
 
 import { IAmazonS3BuildCacheProviderOptionsAdvanced } from './AmazonS3BuildCacheProvider';
 import { IGetFetchOptions, IPutFetchOptions, WebClient } from './WebClient';
+import { IAmazonS3Credentials, fromRushEnv } from './AmazonS3Credentials';
 
 const CONTENT_HASH_HEADER_NAME: 'x-amz-content-sha256' = 'x-amz-content-sha256';
 const DATE_HEADER_NAME: 'x-amz-date' = 'x-amz-date';
 const HOST_HEADER_NAME: 'host' = 'host';
 const SECURITY_TOKEN_HEADER_NAME: 'x-amz-security-token' = 'x-amz-security-token';
-
-/**
- * Credentials for authorizing and signing requests to an Amazon S3 endpoint.
- *
- * @public
- */
-export interface IAmazonS3Credentials {
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken: string | undefined;
-}
 
 interface IIsoDateString {
   date: string;
@@ -116,20 +106,7 @@ export class AmazonS3Client {
   public static tryDeserializeCredentials(
     credentialString: string | undefined
   ): IAmazonS3Credentials | undefined {
-    if (!credentialString) {
-      return undefined;
-    }
-
-    const fields: string[] = credentialString.split(':');
-    if (fields.length < 2 || fields.length > 3) {
-      throw new Error('Amazon S3 credential is in an unexpected format.');
-    }
-
-    return {
-      accessKeyId: fields[0],
-      secretAccessKey: fields[1],
-      sessionToken: fields[2]
-    };
+    return fromRushEnv(credentialString);
   }
 
   public async getObjectAsync(objectName: string): Promise<Buffer | undefined> {

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
@@ -32,9 +32,19 @@ export const fromAmazonEnv = (): IAmazonS3Credentials | undefined => {
       secretAccessKey,
       sessionToken
     };
+  } else if (accessKeyId) {
+    throw new Error(
+      `The "${AWS_ACCESS_KEY_ID}" env variable is set, but the "${AWS_SECRET_ACCESS_KEY}" `+
+      `env variable is not set. Both or neither must be provided.`
+    );
+  } else if (secretAccessKey) {
+    throw new Error(
+      `The "${AWS_SECRET_ACCESS_KEY}" env variable is set, but the "${AWS_ACCESS_KEY_ID}" `+
+      `env variable is not set. Both or neither must be provided.`
+    );
+  } else {
+    return undefined;
   }
-
-  return undefined;
 };
 
 /**

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import { EnvironmentConfiguration } from '@rushstack/rush-sdk';
 
 export const AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID' = 'AWS_ACCESS_KEY_ID';

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Credentials.ts
@@ -1,0 +1,57 @@
+import { EnvironmentConfiguration } from '@rushstack/rush-sdk';
+
+export const AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID' = 'AWS_ACCESS_KEY_ID';
+export const AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY' = 'AWS_SECRET_ACCESS_KEY';
+export const AWS_SESSION_TOKEN: 'AWS_SESSION_TOKEN' = 'AWS_SESSION_TOKEN';
+
+/**
+ * Credentials for authorizing and signing requests to an Amazon S3 endpoint.
+ *
+ * @public
+ */
+export interface IAmazonS3Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string | undefined;
+}
+
+/**
+ * Attempt to read credentials from the commonly used AWS_* env vars.
+ */
+export const fromAmazonEnv = (): IAmazonS3Credentials | undefined => {
+  const accessKeyId: string | undefined = process.env[AWS_ACCESS_KEY_ID];
+  const secretAccessKey: string | undefined = process.env[AWS_SECRET_ACCESS_KEY];
+  const sessionToken: string | undefined = process.env[AWS_SESSION_TOKEN];
+
+  if (accessKeyId && secretAccessKey) {
+    return {
+      accessKeyId,
+      secretAccessKey,
+      sessionToken
+    };
+  }
+
+  return undefined;
+};
+
+/**
+ * Attempt to parse credentials set from the RUSH_BUILD_CACHE_CREDENTIAL env var.
+ */
+export const fromRushEnv = (
+  credential = EnvironmentConfiguration.buildCacheCredential
+): IAmazonS3Credentials | undefined => {
+  if (!credential) {
+    return undefined;
+  }
+
+  const fields: string[] = credential.split(':');
+  if (fields.length < 2 || fields.length > 3) {
+    throw new Error(`Rush build cache credential is in an unexpected format.`);
+  }
+
+  return {
+    accessKeyId: fields[0],
+    secretAccessKey: fields[1],
+    sessionToken: fields[2]
+  };
+};

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
@@ -3,7 +3,7 @@
 
 import { RushAmazonS3BuildCachePlugin } from './RushAmazonS3BuildCachePlugin';
 
-export { IAmazonS3Credentials } from './AmazonS3Credentials';
+export { type IAmazonS3Credentials } from './AmazonS3Credentials';
 export { AmazonS3Client } from './AmazonS3Client';
 export { WebClient, IGetFetchOptions, IPutFetchOptions, WebClientResponse } from './WebClient';
 export default RushAmazonS3BuildCachePlugin;

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
@@ -3,7 +3,8 @@
 
 import { RushAmazonS3BuildCachePlugin } from './RushAmazonS3BuildCachePlugin';
 
-export { AmazonS3Client, IAmazonS3Credentials } from './AmazonS3Client';
+export { IAmazonS3Credentials } from './AmazonS3Credentials';
+export { AmazonS3Client } from './AmazonS3Client';
 export { WebClient, IGetFetchOptions, IPutFetchOptions, WebClientResponse } from './WebClient';
 export default RushAmazonS3BuildCachePlugin;
 export {

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
@@ -7,7 +7,7 @@ import { Response, ResponseInit } from 'node-fetch';
 import { IAmazonS3BuildCacheProviderOptionsAdvanced } from '../AmazonS3BuildCacheProvider';
 import { AmazonS3Client } from '../AmazonS3Client';
 import { WebClient } from '../WebClient';
-import { IAmazonS3Credentials } from '../AmazonS3Credentials';
+import type { IAmazonS3Credentials } from '../AmazonS3Credentials';
 
 const webClient = new WebClient();
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Client.test.ts
@@ -5,8 +5,9 @@ import { ConsoleTerminalProvider, Terminal } from '@rushstack/node-core-library'
 import { Response, ResponseInit } from 'node-fetch';
 
 import { IAmazonS3BuildCacheProviderOptionsAdvanced } from '../AmazonS3BuildCacheProvider';
-import { AmazonS3Client, IAmazonS3Credentials } from '../AmazonS3Client';
+import { AmazonS3Client } from '../AmazonS3Client';
 import { WebClient } from '../WebClient';
+import { IAmazonS3Credentials } from '../AmazonS3Credentials';
 
 const webClient = new WebClient();
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
@@ -20,6 +20,10 @@ describe('Amazon S3 Credentials', () => {
       oldEnvAwsAccessKeyId = process.env[AWS_ACCESS_KEY_ID];
       oldEnvAwsSecretAccessKey = process.env[AWS_SECRET_ACCESS_KEY];
       oldEnvAwsSessionToken = process.env[AWS_SESSION_TOKEN];
+      
+      delete process.env[AWS_ACCESS_KEY_ID];
+      delete process.env[AWS_SECRET_ACCESS_KEY];
+      delete process.env[AWS_SESSION_TOKEN];
     });
     
     afterEach(() => {
@@ -55,10 +59,11 @@ describe('Amazon S3 Credentials', () => {
 
     it('returns undefined if access key and secret are not both present', () => {
       process.env[AWS_ACCESS_KEY_ID] = AWS_ACCESS_KEY_ID;
+      expect(() => fromAmazonEnv()).toThrowErrorMatchingSnapshot();
 
-      const credentials = fromAmazonEnv();
-
-      expect(credentials).toBeUndefined();
+      delete process.env[AWS_ACCESS_KEY_ID];
+      process.env[AWS_SECRET_ACCESS_KEY] = AWS_SECRET_ACCESS_KEY;
+      expect(() => fromAmazonEnv()).toThrowErrorMatchingSnapshot();
     });
   });
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
@@ -1,0 +1,83 @@
+import {
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+  AWS_SESSION_TOKEN,
+  fromAmazonEnv,
+  fromRushEnv
+} from '../AmazonS3Credentials';
+import { EnvironmentConfiguration } from '@rushstack/rush-sdk';
+
+describe('Amazon S3 Credentials', () => {
+  describe(fromAmazonEnv.name, () => {
+    afterEach(() => {
+      delete process.env[AWS_ACCESS_KEY_ID];
+      delete process.env[AWS_SECRET_ACCESS_KEY];
+      delete process.env[AWS_SESSION_TOKEN];
+    });
+
+    it('returns AWS vars when present in env', () => {
+      process.env[AWS_ACCESS_KEY_ID] = AWS_ACCESS_KEY_ID;
+      process.env[AWS_SECRET_ACCESS_KEY] = AWS_SECRET_ACCESS_KEY;
+      process.env[AWS_SESSION_TOKEN] = AWS_SESSION_TOKEN;
+
+      const credentials = fromAmazonEnv();
+
+      expect(credentials).toBeDefined();
+      expect(credentials!.accessKeyId).toBe(AWS_ACCESS_KEY_ID);
+      expect(credentials!.secretAccessKey).toBe(AWS_SECRET_ACCESS_KEY);
+      expect(credentials!.sessionToken).toBe(AWS_SESSION_TOKEN);
+    });
+
+    it('returns undefined sessionToken when not present', () => {
+      process.env[AWS_ACCESS_KEY_ID] = AWS_ACCESS_KEY_ID;
+      process.env[AWS_SECRET_ACCESS_KEY] = AWS_SECRET_ACCESS_KEY;
+
+      const credentials = fromAmazonEnv();
+
+      expect(credentials).toBeDefined();
+      expect(credentials!.accessKeyId).toBe(AWS_ACCESS_KEY_ID);
+      expect(credentials!.secretAccessKey).toBe(AWS_SECRET_ACCESS_KEY);
+      expect(credentials!.sessionToken).toBeUndefined();
+    });
+
+    it('returns undefined if access key and secret are not both present', () => {
+      process.env[AWS_ACCESS_KEY_ID] = AWS_ACCESS_KEY_ID;
+
+      const credentials = fromAmazonEnv();
+
+      expect(credentials).toBeUndefined();
+    });
+  });
+
+  describe(fromRushEnv.name, () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('parses Rush build cache credential by default', () => {
+      jest
+        .spyOn(EnvironmentConfiguration, 'buildCacheCredential', 'get')
+        .mockReturnValue('accessKey:secretKey');
+
+      const credentials = fromRushEnv();
+
+      expect(credentials).toBeDefined();
+      expect(credentials!.accessKeyId).toBe('accessKey');
+      expect(credentials!.secretAccessKey).toBe('secretKey');
+      expect(credentials!.sessionToken).toBeUndefined();
+    });
+
+    it('allows passing cached credentials', () => {
+      const credentials = fromRushEnv('accessKey:secretKey:sessionToken');
+
+      expect(credentials).toBeDefined();
+      expect(credentials!.accessKeyId).toBe('accessKey');
+      expect(credentials!.secretAccessKey).toBe('secretKey');
+      expect(credentials!.sessionToken).toBe('sessionToken');
+    });
+
+    it.each(['invalid', 'invalid:x:x:x'])('throws format error when "%s" is parsed', (credential) => {
+      expect(() => fromRushEnv(credential)).toThrow('unexpected format');
+    });
+  });
+});

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
@@ -12,24 +12,44 @@ import { EnvironmentConfiguration } from '@rushstack/rush-sdk';
 
 describe('Amazon S3 Credentials', () => {
   describe(fromAmazonEnv.name, () => {
+    let isOldEnvAwsAccessKeyIdSet: boolean;
     let oldEnvAwsAccessKeyId: string | undefined;
+    let isOldEnvAwsSecretAccessKeySet: boolean;
     let oldEnvAwsSecretAccessKey: string | undefined;
+    let isOldEnvAwsSessionTokenSet: boolean;
     let oldEnvAwsSessionToken: string | undefined;
-    
+
     beforeEach(() => {
+      isOldEnvAwsAccessKeyIdSet = AWS_ACCESS_KEY_ID in process.env;
       oldEnvAwsAccessKeyId = process.env[AWS_ACCESS_KEY_ID];
+      isOldEnvAwsSecretAccessKeySet = AWS_SECRET_ACCESS_KEY in process.env;
       oldEnvAwsSecretAccessKey = process.env[AWS_SECRET_ACCESS_KEY];
+      isOldEnvAwsSessionTokenSet = AWS_SESSION_TOKEN in process.env;
       oldEnvAwsSessionToken = process.env[AWS_SESSION_TOKEN];
-      
+
       delete process.env[AWS_ACCESS_KEY_ID];
       delete process.env[AWS_SECRET_ACCESS_KEY];
       delete process.env[AWS_SESSION_TOKEN];
     });
-    
+
     afterEach(() => {
-      process.env[AWS_ACCESS_KEY_ID] = oldEnvAwsAccessKeyId;
-      process.env[AWS_SECRET_ACCESS_KEY] = oldEnvAwsSecretAccessKey;
-      process.env[AWS_SESSION_TOKEN] = oldEnvAwsSessionToken;
+      if (isOldEnvAwsAccessKeyIdSet) {
+        process.env[AWS_ACCESS_KEY_ID] = oldEnvAwsAccessKeyId;
+      } else {
+        delete process.env[AWS_ACCESS_KEY_ID];
+      }
+
+      if (isOldEnvAwsSecretAccessKeySet) {
+        process.env[AWS_SECRET_ACCESS_KEY] = oldEnvAwsSecretAccessKey;
+      } else {
+        delete process.env[AWS_SECRET_ACCESS_KEY];
+      }
+
+      if (isOldEnvAwsSessionTokenSet) {
+        process.env[AWS_SESSION_TOKEN] = oldEnvAwsSessionToken;
+      } else {
+        delete process.env[AWS_SESSION_TOKEN];
+      }
     });
 
     it('returns AWS vars when present in env', () => {
@@ -59,11 +79,11 @@ describe('Amazon S3 Credentials', () => {
 
     it('returns undefined if access key and secret are not both present', () => {
       process.env[AWS_ACCESS_KEY_ID] = AWS_ACCESS_KEY_ID;
-      expect(() => fromAmazonEnv()).toThrowErrorMatchingSnapshot();
+      expect(() => fromAmazonEnv()).toThrowErrorMatchingInlineSnapshot(`"The \\"AWS_ACCESS_KEY_ID\\" env variable is set, but the \\"AWS_SECRET_ACCESS_KEY\\" env variable is not set. Both or neither must be provided."`);
 
       delete process.env[AWS_ACCESS_KEY_ID];
       process.env[AWS_SECRET_ACCESS_KEY] = AWS_SECRET_ACCESS_KEY;
-      expect(() => fromAmazonEnv()).toThrowErrorMatchingSnapshot();
+      expect(() => fromAmazonEnv()).toThrowErrorMatchingInlineSnapshot(`"The \\"AWS_SECRET_ACCESS_KEY\\" env variable is set, but the \\"AWS_ACCESS_KEY_ID\\" env variable is not set. Both or neither must be provided."`);
     });
   });
 

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
@@ -12,10 +12,20 @@ import { EnvironmentConfiguration } from '@rushstack/rush-sdk';
 
 describe('Amazon S3 Credentials', () => {
   describe(fromAmazonEnv.name, () => {
+    let oldEnvAwsAccessKeyId: string | undefined;
+    let oldEnvAwsSecretAccessKey: string | undefined;
+    let oldEnvAwsSessionToken: string | undefined;
+    
+    beforeEach(() => {
+      oldEnvAwsAccessKeyId = process.env[AWS_ACCESS_KEY_ID];
+      oldEnvAwsSecretAccessKey = process.env[AWS_SECRET_ACCESS_KEY];
+      oldEnvAwsSessionToken = process.env[AWS_SESSION_TOKEN];
+    });
+    
     afterEach(() => {
-      delete process.env[AWS_ACCESS_KEY_ID];
-      delete process.env[AWS_SECRET_ACCESS_KEY];
-      delete process.env[AWS_SESSION_TOKEN];
+      process.env[AWS_ACCESS_KEY_ID] = oldEnvAwsAccessKeyId;
+      process.env[AWS_SECRET_ACCESS_KEY] = oldEnvAwsSecretAccessKey;
+      process.env[AWS_SESSION_TOKEN] = oldEnvAwsSessionToken;
     });
 
     it('returns AWS vars when present in env', () => {

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/test/AmazonS3Credentials.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import {
   AWS_ACCESS_KEY_ID,
   AWS_SECRET_ACCESS_KEY,


### PR DESCRIPTION

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->
- check for existence of commonly used environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`
- add unit tests for new function as well as existing function for `RUSH_BUILD_CACHE_CREDENTIAL`
- resolve #4115
## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
Added a function for reading `AWS` vars that easily falls back to the Rush build cache env var if they aren't present. Refactored existing credential parsing (extracted out to module) to aid in unit testing. I considered importing https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-node but could not figure out build issues once added, it's possible they don't support TypeScript 5 yet. The `fromEnv` provider they export is essentially what I added here and it a trivial amount of code.
## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->
1. Assumed AWS IAM role using `aws sts assume-role` that has access to build cache bucket
1. `eval $(aws configure export-credentials --format env)` to set cred vars
1.  Invoked `rush build` with `"isCacheWriteAllowed": true` and verified that the build cache was successfully read/updated locally and in s3 using the credentials exported.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->
https://rushjs.io/pages/maintainer/build_cache/#ci-setup 
While these changes did not modify documented behavior of existing rush env var, we could call out that it checks for `AWS_*` vars for `amazon-s3` now.
<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
