### PR TITLE
[eslint-patch] add check for invalid module path to fallback to relative path when loading eslint modules for nextjs

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-patch-4172-fix-import-path_2023-06-07-15-09.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-patch-4172-fix-import-path_2023-06-07-15-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "add test for invalid import path to fallback to relative path when loading eslint module",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-patch/eslint-patch-4172-fix-import-path_2023-06-07-15-09.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-patch-4172-fix-import-path_2023-06-07-15-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-patch",
-      "comment": "add test for invalid import path to fallback to relative path when loading eslint module",
+      "comment": "Add test for invalid importer path to fallback to relative path when loading eslint 6 plugins",
       "type": "patch"
     }
   ],

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -15,10 +15,7 @@ const isModuleResolutionError: (ex: unknown) => boolean = (ex) =>
 
 // error: "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ''"
 const isInvalidImporterPath: (ex: unknown) => boolean = (ex) =>
-  typeof ex === 'object' &&
-  !!ex &&
-  'code' in ex &&
-  (ex as { code: unknown }).code === 'ERR_INVALID_ARG_VALUE';
+  (ex as { code: unknown } | undefined)?.code === 'ERR_INVALID_ARG_VALUE';
 
 // Module path for eslintrc.cjs
 // Example: ".../@eslint/eslintrc/dist/eslintrc.cjs"

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -14,7 +14,7 @@ const isModuleResolutionError: (ex: unknown) => boolean = (ex) =>
   typeof ex === 'object' && !!ex && 'code' in ex && (ex as { code: unknown }).code === 'MODULE_NOT_FOUND';
 
 // error: "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ''"
-const isInvalidImporterPath: (ex: unknow) => boolean = (ex) =>
+const isInvalidImporterPath: (ex: unknown) => boolean = (ex) =>
   typeof ex === 'object' &&
   !!ex &&
   'code' in ex &&

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -13,6 +13,13 @@ const fs = require('fs');
 const isModuleResolutionError: (ex: unknown) => boolean = (ex) =>
   typeof ex === 'object' && !!ex && 'code' in ex && (ex as { code: unknown }).code === 'MODULE_NOT_FOUND';
 
+// error: "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ''"
+const isInvalidImporterPath: (ex: unknow) => boolean = (ex) =>
+  typeof ex === 'object' &&
+  !!ex &&
+  'code' in ex &&
+  (ex as { code: unknown }).code === 'ERR_INVALID_ARG_VALUE';
+
 // Module path for eslintrc.cjs
 // Example: ".../@eslint/eslintrc/dist/eslintrc.cjs"
 let eslintrcBundlePath: string | undefined = undefined;
@@ -213,7 +220,7 @@ if (!ConfigArrayFactory.__patched) {
             // resolve using importerPath instead of relativeToPath
             return originalResolve.call(this, moduleName, importerPath);
           } catch (e) {
-            if (isModuleResolutionError(e)) {
+            if (isModuleResolutionError(e) || isInvalidImporterPath(e)) {
               return originalResolve.call(this, moduleName, relativeToPath);
             }
             throw e;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

fixes #4172 

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

using `prettier-eslint` with the `nextjs` eslint module fails due to the module path loading. 

the error being thrown is `TypeError [ERR_INVALID_ARG_VALUE]` so in the catch where `isModuleResolutionError` is checked it returns false (different error type) and it never reaches trying to load the module via `relativePath`.

the solution [listed in this issue](https://github.com/prettier/prettier-eslint-cli/issues/434#issuecomment-1207331852) works perfectly. 

this PR fixes the issue by introducing another error checker `isInvalidImporterPath` looking for this type of error. if either `isModuleResolutionError` or `isInvalidImporterPath` are true then it will use the `relativePath`.

fully backwards compatible by simply introducing an additional branch of logic. 


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

ran `prettier-eslint` and it was fixed. no effect on any existing logic, just adds an additional branch of logic for this specific issue.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

no change. followed code style for introducing fix.

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
