### PR TITLE
[rush-lib] fix typo on `startingFolder`

### DIFF
--- a/common/changes/@microsoft/rush/pr-4167_2023-06-06-09-30.json
+++ b/common/changes/@microsoft/rush/pr-4167_2023-06-06-09-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fix typo in docs for `startingFolder`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/pr-4167_2023-06-06-09-30.json
+++ b/common/changes/@microsoft/rush/pr-4167_2023-06-06-09-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fix typo in docs for `startingFolder`",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -194,7 +194,7 @@ export interface ITryFindRushJsonLocationOptions {
   showVerbose?: boolean; // Defaults to false (inverse of old `verbose` parameter)
 
   /**
-   * The folder path where the search will start.  Defaults tot he current working directory.
+   * The folder path where the search will start.  Defaults to the current working directory.
    */
   startingFolder?: string; // Defaults to cwd
 }


### PR DESCRIPTION
## Summary

Fix typo on `startingFolder`