### PR TITLE
Load schemas via import.

### DIFF
--- a/apps/api-documenter/src/documenters/DocumenterConfig.ts
+++ b/apps/api-documenter/src/documenters/DocumenterConfig.ts
@@ -4,6 +4,7 @@
 import * as path from 'path';
 import { JsonSchema, JsonFile, NewlineKind } from '@rushstack/node-core-library';
 import { IConfigFile } from './IConfigFile';
+import apiDocumenterSchema from '../schemas/api-documenter.schema.json';
 
 /**
  * Helper for loading the api-documenter.json file format.  Later when the schema is more mature,
@@ -23,9 +24,7 @@ export class DocumenterConfig {
   /**
    * The JSON Schema for API Documenter config file (api-documenter.schema.json).
    */
-  public static readonly jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '..', 'schemas', 'api-documenter.schema.json')
-  );
+  public static readonly jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(apiDocumenterSchema);
 
   /**
    * The config file name "api-documenter.json".

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -57,10 +57,9 @@ import { IYamlTocFile, IYamlTocItem } from '../yaml/IYamlTocFile';
 import { Utilities } from '../utils/Utilities';
 import { CustomMarkdownEmitter } from '../markdown/CustomMarkdownEmitter';
 import { convertUDPYamlToSDP } from '../utils/ToSdpConvertHelper';
+import typescriptSchema from '../yaml/typescript.schema.json';
 
-const yamlApiSchema: JsonSchema = JsonSchema.fromFile(
-  path.join(__dirname, '..', 'yaml', 'typescript.schema.json')
-);
+const yamlApiSchema: JsonSchema = JsonSchema.fromLoadedObject(typescriptSchema);
 
 interface IYamlReferences {
   references: IYamlReference[];

--- a/apps/api-documenter/tsconfig.json
+++ b/apps/api-documenter/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -25,6 +25,8 @@ import { EnumMemberOrder } from '@microsoft/api-extractor-model';
 import { TSDocConfiguration } from '@microsoft/tsdoc';
 import { TSDocConfigFile } from '@microsoft/tsdoc-config';
 
+import apiExtractorSchema from '../schemas/api-extractor.schema.json';
+
 /**
  * Tokens used during variable expansion of path fields from api-extractor.json.
  */
@@ -187,9 +189,7 @@ export class ExtractorConfig {
   /**
    * The JSON Schema for API Extractor config file (api-extractor.schema.json).
    */
-  public static readonly jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '../schemas/api-extractor.schema.json')
-  );
+  public static readonly jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(apiExtractorSchema);
 
   /**
    * The config file name "api-extractor.json".

--- a/apps/api-extractor/tsconfig.json
+++ b/apps/api-extractor/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["heft-jest", "node"]
+    "types": ["heft-jest", "node"],
+    "resolveJsonModule": true
   }
 }

--- a/apps/heft/src/configuration/HeftPluginConfiguration.ts
+++ b/apps/heft/src/configuration/HeftPluginConfiguration.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { JsonFile, JsonSchema } from '@rushstack/node-core-library';
 
 import {
@@ -12,6 +11,7 @@ import {
   type IHeftTaskPluginDefinitionJson
 } from './HeftPluginDefinition';
 import type { IHeftConfigurationJsonPluginSpecifier } from '../utilities/CoreConfigFiles';
+import heftPluginSchema from '../schemas/heft-plugin.schema.json';
 
 export interface IHeftPluginConfigurationJson {
   lifecyclePlugins?: IHeftLifecyclePluginDefinitionJson[];
@@ -24,9 +24,7 @@ const HEFT_PLUGIN_CONFIGURATION_FILENAME: 'heft-plugin.json' = 'heft-plugin.json
  * Loads and validates the heft-plugin.json file.
  */
 export class HeftPluginConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
-    path.join(__dirname, '..', 'schemas', 'heft-plugin.schema.json')
-  );
+  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(heftPluginSchema);
   private static _pluginConfigurationPromises: Map<string, Promise<HeftPluginConfiguration>> = new Map();
 
   private readonly _heftPluginConfigurationJson: IHeftPluginConfigurationJson;

