### PR TITLE
[heft-webpack] Support config fallback via hook

### DIFF
--- a/apps/heft/src/pluginFramework/logging/MockScopedLogger.ts
+++ b/apps/heft/src/pluginFramework/logging/MockScopedLogger.ts
@@ -1,0 +1,36 @@
+import type { ITerminal } from '@rushstack/node-core-library';
+
+import type { IScopedLogger } from './ScopedLogger';
+
+/**
+ * Implementation of IScopedLogger for use by unit tests.
+ *
+ * @internal
+ */
+export class MockScopedLogger implements IScopedLogger {
+  public errors: Error[] = [];
+  public warnings: Error[] = [];
+
+  public loggerName: string = 'mockLogger';
+
+  public terminal: ITerminal;
+
+  public constructor(terminal: ITerminal) {
+    this.terminal = terminal;
+  }
+  public get hasErrors(): boolean {
+    return this.errors.length > 0;
+  }
+
+  public emitError(error: Error): void {
+    this.errors.push(error);
+  }
+  public emitWarning(warning: Error): void {
+    this.warnings.push(warning);
+  }
+
+  public resetErrorsAndWarnings(): void {
+    this.errors.length = 0;
+    this.warnings.length = 0;
+  }
+}

--- a/apps/heft/src/pluginFramework/logging/MockScopedLogger.ts
+++ b/apps/heft/src/pluginFramework/logging/MockScopedLogger.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { ITerminal } from '@rushstack/node-core-library';
 
 import type { IScopedLogger } from './ScopedLogger';

--- a/common/changes/@rushstack/heft-webpack4-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-webpack4-plugin",
-      "comment": "Moved loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
+      "comment": "Move loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-webpack4-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Moved loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Moved loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-webpack5-plugin",
-      "comment": "Moved loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
+      "comment": "Move loading of webpack config file into the `onLoadConfiguration` hook to allow other plugins to define fallback behavior, rather than only overriding the config file.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Added MockScopedLogger to help plugin authors with unit testing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/heft/heft-webpack-config-fallback_2023-06-13-21-07.json
+++ b/common/changes/@rushstack/heft/heft-webpack-config-fallback_2023-06-13-21-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft",
-      "comment": "Added MockScopedLogger to help plugin authors with unit testing.",
+      "comment": "Add MockScopedLogger to help plugin authors with unit testing.",
       "type": "patch"
     }
   ],

