### PR TITLE
[heft-jest-plugin] Add --test-path-ignore-patterns CLI option.

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/drieman-rushTestPathIgnorePatterns_2023-06-09-04-49.json
+++ b/common/changes/@rushstack/heft-jest-plugin/drieman-rushTestPathIgnorePatterns_2023-06-09-04-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Added --test-path-ignore-patterns support for subtractive test selection to complement existing additive support.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/heft-plugin.json
+++ b/heft-plugins/heft-jest-plugin/heft-plugin.json
@@ -54,6 +54,12 @@
           "description": "Run only tests with a name that matches a regular expression.  The REGEXP is matched against the full name, which is a combination of the test name and all its surrounding describe blocks.  This corresponds to the \"--testNamePattern\" parameter in Jest's documentation."
         },
         {
+          "longName": "--test-path-ignore-patterns",
+          "parameterKind": "string",
+          "argumentName": "REGEXP",
+          "description": "Avoid running tests with a source file path that matches one ore more regular expressions.  On Windows you will need to use \"/\" instead of \"\\\".  This corresponds to the \"--testPathIgnorePatterns\" parameter in Jest's documentation."
+        },
+        {
           "longName": "--test-path-pattern",
           "parameterKind": "string",
           "argumentName": "REGEXP",

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -105,6 +105,7 @@ export interface IJestPluginOptions {
   passWithNoTests?: boolean;
   silent?: boolean;
   testNamePattern?: string;
+  testPathIgnorePatterns?: string;
   testPathPattern?: string;
   testTimeout?: number;
   updateSnapshots?: boolean;
@@ -183,6 +184,9 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
     const maxWorkersParameter: CommandLineStringParameter = parameters.getStringParameter('--max-workers');
     const testNamePatternParameter: CommandLineStringParameter =
       parameters.getStringParameter('--test-name-pattern');
+    const testPathIgnorePatternsParameter: CommandLineStringParameter = parameters.getStringParameter(
+      '--test-path-ignore-patterns'
+    );
     const testPathPatternParameter: CommandLineStringParameter =
       parameters.getStringParameter('--test-path-pattern');
 
@@ -208,6 +212,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       passWithNoTests: true,
       silent: silentParameter.value || pluginOptions?.silent,
       testNamePattern: testNamePatternParameter.value || pluginOptions?.testNamePattern,
+      testPathIgnorePatterns: testPathIgnorePatternsParameter.value || pluginOptions?.testPathIgnorePatterns,
       testPathPattern: testPathPatternParameter.value || pluginOptions?.testPathPattern,
       testTimeout: testTimeoutParameter.value ?? pluginOptions?.testTimeout,
       updateSnapshots: updateSnapshotsParameter.value || pluginOptions?.updateSnapshots
@@ -564,6 +569,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
 
       silent: options.silent || false,
       testNamePattern: options.testNamePattern,
+      testPathIgnorePatterns: options.testPathIgnorePatterns ? [options.testPathIgnorePatterns] : undefined,
       testPathPattern: options.testPathPattern ? [options.testPathPattern] : undefined,
       testTimeout: options.testTimeout,
       maxWorkers: options.maxWorkers,


### PR DESCRIPTION
## Summary
Users sometimes need to run "all tests except..."
For example, one might have both unit tests and integration tests in the same project (even mixed in the same folders) and could need an exclusion pattern to run only the unit tests, or run only the integration tests.
Jest accepts the "testPathIgnorePatterns" CLI argument to support this but Heft-jest-plugin was not piping such an argument through.  This PR adds that missing support.

## Details
I simply followed the pattern of the existing similar "testPathPattern", to add the new "--test-path-ignore-patterns" argument which maps to the "testPathIgnorePatterns" Jest argument.

This is the second take at pushing the same feature due to major change conflicts accumulated while the original PR was waiting to merge.

## How it was tested
After building, in my rushstack mono-repo I went into libraries/rush-lib as it has a lot of tests.  I executed commands like these, which all seem to operate as expected, reducing the total number of tests executed from the 325 tests that normally execute:
* `rushx test --test-path-ignore-patterns Shrink`
* `rushx test --test-path-ignore-patterns Shrink\|Com\|Oper\|Look\|Telem\|Last`

## Impacted documentation
From what I'm aware of, the CLI output for the new option would need to be updated at, for example, https://rushstack.io/pages/heft/cli/#heft-test - not sure if that is automated or whatnot?