--- a/common/changes/@microsoft/api-documenter/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@microsoft/api-documenter/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-documenter"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@microsoft/api-extractor/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@microsoft/rush/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-api-extractor-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/heft-jest-plugin/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-jest-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/heft-sass-plugin/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-sass-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-typescript-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/heft/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/localization-utilities/load-schema-via-import_2023-06-08-00-07.json
+++ b/common/changes/@rushstack/localization-utilities/load-schema-via-import_2023-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/localization-utilities"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
+++ b/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
@@ -12,12 +12,12 @@ import type {
 import { ConfigurationFile } from '@rushstack/heft-config-file';
 
 import { ApiExtractorRunner } from './ApiExtractorRunner';
+import apiExtractorConfigSchema from './schemas/api-extractor-task.schema.json';
 
 // eslint-disable-next-line @rushstack/no-new-null
 const UNINITIALIZED: null = null;
 
 const PLUGIN_NAME: string = 'api-extractor-plugin';
-const TASK_CONFIG_SCHEMA_PATH: string = `${__dirname}/schemas/api-extractor-task.schema.json`;
 const TASK_CONFIG_RELATIVE_PATH: string = './config/api-extractor-task.json';
 const EXTRACTOR_CONFIG_FILENAME: typeof TApiExtractor.ExtractorConfig.FILENAME = 'api-extractor.json';
 const LEGACY_EXTRACTOR_CONFIG_RELATIVE_PATH: string = `./${EXTRACTOR_CONFIG_FILENAME}`;
@@ -158,7 +158,7 @@ export default class ApiExtractorPlugin implements IHeftTaskPlugin {
     if (!this._apiExtractorTaskConfigurationFileLoader) {
       this._apiExtractorTaskConfigurationFileLoader = new ConfigurationFile<IApiExtractorTaskConfiguration>({
         projectRelativeFilePath: TASK_CONFIG_RELATIVE_PATH,
-        jsonSchemaPath: TASK_CONFIG_SCHEMA_PATH
+        jsonSchemaObject: apiExtractorConfigSchema
       });
     }
 

--- a/heft-plugins/heft-api-extractor-plugin/tsconfig.json
+++ b/heft-plugins/heft-api-extractor-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "resolveJsonModule": true
   }
 }

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -42,6 +42,7 @@ import {
 import type { IHeftJestReporterOptions } from './HeftJestReporter';
 import { jestResolve } from './JestUtils';
 import { TerminalWritableStream } from './TerminalWritableStream';
+import anythingSchema from './schemas/anything.schema.json';
 
 const jestPluginSymbol: unique symbol = Symbol('heft-jest-plugin');
 interface IWithJestPlugin {
@@ -642,9 +643,6 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
     projectRelativeFilePath: string
   ): ConfigurationFile<IHeftJestConfiguration> {
     if (!JestPlugin._jestConfigurationFileLoader) {
-      // Bypass Jest configuration validation
-      const schemaPath: string = `${__dirname}/schemas/anything.schema.json`;
-
       // By default, ConfigurationFile will replace all objects, so we need to provide merge functions for these
       const shallowObjectInheritanceFunc: <T extends Record<string, unknown> | undefined>(
         currentObject: T,
@@ -690,7 +688,8 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
 
       JestPlugin._jestConfigurationFileLoader = new ConfigurationFile<IHeftJestConfiguration>({
         projectRelativeFilePath: projectRelativeFilePath,
-        jsonSchemaPath: schemaPath,
+        // Bypass Jest configuration validation
+        jsonSchemaObject: anythingSchema,
         propertyInheritance: {
           moduleNameMapper: {
             inheritanceType: InheritanceType.custom,

--- a/heft-plugins/heft-jest-plugin/tsconfig.json
+++ b/heft-plugins/heft-jest-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node", "heft-jest"]
+    "types": ["node", "heft-jest"],
+    "resolveJsonModule": true
   }
 }

--- a/heft-plugins/heft-sass-plugin/src/SassPlugin.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassPlugin.ts
@@ -14,11 +14,11 @@ import type {
 import { ConfigurationFile } from '@rushstack/heft-config-file';
 
 import { ISassConfiguration, SassProcessor } from './SassProcessor';
+import sassConfigSchema from './schemas/heft-sass-plugin.schema.json';
 
 export interface ISassConfigurationJson extends Partial<ISassConfiguration> {}
 
 const PLUGIN_NAME: 'sass-plugin' = 'sass-plugin';
-const PLUGIN_SCHEMA_PATH: string = `${__dirname}/schemas/heft-sass-plugin.schema.json`;
 const SASS_CONFIGURATION_LOCATION: string = 'config/sass.json';
 
 export default class SassPlugin implements IHeftPlugin {
@@ -122,9 +122,9 @@ export default class SassPlugin implements IHeftPlugin {
   ): Promise<ISassConfiguration> {
     if (!this._sassConfiguration) {
       if (!SassPlugin._sassConfigurationLoader) {
-        SassPlugin._sassConfigurationLoader = new ConfigurationFile<ISassConfigurationJson>({
+        SassPlugin._sassConfigurationLoader = new ConfigurationFile({
           projectRelativeFilePath: SASS_CONFIGURATION_LOCATION,
-          jsonSchemaPath: PLUGIN_SCHEMA_PATH
+          jsonSchemaObject: sassConfigSchema
         });
       }
 

--- a/heft-plugins/heft-sass-plugin/tsconfig.json
+++ b/heft-plugins/heft-sass-plugin/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "./custom-typings/**/*.ts"]
 }

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -18,6 +18,8 @@ import type {
 } from '@rushstack/heft';
 
 import { TypeScriptBuilder, ITypeScriptBuilderConfiguration } from './TypeScriptBuilder';
+import anythingSchema from './schemas/anything.schema.json';
+import typescriptConfigSchema from './schemas/typescript.schema.json';
 
 /**
  * The name of the plugin, as specified in heft-plugin.json
@@ -140,10 +142,9 @@ export async function loadTypeScriptConfigurationFileAsync(
   if (!typescriptConfigurationFilePromise) {
     // Ensure that the file loader has been initialized.
     if (!_typeScriptConfigurationFileLoader) {
-      const schemaPath: string = `${__dirname}/schemas/typescript.schema.json`;
       _typeScriptConfigurationFileLoader = new ConfigurationFile<ITypeScriptConfigurationJson>({
         projectRelativeFilePath: 'config/typescript.json',
-        jsonSchemaPath: schemaPath,
+        jsonSchemaObject: typescriptConfigSchema,
         propertyInheritance: {
           staticAssetsToCopy: {
             // When merging objects, arrays will be automatically appended
@@ -205,10 +206,9 @@ export async function loadPartialTsconfigFileAsync(
     } else {
       // Ensure that the file loader has been initialized.
       if (!_partialTsconfigFileLoader) {
-        const schemaPath: string = `${__dirname}/schemas/anything.schema.json`;
         _partialTsconfigFileLoader = new ConfigurationFile<IPartialTsconfig>({
           projectRelativeFilePath: typeScriptConfigurationJson?.project || 'tsconfig.json',
-          jsonSchemaPath: schemaPath,
+          jsonSchemaObject: anythingSchema,
           propertyInheritance: {
             compilerOptions: {
               inheritanceType: InheritanceType.merge

--- a/heft-plugins/heft-typescript-plugin/tsconfig.json
+++ b/heft-plugins/heft-typescript-plugin/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "types": ["node"],
-    "lib": ["ES2019"]
+    "lib": ["ES2019"],
+    "resolveJsonModule": true
   }
 }

--- a/libraries/localization-utilities/src/parsers/parseLocJson.ts
+++ b/libraries/localization-utilities/src/parsers/parseLocJson.ts
@@ -4,9 +4,9 @@
 import { JsonFile, JsonSchema } from '@rushstack/node-core-library';
 
 import { ILocalizationFile, IParseFileOptions } from '../interfaces';
+import locJsonSchema from '../schemas/locJson.schema.json';
 
-// Use `require` here to allow this package to be bundled with Webpack.
-const LOC_JSON_SCHEMA: JsonSchema = JsonSchema.fromLoadedObject(require('../schemas/locJson.schema.json'));
+const LOC_JSON_SCHEMA: JsonSchema = JsonSchema.fromLoadedObject(locJsonSchema);
 
 /**
  * @public

--- a/libraries/localization-utilities/tsconfig.json
+++ b/libraries/localization-utilities/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
     "target": "ES2019",
-    "types": ["heft-jest", "node"]
+    "types": ["heft-jest", "node"],
+    "resolveJsonModule": true
   }
 }

--- a/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
@@ -7,6 +7,7 @@ import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file'
 import { Async, ITerminal } from '@rushstack/node-core-library';
 import { RigConfig } from '@rushstack/rig-package';
 import type { RushConfigurationProject } from '@rushstack/rush-sdk';
+import rushProjectServeSchema from './schemas/rush-project-serve.schema.json';
 
 export interface IRushProjectServeJson {
   routing: IRoutingRuleJson[];
@@ -40,10 +41,9 @@ export class RushServeConfiguration {
   private readonly _loader: ConfigurationFile<IRushProjectServeJson>;
 
   public constructor() {
-    const jsonSchemaPath: string = `${__dirname}/schemas/rush-project-serve.schema.json`;
     this._loader = new ConfigurationFile<IRushProjectServeJson>({
       projectRelativeFilePath: 'config/rush-project-serve.json',
-      jsonSchemaPath,
+      jsonSchemaObject: rushProjectServeSchema,
       propertyInheritance: {
         routing: {
           inheritanceType: InheritanceType.append

--- a/rush-plugins/rush-serve-plugin/tsconfig.json
+++ b/rush-plugins/rush-serve-plugin/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "types": ["heft-jest", "node"],
     // express hackery makes this necessary
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Summary

Load (almost) all schemas via import.

## Details

Removes path generation from schema schema references, isntead loading them via `import`s.

## How it was tested

Built.