### PR TITLE
[rush] Silence cache logs in quiet mode and write cache logs to a `*.cache.log` file.

### DIFF
--- a/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-17.json
+++ b/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Write cache logs to their own file(s).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-19.json
+++ b/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Write cache logs to their own file(s).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-19.json
+++ b/common/changes/@microsoft/rush/silence-cache-logging-in-quiet-mode_2023-06-06-22-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Write cache logs to their own file(s).",
+      "comment": "Fix an issue where cache logging data was always written to stdout.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
+++ b/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
@@ -34,10 +34,16 @@ export class ProjectLogWritable extends TerminalWritable {
       projectFolder: string,
       logFilenameIdentifier: string,
       logFolder?: string
-    ): { logPath: string; errorLogPath: string; relativeLogPath: string; relativeErrorLogPath: string } {
+    ): {
+      logPath: string;
+      errorLogPath: string;
+      relativeLogPath: string;
+      relativeErrorLogPath: string;
+    } {
       const unscopedProjectName: string = PackageNameParsers.permissive.getUnscopedName(project.packageName);
-      const logFilename: string = `${unscopedProjectName}.${logFilenameIdentifier}.log`;
-      const errorLogFilename: string = `${unscopedProjectName}.${logFilenameIdentifier}.error.log`;
+      const logFileBaseName: string = `${unscopedProjectName}.${logFilenameIdentifier}`;
+      const logFilename: string = `${logFileBaseName}.log`;
+      const errorLogFilename: string = `${logFileBaseName}.error.log`;
 
       const relativeLogPath: string = logFolder ? `${logFolder}/${logFilename}` : logFilename;
       const relativeErrorLogPath: string = logFolder ? `${logFolder}/${errorLogFilename}` : errorLogFilename;

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -188,7 +188,9 @@ export class ShellOperationRunner implements IOperationRunner {
       const terminal: Terminal = new Terminal(terminalProvider);
 
       // Controls the log for the cache subsystem
-      const buildCacheCollatedTerminal: CollatedTerminal = new CollatedTerminal(context.collatedWriter);
+      const buildCacheCollatedTerminal: CollatedTerminal = new CollatedTerminal(
+        context.quietMode ? discardTransform : context.collatedWriter
+      );
       const buildCacheTerminalProvider: CollatedTerminalProvider = new CollatedTerminalProvider(
         buildCacheCollatedTerminal,
         {

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -157,14 +157,16 @@ export class ShellOperationRunner implements IOperationRunner {
 
     try {
       //#region CACHE LOGGING
-      const cacheDiscardTransform: DiscardStdoutTransform = new DiscardStdoutTransform({
-        destination: context.collatedWriter
-      });
+      let cacheConsoleWritable: TerminalWritable;
+      if (context.quietMode) {
+        cacheConsoleWritable = new DiscardStdoutTransform({
+          destination: context.collatedWriter
+        });
+      } else {
+        cacheConsoleWritable = context.collatedWriter;
+      }
 
       let cacheCollatedTerminal: CollatedTerminal;
-      const cacheConsoleWritable: TerminalWritable = context.quietMode
-        ? cacheDiscardTransform
-        : context.collatedWriter;
       if (cacheProjectLogWritable) {
         const cacheSplitterTransform: SplitterTransform = new SplitterTransform({
           destinations: [cacheConsoleWritable, cacheProjectLogWritable]
@@ -180,7 +182,7 @@ export class ShellOperationRunner implements IOperationRunner {
           debugEnabled: context.debugMode
         }
       );
-      const buildCacheTerminal: Terminal | undefined = new Terminal(buildCacheTerminalProvider);
+      const buildCacheTerminal: Terminal = new Terminal(buildCacheTerminalProvider);
       //#endregion
 
       //#region OPERATION LOGGING
@@ -450,7 +452,7 @@ export class ShellOperationRunner implements IOperationRunner {
 
         const [, cacheWriteSuccess] = await Promise.all([writeProjectStatePromise, setCacheEntryPromise]);
 
-        if (terminalProvider.hasErrors) {
+        if (buildCacheTerminalProvider.hasErrors) {
           status = OperationStatus.Failure;
         } else if (cacheWriteSuccess === false) {
           status = OperationStatus.SuccessWithWarning;


### PR DESCRIPTION
## Summary

This fixes a regression where cache logs were always written to stdout. It also creates `*cache.log` files for that data.

## How it was tested

Ran `rush build` in a repo with caching enabled.