### PR TITLE
[heft] Add support for short names to Heft plugins and provide better handling of ambiguous parameters

### DIFF
--- a/apps/heft/src/configuration/HeftPluginDefinition.ts
+++ b/apps/heft/src/configuration/HeftPluginDefinition.ts
@@ -20,6 +20,10 @@ export interface IBaseParameterJson {
    */
   longName: string;
   /**
+   * An optional short form of the parameter (e.g. \"-v\" instead of \"--verbose\").
+   */
+  shortName?: string;
+  /**
    * A detailed description of the parameter, which appears when requesting help for the command (e.g. \"rush --help my-command\").
    */
   description: string;

--- a/apps/heft/src/pluginFramework/HeftParameterManager.ts
+++ b/apps/heft/src/pluginFramework/HeftParameterManager.ts
@@ -266,8 +266,6 @@ export class HeftParameterManager {
       this._parametersByDefinition.get(pluginDefinition)!;
 
     for (const parameter of pluginDefinition.pluginParameters) {
-      // Short names are excluded since it would be difficult and confusing to de-dupe/handle shortname
-      // conflicts as well as longname conflicts
       let definedParameter: CommandLineParameter;
       switch (parameter.parameterKind) {
         case 'choiceList': {

--- a/apps/heft/src/pluginFramework/HeftParameterManager.ts
+++ b/apps/heft/src/pluginFramework/HeftParameterManager.ts
@@ -276,6 +276,7 @@ export class HeftParameterManager {
             required: parameter.required,
             alternatives: parameter.alternatives.map((p: IChoiceParameterAlternativeJson) => p.name),
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -287,6 +288,7 @@ export class HeftParameterManager {
             alternatives: parameter.alternatives.map((p: IChoiceParameterAlternativeJson) => p.name),
             defaultValue: parameter.defaultValue,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -296,6 +298,7 @@ export class HeftParameterManager {
             description: parameter.description,
             required: parameter.required,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -306,6 +309,7 @@ export class HeftParameterManager {
             required: parameter.required,
             argumentName: parameter.argumentName,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -317,6 +321,7 @@ export class HeftParameterManager {
             argumentName: parameter.argumentName,
             defaultValue: parameter.defaultValue,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -327,6 +332,7 @@ export class HeftParameterManager {
             required: parameter.required,
             argumentName: parameter.argumentName,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;
@@ -338,6 +344,7 @@ export class HeftParameterManager {
             argumentName: parameter.argumentName,
             defaultValue: parameter.defaultValue,
             parameterLongName: parameter.longName,
+            parameterShortName: parameter.shortName,
             parameterScope: pluginDefinition.pluginParameterScope
           });
           break;

--- a/apps/heft/src/schemas/heft-plugin.schema.json
+++ b/apps/heft/src/schemas/heft-plugin.schema.json
@@ -27,6 +27,12 @@
           "type": "string",
           "pattern": "^-(-[a-z0-9]+)+$"
         },
+        "shortName": {
+          "title": "Short Name",
+          "description": "A optional short form of the parameter (e.g. \"-v\" instead of \"--verbose\")",
+          "type": "string",
+          "pattern": "^-[a-zA-Z]$"
+        },
         "description": {
           "title": "Parameter Description",
           "description": "A detailed description of the parameter, which appears when requesting help for the command (e.g. \"heft phaseName --help my-command\").",
@@ -90,6 +96,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
@@ -145,6 +152,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
@@ -175,6 +183,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" }
           }
@@ -214,6 +223,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
@@ -251,6 +261,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
@@ -292,6 +303,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 
@@ -329,6 +341,7 @@
           "properties": {
             "parameterKind": { "$ref": "#/definitions/anything" },
             "longName": { "$ref": "#/definitions/anything" },
+            "shortName": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
             "required": { "$ref": "#/definitions/anything" },
 

--- a/common/changes/@rushstack/heft-jest-plugin/user-danade-AmbiguousParameters_2023-06-12-18-40.json
+++ b/common/changes/@rushstack/heft-jest-plugin/user-danade-AmbiguousParameters_2023-06-12-18-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Add support for using '-u' for the '--update-snapshots' parameter and '-t' for the '--test-name-pattern' parameter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft/user-danade-AmbiguousParameters_2023-06-12-18-40.json
+++ b/common/changes/@rushstack/heft/user-danade-AmbiguousParameters_2023-06-12-18-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add plugin support for parameter short-names.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/ts-command-line/user-danade-AmbiguousParameters_2023-06-12-18-40.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-AmbiguousParameters_2023-06-12-18-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Add support for handling ambiguous parameters when conflicting parameters are provided but they provide a non-conflicting alternative (e.g. parameters with the same short-name but different long-names, scoped parameters with the same long-name but different scopes). When using an ambiguous parameter on the CLI, an error message describing the ambiguous parameter usage will appear.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -121,6 +121,8 @@ export abstract class CommandLineParameter {
     constructor(definition: IBaseCommandLineDefinition);
     abstract appendToArgList(argList: string[]): void;
     readonly description: string;
+    // @internal
+    _disableShortName(): void;
     readonly environmentVariable: string | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
@@ -135,7 +137,7 @@ export abstract class CommandLineParameter {
     readonly scopedLongName: string | undefined;
     // @internal
     abstract _setValue(data: any): void;
-    readonly shortName: string | undefined;
+    get shortName(): string | undefined;
     readonly undocumentedSynonyms: string[] | undefined;
     // (undocumented)
     protected validateDefaultValue(hasDefaultValue: boolean): void;

--- a/heft-plugins/heft-jest-plugin/heft-plugin.json
+++ b/heft-plugins/heft-jest-plugin/heft-plugin.json
@@ -49,6 +49,7 @@
         },
         {
           "longName": "--test-name-pattern",
+          "shortName": "-t",
           "parameterKind": "string",
           "argumentName": "REGEXP",
           "description": "Run only tests with a name that matches a regular expression.  The REGEXP is matched against the full name, which is a combination of the test name and all its surrounding describe blocks.  This corresponds to the \"--testNamePattern\" parameter in Jest's documentation."
@@ -73,6 +74,7 @@
         },
         {
           "longName": "--update-snapshots",
+          "shortName": "-u",
           "parameterKind": "flag",
           "description": "Update Jest snapshots while running the tests.  This corresponds to the \"--updateSnapshots\" parameter in Jest."
         }

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -56,6 +56,8 @@ const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
  * @public
  */
 export abstract class CommandLineParameter {
+  private _shortNameValue: string | undefined;
+
   /**
    * A unique internal key used to retrieve the value from the parser's dictionary.
    * @internal
@@ -70,9 +72,6 @@ export abstract class CommandLineParameter {
    * including double dashes, eg. "--scope:do-something". Otherwise undefined.
    */
   public readonly scopedLongName: string | undefined;
-
-  /** {@inheritDoc IBaseCommandLineDefinition.parameterShortName} */
-  public readonly shortName: string | undefined;
 
   /** {@inheritDoc IBaseCommandLineDefinition.parameterGroup} */
   public readonly parameterGroup: string | typeof SCOPING_PARAMETER_GROUP | undefined;
@@ -95,7 +94,7 @@ export abstract class CommandLineParameter {
   /** @internal */
   public constructor(definition: IBaseCommandLineDefinition) {
     this.longName = definition.parameterLongName;
-    this.shortName = definition.parameterShortName;
+    this._shortNameValue = definition.parameterShortName;
     this.parameterGroup = definition.parameterGroup;
     this.parameterScope = definition.parameterScope;
     this.description = definition.description;
@@ -166,11 +165,24 @@ export abstract class CommandLineParameter {
     }
   }
 
+  /** {@inheritDoc IBaseCommandLineDefinition.parameterShortName} */
+  public get shortName(): string | undefined {
+    return this._shortNameValue;
+  }
+
   /**
    * Called internally by CommandLineParameterProvider._processParsedData()
    * @internal
    */
   public abstract _setValue(data: any): void; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  /**
+   * Called internally by CommandLineParameterProvider._registerDefinedParameters()
+   * @internal
+   */
+  public _disableShortName(): void {
+    this._shortNameValue = undefined;
+  }
 
   /**
    * Returns additional text used by the help formatter.

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -427,9 +427,9 @@ export abstract class CommandLineParameterProvider {
       }
     }
 
-    // Loop through all parameters and register them. If there are any duplicates, ensure that they have provided
-    // a scope and register them with the scope. The duplicate long names will be reported as an error if the
-    // user attempts to use them.
+    // Then, loop through all parameters and register them. If there are any duplicates, ensure that they have
+    // provided a scope and register them with the scope. The duplicate long names will be reported as an error
+    // if the user attempts to use them.
     for (const longNameParameters of this._parametersByLongName.values()) {
       const useScopedLongName: boolean = longNameParameters.length > 1;
       for (const parameter of longNameParameters) {
@@ -520,9 +520,14 @@ export abstract class CommandLineParameterProvider {
               nonAmbiguousLongNames.push(parameter.longName);
             }
           }
+
+          // Throw an error including the non-ambiguous long names for the parameters that have the ambiguous
+          // short name, ex.
+          // Error: The short parameter name "-p" is ambiguous. It could refer to any of the following
+          // parameters: "--param1", "--param2"
           throw new Error(
-            `The provided parameter "${parameterName}" is ambiguous. It could reference any of ` +
-              `the following parameters: ${nonAmbiguousLongNames.join(', ')}.`
+            `The short parameter name "${parameterName}" is ambiguous. It could refer to any of ` +
+              `the following parameters: "${nonAmbiguousLongNames.join('", "')}"`
           );
         }
 
@@ -541,14 +546,19 @@ export abstract class CommandLineParameterProvider {
               return p.scopedLongName;
             }
           );
+
+          // Throw an error including the non-ambiguous scoped long names for the parameters that have the
+          // ambiguous long name, ex.
+          // Error: The parameter name "--param" is ambiguous. It could refer to any of the following
+          // parameters: "--scope1:param", "--scope2:param"
           throw new Error(
-            `The provided parameter "${parameterName}" is ambiguous. It could reference any of ` +
-              `the following parameters: ${nonAmbiguousLongNames.join(', ')}.`
+            `The parameter name "${parameterName}" is ambiguous. It could refer to any of ` +
+              `the following parameters: "${nonAmbiguousLongNames.join('", "')}"`
           );
         }
 
         // This shouldn't happen, but we also shouldn't allow the user to use the ambiguous parameter
-        throw new Error(`The provided parameter "${parameterName}" is ambiguous.`);
+        throw new Error(`The parameter name "${parameterName}" is ambiguous.`);
       }
     }
 

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -415,9 +415,9 @@ export abstract class CommandLineParameterProvider {
 
     const ambiguousParameterNames: Set<string> = new Set();
 
-    // First, loop through all parameters with shortnames. If there are any duplicates, disable the shortnames
-    // since we can't prefix scopes to deduplicate them. The duplicate shortnames will be reported as errors
-    // if the user attempts to use them.
+    // First, loop through all parameters with short names. If there are any duplicates, disable the short names
+    // since we can't prefix scopes to short names in order to deduplicate them. The duplicate short names will
+    // be reported as errors if the user attempts to use them.
     for (const [shortName, shortNameParameters] of this._parametersByShortName.entries()) {
       if (shortNameParameters.length > 1) {
         for (const parameter of shortNameParameters) {
@@ -427,9 +427,9 @@ export abstract class CommandLineParameterProvider {
       }
     }
 
-    // Then loop through all parameters and register them. If there are any duplicates, ensure that they have
-    // provided a scope and register them with the scope. The original longname for these parameters will be
-    // reported as an error if the attempts tries to use it.
+    // Loop through all parameters and register them. If there are any duplicates, ensure that they have provided
+    // a scope and register them with the scope. The duplicate long names will be reported as an error if the
+    // user attempts to use them.
     for (const longNameParameters of this._parametersByLongName.values()) {
       const useScopedLongName: boolean = longNameParameters.length > 1;
       for (const parameter of longNameParameters) {
@@ -446,7 +446,7 @@ export abstract class CommandLineParameterProvider {
       }
     }
 
-    // Register silent parameters for the ambiguous shortnames and longnames to ensure that users are made
+    // Register silent parameters for the ambiguous short names and long names to ensure that users are made
     // aware that the provided argument is ambiguous.
     for (const ambiguousParameterName of ambiguousParameterNames) {
       this._registerAmbiguousParameter(ambiguousParameterName);
@@ -500,7 +500,7 @@ export abstract class CommandLineParameterProvider {
           for (const parameter of duplicateShortNameParameters) {
             const matchingLongNameParameters: CommandLineParameter[] | undefined =
               this._parametersByLongName.get(parameter.longName);
-            if (!matchingLongNameParameters) {
+            if (!matchingLongNameParameters?.length) {
               // This should never happen
               throw new Error(
                 `Unable to find long name parameters for ambiguous short name parameter "${parameterName}".`

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -111,10 +111,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    */
   public get parameters(): ReadonlyArray<CommandLineParameter> {
     if (this._scopedCommandLineParser) {
-      return ([] as CommandLineParameter[]).concat(
-        super.parameters,
-        this._scopedCommandLineParser.parameters
-      );
+      return [...super.parameters, ...this._scopedCommandLineParser.parameters];
     } else {
       return super.parameters;
     }

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -111,7 +111,10 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    */
   public get parameters(): ReadonlyArray<CommandLineParameter> {
     if (this._scopedCommandLineParser) {
-      return [...super.parameters, ...this._scopedCommandLineParser.parameters];
+      return ([] as CommandLineParameter[]).concat(
+        super.parameters,
+        this._scopedCommandLineParser.parameters
+      );
     } else {
       return super.parameters;
     }
@@ -167,7 +170,9 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
             `arguments: ${this.remainder.values[0]}.`
         );
       }
-      scopedArgs.push(...this.remainder.values.slice(1));
+      for (const scopedArg of this.remainder.values.slice(1)) {
+        scopedArgs.push(scopedArg);
+      }
     }
 
     // Call the scoped parser using only the scoped args to handle parsing

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -143,12 +143,14 @@ class AmbiguousScopedAction extends ScopedCommandLineAction {
     });
     this._scope1Arg = scopedParameterProvider.defineStringParameter({
       parameterLongName: '--arg',
+      parameterShortName: '-a',
       parameterScope: 'scope1',
       argumentName: 'ARG',
       description: 'The argument'
     });
     this._scope2Arg = scopedParameterProvider.defineStringParameter({
       parameterLongName: '--arg',
+      parameterShortName: '-a',
       parameterScope: 'scope2',
       argumentName: 'ARG',
       description: 'The argument'
@@ -212,6 +214,14 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
 
     await expect(
       commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '-s'])
+    ).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('fails to execute when an ambiguous short name is provided to a scoping action with a matching ambiguous long name', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
+
+    await expect(
+      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '-a'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -157,6 +157,7 @@ class AmbiguousScopedAction extends ScopedCommandLineAction {
     });
     this._nonConflictingArg = scopedParameterProvider.defineStringParameter({
       parameterLongName: '--non-conflicting-arg',
+      parameterShortName: '-a',
       parameterScope: 'scope',
       argumentName: 'ARG',
       description: 'The argument'

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { CommandLineAction } from '../providers/CommandLineAction';
+import { CommandLineStringParameter } from '../parameters/CommandLineStringParameter';
+import { CommandLineParser } from '../providers/CommandLineParser';
+import { ScopedCommandLineAction } from '../providers/ScopedCommandLineAction';
+import { CommandLineFlagParameter } from '../parameters/CommandLineFlagParameter';
+import { CommandLineParameterProvider } from '../providers/CommandLineParameterProvider';
+import { SCOPING_PARAMETER_GROUP } from '../Constants';
+
+class GenericCommandLine extends CommandLineParser {
+  public constructor(actionType: new () => CommandLineAction) {
+    super({
+      toolFilename: 'example',
+      toolDescription: 'An example project'
+    });
+
+    this.addAction(new actionType());
+  }
+}
+
+class AmbiguousAction extends CommandLineAction {
+  public done: boolean = false;
+  private _short1Arg: CommandLineStringParameter;
+  private _shortArg2: CommandLineStringParameter;
+  private _scope1Arg: CommandLineStringParameter;
+  private _scope2Arg: CommandLineStringParameter;
+  private _nonConflictingArg: CommandLineStringParameter;
+
+  public constructor() {
+    super({
+      actionName: 'do:the-job',
+      summary: 'does the job',
+      documentation: 'a longer description'
+    });
+
+    this._short1Arg = this.defineStringParameter({
+      parameterLongName: '--short1',
+      parameterShortName: '-s',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._shortArg2 = this.defineStringParameter({
+      parameterLongName: '--short2',
+      parameterShortName: '-s',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._scope1Arg = this.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope1',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._scope2Arg = this.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope2',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._nonConflictingArg = this.defineStringParameter({
+      parameterLongName: '--non-conflicting-arg',
+      parameterScope: 'scope',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+  }
+
+  protected async onExecute(): Promise<void> {
+    expect(this._short1Arg.value).toEqual('short1value');
+    expect(this._shortArg2.value).toEqual('short2value');
+    expect(this._scope1Arg.value).toEqual('scope1value');
+    expect(this._scope2Arg.value).toEqual('scope2value');
+    expect(this._nonConflictingArg.value).toEqual('nonconflictingvalue');
+    this.done = true;
+  }
+}
+
+class AmbiguousScopedAction extends ScopedCommandLineAction {
+  public done: boolean = false;
+  public short1Value: string | undefined;
+  public short2Value: string | undefined;
+  public scope1Value: string | undefined;
+  public scope2Value: string | undefined;
+  public nonConflictingValue: string | undefined;
+  private _scopingArg: CommandLineFlagParameter | undefined;
+  private _short1Arg: CommandLineStringParameter | undefined;
+  private _short2Arg: CommandLineStringParameter | undefined;
+  private _scope1Arg: CommandLineStringParameter | undefined;
+  private _scope2Arg: CommandLineStringParameter | undefined;
+  private _nonConflictingArg: CommandLineStringParameter | undefined;
+
+  public constructor() {
+    super({
+      actionName: 'scoped-action',
+      summary: 'does the scoped action',
+      documentation: 'a longer description'
+    });
+  }
+
+  protected async onExecute(): Promise<void> {
+    expect(this._scopingArg?.value).toEqual(true);
+    if (this._short1Arg?.value) {
+      this.short1Value = this._short1Arg.value;
+    }
+    if (this._short2Arg?.value) {
+      this.short2Value = this._short2Arg.value;
+    }
+    if (this._scope1Arg?.value) {
+      this.scope1Value = this._scope1Arg.value;
+    }
+    if (this._scope2Arg?.value) {
+      this.scope2Value = this._scope2Arg.value;
+    }
+    if (this._nonConflictingArg?.value) {
+      this.nonConflictingValue = this._nonConflictingArg.value;
+    }
+    this.done = true;
+  }
+
+  protected onDefineUnscopedParameters(): void {
+    // At least one scoping parameter is required to be defined on a scoped action
+    this._scopingArg = this.defineFlagParameter({
+      parameterLongName: '--scoping',
+      description: 'The scoping parameter',
+      parameterGroup: SCOPING_PARAMETER_GROUP
+    });
+  }
+
+  protected onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void {
+    this._short1Arg = scopedParameterProvider.defineStringParameter({
+      parameterLongName: '--short1',
+      parameterShortName: '-s',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._short2Arg = scopedParameterProvider.defineStringParameter({
+      parameterLongName: '--short2',
+      parameterShortName: '-s',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._scope1Arg = scopedParameterProvider.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope1',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._scope2Arg = scopedParameterProvider.defineStringParameter({
+      parameterLongName: '--arg',
+      parameterScope: 'scope2',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+    this._nonConflictingArg = scopedParameterProvider.defineStringParameter({
+      parameterLongName: '--non-conflicting-arg',
+      parameterScope: 'scope',
+      argumentName: 'ARG',
+      description: 'The argument'
+    });
+  }
+}
+
+describe(`Ambiguous ${CommandLineParser.name}`, () => {
+  it('fails to execute when an ambiguous short name is provided', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
+
+    await expect(
+      commandLineParser.executeWithoutErrorHandling(['do:the-job', '-s'])
+    ).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('can execute the non-ambiguous scoped long names', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
+
+    await commandLineParser.execute([
+      'do:the-job',
+      '--short1',
+      'short1value',
+      '--short2',
+      'short2value',
+      '--scope1:arg',
+      'scope1value',
+      '--scope2:arg',
+      'scope2value',
+      '--non-conflicting-arg',
+      'nonconflictingvalue'
+    ]);
+    expect(commandLineParser.selectedAction).toBeDefined();
+    expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');
+
+    const action: AmbiguousAction = commandLineParser.selectedAction as AmbiguousAction;
+    expect(action.done).toBe(true);
+
+    expect(action.renderHelpText()).toMatchSnapshot();
+    expect(action.getParameterStringMap()).toMatchSnapshot();
+  });
+
+  it('fails to execute when an ambiguous long name is provided', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
+
+    await expect(
+      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--arg', 'test'])
+    ).rejects.toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
+  it('fails to execute when an ambiguous short name is provided to a scoping action', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
+
+    await expect(
+      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '-s'])
+    ).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('can execute the non-ambiguous scoped long names on the scoping action', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
+
+    await commandLineParser.execute([
+      'scoped-action',
+      '--scoping',
+      '--',
+      '--short1',
+      'short1value',
+      '--short2',
+      'short2value',
+      '--scope1:arg',
+      'scope1value',
+      '--scope2:arg',
+      'scope2value',
+      '--non-conflicting-arg',
+      'nonconflictingvalue'
+    ]);
+    expect(commandLineParser.selectedAction).toBeDefined();
+    expect(commandLineParser.selectedAction!.actionName).toEqual('scoped-action');
+
+    const action: AmbiguousScopedAction = commandLineParser.selectedAction as AmbiguousScopedAction;
+    expect(action.done).toBe(true);
+    expect(action.short1Value).toEqual('short1value');
+    expect(action.short2Value).toEqual('short2value');
+    expect(action.scope1Value).toEqual('scope1value');
+    expect(action.scope2Value).toEqual('scope2value');
+    expect(action.nonConflictingValue).toEqual('nonconflictingvalue');
+  });
+
+  it('fails to execute when an ambiguous long name is provided to a scoping action', async () => {
+    const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
+
+    await expect(
+      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--arg', 'test'])
+    ).rejects.toThrowErrorMatchingSnapshot();
+  });
+});

--- a/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
@@ -36,3 +36,5 @@ exports[`Ambiguous CommandLineParser fails to execute when an ambiguous short na
 exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous long name is provided to a scoping action 1`] = `"The provided parameter \\"--arg\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg."`;
 
 exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action 1`] = `"The provided parameter \\"-s\\" is ambiguous. It could reference any of the following parameters: --short1, --short2."`;
+
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action with a matching ambiguous long name 1`] = `"The provided parameter \\"-a\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg, --non-conflicting-arg."`;

--- a/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
@@ -29,12 +29,12 @@ Object {
 }
 `;
 
-exports[`Ambiguous CommandLineParser fails to execute when an ambiguous long name is provided 1`] = `"The provided parameter \\"--arg\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg."`;
+exports[`Ambiguous CommandLineParser fails to execute when an ambiguous long name is provided 1`] = `"The parameter name \\"--arg\\" is ambiguous. It could refer to any of the following parameters: \\"--scope1:arg\\", \\"--scope2:arg\\""`;
 
-exports[`Ambiguous CommandLineParser fails to execute when an ambiguous short name is provided 1`] = `"The provided parameter \\"-s\\" is ambiguous. It could reference any of the following parameters: --short1, --short2."`;
+exports[`Ambiguous CommandLineParser fails to execute when an ambiguous short name is provided 1`] = `"The short parameter name \\"-s\\" is ambiguous. It could refer to any of the following parameters: \\"--short1\\", \\"--short2\\""`;
 
-exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous long name is provided to a scoping action 1`] = `"The provided parameter \\"--arg\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg."`;
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous long name is provided to a scoping action 1`] = `"The parameter name \\"--arg\\" is ambiguous. It could refer to any of the following parameters: \\"--scope1:arg\\", \\"--scope2:arg\\""`;
 
-exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action 1`] = `"The provided parameter \\"-s\\" is ambiguous. It could reference any of the following parameters: --short1, --short2."`;
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action 1`] = `"The short parameter name \\"-s\\" is ambiguous. It could refer to any of the following parameters: \\"--short1\\", \\"--short2\\""`;
 
-exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action with a matching ambiguous long name 1`] = `"The provided parameter \\"-a\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg, --non-conflicting-arg."`;
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action with a matching ambiguous long name 1`] = `"The short parameter name \\"-a\\" is ambiguous. It could refer to any of the following parameters: \\"--scope1:arg\\", \\"--scope2:arg\\", \\"--non-conflicting-arg\\""`;

--- a/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/AmbiguousCommandLineParser.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ambiguous CommandLineParser can execute the non-ambiguous scoped long names 1`] = `
+"usage: example do:the-job [-h] [--short1 ARG] [--short2 ARG]
+                          [--scope1:arg ARG] [--scope2:arg ARG]
+                          [--non-conflicting-arg ARG]
+                          
+
+a longer description
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  --short1 ARG          The argument
+  --short2 ARG          The argument
+  --scope1:arg ARG      The argument
+  --scope2:arg ARG      The argument
+  --non-conflicting-arg ARG, --scope:non-conflicting-arg ARG
+                        The argument
+"
+`;
+
+exports[`Ambiguous CommandLineParser can execute the non-ambiguous scoped long names 2`] = `
+Object {
+  "--scope1:arg": "\\"scope1value\\"",
+  "--scope2:arg": "\\"scope2value\\"",
+  "--scope:non-conflicting-arg": "\\"nonconflictingvalue\\"",
+  "--short1": "\\"short1value\\"",
+  "--short2": "\\"short2value\\"",
+}
+`;
+
+exports[`Ambiguous CommandLineParser fails to execute when an ambiguous long name is provided 1`] = `"The provided parameter \\"--arg\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg."`;
+
+exports[`Ambiguous CommandLineParser fails to execute when an ambiguous short name is provided 1`] = `"The provided parameter \\"-s\\" is ambiguous. It could reference any of the following parameters: --short1, --short2."`;
+
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous long name is provided to a scoping action 1`] = `"The provided parameter \\"--arg\\" is ambiguous. It could reference any of the following parameters: --scope1:arg, --scope2:arg."`;
+
+exports[`Ambiguous scoping CommandLineParser fails to execute when an ambiguous short name is provided to a scoping action 1`] = `"The provided parameter \\"-s\\" is ambiguous. It could reference any of the following parameters: --short1, --short2."`;


### PR DESCRIPTION
## Summary

Before the upgrade to Heft, short-names were supported in Heft plugin custom parameters. This support was removed during the Heft upgrade to simplify handling of conflicting parameter names. This PR adds the support for short-names back to Heft, and enables the previously-used `-u` and `-t` short-names in `@rushstack/heft-jest-plugin`. Additionally, better handling of ambiguous parameter names was added to `@rushstack/ts-command-line` to support this feature.

## Details

`@rushstack/ts-command-line` now supports better reporting of ambiguous parameters, removing the need to limit Heft plugins to long-names only. The behavior is as follows:
- Ambiguous short-names are entirely disabled, because short-names cannot be deduped by using a scope. If an ambiguous short-name is provided, an error message will be displayed indicating all non-ambiguous options for the provided parameter, ex.:
  `Error: The provided parameter "-t" is ambiguous. It could reference any of the following parameters: --test-name-pattern, --test-path-ignore-patterns.`
- Ambiguous long-names have the same behavior. If an ambiguous long-name is provided, an error message will be displayed indicating all the scoped long-name options for the provided parameter

## How it was tested

Added tests, tested using `heft-jest-plugin`

## Impacted documentation

Schema for heft-plugin.json has been modified to include `shortName` support for parameters. CC @octogonz 
