### PR TITLE
[heft] Remove the deprecated `cacheFolderPath` property from the session object

### DIFF
--- a/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
@@ -37,13 +37,6 @@ export interface IHeftLifecycleSession {
   readonly parameters: IHeftParameters;
 
   /**
-   * The cache folder for the lifecycle plugin. This is an alias for tempFolderPath.
-   *
-   * @deprecated Use `tempFolderPath` instead.
-   */
-  readonly cacheFolderPath: string;
-
-  /**
    * The temp folder for the lifecycle plugin. This folder is unique for each lifecycle plugin,
    * and will be cleaned when Heft is run with `--clean`.
    *
@@ -153,7 +146,6 @@ export class HeftLifecycleSession implements IHeftLifecycleSession {
 
   public readonly hooks: IHeftLifecycleHooks;
   public readonly parameters: IHeftParameters;
-  public readonly cacheFolderPath: string;
   public readonly tempFolderPath: string;
   public readonly logger: IScopedLogger;
   public readonly debug: boolean;
@@ -177,9 +169,6 @@ export class HeftLifecycleSession implements IHeftLifecycleSession {
 
     // <projectFolder>/temp/<phaseName>.<taskName>
     this.tempFolderPath = path.join(options.heftConfiguration.tempFolderPath, uniquePluginFolderName);
-
-    // Preserved for cyclic dependency issues
-    this.cacheFolderPath = this.tempFolderPath;
 
     this._pluginHost = options.pluginHost;
   }

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -97,13 +97,6 @@ export interface IHeftTaskSession {
   readonly parsedCommandLine: IHeftParsedCommandLine;
 
   /**
-   * The cache folder for the task. This is an alias for the temp folder.
-   *
-   * @deprecated Use `tempFolderPath` instead.
-   */
-  readonly cacheFolderPath: string;
-
-  /**
    * The temp folder for the task. This folder is unique for each task, and will be cleaned
    * when Heft is run with `--clean`.
    *
@@ -232,7 +225,6 @@ export interface IHeftTaskSessionOptions extends IHeftPhaseSessionOptions {
 export class HeftTaskSession implements IHeftTaskSession {
   public readonly taskName: string;
   public readonly hooks: IHeftTaskHooks;
-  public readonly cacheFolderPath: string;
   public readonly tempFolderPath: string;
   public readonly logger: IScopedLogger;
 
@@ -294,9 +286,6 @@ export class HeftTaskSession implements IHeftTaskSession {
 
     // <projectFolder>/temp/<phaseName>.<taskName>
     this.tempFolderPath = path.join(tempFolder, uniqueTaskFolderName);
-
-    // Preserved for backwards compatibility due to cyclic dependencies.
-    this.cacheFolderPath = this.tempFolderPath;
 
     this._options = options;
   }

--- a/common/changes/@rushstack/heft/remove-deprecated-property_2023-06-13-03-22.json
+++ b/common/changes/@rushstack/heft/remove-deprecated-property_2023-06-13-03-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Remove the deprecated `cacheFolderPath` property from the session object.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -147,8 +147,6 @@ export interface IHeftLifecyclePlugin<TOptions = void> extends IHeftPlugin<IHeft
 
 // @public
 export interface IHeftLifecycleSession {
-    // @deprecated
-    readonly cacheFolderPath: string;
     readonly hooks: IHeftLifecycleHooks;
     readonly logger: IScopedLogger;
     readonly parameters: IHeftParameters;
@@ -226,8 +224,6 @@ export interface IHeftTaskRunIncrementalHookOptions extends IHeftTaskRunHookOpti
 
 // @public
 export interface IHeftTaskSession {
-    // @deprecated
-    readonly cacheFolderPath: string;
     readonly hooks: IHeftTaskHooks;
     readonly logger: IScopedLogger;
     readonly parameters: IHeftParameters;


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/microsoft/rushstack/pull/4194#pullrequestreview-1476171281.

## How it was tested

N/A