### PR TITLE
[heft] Remove `taskEvent` configuration and replace it with directly-referenced plugins

### DIFF
--- a/apps/heft/.npmignore
+++ b/apps/heft/.npmignore
@@ -30,3 +30,4 @@
 # (Add your project-specific overrides here)
 !/includes/**
 !UPGRADING.md
+!heft-plugin.json

--- a/apps/heft/UPGRADING.md
+++ b/apps/heft/UPGRADING.md
@@ -1,5 +1,48 @@
 # Upgrade notes for @rushstack/heft
 
+### Heft 0.53.0
+The `taskEvent` configuration option in heft.json has been removed, and use of any `taskEvent`-based functionality is now accomplished by referencing the plugins directly within the `@rushstack/heft` package.
+
+Old format:
+```json
+{
+  "phasesByName": {
+    "build": {
+      "tasksbyName": {
+        "perform-copy": {
+          "taskEvent": {
+            "eventKind": "copyFiles",
+            "options": {
+              ...
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+New format:
+```json
+{
+  "phasesByName": {
+    "build": {
+      "tasksbyName": {
+        "perform-copy": {
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
+            "options": {
+              ...
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Heft 0.52.0
 
 The `nodeService` built-in plugin now supports the `--serve` parameter, to be consistent with the `@rushstack/heft-webpack5-plugin` dev server.
@@ -141,8 +184,9 @@ The following is an example "heft.json" file defining both a "build" and a "test
           }
         },
         "copy-assets": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "packageName": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {

--- a/apps/heft/UPGRADING.md
+++ b/apps/heft/UPGRADING.md
@@ -3,6 +3,12 @@
 ### Heft 0.53.0
 The `taskEvent` configuration option in heft.json has been removed, and use of any `taskEvent`-based functionality is now accomplished by referencing the plugins directly within the `@rushstack/heft` package.
 
+Plugin name mappings for previously-existing task events are:
+- `copyFiles` -> `copy-files-plugin`
+- `deleteFiles` -> `delete-files-plugin`
+- `runScript` -> `run-script-plugin`
+- `nodeService` -> `node-service-plugin`
+
 Old format:
 ```json
 {

--- a/apps/heft/UPGRADING.md
+++ b/apps/heft/UPGRADING.md
@@ -118,13 +118,13 @@ Lifecycle plugins are specified in the top-level `heftPlugins` array. Plugins ca
 
   "heftPlugins": [
     {
-      "packageName": "@rushstack/heft-metrics-reporter",
+      "pluginPackage": "@rushstack/heft-metrics-reporter",
       "options": {
         "disableMetrics": true
       }
     },
     {
-      "packageName": "@rushstack/heft-initialization-plugin",
+      "pluginPackage": "@rushstack/heft-initialization-plugin",
       "pluginName": "my-lifecycle-plugin"
     }
   ]
@@ -145,7 +145,7 @@ The following is an example "heft.json" file defining both a "build" and a "test
   // "heftPlugins" can be used alongside "phasesByName"
   "heftPlugins": [
     {
-      "packageName": "@rushstack/heft-metrics-reporter"
+      "pluginPackage": "@rushstack/heft-metrics-reporter"
     }
   ],
 
@@ -174,7 +174,7 @@ The following is an example "heft.json" file defining both a "build" and a "test
         },
         "copy-assets": {
           "taskPlugin": {
-            "packageName": "@rushstack/heft",
+            "pluginPackage": "@rushstack/heft",
             "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [

--- a/apps/heft/UPGRADING.md
+++ b/apps/heft/UPGRADING.md
@@ -9,35 +9,18 @@ Plugin name mappings for previously-existing task events are:
 - `runScript` -> `run-script-plugin`
 - `nodeService` -> `node-service-plugin`
 
-Old format:
-```json
+Example diff of a heft.json file that uses the `copyFiles` task event:
+```diff
 {
   "phasesByName": {
     "build": {
       "tasksbyName": {
         "perform-copy": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
-            "options": {
-              ...
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-New format:
-```json
-{
-  "phasesByName": {
-    "build": {
-      "tasksbyName": {
-        "perform-copy": {
-          "taskPlugin": {
-            "pluginPackage": "@rushstack/heft",
-            "pluginName": "copy-files-plugin",
+-          "taskEvent": {
+-            "eventKind": "copyFiles",
++          "taskPlugin": {
++            "pluginPackage": "@rushstack/heft",
++            "pluginName": "copy-files-plugin",
             "options": {
               ...
             }

--- a/apps/heft/heft-plugin.json
+++ b/apps/heft/heft-plugin.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft-plugin.schema.json",
+
+  "lifecyclePlugins": [],
+
+  "taskPlugins": [
+    {
+      "pluginName": "copy-files-plugin",
+      "entryPoint": "./lib/plugins/CopyFilesPlugin",
+      "optionsSchema": "./lib/schemas/copy-files-options.schema.json"
+    },
+    {
+      "pluginName": "delete-files-plugin",
+      "entryPoint": "./lib/plugins/DeleteFilesPlugin",
+      "optionsSchema": "./lib/schemas/delete-files-options.schema.json"
+    },
+    {
+      "pluginName": "node-service-plugin",
+      "entryPoint": "./lib/plugins/NodeServicePlugin",
+      "parameterScope": "node-service",
+      "parameters": [
+        {
+          "longName": "--serve",
+          "parameterKind": "flag",
+          "description": "Start a local web server for testing purposes. This parameter is only available when running in watch mode."
+        }
+      ]
+    },
+    {
+      "pluginName": "run-script-plugin",
+      "entryPoint": "./lib/plugins/RunScriptPlugin",
+      "optionsSchema": "./lib/schemas/run-script-options.schema.json"
+    }
+  ]
+}

--- a/apps/heft/src/configuration/HeftPluginDefinition.ts
+++ b/apps/heft/src/configuration/HeftPluginDefinition.ts
@@ -211,7 +211,7 @@ export abstract class HeftPluginDefinitionBase {
     }
 
     // Ensure that plugin names are unique. Main reason for this restriction is to ensure that command-line
-    // parameter conflicts can be handled/undocumented synonms can be provided in all scenarios
+    // parameter conflicts can be handled/undocumented synonyms can be provided in all scenarios
     const existingPluginPath: string | undefined = HeftPluginDefinitionBase._loadedPluginPathsByName.get(
       this.pluginName
     );

--- a/apps/heft/src/pluginFramework/HeftLifecycle.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycle.ts
@@ -8,7 +8,10 @@ import { HeftPluginConfiguration } from '../configuration/HeftPluginConfiguratio
 import { HeftPluginHost } from './HeftPluginHost';
 import type { InternalHeftSession } from './InternalHeftSession';
 import type { IHeftConfigurationJsonPluginSpecifier } from '../utilities/CoreConfigFiles';
-import type { HeftLifecyclePluginDefinition } from '../configuration/HeftPluginDefinition';
+import type {
+  HeftLifecyclePluginDefinition,
+  HeftPluginDefinitionBase
+} from '../configuration/HeftPluginDefinition';
 import type { IHeftLifecyclePlugin, IHeftPlugin } from './IHeftPlugin';
 import {
   HeftLifecycleSession,
@@ -144,11 +147,12 @@ export class HeftLifecycle extends HeftPluginHost {
       let pluginConfigurationIndex: number = 0;
       for (const pluginSpecifier of this._lifecyclePluginSpecifiers) {
         const pluginConfiguration: HeftPluginConfiguration = pluginConfigurations[pluginConfigurationIndex++];
-        const pluginDefinition: HeftLifecyclePluginDefinition =
+        const pluginDefinition: HeftPluginDefinitionBase =
           pluginConfiguration.getPluginDefinitionBySpecifier(pluginSpecifier);
 
         // Ensure the plugin is a lifecycle plugin
-        if (!pluginConfiguration.lifecyclePluginDefinitions.has(pluginDefinition)) {
+        const isLifecyclePlugin: boolean = pluginConfiguration.isLifecyclePluginDefinition(pluginDefinition);
+        if (!isLifecyclePlugin) {
           throw new Error(
             `Plugin ${JSON.stringify(pluginDefinition.pluginName)} from package ` +
               `${JSON.stringify(pluginSpecifier.pluginPackage)} is not a lifecycle plugin.`

--- a/apps/heft/src/pluginFramework/HeftTask.ts
+++ b/apps/heft/src/pluginFramework/HeftTask.ts
@@ -130,13 +130,15 @@ export class HeftTask {
     );
     const pluginDefinition: HeftPluginDefinitionBase =
       pluginConfiguration.getPluginDefinitionBySpecifier(pluginSpecifier);
-    if (!pluginConfiguration.taskPluginDefinitions.has(pluginDefinition)) {
+
+    const isTaskPluginDefinition: boolean = pluginConfiguration.isTaskPluginDefinition(pluginDefinition);
+    if (!isTaskPluginDefinition) {
       throw new Error(
         `Plugin ${JSON.stringify(pluginSpecifier.pluginName)} specified by task ` +
           `${JSON.stringify(this._taskName)} is not a task plugin.`
       );
     }
-    return pluginDefinition as HeftTaskPluginDefinition;
+    return pluginDefinition;
   }
 
   private _validate(): void {

--- a/apps/heft/src/pluginFramework/HeftTask.ts
+++ b/apps/heft/src/pluginFramework/HeftTask.ts
@@ -4,9 +4,9 @@
 import { InternalError } from '@rushstack/node-core-library';
 
 import { HeftPluginConfiguration } from '../configuration/HeftPluginConfiguration';
-import {
+import type {
   HeftTaskPluginDefinition,
-  type HeftPluginDefinitionBase
+  HeftPluginDefinitionBase
 } from '../configuration/HeftPluginDefinition';
 import type { HeftPhase } from './HeftPhase';
 import type {
@@ -17,78 +17,6 @@ import type { IHeftTaskPlugin } from '../pluginFramework/IHeftPlugin';
 import type { IScopedLogger } from '../pluginFramework/logging/ScopedLogger';
 
 const RESERVED_TASK_NAMES: Set<string> = new Set(['clean']);
-
-let _copyFilesPluginDefinition: HeftTaskPluginDefinition | undefined;
-function _getCopyFilesPluginDefinition(): HeftTaskPluginDefinition {
-  if (!_copyFilesPluginDefinition) {
-    _copyFilesPluginDefinition = HeftTaskPluginDefinition.loadFromObject({
-      heftPluginDefinitionJson: {
-        pluginName: 'copy-files-plugin',
-        entryPoint: './lib/plugins/CopyFilesPlugin',
-        optionsSchema: './lib/schemas/copy-files-options.schema.json'
-      },
-      packageRoot: `${__dirname}/../..`,
-      packageName: '@rushstack/heft'
-    });
-  }
-  return _copyFilesPluginDefinition;
-}
-
-let _deleteFilesPluginDefinition: HeftTaskPluginDefinition | undefined;
-function _getDeleteFilesPluginDefinition(): HeftTaskPluginDefinition {
-  if (!_deleteFilesPluginDefinition) {
-    _deleteFilesPluginDefinition = HeftTaskPluginDefinition.loadFromObject({
-      heftPluginDefinitionJson: {
-        pluginName: 'delete-files-plugin',
-        entryPoint: './lib/plugins/DeleteFilesPlugin',
-        optionsSchema: './lib/schemas/delete-files-options.schema.json'
-      },
-      packageRoot: `${__dirname}/../..`,
-      packageName: '@rushstack/heft'
-    });
-  }
-  return _deleteFilesPluginDefinition;
-}
-
-let _runScriptPluginDefinition: HeftTaskPluginDefinition | undefined;
-function _getRunScriptPluginDefinition(): HeftTaskPluginDefinition {
-  if (!_runScriptPluginDefinition) {
-    _runScriptPluginDefinition = HeftTaskPluginDefinition.loadFromObject({
-      heftPluginDefinitionJson: {
-        pluginName: 'run-script-plugin',
-        entryPoint: './lib/plugins/RunScriptPlugin',
-        optionsSchema: './lib/schemas/run-script-options.schema.json'
-      },
-      packageRoot: `${__dirname}/../..`,
-      packageName: '@rushstack/heft'
-    });
-  }
-  return _runScriptPluginDefinition;
-}
-
-let _nodeServicePluginDefinition: HeftTaskPluginDefinition | undefined;
-function _getNodeServicePluginDefinition(): HeftTaskPluginDefinition {
-  if (!_nodeServicePluginDefinition) {
-    _nodeServicePluginDefinition = HeftTaskPluginDefinition.loadFromObject({
-      heftPluginDefinitionJson: {
-        pluginName: 'node-service-plugin',
-        entryPoint: './lib/plugins/NodeServicePlugin',
-        parameterScope: 'node-service',
-        parameters: [
-          {
-            longName: '--serve',
-            parameterKind: 'flag',
-            description:
-              'Start a local web server for testing purposes.  This parameter is only available when running in watch mode.'
-          }
-        ]
-      },
-      packageRoot: `${__dirname}/../..`,
-      packageName: '@rushstack/heft'
-    });
-  }
-  return _nodeServicePluginDefinition;
-}
 
 /**
  * @internal
@@ -141,7 +69,7 @@ export class HeftTask {
   }
 
   public get pluginOptions(): object | undefined {
-    return this._taskSpecifier.taskEvent?.options || this._taskSpecifier.taskPlugin?.options;
+    return this._taskSpecifier.taskPlugin.options;
   }
 
   public get dependencyTasks(): Set<HeftTask> {
@@ -193,57 +121,22 @@ export class HeftTask {
   }
 
   private async _loadTaskPluginDefintionAsync(): Promise<HeftTaskPluginDefinition> {
-    if (this._taskSpecifier.taskEvent && this._taskSpecifier.taskPlugin) {
-      // This is validated in the schema so this shouldn't happen, but throw just in case.
+    // taskPlugin.pluginPackage should already be resolved to the package root.
+    // See CoreConfigFiles.heftConfigFileLoader
+    const pluginSpecifier: IHeftConfigurationJsonPluginSpecifier = this._taskSpecifier.taskPlugin;
+    const pluginConfiguration: HeftPluginConfiguration = await HeftPluginConfiguration.loadFromPackageAsync(
+      pluginSpecifier.pluginPackageRoot,
+      pluginSpecifier.pluginPackage
+    );
+    const pluginDefinition: HeftPluginDefinitionBase =
+      pluginConfiguration.getPluginDefinitionBySpecifier(pluginSpecifier);
+    if (!pluginConfiguration.taskPluginDefinitions.has(pluginDefinition)) {
       throw new Error(
-        `Task ${JSON.stringify(this._taskName)} has both a taskEvent and a taskPlugin. ` +
-          `Only one of these can be specified.`
+        `Plugin ${JSON.stringify(pluginSpecifier.pluginName)} specified by task ` +
+          `${JSON.stringify(this._taskName)} is not a task plugin.`
       );
     }
-
-    if (this._taskSpecifier.taskEvent) {
-      switch (this._taskSpecifier.taskEvent.eventKind) {
-        case 'copyFiles': {
-          return _getCopyFilesPluginDefinition();
-        }
-        case 'deleteFiles': {
-          return _getDeleteFilesPluginDefinition();
-        }
-        case 'runScript': {
-          return _getRunScriptPluginDefinition();
-        }
-        case 'nodeService': {
-          return _getNodeServicePluginDefinition();
-        }
-        default: {
-          throw new InternalError(
-            `Unknown task event kind ${JSON.stringify(this._taskSpecifier.taskEvent.eventKind)}`
-          );
-        }
-      }
-    } else if (this._taskSpecifier.taskPlugin) {
-      // taskPlugin.pluginPackage should already be resolved to the package root.
-      // See CoreConfigFiles.heftConfigFileLoader
-      const pluginSpecifier: IHeftConfigurationJsonPluginSpecifier = this._taskSpecifier.taskPlugin;
-      const pluginConfiguration: HeftPluginConfiguration = await HeftPluginConfiguration.loadFromPackageAsync(
-        pluginSpecifier.pluginPackageRoot,
-        pluginSpecifier.pluginPackage
-      );
-      const pluginDefinition: HeftPluginDefinitionBase =
-        pluginConfiguration.getPluginDefinitionBySpecifier(pluginSpecifier);
-      if (!pluginConfiguration.taskPluginDefinitions.has(pluginDefinition)) {
-        throw new Error(
-          `Plugin ${JSON.stringify(pluginSpecifier.pluginName)} specified by task ` +
-            `${JSON.stringify(this._taskName)} is not a task plugin.`
-        );
-      }
-      return pluginDefinition as HeftTaskPluginDefinition;
-    } else {
-      // This is validated in the schema so this shouldn't happen, but throw just in case
-      throw new InternalError(
-        `Task ${JSON.stringify(this._taskName)} has no specified task event or task plugin.`
-      );
-    }
+    return pluginDefinition as HeftTaskPluginDefinition;
   }
 
   private _validate(): void {
@@ -252,8 +145,8 @@ export class HeftTask {
         `Task name ${JSON.stringify(this.taskName)} is reserved and cannot be used as a task name.`
       );
     }
-    if (!this._taskSpecifier.taskEvent && !this._taskSpecifier.taskPlugin) {
-      throw new Error(`Task ${JSON.stringify(this.taskName)} has no specified task event or task plugin.`);
+    if (!this._taskSpecifier.taskPlugin) {
+      throw new Error(`Task ${JSON.stringify(this.taskName)} has no specified task plugin.`);
     }
   }
 }

--- a/apps/heft/src/plugins/RunScriptPlugin.ts
+++ b/apps/heft/src/plugins/RunScriptPlugin.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
 import type { HeftConfiguration } from '../configuration/HeftConfiguration';
 import type { IHeftTaskPlugin } from '../pluginFramework/IHeftPlugin';
 import type { IHeftTaskSession, IHeftTaskRunHookOptions } from '../pluginFramework/HeftTaskSession';
@@ -53,10 +54,10 @@ export default class RunScriptPlugin implements IHeftTaskPlugin<IRunScriptPlugin
     pluginOptions: IRunScriptPluginOptions,
     runOptions: IHeftTaskRunHookOptions
   ): Promise<void> {
-    // The scriptPath property should be fully resolved since it is included in the resolution logic used by
-    // HeftConfiguration
-    const resolvedModulePath: string = pluginOptions.scriptPath;
-
+    const resolvedModulePath: string = path.resolve(
+      heftConfiguration.buildFolderPath,
+      pluginOptions.scriptPath
+    );
     const runScript: IRunScript = await import(resolvedModulePath);
     if (!runScript.runAsync) {
       throw new Error(

--- a/apps/heft/src/schemas/heft.schema.json
+++ b/apps/heft/src/schemas/heft.schema.json
@@ -175,29 +175,9 @@
                   "type": "object",
                   "description": "Defines a Heft task.",
                   "additionalProperties": false,
-                  "oneOf": [
-                    {
-                      "required": ["taskPlugin"],
-                      "properties": {
-                        "taskPlugin": { "$ref": "#/definitions/heft-plugin" }
-                      }
-                    },
-                    {
-                      "required": ["taskEvent"],
-                      "properties": {
-                        "taskEvent": { "$ref": "#/definitions/heft-event" }
-                      }
-                    }
-                  ],
+                  "required": ["taskPlugin"],
                   "properties": {
-                    "taskPlugin": {
-                      "description": "A plugin that can be used to extend Heft functionality.",
-                      "type": "object"
-                    },
-                    "taskEvent": {
-                      "description": "An event that can be used to extend Heft functionality.",
-                      "type": "object"
-                    },
+                    "taskPlugin": { "$ref": "#/definitions/heft-plugin" },
 
                     "taskDependencies": {
                       "type": "array",

--- a/apps/heft/src/utilities/CoreConfigFiles.ts
+++ b/apps/heft/src/utilities/CoreConfigFiles.ts
@@ -4,18 +4,16 @@
 import * as path from 'path';
 import {
   ConfigurationFile,
-  IJsonPathMetadataResolverOptions,
   InheritanceType,
-  PathResolutionMethod
+  PathResolutionMethod,
+  type IJsonPathMetadataResolverOptions
 } from '@rushstack/heft-config-file';
-import { Import, ITerminal } from '@rushstack/node-core-library';
+import { Import, type ITerminal } from '@rushstack/node-core-library';
 import type { RigConfig } from '@rushstack/rig-package';
 
 import type { IDeleteOperation } from '../plugins/DeleteFilesPlugin';
 import type { INodeServicePluginConfiguration } from '../plugins/NodeServicePlugin';
 import { Constants } from './Constants';
-
-export type HeftEventKind = 'copyFiles' | 'deleteFiles' | 'runScript' | 'nodeService';
 
 export interface IHeftConfigurationJsonActionReference {
   actionName: string;
@@ -24,11 +22,6 @@ export interface IHeftConfigurationJsonActionReference {
 
 export interface IHeftConfigurationJsonAliases {
   [aliasName: string]: IHeftConfigurationJsonActionReference;
-}
-
-export interface IHeftConfigurationJsonEventSpecifier {
-  eventKind: HeftEventKind;
-  options?: object;
 }
 
 export interface IHeftConfigurationJsonPluginSpecifier {
@@ -40,8 +33,7 @@ export interface IHeftConfigurationJsonPluginSpecifier {
 
 export interface IHeftConfigurationJsonTaskSpecifier {
   taskDependencies?: string[];
-  taskEvent?: IHeftConfigurationJsonEventSpecifier;
-  taskPlugin?: IHeftConfigurationJsonPluginSpecifier;
+  taskPlugin: IHeftConfigurationJsonPluginSpecifier;
 }
 
 export interface IHeftConfigurationJsonTasks {
@@ -91,7 +83,8 @@ export class CoreConfigFiles {
         const configurationFileDirectory: string = path.dirname(configurationFilePath);
         return Import.resolvePackage({
           packageName: propertyValue,
-          baseFolderPath: configurationFileDirectory
+          baseFolderPath: configurationFileDirectory,
+          allowSelfReference: true
         });
       };
 
@@ -115,12 +108,7 @@ export class CoreConfigFiles {
           '$.phasesByName.*.tasksByName.*.taskPlugin.pluginPackage': {
             pathResolutionMethod: PathResolutionMethod.custom,
             customResolver: pluginPackageResolver
-          },
-          // Special handling for "runScript" task events to resolve the script path
-          '$.phasesByName.*.tasksByName[?(@.taskEvent && @.taskEvent.eventKind == "runScript")].taskEvent.options.scriptPath':
-            {
-              pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToProjectRoot
-            }
+          }
         }
       });
     }

--- a/apps/lockfile-explorer-web/config/heft.json
+++ b/apps/lockfile-explorer-web/config/heft.json
@@ -15,8 +15,9 @@
       "tasksByName": {
         "copy-stub": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {

--- a/apps/lockfile-explorer/config/heft.json
+++ b/apps/lockfile-explorer/config/heft.json
@@ -14,8 +14,9 @@
     "build": {
       "tasksByName": {
         "copy-app-bundle": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {

--- a/build-tests/heft-copy-files-test/config/heft.json
+++ b/build-tests/heft-copy-files-test/config/heft.json
@@ -39,8 +39,9 @@
 
       "tasksByName": {
         "perform-copy": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {

--- a/build-tests/heft-fastify-test/config/heft.json
+++ b/build-tests/heft-fastify-test/config/heft.json
@@ -22,8 +22,9 @@
         },
         "node-service": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "nodeService"
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "node-service-plugin"
           }
         }
       }

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -39,36 +39,36 @@ importers:
 
   typescript-newest-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.51.0.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.1.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.1.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.52.1.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.3.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.3.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~5.0.4
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.1.tgz_@rushstack+heft@0.51.0
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.1.tgz_@rushstack+heft@0.51.0
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_ucoohk2w7gukx6ccuul7rl7pnq
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.52.1.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.3.tgz_@rushstack+heft@0.52.1
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.3.tgz_@rushstack+heft@0.52.1
       eslint: 8.7.0
       tslint: 5.20.1_typescript@5.0.4
       typescript: 5.0.4
 
   typescript-v4-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.0.tgz
-      '@rushstack/heft': file:rushstack-heft-0.51.0.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.1.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.1.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.1.tgz
+      '@rushstack/heft': file:rushstack-heft-0.52.1.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.3.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.3.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.7.0
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz_valmiib6gbzc7jhcbpocdsabay
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.1.tgz_@rushstack+heft@0.51.0
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.1.tgz_@rushstack+heft@0.51.0
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_valmiib6gbzc7jhcbpocdsabay
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.52.1.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.3.tgz_@rushstack+heft@0.52.1
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.3.tgz_@rushstack+heft@0.52.1
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.7.4
       typescript: 4.7.4
@@ -1888,6 +1888,10 @@ packages:
 
   /graceful-fs/4.2.4:
     resolution: {integrity: sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=}
+
+  /graceful-fs/4.2.9:
+    resolution: {integrity: sha1-BBsF30V1Xlh6JJQiebnRExRuHJY=}
+    dev: true
 
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4=}
@@ -3763,7 +3767,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.9
     dev: true
 
   /wcwidth/1.0.1:
@@ -3908,14 +3912,14 @@ packages:
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz_@types+node@14.18.36
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz_@types+node@14.18.36
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz_@types+node@14.18.36
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.3.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.23.tgz_@types+node@14.18.36
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.2.10.tgz_@types+node@14.18.36
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.241.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.16.tgz_@types+node@14.18.36
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
       builtin-modules: 3.1.0
@@ -3947,16 +3951,16 @@ packages:
       - encoding
       - supports-color
 
-  file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz
+  file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz
     name: '@rushstack/eslint-config'
-    version: 3.3.0
+    version: 3.3.1
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
-      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.0.tgz
+      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz
       '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
       '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.7.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
       '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.6.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
@@ -3973,16 +3977,16 @@ packages:
       - supports-color
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz_valmiib6gbzc7jhcbpocdsabay:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-3.3.0.tgz
+  file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_valmiib6gbzc7jhcbpocdsabay:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz
     name: '@rushstack/eslint-config'
-    version: 3.3.0
+    version: 3.3.1
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
-      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.0.tgz
+      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz
       '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_valmiib6gbzc7jhcbpocdsabay
       '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.7.0.tgz_valmiib6gbzc7jhcbpocdsabay
       '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.6.0.tgz_valmiib6gbzc7jhcbpocdsabay
@@ -3999,10 +4003,10 @@ packages:
       - supports-color
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-patch-1.3.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-patch-1.3.0.tgz}
+  file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz}
     name: '@rushstack/eslint-patch'
-    version: 1.3.0
+    version: 1.3.1
     dev: true
 
   file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
@@ -4101,17 +4105,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.51.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.51.0.tgz}
+  file:../temp/tarballs/rushstack-heft-0.52.1.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.52.1.tgz}
     name: '@rushstack/heft'
-    version: 0.51.0
+    version: 0.52.1
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.13.3.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -4125,58 +4129,58 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.12.3
+    version: 0.12.4
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz}
-    id: file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz
+  file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz}
+    id: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
     name: '@rushstack/heft-config-file'
-    version: 0.12.3
+    version: 0.12.4
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.1.tgz_@rushstack+heft@0.51.0:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.1.tgz}
-    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.1.tgz
+  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.3.tgz_@rushstack+heft@0.52.1:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.3.tgz}
+    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.3.tgz
     name: '@rushstack/heft-lint-plugin'
-    version: 0.1.1
+    version: 0.1.3
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.52.1.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
       semver: 7.3.8
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.1.tgz_@rushstack+heft@0.51.0:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.1.tgz}
-    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.1.tgz
+  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.3.tgz_@rushstack+heft@0.52.1:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.3.tgz}
+    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.3.tgz
     name: '@rushstack/heft-typescript-plugin'
-    version: 0.1.1
+    version: 0.1.3
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.51.0.tgz
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.3.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.52.1.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
       '@types/tapable': 1.0.6
       semver: 7.3.8
       tapable: 1.1.3
@@ -4184,10 +4188,10 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.59.2
+    version: 3.59.3
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4203,11 +4207,11 @@ packages:
       z-schema: 5.0.3
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz}
-    id: file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz
+  file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz}
+    id: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
     name: '@rushstack/node-core-library'
-    version: 3.59.2
+    version: 3.59.3
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4223,35 +4227,35 @@ packages:
       semver: 7.3.8
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.21.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.0.23.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.23.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.23.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.0.21
+    version: 4.0.23
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.2.8.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.2.10.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.2.10.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.2.10.tgz
     name: '@rushstack/package-extractor'
-    version: 0.2.8
+    version: 0.2.10
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.16.tgz_@types+node@14.18.36
       ignore: 5.1.9
       jszip: 3.8.0
       npm-packlist: 2.1.5
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.19.tgz}
+  file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz}
     name: '@rushstack/rig-package'
-    version: 0.3.19
+    version: 0.3.20
     dependencies:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
@@ -4262,36 +4266,36 @@ packages:
     name: '@rushstack/rush-sdk'
     version: 5.99.0
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
       '@types/node-fetch': 2.6.2
       tapable: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.0.239.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.0.241.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.241.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.0.241.tgz
     name: '@rushstack/stream-collator'
-    version: 4.0.239
+    version: 4.0.241
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.16.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.5.14.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.14.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.5.14.tgz
+  file:../temp/tarballs/rushstack-terminal-0.5.16.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.16.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.5.16.tgz
     name: '@rushstack/terminal'
-    version: 0.5.14
+    version: 0.5.16
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.2.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       wordwrap: 1.0.0
 
@@ -4301,10 +4305,10 @@ packages:
     version: 0.2.4
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.13.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.13.3.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.13.3
+    version: 4.14.0
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/build-tests/rush-lib-declaration-paths-test/config/heft.json
+++ b/build-tests/rush-lib-declaration-paths-test/config/heft.json
@@ -8,8 +8,9 @@
       "cleanFiles": [{ "sourcePath": "src" }],
       "tasksByName": {
         "create-src": {
-          "taskEvent": {
-            "eventKind": "runScript",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
             "options": {
               "scriptPath": "./scripts/createSrc.js"
             }
@@ -17,8 +18,9 @@
         },
 
         "copy-src-typings": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {

--- a/common/changes/@microsoft/rush/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
+++ b/common/changes/@microsoft/rush/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/common/changes/@rushstack/heft-node-rig/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
+++ b/common/changes/@rushstack/heft-node-rig/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
+++ b/common/changes/@rushstack/heft/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Remove \"taskEvents\" heft.json configuration option, and replace it with directly referencing the included plugins. More information on this change can be found at https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/lockfile-explorer/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
+++ b/common/changes/@rushstack/lockfile-explorer/user-danade-RemoveTaskEvents_2023-06-08-06-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer"
+}

--- a/libraries/rush-lib/config/heft.json
+++ b/libraries/rush-lib/config/heft.json
@@ -12,8 +12,9 @@
       "tasksByName": {
         "copy-mock-flush-telemetry-plugin": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {
@@ -36,8 +37,9 @@
 
         "copy-empty-modules": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "runScript",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
             "options": {
               "scriptPath": "./scripts/copyEmptyModules.js"
             }

--- a/libraries/rush-sdk/config/heft.json
+++ b/libraries/rush-sdk/config/heft.json
@@ -17,8 +17,9 @@
 
       "tasksByName": {
         "copy-rush-lib-types": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {
@@ -37,8 +38,9 @@
 
         "generate-stubs": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "runScript",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
             "options": {
               "scriptPath": "./lib-shim/generate-stubs.js"
             }

--- a/rigs/heft-node-rig/profiles/default/config/heft.json
+++ b/rigs/heft-node-rig/profiles/default/config/heft.json
@@ -40,8 +40,9 @@
         },
         "node-service": {
           "taskDependencies": ["typescript"],
-          "taskEvent": {
-            "eventKind": "nodeService"
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "node-service-plugin"
           }
         }
       }

--- a/webpack/hashed-folder-copy-plugin/config/heft.json
+++ b/webpack/hashed-folder-copy-plugin/config/heft.json
@@ -12,8 +12,9 @@
 
       "tasksByName": {
         "copy-ambient-types": {
-          "taskEvent": {
-            "eventKind": "copyFiles",
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "copy-files-plugin",
             "options": {
               "copyOperations": [
                 {


### PR DESCRIPTION
## Summary

This PR removes the `taskEvent` option from tasks in heft.json, and replaces it with referencing the `@rushstack/heft` package plugins directly. It also allows for self-referencing of plugin packages.

## Details

The `taskEvent` API was duplicative and unnecessary when plugins provided by Heft could be provided by simply referencing the `@rushstack/heft` package directly as with any other plugin package. Additionally, this change also allows for the `pluginPackage` field to reference the owning package. This will allow for loading plugins specified within the same package that defines the configuration.

Plugin name mappings for previously-existing task events are:
- `copyFiles` -> `copy-files-plugin`
- `deleteFiles` -> `delete-files-plugin`
- `runScript` -> `run-script-plugin`
- `nodeService` -> `node-service-plugin`

Old format:
```json
{
  "phasesByName": {
    "build": {
      "tasksbyName": {
        "perform-copy": {
          "taskEvent": {
            "eventKind": "copyFiles",
            "options": {
              ...
            }
          }
        }
      }
    }
  }
}
```
New format:
```json
{
  "phasesByName": {
    "build": {
      "tasksbyName": {
        "perform-copy": {
          "taskPlugin": {
            "pluginPackage": "@rushstack/heft",
            "pluginName": "copy-files-plugin",
            "options": {
              ...
            }
          }
        }
      }
    }
  }
}
```

## How it was tested
Locally, building the repo.

## Impacted documentation
All documentation referencing Heft `taskEvent` usage will need to be updated. I have updated `UPGRADING.MD` in this PR, and the updated schema will also need to be uploaded to the CDN.


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
