### PR TITLE
[api-documenter] Clean up how api-documenter loads its config file.

### DIFF
--- a/apps/api-documenter/src/cli/GenerateAction.ts
+++ b/apps/api-documenter/src/cli/GenerateAction.ts
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
-
 import { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
 import { DocumenterConfig } from '../documenters/DocumenterConfig';
 import { ExperimentalYamlDocumenter } from '../documenters/ExperimentalYamlDocumenter';
 
-import { FileSystem } from '@rushstack/node-core-library';
 import { MarkdownDocumenter } from '../documenters/MarkdownDocumenter';
 
 export class GenerateAction extends BaseAction {
@@ -26,20 +23,7 @@ export class GenerateAction extends BaseAction {
     // override
     // Look for the config file under the current folder
 
-    let configFilePath: string = path.join(process.cwd(), DocumenterConfig.FILENAME);
-
-    // First try the current folder
-    if (!FileSystem.exists(configFilePath)) {
-      // Otherwise try the standard "config" subfolder
-      configFilePath = path.join(process.cwd(), 'config', DocumenterConfig.FILENAME);
-      if (!FileSystem.exists(configFilePath)) {
-        throw new Error(
-          `Unable to find ${DocumenterConfig.FILENAME} in the current folder or in a "config" subfolder`
-        );
-      }
-    }
-
-    const documenterConfig: DocumenterConfig = DocumenterConfig.loadFile(configFilePath);
+    const documenterConfig: DocumenterConfig = await DocumenterConfig.loadFileAsync(process.cwd());
 
     const { apiModel, outputFolder } = this.buildApiModel();
 

--- a/common/changes/@microsoft/api-documenter/clean-up-config-file-loading_2023-06-11-08-57.json
+++ b/common/changes/@microsoft/api-documenter/clean-up-config-file-loading_2023-06-11-08-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-documenter"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Cleans up the way `api-documenter` loads its config file.

This is a follow-up to https://github.com/microsoft/rushstack/pull/4049.

## How it was tested

Ran tests.