### PR TITLE
[rush-lib] Git hook arg passthrough

### DIFF
--- a/common/changes/@microsoft/rush/git-hook-passthrough_2023-06-14-16-10.json
+++ b/common/changes/@microsoft/rush/git-hook-passthrough_2023-06-14-16-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix git hook passthrough",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/git-hook-passthrough_2023-06-14-16-10.json
+++ b/common/changes/@microsoft/rush/git-hook-passthrough_2023-06-14-16-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix git hook passthrough",
+      "comment": "Fix an issue where arguments weren't passed to git hook scripts.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -487,7 +487,7 @@ SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 SCRIPT_IMPLEMENTATION_PATH="$SCRIPT_DIR/${hookRelativePath}/${filename}"
 
 if [[ -f "$SCRIPT_IMPLEMENTATION_PATH" ]]; then
-  "$SCRIPT_IMPLEMENTATION_PATH"
+  "$SCRIPT_IMPLEMENTATION_PATH" $@
 else
   echo "The ${filename} Git hook no longer exists in your version of the repo. Run 'rush install' or 'rush update' to refresh your installed Git hooks." >&2
 fi


### PR DESCRIPTION
## Summary

New delegate git hook scripts do not pass through the args that git normally passes to commit hooks.

This ensures that all args are passed through.

Fixes #4200

## How it was tested

Manually changed the commit hook delegate scripts in a test repo to mirror this change. Confirmed that this did then pass through the arguments from git.
