### PR TITLE
[heft] Clarify CHANGELOG.md

### DIFF
--- a/apps/heft/CHANGELOG.json
+++ b/apps/heft/CHANGELOG.json
@@ -13,7 +13,7 @@
         ],
         "minor": [
           {
-            "comment": "Remove \"taskEvents\" heft.json configuration option, and replace it with directly referencing the included plugins. More information on this change can be found at https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md"
+            "comment": "(BREAKING CHANGE) Remove \"taskEvents\" heft.json configuration option, and replace it with directly referencing the included plugins. Please read https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md"
           }
         ]
       }
@@ -52,7 +52,7 @@
             "comment": "Add a new API IHeftTaskSession.parsedCommandLine for accessing the invoked command name"
           },
           {
-            "comment": "The built-in task NodeServicePlugin now supports the \"--serve\" mode with semantics similar to heft-webpack5-plugin"
+            "comment": "(BREAKING CHANGE) The built-in task NodeServicePlugin now supports the \"--serve\" mode with semantics similar to heft-webpack5-plugin. Please read https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md"
           }
         ],
         "patch": [
@@ -89,7 +89,7 @@
       "comments": {
         "minor": [
           {
-            "comment": "Overhaul to support splitting single-project builds into more phases than \"build\" and \"test\", to align with Rush phased commands. See UPGRADING.md for details."
+            "comment": "(BREAKING CHANGE) Overhaul to support splitting single-project builds into more phases than \"build\" and \"test\", to align with Rush phased commands. Please read https://github.com/microsoft/rushstack/blob/main/apps/heft/UPGRADING.md"
           }
         ]
       }

--- a/common/changes/@rushstack/heft/main_2023-06-09-16-37.json
+++ b/common/changes/@rushstack/heft/main_2023-06-09-16-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Revise CHANGELOG.md to more clearly identify the breaking changes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
Heft's **CHANGELOG.md** was missing the `(BREAKING CHANGE)` identifier, which is particularly confusing since we've been using SemVer MINOR bumps for breaking changes while the major version number is `0`.