### PR TITLE
[heft-jest] Add customExportConditions, web config

### DIFF
--- a/build-tests-samples/heft-storybook-react-tutorial/config/jest.config.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/jest.config.json
@@ -1,17 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }

--- a/build-tests/heft-minimal-rig-test/profiles/default/config/jest.config.json
+++ b/build-tests/heft-minimal-rig-test/profiles/default/config/jest.config.json
@@ -1,17 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }

--- a/build-tests/heft-sass-test/config/jest.config.json
+++ b/build-tests/heft-sass-test/config/jest.config.json
@@ -1,19 +1,5 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ],
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json",
 
   "moduleFileExtensions": ["js", "css", "json", "node"]
 }

--- a/build-tests/heft-webpack4-everything-test/config/jest.config.json
+++ b/build-tests/heft-webpack4-everything-test/config/jest.config.json
@@ -1,16 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }

--- a/build-tests/heft-webpack5-everything-test/config/jest.config.json
+++ b/build-tests/heft-webpack5-everything-test/config/jest.config.json
@@ -1,16 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }

--- a/common/changes/@rushstack/heft-jest-plugin/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-jest-plugin/jest-config-fork_2023-06-06-01-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Adds a new base config for web projects, jest-web.config.json. Adds the \"customExportConditions\" field to both base configs with sensible defaults.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-jest-plugin/jest-config-fork_2023-06-06-01-55.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/heft-jest-plugin",
       "comment": "Adds a new base config for web projects, jest-web.config.json. Adds the \"customExportConditions\" field to both base configs with sensible defaults.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/heft-jest-plugin"

--- a/common/changes/@rushstack/heft-node-rig/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-node-rig/jest-config-fork_2023-06-06-01-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Updated Jest environment \"customExportConditions\" to [\"require\", \"node\"]",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-node-rig/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-node-rig/jest-config-fork_2023-06-06-01-55.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/heft-node-rig",
       "comment": "Updated Jest environment \"customExportConditions\" to [\"require\", \"node\"]",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/heft-node-rig"

--- a/common/changes/@rushstack/heft-web-rig/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-web-rig/jest-config-fork_2023-06-06-01-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Update Jest environment \"customExportConditions\" to [\"require\", \"node\", \"umd\"]",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/changes/@rushstack/heft-web-rig/jest-config-fork_2023-06-06-01-55.json
+++ b/common/changes/@rushstack/heft-web-rig/jest-config-fork_2023-06-06-01-55.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/heft-web-rig",
       "comment": "Update Jest environment \"customExportConditions\" to [\"require\", \"node\", \"umd\"]",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/heft-web-rig"

--- a/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
+++ b/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
@@ -18,7 +18,7 @@
   // "Adding '<rootDir>/lib' here enables lib/__mocks__ to be used for mocking Node.js system modules
   "roots": ["<rootDir>/lib"],
 
-  "testMatch": ["<rootDir>/lib/**/*.test.js"],
+  "testMatch": ["<rootDir>/lib/**/*.test.{cjs,js}"],
   "testPathIgnorePatterns": ["/node_modules/"],
 
   // Code coverage tracking is disabled by default; set this to true to enable it
@@ -30,9 +30,9 @@
   "coverageProvider": "v8",
 
   "collectCoverageFrom": [
-    "lib/**/*.js",
+    "lib/**/*.{cjs,js}",
     "!lib/**/*.d.ts",
-    "!lib/**/*.test.js",
+    "!lib/**/*.test.{cjs,js}",
     "!lib/**/test/**",
     "!lib/**/__tests__/**",
     "!lib/**/__fixtures__/**",
@@ -40,8 +40,11 @@
   ],
   "coveragePathIgnorePatterns": ["/node_modules/"],
 
+  "testEnvironment": "jest-environment-node",
+
   "testEnvironmentOptions": {
-    "url": "http://localhost/"
+    "url": "http://localhost/",
+    "customExportConditions": ["require", "node"]
   },
 
   // Retain pre-Jest 29 snapshot behavior

