### PR TITLE
[rush-lib] remove redundant or broken references to preminor and release

### DIFF
--- a/common/changes/@microsoft/rush/issue_1335_2023-06-02-20-54.json
+++ b/common/changes/@microsoft/rush/issue_1335_2023-06-02-20-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING API CHANGE) Remove unused members of the `BumpType` API. See https://github.com/microsoft/rushstack/issues/1335 for details.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -40,7 +40,7 @@
   //    * When creating a release branch in Git, this field should be updated according to the
   //    * type of release.
   //    *
-  //    * Valid values are: "prerelease", "release", "minor", "patch", "major"
+  //    * Valid values are: "prerelease", "minor", "patch", "major"
   //    */
   //   "nextBump": "prerelease",
   //

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -80,8 +80,6 @@ export enum BumpType {
     // (undocumented)
     'patch' = 2,
     // (undocumented)
-    'preminor' = 3,
-    // (undocumented)
     'prerelease' = 1
 }
 

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
@@ -41,7 +41,7 @@
      * When creating a release branch in Git, this field should be updated according to the
      * type of release.
      *
-     * Valid values are: "prerelease", "release", "minor", "patch", "major"
+     * Valid values are: "prerelease", "minor", "patch", "major"
      */
     "nextBump": "prerelease",
 

--- a/libraries/rush-lib/src/api/VersionPolicy.ts
+++ b/libraries/rush-lib/src/api/VersionPolicy.ts
@@ -24,17 +24,15 @@ const lodash: typeof import('lodash') = Import.lazy('lodash', require);
  */
 export enum BumpType {
   // No version bump
-  'none',
+  'none' = 0,
   // Prerelease version bump
-  'prerelease',
+  'prerelease' = 1,
   // Patch version bump
-  'patch',
-  // Preminor version bump
-  'preminor',
+  'patch' = 2,
   // Minor version bump
-  'minor',
+  'minor' = 4,
   // Major version bump
-  'major'
+  'major' = 5
 }
 
 /**

--- a/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
@@ -90,14 +90,6 @@ describe(VersionPolicy.name, () => {
       expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
     });
 
-    it('bumps version for preminor release', () => {
-      expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
-      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;
-      lockStepVersionPolicy.bump(BumpType.preminor, 'pr');
-      expect(lockStepVersionPolicy.version).toEqual('1.2.0-pr.0');
-      expect(lockStepVersionPolicy.nextBump).toEqual(BumpType.patch);
-    });
-
     it('bumps version for minor release', () => {
       expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -75,7 +75,7 @@ export class VersionAction extends BaseRushAction {
       argumentName: 'BUMPTYPE',
       description:
         'Overrides the bump type in the version-policy.json for the specified version policy. ' +
-        'Valid BUMPTYPE values include: prerelease, patch, preminor, minor, major. ' +
+        'Valid BUMPTYPE values include: prerelease, patch, minor, major. ' +
         'This setting only works for lock-step version policy in bump action.'
     });
     this._prereleaseIdentifier = this.defineStringParameter({
@@ -197,7 +197,7 @@ export class VersionAction extends BaseRushAction {
     if (this._overwriteBump.value && !Enum.tryGetValueByKey(BumpType, this._overwriteBump.value)) {
       throw new Error(
         'The value of override-bump is not valid.  ' +
-          'Valid values include prerelease, patch, preminor, minor, and major'
+          'Valid values include prerelease, patch, minor, and major'
       );
     }
   }

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1298,9 +1298,9 @@ Optional arguments:
   --override-bump BUMPTYPE
                         Overrides the bump type in the version-policy.json 
                         for the specified version policy. Valid BUMPTYPE 
-                        values include: prerelease, patch, preminor, minor, 
-                        major. This setting only works for lock-step version 
-                        policy in bump action.
+                        values include: prerelease, patch, minor, major. This 
+                        setting only works for lock-step version policy in 
+                        bump action.
   --override-prerelease-id ID
                         Overrides the prerelease identifier in the version 
                         value of version-policy.json for the specified 

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -338,7 +338,6 @@ export class PublishUtilities {
       case 'patch':
         return ChangeType.patch;
       case 'premajor':
-      case 'preminor':
       case 'prepatch':
       case 'prerelease':
         return ChangeType.hotfix;

--- a/libraries/rush-lib/src/schemas/version-policies.schema.json
+++ b/libraries/rush-lib/src/schemas/version-policies.schema.json
@@ -68,7 +68,7 @@
         },
         "nextBump": {
           "description": "Type of next version bump",
-          "enum": ["none", "prerelease", "release", "minor", "patch", "major"]
+          "enum": ["none", "prerelease", "minor", "patch", "major"]
         },
         "mainProject": {
           "description": "The main project for this version policy",


### PR DESCRIPTION
Remove references to preminor and release in code, documentation, and tests.

Fixes #1335
