### PR TITLE
[eslint-patch] add invalid importer path test to ESLint 7.x || 8.x block

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-patch-invalid-importer-path_2023-06-14-21-56.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-patch-invalid-importer-path_2023-06-14-21-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "[eslint-patch] add invalid importer path test to ESLint 7.x || 8.x block",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -238,7 +238,7 @@ if (!ConfigArrayFactory.__patched) {
             // resolve using ctx.filePath instead of relativeToPath
             return originalResolve.call(this, moduleName, ctx.filePath);
           } catch (e) {
-            if (isModuleResolutionError(e)) {
+            if (isModuleResolutionError(e) || isInvalidImporterPath(e)) {
               return originalResolve.call(this, moduleName, relativeToPath);
             }
             throw e;


### PR DESCRIPTION
## Summary

adds the fix from #4174 to the ESLint 7.x || 8.x block 

## Details

during the previous patch the logic was moved to the 6.x block. it is safe to leave there but the original intent (to fix the bug that prompted the patch) was for it to be in the 7.x || 8.x block

## How it was tested

ran `prettier-eslint` using the patch and it was fixed

## Impacted documentation

none
