### PR TITLE
[heft-typescript] Force emit an error if warnings are encountered in solution mode

### DIFF
--- a/common/changes/@rushstack/heft-typescript-plugin/typescript-solution-error_2023-06-08-20-38.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/typescript-solution-error_2023-06-08-20-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Emit error if warnings are encountered when building in solution mode. This avoids confusion because the TypeScript compiler implicitly sets `noEmitOnError: true` when building in solution mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}


### PR DESCRIPTION
## Summary
The TypeScript compiler implicitly sets `noEmitOnError: true` when invoked in solution mode. This PR ensures that Heft enters an error state if the compiler does not emit outputs, so that subsequent build steps do not get processed.

## Details
In both watch and non-watch solution mode, if one or more warnings are encountered, also emits an informative error directing the user to fix the warnings to be able to continue, and why.

## How it was tested
Using the heft-typescript-composite-test project, modified source code of the leaf tsconfig project to have a warning and validated that it enters the error state, both in watch mode and normal build mode.

Sample output:
```
[build:typescript] Warning: build-tests/heft-typescript-composite-test/src/test/ExampleTest.test.ts:12:9 - (TS6133) 'x' is declared but its value is never read.
[build:typescript] Error: TypeScript encountered 1 warning and is configured to build project references. As a result, no files were emitted. Please fix the reported warnings to proceed.
```
![image](https://github.com/microsoft/rushstack/assets/26827560/e1d6e8f1-bbb3-4bf3-8fd4-e9c9aa2b127b)

## Impacted documentation
None.