### PR TITLE
[rush] Fix an issue where Rush would attempt to open a project's log file for writing twice.

### DIFF
--- a/common/changes/@microsoft/rush/fix-log-double-open_2023-06-14-18-49.json
+++ b/common/changes/@microsoft/rush/fix-log-double-open_2023-06-14-18-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Rush would attempt to open a project's log file for writing twice.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
+++ b/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
@@ -60,39 +60,39 @@ export class ProjectLogWritable extends TerminalWritable {
     }
 
     const projectFolder: string = this._project.projectFolder;
-    const {
-      logPath: legacyLogPath,
-      errorLogPath: legacyErrorLogPath,
-      relativeLogPath: legacyRelativeLogPath,
-      relativeErrorLogPath: legacyRelativeErrorLogPath
-    } = getLogFilePaths(projectFolder, 'build');
-    // If the phased commands experiment is enabled, put logs under `rush-logs`
-    if (project.rushConfiguration.experimentsConfiguration.configuration.phasedCommands) {
-      // Delete the legacy logs
-      FileSystem.deleteFile(legacyLogPath);
-      FileSystem.deleteFile(legacyErrorLogPath);
+    // Delete the legacy logs
+    const { logPath: legacyLogPath, errorLogPath: legacyErrorLogPath } = getLogFilePaths(
+      projectFolder,
+      'build'
+    );
+    FileSystem.deleteFile(legacyLogPath);
+    FileSystem.deleteFile(legacyErrorLogPath);
 
+    // If the phased commands experiment is enabled, put logs under `rush-logs`
+    let logFolder: string | undefined;
+    if (project.rushConfiguration.experimentsConfiguration.configuration.phasedCommands) {
       const logPathPrefix: string = `${projectFolder}/${RushConstants.rushLogsFolderName}`;
       FileSystem.ensureFolder(logPathPrefix);
-
-      const { logPath, errorLogPath, relativeLogPath, relativeErrorLogPath } = getLogFilePaths(
-        projectFolder,
-        logFilenameIdentifier,
-        RushConstants.rushLogsFolderName
-      );
-      this.logPath = logPath;
-      this.errorLogPath = errorLogPath;
-      this.relativeLogPath = relativeLogPath;
-      this.relativeErrorLogPath = relativeErrorLogPath;
-    } else {
-      this.logPath = legacyLogPath;
-      this.errorLogPath = legacyErrorLogPath;
-      this.relativeLogPath = legacyRelativeLogPath;
-      this.relativeErrorLogPath = legacyRelativeErrorLogPath;
+      logFolder = RushConstants.rushLogsFolderName;
     }
 
-    FileSystem.deleteFile(this.logPath);
-    FileSystem.deleteFile(this.errorLogPath);
+    const { logPath, errorLogPath, relativeLogPath, relativeErrorLogPath } = getLogFilePaths(
+      projectFolder,
+      logFilenameIdentifier,
+      logFolder
+    );
+    this.logPath = logPath;
+    this.errorLogPath = errorLogPath;
+    this.relativeLogPath = relativeLogPath;
+    this.relativeErrorLogPath = relativeErrorLogPath;
+
+    if (legacyLogPath !== this.logPath) {
+      FileSystem.deleteFile(this.logPath);
+    }
+
+    if (legacyErrorLogPath !== this.errorLogPath) {
+      FileSystem.deleteFile(this.errorLogPath);
+    }
 
     this._logWriter = FileWriter.open(this.logPath);
   }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -142,6 +142,7 @@ export class ShellOperationRunner implements IOperationRunner {
   private async _executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
     // Only open the *.cache.log file(s) if the cache is enabled.
     const cacheProjectLogWritable: ProjectLogWritable | undefined = this._buildCacheConfiguration
+      ?.buildCacheEnabled
       ? new ProjectLogWritable(
           this._rushProject,
           context.collatedWriter.terminal,


### PR DESCRIPTION
## Summary

An issue was recently introduced where, in a project without phased builds, but with cache enabled, we'd try to open the `<projectName>.build.log` file twice. This PR makes the log always `<projectName>.<operationName>.log` and the cache always `<projectName>.<operationName>.cache.log`.

Fixes https://github.com/microsoft/rushstack/issues/4199

## How it was tested

Tested against https://github.com/MsBeiBei/ANADI