--- a/heft-plugins/heft-jest-plugin/includes/jest-web.config.json
+++ b/heft-plugins/heft-jest-plugin/includes/jest-web.config.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./jest-shared.config.json",
+
+  "roots": ["<rootDir>/lib-commonjs"],
+
+  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
+
+  "testEnvironment": "jest-environment-jsdom",
+
+  "testEnvironmentOptions": {
+    "url": "http://localhost/",
+    "customExportConditions": ["require", "node", "umd"]
+  },
+
+  "collectCoverageFrom": [
+    "lib-commonjs/**/*.js",
+    "!lib-commonjs/**/*.d.ts",
+    "!lib-commonjs/**/*.test.js",
+    "!lib-commonjs/**/test/**",
+    "!lib-commonjs/**/__tests__/**",
+    "!lib-commonjs/**/__fixtures__/**",
+    "!lib-commonjs/**/__mocks__/**"
+  ]
+}

--- a/heft-plugins/heft-jest-plugin/includes/jest-web.config.json
+++ b/heft-plugins/heft-jest-plugin/includes/jest-web.config.json
@@ -1,16 +1,29 @@
 {
   "extends": "./jest-shared.config.json",
 
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
   "testEnvironment": "jest-environment-jsdom",
 
   "testEnvironmentOptions": {
     "url": "http://localhost/",
+
+    // For web projects, we write ESM output (with "import" statements") into the "lib" folder
+    // to be processed by Webpack or other tree-shaking bundlers.
+    // We also write CommonJS output (with "require()" calls") into the "lib-commonjs" folder
+    // to be processed by Jest.  We do this because the Jest requires the --experimental-vm-modules flag
+    // in order to load ESM, and also because the interop story between CommonJS and ESM in NodeJs is
+    // very finicky.
+    //
+    // The jest-environment-jsdom package now sets "customExportConditions" to ["browser"],
+    // which often selects an ESM entry point when resolving packages. This is incorrect for
+    // our setup.  The setting below fixes that.  For details, refer to these docs:
+    // https://nodejs.org/api/packages.html#conditional-exports
     "customExportConditions": ["require", "node", "umd"]
   },
+
+  // For web projects, `lib/` is normally ESM, so we route to the CommonJS output in `lib-commonjs/` instead.
+  "roots": ["<rootDir>/lib-commonjs"],
+
+  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
 
   "collectCoverageFrom": [
     "lib-commonjs/**/*.js",

--- a/rigs/heft-node-rig/profiles/default/config/jest.config.json
+++ b/rigs/heft-node-rig/profiles/default/config/jest.config.json
@@ -1,5 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "testEnvironment": "jest-environment-node"
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json"
 }

--- a/rigs/heft-web-rig/profiles/app/config/jest.config.json
+++ b/rigs/heft-web-rig/profiles/app/config/jest.config.json
@@ -1,20 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "testEnvironment": "jest-environment-jsdom",
-
-  // "Adding '<rootDir>/lib-commonjs' here enables lib-commonjs/__mocks__ to be used for mocking Node.js system modules
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }

--- a/rigs/heft-web-rig/profiles/library/config/jest.config.json
+++ b/rigs/heft-web-rig/profiles/library/config/jest.config.json
@@ -1,20 +1,3 @@
 {
-  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
-
-  "testEnvironment": "jest-environment-jsdom",
-
-  // "Adding '<rootDir>/lib-commonjs' here enables lib-commonjs/__mocks__ to be used for mocking Node.js system modules
-  "roots": ["<rootDir>/lib-commonjs"],
-
-  "testMatch": ["<rootDir>/lib-commonjs/**/*.test.js"],
-
-  "collectCoverageFrom": [
-    "lib-commonjs/**/*.js",
-    "!lib-commonjs/**/*.d.ts",
-    "!lib-commonjs/**/*.test.js",
-    "!lib-commonjs/**/test/**",
-    "!lib-commonjs/**/__tests__/**",
-    "!lib-commonjs/**/__fixtures__/**",
-    "!lib-commonjs/**/__mocks__/**"
-  ]
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json"
 }


### PR DESCRIPTION
## Summary
Adds a new base config for web projects.
Updates "customExportConditions" field for web and node projects.

## Details
Node projects will now use `["require", "node"]`.
Web projects will use `["require", "node", "umd"]`, because `"browser"` tends to return ESM, and Jest is configured to run CommonJS.

## How it was tested
`rush test -v`
Matching behavior used in external repos that consume the rigs.

## Impacted documentation
Any docs about the base config.