### PR TITLE
forcing newer version of cosmiconfig to fix CVE for yaml

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -3914,11 +3914,11 @@ packages:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz_@types+node@14.18.36
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.20.tgz_@types+node@14.18.36
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.2.7.tgz_@types+node@14.18.36
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz_@types+node@14.18.36
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.238.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.13.tgz_@types+node@14.18.36
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.3.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
@@ -4227,25 +4227,25 @@ packages:
       semver: 7.3.8
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.0.20.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.20.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.20.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.0.20
+    version: 4.0.21
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.2.7.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.2.7.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.2.7.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz
     name: '@rushstack/package-extractor'
-    version: 0.2.7
+    version: 0.2.8
     dependencies:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.13.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
       ignore: 5.1.9
       jszip: 3.8.0
       npm-packlist: 2.1.5
@@ -4273,22 +4273,22 @@ packages:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.0.238.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.238.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.0.238.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz
     name: '@rushstack/stream-collator'
-    version: 4.0.238
+    version: 4.0.239
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.13.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.5.13.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.13.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.5.13.tgz
+  file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.14.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.5.14.tgz
     name: '@rushstack/terminal'
-    version: 0.5.13
+    version: 0.5.14
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -93,7 +93,8 @@
     // "example2": "npm:@company/example2@^1.0.0"
     // TODO: Remove once https://github.com/dylang/npm-check/issues/499
     // has been closed and a new version of `npm-check` is published.
-    "package-json": "^7"
+    "package-json": "^7",
+    "cosmiconfig": "^8.1.3"
   },
 
   /**

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   package-json: ^7
+  cosmiconfig: ^8.1.3
 
 packageExtensionsChecksum: 41333d2d0915bdc80c909c31c409a3a2
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "11090fa7e64066c4dfb665c227aeefa6126794fa",
+  "pnpmShrinkwrapHash": "db3255b43c9c3326e5a32dd7326f4726d37bdd91",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }


### PR DESCRIPTION
## Summary
Package cosmiconfig was updated from 7.1.0 to 8.1.3 
 
## Details
The yaml package version 1.10.2 has a vulnerability. The cosmiconfig 7.1.0 has a dependencie on the yaml 1.10.2. Newer versions of cosmioconfig depend on newer versions of yaml which dont have the vunerability.
Using the globalOverrides, forcing cosmiconfig version to 8.13 to remove vulnerability

## How it was tested
Manual rush install and build