--- a/common/reviews/api/heft-webpack4-plugin.api.md
+++ b/common/reviews/api/heft-webpack4-plugin.api.md
@@ -52,6 +52,9 @@ export interface IWebpackPluginAccessorParameters {
 // @public (undocumented)
 export const PluginName: 'webpack4-plugin';
 
+// @public
+export const STAGE_LOAD_LOCAL_CONFIG: 1000;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/common/reviews/api/heft-webpack5-plugin.api.md
+++ b/common/reviews/api/heft-webpack5-plugin.api.md
@@ -52,6 +52,9 @@ export interface IWebpackPluginAccessorParameters {
 // @public (undocumented)
 export const PluginName: 'webpack5-plugin';
 
+// @public
+export const STAGE_LOAD_LOCAL_CONFIG: 1000;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -16,8 +16,13 @@ import type {
   IHeftTaskRunIncrementalHookOptions
 } from '@rushstack/heft';
 
-import type { IWebpackConfiguration, IWebpackPluginAccessor } from './shared';
-import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
+import {
+  PLUGIN_NAME,
+  type IWebpackConfiguration,
+  type IWebpackPluginAccessor,
+  type IWebpackPluginAccessorHooks
+} from './shared';
+import { tryLoadWebpackConfigurationAsync } from './WebpackConfigurationLoader';
 import {
   DeferredWatchFileSystem,
   type IWatchFileSystem,
@@ -53,20 +58,15 @@ type ExtendedMultiCompiler = TWebpack.MultiCompiler & {
 };
 
 export interface IWebpackPluginOptions {
-  devConfigurationPath: string | undefined;
-  configurationPath: string | undefined;
+  devConfigurationPath?: string | undefined;
+  configurationPath?: string | undefined;
 }
 
-/**
- * @public
- */
-export const PLUGIN_NAME: 'webpack4-plugin' = 'webpack4-plugin';
 const SERVE_PARAMETER_LONG_NAME: '--serve' = '--serve';
 const WEBPACK_PACKAGE_NAME: 'webpack' = 'webpack';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: 'webpack-dev-server' = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: 'WEBPACK_DEV_SERVER' = 'WEBPACK_DEV_SERVER';
 const WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME: 'webpack-dev-middleware' = 'webpack-dev-middleware';
-const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
 
 /**
  * @internal
@@ -76,7 +76,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   private _isServeMode: boolean = false;
   private _webpack: typeof TWebpack | undefined;
   private _webpackCompiler: ExtendedCompiler | ExtendedMultiCompiler | undefined;
-  private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED = UNINITIALIZED;
+  private _webpackConfiguration: IWebpackConfiguration | undefined | false = false;
   private _webpackCompilationDonePromise: Promise<void> | undefined;
   private _webpackCompilationDonePromiseResolveFn: (() => void) | undefined;
   private _watchFileSystems: Set<DeferredWatchFileSystem> | undefined;
@@ -87,12 +87,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   public get accessor(): IWebpackPluginAccessor {
     if (!this._accessor) {
       this._accessor = {
-        hooks: {
-          onLoadConfiguration: new AsyncSeriesBailHook(),
-          onConfigure: new AsyncSeriesHook(['webpackConfiguration']),
-          onAfterConfigure: new AsyncParallelHook(['webpackConfiguration']),
-          onEmitStats: new AsyncParallelHook(['webpackStats'])
-        },
+        hooks: _createAccessorHooks(),
         parameters: {
           isServeMode: this._isServeMode
         }
@@ -104,7 +99,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   public apply(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    options: IWebpackPluginOptions
+    options: IWebpackPluginOptions = {}
   ): void {
     this._isServeMode = taskSession.parameters.getFlagParameter(SERVE_PARAMETER_LONG_NAME).value;
     if (!taskSession.parameters.watch && this._isServeMode) {
@@ -133,64 +128,36 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     options: IWebpackPluginOptions,
     requestRun?: () => void
   ): Promise<IWebpackConfiguration | undefined> {
-    if (this._webpackConfiguration === UNINITIALIZED) {
-      // Obtain the webpack configuration by calling into the hook. If undefined
-      // is returned, load the default Webpack configuration.
-      taskSession.logger.terminal.writeVerboseLine(
-        'Attempting to load Webpack configuration via external plugins'
-      );
-      let webpackConfiguration: IWebpackConfiguration | false | undefined =
-        await this.accessor.hooks.onLoadConfiguration.promise();
-      if (webpackConfiguration === undefined) {
-        taskSession.logger.terminal.writeVerboseLine('Attempt to load the default Webpack configuration');
-        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-          taskSession.logger,
-          taskSession.parameters.production,
-          taskSession.parameters.watch && this._isServeMode
+    if (this._webpackConfiguration === false) {
+      const webpackConfiguration: IWebpackConfiguration | false | undefined =
+        await tryLoadWebpackConfigurationAsync(
+          {
+            taskSession,
+            heftConfiguration,
+            hooks: this.accessor.hooks,
+            serveMode: this._isServeMode,
+            loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+          },
+          options
         );
-        webpackConfiguration = await configurationLoader.tryLoadWebpackConfigurationAsync({
-          ...options,
-          taskSession,
-          heftConfiguration,
-          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-        });
-      }
 
-      if (webpackConfiguration === false) {
-        taskSession.logger.terminal.writeLine('Webpack disabled by external plugin');
-        this._webpackConfiguration = undefined;
-      } else if (
-        webpackConfiguration === undefined ||
-        (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
-      ) {
-        taskSession.logger.terminal.writeLine('No Webpack configuration found');
-        this._webpackConfiguration = undefined;
-      } else {
-        if (this.accessor.hooks.onConfigure.isUsed()) {
-          // Allow for plugins to customise the configuration
-          await this.accessor.hooks.onConfigure.promise(webpackConfiguration);
-        }
-        if (this.accessor.hooks.onAfterConfigure.isUsed()) {
-          // Provide the finalized configuration
-          await this.accessor.hooks.onAfterConfigure.promise(webpackConfiguration);
-        }
-        this._webpackConfiguration = webpackConfiguration;
-
-        if (requestRun) {
-          const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);
-          this._watchFileSystems = overrideWatchFSPlugin.fileSystems;
-          for (const config of Array.isArray(webpackConfiguration)
-            ? webpackConfiguration
-            : [webpackConfiguration]) {
-            if (!config.plugins) {
-              config.plugins = [overrideWatchFSPlugin];
-            } else {
-              config.plugins.unshift(overrideWatchFSPlugin);
-            }
+      if (webpackConfiguration && requestRun) {
+        const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);
+        this._watchFileSystems = overrideWatchFSPlugin.fileSystems;
+        for (const config of Array.isArray(webpackConfiguration)
+          ? webpackConfiguration
+          : [webpackConfiguration]) {
+          if (!config.plugins) {
+            config.plugins = [overrideWatchFSPlugin];
+          } else {
+            config.plugins.unshift(overrideWatchFSPlugin);
           }
         }
       }
+
+      this._webpackConfiguration = webpackConfiguration;
     }
+
     return this._webpackConfiguration;
   }
 
@@ -495,4 +462,16 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
       }
     }
   }
+}
+
+/**
+ * @internal
+ */
+export function _createAccessorHooks(): IWebpackPluginAccessorHooks {
+  return {
+    onLoadConfiguration: new AsyncSeriesBailHook(),
+    onConfigure: new AsyncSeriesHook(['webpackConfiguration']),
+    onAfterConfigure: new AsyncParallelHook(['webpackConfiguration']),
+    onEmitStats: new AsyncParallelHook(['webpackStats'])
+  };
 }

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -129,17 +129,16 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     requestRun?: () => void
   ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === false) {
-      const webpackConfiguration: IWebpackConfiguration | false | undefined =
-        await tryLoadWebpackConfigurationAsync(
-          {
-            taskSession,
-            heftConfiguration,
-            hooks: this.accessor.hooks,
-            serveMode: this._isServeMode,
-            loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-          },
-          options
-        );
+      const webpackConfiguration: IWebpackConfiguration | undefined = await tryLoadWebpackConfigurationAsync(
+        {
+          taskSession,
+          heftConfiguration,
+          hooks: this.accessor.hooks,
+          serveMode: this._isServeMode,
+          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+        },
+        options
+      );
 
       if (webpackConfiguration && requestRun) {
         const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts
@@ -1,0 +1,149 @@
+import type { HeftConfiguration, IHeftParameters, IHeftTaskSession, IScopedLogger } from '@rushstack/heft';
+import { MockScopedLogger } from '@rushstack/heft/lib/pluginFramework/logging/MockScopedLogger';
+import { type ITerminal, StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
+
+import * as WebpackConfigurationLoader from './WebpackConfigurationLoader';
+import { _createAccessorHooks } from './Webpack4Plugin';
+import { type IWebpackConfiguration, STAGE_LOAD_LOCAL_CONFIG } from './shared';
+
+interface IMockLoadWebpackConfigurationOptions
+  extends WebpackConfigurationLoader.ILoadWebpackConfigurationOptions {
+  loadWebpackAsyncFn: jest.Mock;
+  _terminalProvider: StringBufferTerminalProvider;
+  _tryLoadConfigFileAsync: jest.Mock;
+}
+
+describe(WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync.name, () => {
+  function createOptions(production: boolean, serveMode: boolean): IMockLoadWebpackConfigurationOptions {
+    const terminalProvider: StringBufferTerminalProvider = new StringBufferTerminalProvider(false);
+    const terminal: ITerminal = new Terminal(terminalProvider);
+    const logger: IScopedLogger = new MockScopedLogger(terminal);
+    const buildFolderPath: string = __dirname;
+
+    const parameters: Partial<IHeftParameters> = {
+      production
+    };
+
+    const taskSession: IHeftTaskSession = {
+      logger,
+      parameters: parameters as unknown as IHeftParameters,
+      // Other values unused during these tests
+      hooks: undefined!,
+      parsedCommandLine: undefined!,
+      requestAccessToPluginByName: undefined!,
+      taskName: 'webpack',
+      tempFolderPath: `${__dirname}/temp`
+    };
+
+    const heftConfiguration: Partial<HeftConfiguration> = {
+      buildFolderPath
+    };
+
+    return {
+      taskSession,
+      heftConfiguration: heftConfiguration as unknown as HeftConfiguration,
+      hooks: _createAccessorHooks(),
+      loadWebpackAsyncFn: jest.fn(),
+      serveMode,
+
+      _terminalProvider: terminalProvider,
+      _tryLoadConfigFileAsync: jest.fn()
+    };
+  }
+
+  it(`onLoadConfiguration can return false`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onLoadConfiguration: jest.Mock = jest.fn();
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onLoadConfiguration.tap('test', onLoadConfiguration);
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    onLoadConfiguration.mockReturnValue(false);
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBeUndefined();
+    expect(onLoadConfiguration).toHaveBeenCalledTimes(1);
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(0);
+    expect(onConfigure).toHaveBeenCalledTimes(0);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(0);
+  });
+
+  it(`calls tryLoadWebpackConfigurationFileAsync`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(undefined));
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBeUndefined();
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(0);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(0);
+  });
+
+  it(`can fall back`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onLoadConfiguration: jest.Mock = jest.fn();
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onLoadConfiguration.tap(
+      { name: 'test', stage: STAGE_LOAD_LOCAL_CONFIG + 1 },
+      onLoadConfiguration
+    );
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(undefined));
+
+    const mockConfig: IWebpackConfiguration = {};
+    onLoadConfiguration.mockReturnValue(mockConfig);
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBe(mockConfig);
+
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onLoadConfiguration).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(1);
+
+    expect(onConfigure).toHaveBeenCalledWith(mockConfig);
+    expect(onAfterConfigure).toHaveBeenCalledWith(mockConfig);
+  });
+
+  it(`respects hook order`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    const mockConfig: IWebpackConfiguration = {};
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(mockConfig));
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBe(mockConfig);
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledWith(mockConfig);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(1);
+    expect(onAfterConfigure).toHaveBeenCalledWith(mockConfig);
+  });
+});

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { HeftConfiguration, IHeftParameters, IHeftTaskSession, IScopedLogger } from '@rushstack/heft';
 import { MockScopedLogger } from '@rushstack/heft/lib/pluginFramework/logging/MockScopedLogger';
 import { type ITerminal, StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';

--- a/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.ts
@@ -4,10 +4,16 @@
 import * as path from 'path';
 import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
-import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
+import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 import type { IWebpackPluginOptions } from './Webpack4Plugin';
-import type { IWebpackConfiguration, IWebpackConfigurationFnEnvironment } from './shared';
+import {
+  PLUGIN_NAME,
+  STAGE_LOAD_LOCAL_CONFIG,
+  type IWebpackConfiguration,
+  type IWebpackConfigurationFnEnvironment,
+  type IWebpackPluginAccessorHooks
+} from './shared';
 
 type IWebpackConfigJsExport =
   | TWebpack.Configuration
@@ -18,101 +24,165 @@ type IWebpackConfigJsExport =
   | ((env: IWebpackConfigurationFnEnvironment) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
 
-interface ILoadWebpackConfigurationOptions extends IWebpackPluginOptions {
+/**
+ * @internal
+ */
+export interface ILoadWebpackConfigurationOptions {
   taskSession: IHeftTaskSession;
   heftConfiguration: HeftConfiguration;
+  serveMode: boolean;
   loadWebpackAsyncFn: () => Promise<typeof TWebpack>;
+  hooks: Pick<IWebpackPluginAccessorHooks, 'onLoadConfiguration' | 'onConfigure' | 'onAfterConfigure'>;
+
+  _tryLoadConfigFileAsync?: typeof tryLoadWebpackConfigurationFileAsync;
 }
 
 const DEFAULT_WEBPACK_CONFIG_PATH: './webpack.config.js' = './webpack.config.js';
 const DEFAULT_WEBPACK_DEV_CONFIG_PATH: './webpack.dev.config.js' = './webpack.dev.config.js';
 
-export class WebpackConfigurationLoader {
-  private readonly _logger: IScopedLogger;
-  private readonly _production: boolean;
-  private readonly _serveMode: boolean;
+/**
+ * @internal
+ */
+export async function tryLoadWebpackConfigurationAsync(
+  options: ILoadWebpackConfigurationOptions,
+  pluginOptions: IWebpackPluginOptions
+): Promise<IWebpackConfiguration | undefined> {
+  const { taskSession, hooks, _tryLoadConfigFileAsync = tryLoadWebpackConfigurationFileAsync } = options;
+  const { logger } = taskSession;
+  const { terminal } = logger;
 
-  public constructor(logger: IScopedLogger, production: boolean, serveMode: boolean) {
-    this._logger = logger;
-    this._production = production;
-    this._serveMode = serveMode;
+  // Apply default behavior. Due to the state of `this._webpackConfiguration`, this code
+  // will execute exactly once.
+  hooks.onLoadConfiguration.tapPromise(
+    {
+      name: PLUGIN_NAME,
+      stage: STAGE_LOAD_LOCAL_CONFIG
+    },
+    async () => {
+      terminal.writeVerboseLine(`Attempting to load Webpack configuration from local file`);
+      const webpackConfiguration: IWebpackConfiguration | undefined = await _tryLoadConfigFileAsync(
+        options,
+        pluginOptions
+      );
+
+      if (webpackConfiguration) {
+        terminal.writeVerboseLine(`Loaded Webpack configuration from local file.`);
+      }
+
+      return webpackConfiguration;
+    }
+  );
+
+  // Obtain the webpack configuration by calling into the hook.
+  // The local configuration is loaded at STAGE_LOAD_LOCAL_CONFIG
+  terminal.writeVerboseLine('Attempting to load Webpack configuration');
+  let webpackConfiguration: IWebpackConfiguration | false | undefined =
+    await hooks.onLoadConfiguration.promise();
+
+  if (webpackConfiguration === false) {
+    terminal.writeLine('Webpack disabled by external plugin');
+    webpackConfiguration = undefined;
+  } else if (
+    webpackConfiguration === undefined ||
+    (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
+  ) {
+    terminal.writeLine('No Webpack configuration found');
+    webpackConfiguration = undefined;
+  } else {
+    if (hooks.onConfigure.isUsed()) {
+      // Allow for plugins to customise the configuration
+      await hooks.onConfigure.promise(webpackConfiguration);
+    }
+    if (hooks.onAfterConfigure.isUsed()) {
+      // Provide the finalized configuration
+      await hooks.onAfterConfigure.promise(webpackConfiguration);
+    }
+  }
+  return webpackConfiguration;
+}
+
+/**
+ * @internal
+ */
+export async function tryLoadWebpackConfigurationFileAsync(
+  options: ILoadWebpackConfigurationOptions,
+  pluginOptions: IWebpackPluginOptions
+): Promise<IWebpackConfiguration | undefined> {
+  // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
+  // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
+
+  const { taskSession, heftConfiguration, loadWebpackAsyncFn, serveMode } = options;
+  const {
+    logger,
+    parameters: { production }
+  } = taskSession;
+  const { terminal } = logger;
+  const { configurationPath, devConfigurationPath } = pluginOptions;
+  let webpackConfigJs: IWebpackConfigJs | undefined;
+
+  try {
+    const buildFolderPath: string = heftConfiguration.buildFolderPath;
+    if (serveMode) {
+      const devConfigPath: string = path.resolve(
+        buildFolderPath,
+        devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH
+      );
+      terminal.writeVerboseLine(`Attempting to load webpack configuration from "${devConfigPath}".`);
+      webpackConfigJs = await _tryLoadWebpackConfigurationFileInnerAsync(devConfigPath);
+    }
+
+    if (!webpackConfigJs) {
+      const configPath: string = path.resolve(
+        buildFolderPath,
+        configurationPath || DEFAULT_WEBPACK_CONFIG_PATH
+      );
+      terminal.writeVerboseLine(`Attempting to load webpack configuration from "${configPath}".`);
+      webpackConfigJs = await _tryLoadWebpackConfigurationFileInnerAsync(configPath);
+    }
+  } catch (error) {
+    logger.emitError(error as Error);
   }
 
-  public async tryLoadWebpackConfigurationAsync(
-    options: ILoadWebpackConfigurationOptions
-  ): Promise<IWebpackConfiguration | undefined> {
-    // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
-    // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
+  if (webpackConfigJs) {
+    const webpackConfig: IWebpackConfigJsExport =
+      (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
 
-    const { taskSession, heftConfiguration, configurationPath, devConfigurationPath, loadWebpackAsyncFn } =
-      options;
-    let webpackConfigJs: IWebpackConfigJs | undefined;
+    if (typeof webpackConfig === 'function') {
+      // Defer loading of webpack until we know for sure that we will need it
+      return webpackConfig({
+        prod: production,
+        production,
+        taskSession,
+        heftConfiguration,
+        webpack: await loadWebpackAsyncFn()
+      });
+    } else {
+      return webpackConfig;
+    }
+  } else {
+    return undefined;
+  }
+}
 
+/**
+ * @internal
+ */
+export async function _tryLoadWebpackConfigurationFileInnerAsync(
+  configurationPath: string
+): Promise<IWebpackConfigJs | undefined> {
+  const configExists: boolean = await FileSystem.existsAsync(configurationPath);
+  if (configExists) {
     try {
-      const buildFolderPath: string = heftConfiguration.buildFolderPath;
-      if (this._serveMode) {
-        const devConfigPath: string = path.resolve(
-          buildFolderPath,
-          devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH
-        );
-        this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${devConfigPath}".`
-        );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(devConfigPath);
+      return await import(configurationPath);
+    } catch (e) {
+      const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
+      if (error.code === 'ERR_MODULE_NOT_FOUND') {
+        // No configuration found, return undefined.
+        return undefined;
       }
-
-      if (!webpackConfigJs) {
-        const configPath: string = path.resolve(
-          buildFolderPath,
-          configurationPath || DEFAULT_WEBPACK_CONFIG_PATH
-        );
-        this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${configPath}".`
-        );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(configPath);
-      }
-    } catch (error) {
-      this._logger.emitError(error as Error);
+      throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
     }
-
-    if (webpackConfigJs) {
-      const webpackConfig: IWebpackConfigJsExport =
-        (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
-
-      if (typeof webpackConfig === 'function') {
-        // Defer loading of webpack until we know for sure that we will need it
-        return webpackConfig({
-          prod: this._production,
-          production: this._production,
-          taskSession,
-          heftConfiguration,
-          webpack: await loadWebpackAsyncFn()
-        });
-      } else {
-        return webpackConfig;
-      }
-    } else {
-      return undefined;
-    }
-  }
-
-  private async _tryLoadWebpackConfigurationInnerAsync(
-    configurationPath: string
-  ): Promise<IWebpackConfigJs | undefined> {
-    const configExists: boolean = await FileSystem.existsAsync(configurationPath);
-    if (configExists) {
-      try {
-        return await import(configurationPath);
-      } catch (e) {
-        const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
-        if (error.code === 'ERR_MODULE_NOT_FOUND') {
-          // No configuration found, return undefined.
-          return undefined;
-        }
-        throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
-      }
-    } else {
-      return undefined;
-    }
+  } else {
+    return undefined;
   }
 }

--- a/heft-plugins/heft-webpack4-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { PLUGIN_NAME as PluginName } from './Webpack4Plugin';
+export { PLUGIN_NAME as PluginName, STAGE_LOAD_LOCAL_CONFIG } from './shared';
 
 export type {
   IWebpackConfigurationWithDevServer,

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -69,9 +69,9 @@ export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpac
 export interface IWebpackPluginAccessorHooks {
   /**
    * A hook that allows for loading custom configurations used by the Webpack
-   * plugin. If a webpack configuration is provided, this will be populated automatically
-   * with the exports of the config file. If a webpack configuration is not provided,
-   * one will be loaded by the Webpack plugin.
+   * plugin. If a tap returns a value other than `undefined` before stage `STAGE_LOAD_LOCAL_CONFIG`,
+   * it will suppress loading from the webpack config file. To provide a fallback behavior in the
+   * absence of a local config file, tap this hook with a `stage` value greater than `STAGE_LOAD_LOCAL_CONFIG`.
    *
    * @remarks
    * Tapable event handlers can return `false` instead of `undefined` to suppress
@@ -118,3 +118,15 @@ export interface IWebpackPluginAccessor {
    */
   readonly parameters: IWebpackPluginAccessorParameters;
 }
+
+/**
+ * The stage in the `onLoadConfiguration` hook at which the config will be loaded from the local
+ * webpack config file.
+ * @public
+ */
+export const STAGE_LOAD_LOCAL_CONFIG: 1000 = 1000;
+
+/**
+ * @public
+ */
+export const PLUGIN_NAME: 'webpack4-plugin' = 'webpack4-plugin';

--- a/heft-plugins/heft-webpack4-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/shared.ts
@@ -69,9 +69,9 @@ export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpac
 export interface IWebpackPluginAccessorHooks {
   /**
    * A hook that allows for loading custom configurations used by the Webpack
-   * plugin. If a tap returns a value other than `undefined` before stage `STAGE_LOAD_LOCAL_CONFIG`,
+   * plugin. If a tap returns a value other than `undefined` before stage {@link STAGE_LOAD_LOCAL_CONFIG},
    * it will suppress loading from the webpack config file. To provide a fallback behavior in the
-   * absence of a local config file, tap this hook with a `stage` value greater than `STAGE_LOAD_LOCAL_CONFIG`.
+   * absence of a local config file, tap this hook with a `stage` value greater than {@link STAGE_LOAD_LOCAL_CONFIG}.
    *
    * @remarks
    * Tapable event handlers can return `false` instead of `undefined` to suppress

--- a/heft-plugins/heft-webpack4-plugin/tsconfig.json
+++ b/heft-plugins/heft-webpack4-plugin/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "heft-jest"]
   }
 }

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -18,25 +18,24 @@ import type {
   IHeftTaskRunIncrementalHookOptions
 } from '@rushstack/heft';
 
-import type { IWebpackConfiguration, IWebpackPluginAccessor } from './shared';
-import { WebpackConfigurationLoader } from './WebpackConfigurationLoader';
+import {
+  type IWebpackConfiguration,
+  type IWebpackPluginAccessor,
+  PLUGIN_NAME,
+  IWebpackPluginAccessorHooks
+} from './shared';
+import { tryLoadWebpackConfigurationAsync } from './WebpackConfigurationLoader';
 import { DeferredWatchFileSystem, OverrideNodeWatchFSPlugin } from './DeferredWatchFileSystem';
 
 export interface IWebpackPluginOptions {
-  devConfigurationPath: string | undefined;
-  configurationPath: string | undefined;
+  devConfigurationPath?: string | undefined;
+  configurationPath?: string | undefined;
 }
-
-/**
- * @public
- */
-export const PLUGIN_NAME: 'webpack5-plugin' = 'webpack5-plugin';
 const SERVE_PARAMETER_LONG_NAME: '--serve' = '--serve';
 const WEBPACK_PACKAGE_NAME: 'webpack' = 'webpack';
 const WEBPACK_DEV_SERVER_PACKAGE_NAME: 'webpack-dev-server' = 'webpack-dev-server';
 const WEBPACK_DEV_SERVER_ENV_VAR_NAME: 'WEBPACK_DEV_SERVER' = 'WEBPACK_DEV_SERVER';
 const WEBPACK_DEV_MIDDLEWARE_PACKAGE_NAME: 'webpack-dev-middleware' = 'webpack-dev-middleware';
-const UNINITIALIZED: 'UNINITIALIZED' = 'UNINITIALIZED';
 
 /**
  * @internal
@@ -46,7 +45,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   private _isServeMode: boolean = false;
   private _webpack: typeof TWebpack | undefined;
   private _webpackCompiler: TWebpack.Compiler | TWebpack.MultiCompiler | undefined;
-  private _webpackConfiguration: IWebpackConfiguration | undefined | typeof UNINITIALIZED = UNINITIALIZED;
+  private _webpackConfiguration: IWebpackConfiguration | undefined | false = false;
   private _webpackCompilationDonePromise: Promise<void> | undefined;
   private _webpackCompilationDonePromiseResolveFn: (() => void) | undefined;
   private _watchFileSystems: Set<DeferredWatchFileSystem> | undefined;
@@ -57,12 +56,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   public get accessor(): IWebpackPluginAccessor {
     if (!this._accessor) {
       this._accessor = {
-        hooks: {
-          onLoadConfiguration: new AsyncSeriesBailHook(),
-          onConfigure: new AsyncSeriesHook(['webpackConfiguration']),
-          onAfterConfigure: new AsyncParallelHook(['webpackConfiguration']),
-          onEmitStats: new AsyncParallelHook(['webpackStats'])
-        },
+        hooks: _createAccessorHooks(),
         parameters: {
           isServeMode: this._isServeMode
         }
@@ -74,7 +68,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
   public apply(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
-    options: IWebpackPluginOptions
+    options: IWebpackPluginOptions = {}
   ): void {
     this._isServeMode = taskSession.parameters.getFlagParameter(SERVE_PARAMETER_LONG_NAME).value;
     if (this._isServeMode && !taskSession.parameters.watch) {
@@ -105,64 +99,36 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     options: IWebpackPluginOptions,
     requestRun?: () => void
   ): Promise<IWebpackConfiguration | undefined> {
-    if (this._webpackConfiguration === UNINITIALIZED) {
-      // Obtain the webpack configuration by calling into the hook. If undefined
-      // is returned, load the default Webpack configuration.
-      taskSession.logger.terminal.writeVerboseLine(
-        'Attempting to load Webpack configuration via external plugins'
-      );
-      let webpackConfiguration: IWebpackConfiguration | false | undefined =
-        await this.accessor.hooks.onLoadConfiguration.promise();
-      if (webpackConfiguration === undefined) {
-        taskSession.logger.terminal.writeVerboseLine('Attempt to load the default Webpack configuration');
-        const configurationLoader: WebpackConfigurationLoader = new WebpackConfigurationLoader(
-          taskSession.logger,
-          taskSession.parameters.production,
-          taskSession.parameters.watch && this._isServeMode
+    if (this._webpackConfiguration === false) {
+      const webpackConfiguration: IWebpackConfiguration | false | undefined =
+        await tryLoadWebpackConfigurationAsync(
+          {
+            taskSession,
+            heftConfiguration,
+            hooks: this.accessor.hooks,
+            serveMode: this._isServeMode,
+            loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+          },
+          options
         );
-        webpackConfiguration = await configurationLoader.tryLoadWebpackConfigurationAsync({
-          ...options,
-          taskSession,
-          heftConfiguration,
-          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-        });
-      }
 
-      if (webpackConfiguration === false) {
-        taskSession.logger.terminal.writeLine('Webpack disabled by external plugin');
-        this._webpackConfiguration = undefined;
-      } else if (
-        webpackConfiguration === undefined ||
-        (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
-      ) {
-        taskSession.logger.terminal.writeLine('No Webpack configuration found');
-        this._webpackConfiguration = undefined;
-      } else {
-        if (this.accessor.hooks.onConfigure.isUsed()) {
-          // Allow for plugins to customise the configuration
-          await this.accessor.hooks.onConfigure.promise(webpackConfiguration);
-        }
-        if (this.accessor.hooks.onAfterConfigure.isUsed()) {
-          // Provide the finalized configuration
-          await this.accessor.hooks.onAfterConfigure.promise(webpackConfiguration);
-        }
-        this._webpackConfiguration = webpackConfiguration;
-
-        if (requestRun) {
-          const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);
-          this._watchFileSystems = overrideWatchFSPlugin.fileSystems;
-          for (const config of Array.isArray(webpackConfiguration)
-            ? webpackConfiguration
-            : [webpackConfiguration]) {
-            if (!config.plugins) {
-              config.plugins = [overrideWatchFSPlugin];
-            } else {
-              config.plugins.unshift(overrideWatchFSPlugin);
-            }
+      if (webpackConfiguration && requestRun) {
+        const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);
+        this._watchFileSystems = overrideWatchFSPlugin.fileSystems;
+        for (const config of Array.isArray(webpackConfiguration)
+          ? webpackConfiguration
+          : [webpackConfiguration]) {
+          if (!config.plugins) {
+            config.plugins = [overrideWatchFSPlugin];
+          } else {
+            config.plugins.unshift(overrideWatchFSPlugin);
           }
         }
       }
+
+      this._webpackConfiguration = webpackConfiguration;
     }
+
     return this._webpackConfiguration;
   }
 
@@ -510,4 +476,16 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
       return new Error(error.message);
     }
   }
+}
+
+/**
+ * @internal
+ */
+export function _createAccessorHooks(): IWebpackPluginAccessorHooks {
+  return {
+    onLoadConfiguration: new AsyncSeriesBailHook(),
+    onConfigure: new AsyncSeriesHook(['webpackConfiguration']),
+    onAfterConfigure: new AsyncParallelHook(['webpackConfiguration']),
+    onEmitStats: new AsyncParallelHook(['webpackStats'])
+  };
 }

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -100,17 +100,16 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     requestRun?: () => void
   ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === false) {
-      const webpackConfiguration: IWebpackConfiguration | false | undefined =
-        await tryLoadWebpackConfigurationAsync(
-          {
-            taskSession,
-            heftConfiguration,
-            hooks: this.accessor.hooks,
-            serveMode: this._isServeMode,
-            loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
-          },
-          options
-        );
+      const webpackConfiguration: IWebpackConfiguration | undefined = await tryLoadWebpackConfigurationAsync(
+        {
+          taskSession,
+          heftConfiguration,
+          hooks: this.accessor.hooks,
+          serveMode: this._isServeMode,
+          loadWebpackAsyncFn: this._loadWebpackAsync.bind(this)
+        },
+        options
+      );
 
       if (webpackConfiguration && requestRun) {
         const overrideWatchFSPlugin: OverrideNodeWatchFSPlugin = new OverrideNodeWatchFSPlugin(requestRun);

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.test.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.test.ts
@@ -1,0 +1,149 @@
+import type { HeftConfiguration, IHeftParameters, IHeftTaskSession, IScopedLogger } from '@rushstack/heft';
+import { MockScopedLogger } from '@rushstack/heft/lib/pluginFramework/logging/MockScopedLogger';
+import { type ITerminal, StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
+
+import * as WebpackConfigurationLoader from './WebpackConfigurationLoader';
+import { _createAccessorHooks } from './Webpack5Plugin';
+import { type IWebpackConfiguration, STAGE_LOAD_LOCAL_CONFIG } from './shared';
+
+interface IMockLoadWebpackConfigurationOptions
+  extends WebpackConfigurationLoader.ILoadWebpackConfigurationOptions {
+  loadWebpackAsyncFn: jest.Mock;
+  _terminalProvider: StringBufferTerminalProvider;
+  _tryLoadConfigFileAsync: jest.Mock;
+}
+
+describe(WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync.name, () => {
+  function createOptions(production: boolean, serveMode: boolean): IMockLoadWebpackConfigurationOptions {
+    const terminalProvider: StringBufferTerminalProvider = new StringBufferTerminalProvider(false);
+    const terminal: ITerminal = new Terminal(terminalProvider);
+    const logger: IScopedLogger = new MockScopedLogger(terminal);
+    const buildFolderPath: string = __dirname;
+
+    const parameters: Partial<IHeftParameters> = {
+      production
+    };
+
+    const taskSession: IHeftTaskSession = {
+      logger,
+      parameters: parameters as unknown as IHeftParameters,
+      // Other values unused during these tests
+      hooks: undefined!,
+      parsedCommandLine: undefined!,
+      requestAccessToPluginByName: undefined!,
+      taskName: 'webpack',
+      tempFolderPath: `${__dirname}/temp`
+    };
+
+    const heftConfiguration: Partial<HeftConfiguration> = {
+      buildFolderPath
+    };
+
+    return {
+      taskSession,
+      heftConfiguration: heftConfiguration as unknown as HeftConfiguration,
+      hooks: _createAccessorHooks(),
+      loadWebpackAsyncFn: jest.fn(),
+      serveMode,
+
+      _terminalProvider: terminalProvider,
+      _tryLoadConfigFileAsync: jest.fn()
+    };
+  }
+
+  it(`onLoadConfiguration can return false`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onLoadConfiguration: jest.Mock = jest.fn();
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onLoadConfiguration.tap('test', onLoadConfiguration);
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    onLoadConfiguration.mockReturnValue(false);
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBeUndefined();
+    expect(onLoadConfiguration).toHaveBeenCalledTimes(1);
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(0);
+    expect(onConfigure).toHaveBeenCalledTimes(0);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(0);
+  });
+
+  it(`calls tryLoadWebpackConfigurationFileAsync`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(undefined));
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBeUndefined();
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(0);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(0);
+  });
+
+  it(`can fall back`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onLoadConfiguration: jest.Mock = jest.fn();
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onLoadConfiguration.tap(
+      { name: 'test', stage: STAGE_LOAD_LOCAL_CONFIG + 1 },
+      onLoadConfiguration
+    );
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(undefined));
+
+    const mockConfig: IWebpackConfiguration = {};
+    onLoadConfiguration.mockReturnValue(mockConfig);
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBe(mockConfig);
+
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onLoadConfiguration).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(1);
+
+    expect(onConfigure).toHaveBeenCalledWith(mockConfig);
+    expect(onAfterConfigure).toHaveBeenCalledWith(mockConfig);
+  });
+
+  it(`respects hook order`, async () => {
+    const options: IMockLoadWebpackConfigurationOptions = createOptions(false, false);
+
+    const onConfigure: jest.Mock = jest.fn();
+    const onAfterConfigure: jest.Mock = jest.fn();
+
+    options.hooks.onConfigure.tap('test', onConfigure);
+    options.hooks.onAfterConfigure.tap('test', onAfterConfigure);
+
+    const mockConfig: IWebpackConfiguration = {};
+
+    options._tryLoadConfigFileAsync.mockReturnValue(Promise.resolve(mockConfig));
+
+    const config: IWebpackConfiguration | undefined =
+      await WebpackConfigurationLoader.tryLoadWebpackConfigurationAsync(options, {});
+    expect(config).toBe(mockConfig);
+    expect(options._tryLoadConfigFileAsync).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+    expect(onConfigure).toHaveBeenCalledWith(mockConfig);
+    expect(onAfterConfigure).toHaveBeenCalledTimes(1);
+    expect(onAfterConfigure).toHaveBeenCalledWith(mockConfig);
+  });
+});

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.test.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import type { HeftConfiguration, IHeftParameters, IHeftTaskSession, IScopedLogger } from '@rushstack/heft';
 import { MockScopedLogger } from '@rushstack/heft/lib/pluginFramework/logging/MockScopedLogger';
 import { type ITerminal, StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';

--- a/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/WebpackConfigurationLoader.ts
@@ -4,10 +4,16 @@
 import * as path from 'path';
 import type * as TWebpack from 'webpack';
 import { FileSystem } from '@rushstack/node-core-library';
-import type { IScopedLogger, IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
+import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 import type { IWebpackPluginOptions } from './Webpack5Plugin';
-import type { IWebpackConfiguration, IWebpackConfigurationFnEnvironment } from './shared';
+import {
+  PLUGIN_NAME,
+  STAGE_LOAD_LOCAL_CONFIG,
+  type IWebpackConfiguration,
+  type IWebpackConfigurationFnEnvironment,
+  type IWebpackPluginAccessorHooks
+} from './shared';
 
 type IWebpackConfigJsExport =
   | TWebpack.Configuration
@@ -18,101 +24,165 @@ type IWebpackConfigJsExport =
   | ((env: IWebpackConfigurationFnEnvironment) => Promise<TWebpack.Configuration | TWebpack.Configuration[]>);
 type IWebpackConfigJs = IWebpackConfigJsExport | { default: IWebpackConfigJsExport };
 
-interface ILoadWebpackConfigurationOptions extends IWebpackPluginOptions {
+/**
+ * @internal
+ */
+export interface ILoadWebpackConfigurationOptions {
   taskSession: IHeftTaskSession;
   heftConfiguration: HeftConfiguration;
+  serveMode: boolean;
   loadWebpackAsyncFn: () => Promise<typeof TWebpack>;
+  hooks: Pick<IWebpackPluginAccessorHooks, 'onLoadConfiguration' | 'onConfigure' | 'onAfterConfigure'>;
+
+  _tryLoadConfigFileAsync?: typeof tryLoadWebpackConfigurationFileAsync;
 }
 
 const DEFAULT_WEBPACK_CONFIG_PATH: './webpack.config.js' = './webpack.config.js';
 const DEFAULT_WEBPACK_DEV_CONFIG_PATH: './webpack.dev.config.js' = './webpack.dev.config.js';
 
-export class WebpackConfigurationLoader {
-  private readonly _logger: IScopedLogger;
-  private readonly _production: boolean;
-  private readonly _serveMode: boolean;
+/**
+ * @internal
+ */
+export async function tryLoadWebpackConfigurationAsync(
+  options: ILoadWebpackConfigurationOptions,
+  pluginOptions: IWebpackPluginOptions
+): Promise<IWebpackConfiguration | undefined> {
+  const { taskSession, hooks, _tryLoadConfigFileAsync = tryLoadWebpackConfigurationFileAsync } = options;
+  const { logger } = taskSession;
+  const { terminal } = logger;
 
-  public constructor(logger: IScopedLogger, production: boolean, serveMode: boolean) {
-    this._logger = logger;
-    this._production = production;
-    this._serveMode = serveMode;
+  // Apply default behavior. Due to the state of `this._webpackConfiguration`, this code
+  // will execute exactly once.
+  hooks.onLoadConfiguration.tapPromise(
+    {
+      name: PLUGIN_NAME,
+      stage: STAGE_LOAD_LOCAL_CONFIG
+    },
+    async () => {
+      terminal.writeVerboseLine(`Attempting to load Webpack configuration from local file`);
+      const webpackConfiguration: IWebpackConfiguration | undefined = await _tryLoadConfigFileAsync(
+        options,
+        pluginOptions
+      );
+
+      if (webpackConfiguration) {
+        terminal.writeVerboseLine(`Loaded Webpack configuration from local file.`);
+      }
+
+      return webpackConfiguration;
+    }
+  );
+
+  // Obtain the webpack configuration by calling into the hook.
+  // The local configuration is loaded at STAGE_LOAD_LOCAL_CONFIG
+  terminal.writeVerboseLine('Attempting to load Webpack configuration');
+  let webpackConfiguration: IWebpackConfiguration | false | undefined =
+    await hooks.onLoadConfiguration.promise();
+
+  if (webpackConfiguration === false) {
+    terminal.writeLine('Webpack disabled by external plugin');
+    webpackConfiguration = undefined;
+  } else if (
+    webpackConfiguration === undefined ||
+    (Array.isArray(webpackConfiguration) && webpackConfiguration.length === 0)
+  ) {
+    terminal.writeLine('No Webpack configuration found');
+    webpackConfiguration = undefined;
+  } else {
+    if (hooks.onConfigure.isUsed()) {
+      // Allow for plugins to customise the configuration
+      await hooks.onConfigure.promise(webpackConfiguration);
+    }
+    if (hooks.onAfterConfigure.isUsed()) {
+      // Provide the finalized configuration
+      await hooks.onAfterConfigure.promise(webpackConfiguration);
+    }
+  }
+  return webpackConfiguration;
+}
+
+/**
+ * @internal
+ */
+export async function tryLoadWebpackConfigurationFileAsync(
+  options: ILoadWebpackConfigurationOptions,
+  pluginOptions: IWebpackPluginOptions
+): Promise<IWebpackConfiguration | undefined> {
+  // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
+  // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
+
+  const { taskSession, heftConfiguration, loadWebpackAsyncFn, serveMode } = options;
+  const {
+    logger,
+    parameters: { production }
+  } = taskSession;
+  const { terminal } = logger;
+  const { configurationPath, devConfigurationPath } = pluginOptions;
+  let webpackConfigJs: IWebpackConfigJs | undefined;
+
+  try {
+    const buildFolderPath: string = heftConfiguration.buildFolderPath;
+    if (serveMode) {
+      const devConfigPath: string = path.resolve(
+        buildFolderPath,
+        devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH
+      );
+      terminal.writeVerboseLine(`Attempting to load webpack configuration from "${devConfigPath}".`);
+      webpackConfigJs = await _tryLoadWebpackConfigurationFileInnerAsync(devConfigPath);
+    }
+
+    if (!webpackConfigJs) {
+      const configPath: string = path.resolve(
+        buildFolderPath,
+        configurationPath || DEFAULT_WEBPACK_CONFIG_PATH
+      );
+      terminal.writeVerboseLine(`Attempting to load webpack configuration from "${configPath}".`);
+      webpackConfigJs = await _tryLoadWebpackConfigurationFileInnerAsync(configPath);
+    }
+  } catch (error) {
+    logger.emitError(error as Error);
   }
 
-  public async tryLoadWebpackConfigurationAsync(
-    options: ILoadWebpackConfigurationOptions
-  ): Promise<IWebpackConfiguration | undefined> {
-    // TODO: Eventually replace this custom logic with a call to this utility in in webpack-cli:
-    // https://github.com/webpack/webpack-cli/blob/next/packages/webpack-cli/lib/groups/ConfigGroup.js
+  if (webpackConfigJs) {
+    const webpackConfig: IWebpackConfigJsExport =
+      (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
 
-    const { taskSession, heftConfiguration, configurationPath, devConfigurationPath, loadWebpackAsyncFn } =
-      options;
-    let webpackConfigJs: IWebpackConfigJs | undefined;
+    if (typeof webpackConfig === 'function') {
+      // Defer loading of webpack until we know for sure that we will need it
+      return webpackConfig({
+        prod: production,
+        production,
+        taskSession,
+        heftConfiguration,
+        webpack: await loadWebpackAsyncFn()
+      });
+    } else {
+      return webpackConfig;
+    }
+  } else {
+    return undefined;
+  }
+}
 
+/**
+ * @internal
+ */
+export async function _tryLoadWebpackConfigurationFileInnerAsync(
+  configurationPath: string
+): Promise<IWebpackConfigJs | undefined> {
+  const configExists: boolean = await FileSystem.existsAsync(configurationPath);
+  if (configExists) {
     try {
-      const buildFolderPath: string = heftConfiguration.buildFolderPath;
-      if (this._serveMode) {
-        const devConfigPath: string = path.resolve(
-          buildFolderPath,
-          devConfigurationPath || DEFAULT_WEBPACK_DEV_CONFIG_PATH
-        );
-        this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${devConfigPath}".`
-        );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(devConfigPath);
+      return await import(configurationPath);
+    } catch (e) {
+      const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
+      if (error.code === 'ERR_MODULE_NOT_FOUND') {
+        // No configuration found, return undefined.
+        return undefined;
       }
-
-      if (!webpackConfigJs) {
-        const configPath: string = path.resolve(
-          buildFolderPath,
-          configurationPath || DEFAULT_WEBPACK_CONFIG_PATH
-        );
-        this._logger.terminal.writeVerboseLine(
-          `Attempting to load webpack configuration from "${configPath}".`
-        );
-        webpackConfigJs = await this._tryLoadWebpackConfigurationInnerAsync(configPath);
-      }
-    } catch (error) {
-      this._logger.emitError(error as Error);
+      throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
     }
-
-    if (webpackConfigJs) {
-      const webpackConfig: IWebpackConfigJsExport =
-        (webpackConfigJs as { default: IWebpackConfigJsExport }).default || webpackConfigJs;
-
-      if (typeof webpackConfig === 'function') {
-        // Defer loading of webpack until we know for sure that we will need it
-        return webpackConfig({
-          prod: this._production,
-          production: this._production,
-          taskSession,
-          heftConfiguration,
-          webpack: await loadWebpackAsyncFn()
-        });
-      } else {
-        return webpackConfig;
-      }
-    } else {
-      return undefined;
-    }
-  }
-
-  private async _tryLoadWebpackConfigurationInnerAsync(
-    configurationPath: string
-  ): Promise<IWebpackConfigJs | undefined> {
-    const configExists: boolean = await FileSystem.existsAsync(configurationPath);
-    if (configExists) {
-      try {
-        return await import(configurationPath);
-      } catch (e) {
-        const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
-        if (error.code === 'ERR_MODULE_NOT_FOUND') {
-          // No configuration found, return undefined.
-          return undefined;
-        }
-        throw new Error(`Error loading webpack configuration at "${configurationPath}": ${e}`);
-      }
-    } else {
-      return undefined;
-    }
+  } else {
+    return undefined;
   }
 }

--- a/heft-plugins/heft-webpack5-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { PLUGIN_NAME as PluginName } from './Webpack5Plugin';
+export { PLUGIN_NAME as PluginName, STAGE_LOAD_LOCAL_CONFIG } from './shared';
 
 export type {
   IWebpackConfigurationWithDevServer,

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -58,9 +58,9 @@ export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpac
 export interface IWebpackPluginAccessorHooks {
   /**
    * A hook that allows for loading custom configurations used by the Webpack
-   * plugin. If a webpack configuration is provided, this will be populated automatically
-   * with the exports of the config file. If a webpack configuration is not provided,
-   * one will be loaded by the Webpack plugin.
+   * plugin. If a tap returns a value other than `undefined` before stage `STAGE_LOAD_LOCAL_CONFIG`,
+   * it will suppress loading from the webpack config file. To provide a fallback behavior in the
+   * absence of a local config file, tap this hook with a `stage` value greater than `STAGE_LOAD_LOCAL_CONFIG`.
    *
    * @remarks
    * Tapable event handlers can return `false` instead of `undefined` to suppress
@@ -107,3 +107,15 @@ export interface IWebpackPluginAccessor {
    */
   readonly parameters: IWebpackPluginAccessorParameters;
 }
+
+/**
+ * The stage in the `onLoadConfiguration` hook at which the config will be loaded from the local
+ * webpack config file.
+ * @public
+ */
+export const STAGE_LOAD_LOCAL_CONFIG: 1000 = 1000;
+
+/**
+ * @public
+ */
+export const PLUGIN_NAME: 'webpack5-plugin' = 'webpack5-plugin';

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -58,9 +58,9 @@ export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpac
 export interface IWebpackPluginAccessorHooks {
   /**
    * A hook that allows for loading custom configurations used by the Webpack
-   * plugin. If a tap returns a value other than `undefined` before stage `STAGE_LOAD_LOCAL_CONFIG`,
+   * plugin. If a tap returns a value other than `undefined` before stage {@link STAGE_LOAD_LOCAL_CONFIG},
    * it will suppress loading from the webpack config file. To provide a fallback behavior in the
-   * absence of a local config file, tap this hook with a `stage` value greater than `STAGE_LOAD_LOCAL_CONFIG`.
+   * absence of a local config file, tap this hook with a `stage` value greater than {@link STAGE_LOAD_LOCAL_CONFIG}.
    *
    * @remarks
    * Tapable event handlers can return `false` instead of `undefined` to suppress

--- a/heft-plugins/heft-webpack5-plugin/tsconfig.json
+++ b/heft-plugins/heft-webpack5-plugin/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "heft-jest"]
   }
 }


### PR DESCRIPTION
## Summary
Gives other Heft plugins that use the accessors from `@rushstack/heft-webpack4-plugin` and `@rushstack/heft-webpack5-plugin` the ability to define fallback behavior for the `onLoadConfiguration` accessor hook.

## Details
Previously, a plugin could either completely override the webpack config file via the `onLoadConfiguration` accessor hook, or, provided that a webpack config file was present and returned a value, use the `onConfigure` hook to modify a result.

This PR moves the loading of the webpack config file into the `onLoadConfiguration` hook at stage `STAGE_LOAD_LOCAL_CONFIG` so that plugins have the option to provide a default config in the absence of the config file, but have the config file take precedence.

## How it was tested
Added unit tests to both plugin for the config loader pipeline.

## Impacted documentation
Only the accessor API documentation.