### PR TITLE
[package-extractor] Allow for `patternsToInclude` and `patternsToExclude` to filter project files

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-PackageExtractorPatterns_2023-06-16-18-46.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-PackageExtractorPatterns_2023-06-16-18-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Allow for include and exclude filters to be provided for projects. This allows for an additional layer of filtering when extracting a package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -112,6 +112,8 @@
     // "ignoreMissing": ["@eslint/*"],
     // "allowedVersions": { "react": "17" },
     // "allowAny": ["@babel/*"]
+    // TODO: Remove once Heft is 1.0.0
+    "allowAny": ["@rushstack/heft"]
   },
 
   /**

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1267,7 +1267,7 @@ importers:
       '@rushstack/heft-lint-plugin': link:../../heft-plugins/heft-lint-plugin
       '@rushstack/heft-typescript-plugin': link:../../heft-plugins/heft-typescript-plugin
       '@types/jest': 29.5.2
-      '@types/node': 20.3.0
+      '@types/node': 20.3.1
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.9.5
       tslint-microsoft-contrib: 6.2.0_uwqr5pcif4g7c56scrk6kqzf7i
@@ -6624,7 +6624,7 @@ packages:
   /@rushstack/heft-api-extractor-plugin/0.1.6_4dchqclsvvgybys5sefjzqvuhm:
     resolution: {integrity: sha512-JVfwQDNq/6IreyGjPhVFevSLMn+IWMRZCC4NTimDE74ZHBb0Sv0CXO0yWPQ5HzExfwuLw7q9/9cno/YzSyIA4g==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-config-file': 0.12.4_@types+node@14.18.36
@@ -6637,7 +6637,7 @@ packages:
   /@rushstack/heft-api-extractor-plugin/0.1.6_nfozjgqil6u3mushzg237yh5re:
     resolution: {integrity: sha512-JVfwQDNq/6IreyGjPhVFevSLMn+IWMRZCC4NTimDE74ZHBb0Sv0CXO0yWPQ5HzExfwuLw7q9/9cno/YzSyIA4g==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': 0.54.0_@types+node@14.18.36
       '@rushstack/heft-config-file': 0.12.4_@types+node@14.18.36
@@ -6661,7 +6661,7 @@ packages:
   /@rushstack/heft-jest-plugin/0.7.7_4dchqclsvvgybys5sefjzqvuhm:
     resolution: {integrity: sha512-R4cCsDf3r+lbJXjJaaJgkOGQ+DPQ0ZorWgR2lNG8JalOzsbUiYAbjgDsDYWcH3ciTYQUivzwz0YYre+00SCNwQ==}
     peerDependencies:
-      '@rushstack/heft': ^0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@jest/core': 29.5.0
       '@jest/reporters': 29.5.0
@@ -6683,7 +6683,7 @@ packages:
   /@rushstack/heft-jest-plugin/0.7.7_nfozjgqil6u3mushzg237yh5re:
     resolution: {integrity: sha512-R4cCsDf3r+lbJXjJaaJgkOGQ+DPQ0ZorWgR2lNG8JalOzsbUiYAbjgDsDYWcH3ciTYQUivzwz0YYre+00SCNwQ==}
     peerDependencies:
-      '@rushstack/heft': ^0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@jest/core': 29.5.0
       '@jest/reporters': 29.5.0
@@ -6705,7 +6705,7 @@ packages:
   /@rushstack/heft-lint-plugin/0.1.7_4dchqclsvvgybys5sefjzqvuhm:
     resolution: {integrity: sha512-U9Y7qHdUXdTMuKHBRB79P9T8uB4pSCaf57QNjUQJVGOO1TQN5I7PgPZrZfCARycNI7w8jAML2RwC9mqYdshgZA==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/node-core-library': 3.59.3_@types+node@14.18.36
@@ -6717,7 +6717,7 @@ packages:
   /@rushstack/heft-lint-plugin/0.1.7_nfozjgqil6u3mushzg237yh5re:
     resolution: {integrity: sha512-U9Y7qHdUXdTMuKHBRB79P9T8uB4pSCaf57QNjUQJVGOO1TQN5I7PgPZrZfCARycNI7w8jAML2RwC9mqYdshgZA==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': 0.54.0_@types+node@14.18.36
       '@rushstack/node-core-library': 3.59.3_@types+node@14.18.36
@@ -6729,7 +6729,7 @@ packages:
   /@rushstack/heft-node-rig/2.2.6_4dchqclsvvgybys5sefjzqvuhm:
     resolution: {integrity: sha512-gslmqOgtE4OfeLIAaMe6eI4VO0DwQ8nH0eaboqTdbud9MVk6mnU01CkLKQHTYI1KrHSO0WxkMnKfYNebDcrt8A==}
     peerDependencies:
-      '@rushstack/heft': ^0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.35.3_@types+node@14.18.36
       '@rushstack/heft': link:../../apps/heft
@@ -6751,7 +6751,7 @@ packages:
   /@rushstack/heft-node-rig/2.2.6_nfozjgqil6u3mushzg237yh5re:
     resolution: {integrity: sha512-gslmqOgtE4OfeLIAaMe6eI4VO0DwQ8nH0eaboqTdbud9MVk6mnU01CkLKQHTYI1KrHSO0WxkMnKfYNebDcrt8A==}
     peerDependencies:
-      '@rushstack/heft': ^0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.35.3_@types+node@14.18.36
       '@rushstack/heft': 0.54.0_@types+node@14.18.36
@@ -6773,7 +6773,7 @@ packages:
   /@rushstack/heft-typescript-plugin/0.1.7_4dchqclsvvgybys5sefjzqvuhm:
     resolution: {integrity: sha512-HswnuZT6hXONYwMFTNQRuvmJCi5BmwHYcxS6Dqfm7W9HqrJHlED/jHuxMQAJdTH+K2cdMdYdCCdwRbzBYonaJw==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-config-file': 0.12.4_@types+node@14.18.36
@@ -6788,7 +6788,7 @@ packages:
   /@rushstack/heft-typescript-plugin/0.1.7_nfozjgqil6u3mushzg237yh5re:
     resolution: {integrity: sha512-HswnuZT6hXONYwMFTNQRuvmJCi5BmwHYcxS6Dqfm7W9HqrJHlED/jHuxMQAJdTH+K2cdMdYdCCdwRbzBYonaJw==}
     peerDependencies:
-      '@rushstack/heft': 0.54.0
+      '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': 0.54.0_@types+node@14.18.36
       '@rushstack/heft-config-file': 0.12.4_@types+node@14.18.36
@@ -9037,8 +9037,8 @@ packages:
     resolution: {integrity: sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==}
     dev: true
 
-  /@types/node/20.3.0:
-    resolution: {integrity: sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==}
+  /@types/node/20.3.1:
+    resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2152,11 +2152,13 @@ importers:
       '@rushstack/webpack-preserve-dynamic-require-plugin': workspace:*
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
+      '@types/minimatch': 3.0.5
       '@types/node': 14.18.36
       '@types/npm-packlist': ~1.1.1
       eslint: ~8.7.0
       ignore: ~5.1.6
       jszip: ~3.8.0
+      minimatch: ~3.0.3
       npm-packlist: ~2.1.2
       webpack: ~5.82.1
     dependencies:
@@ -2165,6 +2167,7 @@ importers:
       '@rushstack/terminal': link:../terminal
       ignore: 5.1.9
       jszip: 3.8.0
+      minimatch: 3.0.8
       npm-packlist: 2.1.5
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
@@ -2174,6 +2177,7 @@ importers:
       '@rushstack/webpack-preserve-dynamic-require-plugin': link:../../webpack/preserve-dynamic-require-plugin
       '@types/glob': 7.1.1
       '@types/heft-jest': 1.0.1
+      '@types/minimatch': 3.0.5
       '@types/node': 14.18.36
       '@types/npm-packlist': 1.1.2
       eslint: 8.7.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "59e1cd739abd783685d293fe09accb5b2517b7a5",
+  "pnpmShrinkwrapHash": "f7e84216fc4d6afef8aa7da108503ae8a6b0e9c3",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -37,6 +37,8 @@ export interface IExtractorProjectConfiguration {
     additionalDependenciesToInclude?: string[];
     additionalProjectsToInclude?: string[];
     dependenciesToExclude?: string[];
+    patternsToExclude?: string[];
+    patternsToInclude?: string[];
     projectFolder: string;
     projectName: string;
 }

--- a/libraries/package-extractor/package.json
+++ b/libraries/package-extractor/package.json
@@ -22,6 +22,7 @@
     "@rushstack/terminal": "workspace:*",
     "ignore": "~5.1.6",
     "jszip": "~3.8.0",
+    "minimatch": "~3.0.3",
     "npm-packlist": "~2.1.2"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@rushstack/webpack-preserve-dynamic-require-plugin": "workspace:*",
     "@types/glob": "7.1.1",
     "@types/heft-jest": "1.0.1",
+    "@types/minimatch": "3.0.5",
     "@types/node": "14.18.36",
     "@types/npm-packlist": "~1.1.1",
     "eslint": "~8.7.0",

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -95,13 +95,15 @@ export interface IExtractorProjectConfiguration {
    */
   projectFolder: string;
   /**
-   * A list of glob patterns to include when extracting this project. If undefined,
-   * all files will be included.
+   * A list of glob patterns to include when extracting this project. If a path is
+   * matched by both "patternsToInclude" and "patternsToExclude", the path will be
+   * excluded. If undefined, all paths will be included.
    */
   patternsToInclude?: string[];
   /**
-   * A list of glob patterns to exclude when extracting this project. If undefined,
-   * no files will be excluded.
+   * A list of glob patterns to exclude when extracting this project. If a path is
+   * matched by both "patternsToInclude" and "patternsToExclude", the path will be
+   * excluded. If undefined, no paths will be excluded.
    */
   patternsToExclude?: string[];
   /**
@@ -638,12 +640,11 @@ export class PackageExtractor {
         return false;
       }
 
-      // Since the includeFilter is used to match against included files, if `includeFilter.ignores()`
-      // returns true, we know that the file is included.
       const isIncluded: boolean = !includeFilters || includeFilters.some((m) => m.match(filePath));
-      // If the file is not included, then we don't need to check the excludeFilter. If it is included,
-      // and there no exclude filter, then we know that the file is not excluded. If there is an exclude
-      // filter, then we need to check it.
+
+      // If the file is not included, then we don't need to check the excludeFilter. If it is included
+      // and there is no exclude filter, then we know that the file is not excluded. If it is included
+      // and there is an exclude filter, then we need to check for a match.
       return !isIncluded || !!excludeFilters?.some((m) => m.match(filePath));
     }
 


### PR DESCRIPTION
## Summary

When searching for all source files to be included in an extraction of a package, allow for providing `patternsToInclude` and `patternsToExclude` to limit which files get included from the local project.

## How it was tested

Locally using various provided patterns.