### PR TITLE
[rig-package] Expose an `IRigConfig` interface and use it in consuming projects' APIs.

### DIFF
--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -16,7 +16,7 @@ import {
   Path,
   NewlineKind
 } from '@rushstack/node-core-library';
-import { RigConfig } from '@rushstack/rig-package';
+import { type IRigConfig, RigConfig } from '@rushstack/rig-package';
 
 import { IConfigFile, IExtractorMessagesConfig } from './IConfigFile';
 import { PackageMetadataManager } from '../analyzer/PackageMetadataManager';
@@ -71,7 +71,7 @@ export interface IExtractorConfigLoadForFolderOptions {
   /**
    * An already constructed `RigConfig` object.  If omitted, then a new `RigConfig` object will be constructed.
    */
-  rigConfig?: RigConfig;
+  rigConfig?: IRigConfig;
 }
 
 /**
@@ -426,7 +426,7 @@ export class ExtractorConfig {
         // If We didn't find it in <packageFolder>/api-extractor.json or <packageFolder>/config/api-extractor.json
         // then check for a rig package
         if (packageFolder) {
-          let rigConfig: RigConfig;
+          let rigConfig: IRigConfig;
           if (options.rigConfig) {
             // The caller provided an already solved RigConfig.  Double-check that it is for the right project.
             if (!Path.isEqual(options.rigConfig.projectFolderPath, packageFolder)) {

--- a/apps/heft/src/configuration/HeftConfiguration.ts
+++ b/apps/heft/src/configuration/HeftConfiguration.ts
@@ -11,7 +11,7 @@ import {
   type ITerminal
 } from '@rushstack/node-core-library';
 import { trueCasePathSync } from 'true-case-path';
-import { RigConfig } from '@rushstack/rig-package';
+import { type IRigConfig, RigConfig } from '@rushstack/rig-package';
 
 import { Constants } from '../utilities/Constants';
 import { RigPackageResolver, type IRigPackageResolver } from './RigPackageResolver';
@@ -39,7 +39,7 @@ export class HeftConfiguration {
   private _projectConfigFolderPath: string | undefined;
   private _cacheFolderPath: string | undefined;
   private _tempFolderPath: string | undefined;
-  private _rigConfig: RigConfig | undefined;
+  private _rigConfig: IRigConfig | undefined;
   private _globalTerminal!: Terminal;
   private _terminalProvider!: ITerminalProvider;
   private _rigPackageResolver!: RigPackageResolver;
@@ -80,7 +80,7 @@ export class HeftConfiguration {
   /**
    * The rig.json configuration for this project, if present.
    */
-  public get rigConfig(): RigConfig {
+  public get rigConfig(): IRigConfig {
     if (!this._rigConfig) {
       throw new InternalError(
         'The rigConfig cannot be accessed until HeftConfiguration.checkForRigAsync() has been called'

--- a/apps/heft/src/configuration/RigPackageResolver.ts
+++ b/apps/heft/src/configuration/RigPackageResolver.ts
@@ -9,7 +9,7 @@ import {
   type INodePackageJson,
   type IPackageJson
 } from '@rushstack/node-core-library';
-import type { RigConfig } from '@rushstack/rig-package';
+import type { IRigConfig } from '@rushstack/rig-package';
 
 /**
  * Rig resolves requested tools from the project's Heft rig.
@@ -29,7 +29,7 @@ export interface IRigPackageResolver {
 export interface IRigPackageResolverOptions {
   buildFolder: string;
   projectPackageJson: IPackageJson;
-  rigConfig: RigConfig;
+  rigConfig: IRigConfig;
 }
 
 /**
@@ -38,7 +38,7 @@ export interface IRigPackageResolverOptions {
 export class RigPackageResolver implements IRigPackageResolver {
   private readonly _buildFolder: string;
   private readonly _projectPackageJson: IPackageJson;
-  private readonly _rigConfig: RigConfig;
+  private readonly _rigConfig: IRigConfig;
   private readonly _packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
   private readonly _resolverCache: Map<string, Promise<string>> = new Map();
 
@@ -100,7 +100,7 @@ export class RigPackageResolver implements IRigPackageResolver {
     }
 
     // See if the project rig has a regular dependency on the package
-    const rigConfiguration: RigConfig = this._rigConfig;
+    const rigConfiguration: IRigConfig = this._rigConfig;
     if (rigConfiguration.rigFound) {
       const rigFolder: string = rigConfiguration.getResolvedProfileFolder();
       const rigPackageJsonPath: string | undefined =

--- a/apps/heft/src/utilities/CoreConfigFiles.ts
+++ b/apps/heft/src/utilities/CoreConfigFiles.ts
@@ -9,7 +9,7 @@ import {
   type IJsonPathMetadataResolverOptions
 } from '@rushstack/heft-config-file';
 import { Import, PackageJsonLookup, type ITerminal, InternalError } from '@rushstack/node-core-library';
-import type { RigConfig } from '@rushstack/rig-package';
+import type { IRigConfig } from '@rushstack/rig-package';
 
 import type { IDeleteOperation } from '../plugins/DeleteFilesPlugin';
 import type { INodeServicePluginConfiguration } from '../plugins/NodeServicePlugin';
@@ -73,7 +73,7 @@ export class CoreConfigFiles {
   public static async loadHeftConfigurationFileForProjectAsync(
     terminal: ITerminal,
     projectPath: string,
-    rigConfig?: RigConfig | undefined
+    rigConfig?: IRigConfig | undefined
   ): Promise<IHeftConfigurationJson> {
     if (!CoreConfigFiles._heftConfigFileLoader) {
       const pluginPackageResolver: (
@@ -197,7 +197,7 @@ export class CoreConfigFiles {
   public static async tryLoadNodeServiceConfigurationFileAsync(
     terminal: ITerminal,
     projectPath: string,
-    rigConfig?: RigConfig | undefined
+    rigConfig?: IRigConfig | undefined
   ): Promise<INodeServicePluginConfiguration | undefined> {
     if (!CoreConfigFiles._nodeServiceConfigurationLoader) {
       const schemaObject: object = await import('../schemas/node-service.schema.json');

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -7,13 +7,13 @@ importers:
 
   rush-lib-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.99.0.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.100.1.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~5.0.4
     dependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.99.0.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.100.1.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
       '@types/node': 14.18.36
@@ -22,53 +22,53 @@ importers:
 
   rush-sdk-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.99.0.tgz
-      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.99.0.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.100.1.tgz
+      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.100.1.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~5.0.4
     dependencies:
-      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.99.0.tgz_@types+node@14.18.36
+      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.100.1.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.99.0.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.100.1.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       rimraf: 4.4.1
       typescript: 5.0.4
 
   typescript-newest-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.53.1.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.6.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.6.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.55.2.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.10.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~5.0.4
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_ucoohk2w7gukx6ccuul7rl7pnq
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.53.1.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.6.tgz_@rushstack+heft@0.53.1
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.6.tgz_@rushstack+heft@0.53.1
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz_ucoohk2w7gukx6ccuul7rl7pnq
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.55.2.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.10.tgz_@rushstack+heft@0.55.2
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.10.tgz_@rushstack+heft@0.55.2
       eslint: 8.7.0
       tslint: 5.20.1_typescript@5.0.4
       typescript: 5.0.4
 
   typescript-v4-test:
     specifiers:
-      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.1.tgz
-      '@rushstack/heft': file:rushstack-heft-0.53.1.tgz
-      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.6.tgz
-      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.6.tgz
+      '@rushstack/eslint-config': file:rushstack-eslint-config-3.3.2.tgz
+      '@rushstack/heft': file:rushstack-heft-0.55.2.tgz
+      '@rushstack/heft-lint-plugin': file:rushstack-heft-lint-plugin-0.1.10.tgz
+      '@rushstack/heft-typescript-plugin': file:rushstack-heft-typescript-plugin-0.1.10.tgz
       eslint: ~8.7.0
       tslint: ~5.20.1
       typescript: ~4.7.0
     devDependencies:
-      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_valmiib6gbzc7jhcbpocdsabay
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.53.1.tgz
-      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.6.tgz_@rushstack+heft@0.53.1
-      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.6.tgz_@rushstack+heft@0.53.1
+      '@rushstack/eslint-config': file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz_valmiib6gbzc7jhcbpocdsabay
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.55.2.tgz
+      '@rushstack/heft-lint-plugin': file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.10.tgz_@rushstack+heft@0.55.2
+      '@rushstack/heft-typescript-plugin': file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.10.tgz_@rushstack+heft@0.55.2
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.7.4
       typescript: 4.7.4
@@ -79,6 +79,7 @@ packages:
     resolution: {integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==}
     dependencies:
       '@babel/highlight': 7.14.0
+    dev: true
 
   /@babel/code-frame/7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -124,6 +125,7 @@ packages:
 
   /@babel/helper-validator-identifier/7.14.0:
     resolution: {integrity: sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==}
+    dev: true
 
   /@babel/helper-validator-identifier/7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
@@ -135,6 +137,7 @@ packages:
       '@babel/helper-validator-identifier': 7.14.0
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: true
 
   /@babel/highlight/7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -308,6 +311,21 @@ packages:
     dependencies:
       rfc4648: 1.5.2
 
+  /@pnpm/crypto.base32-hash/2.0.0:
+    resolution: {integrity: sha512-3ttOeHBpmWRbgJrpDQ8Nwd3W8s8iuiP5YZM0JRyKWaMtX8lu9d7/AKyxPmhYsMJuN+q/1dwHa7QFeDZJ53b0oA==}
+    engines: {node: '>=16.14'}
+    dependencies:
+      rfc4648: 1.5.2
+
+  /@pnpm/dependency-path/2.1.2:
+    resolution: {integrity: sha512-BXEMdGHZG2y8z7hZAVn+r0z+IdszFZbVPpAp3xyDH3gDN30A4HCVhhCUUf0mthqQZsT131jK4HW82EUwEiW01A==}
+    engines: {node: '>=16.14'}
+    dependencies:
+      '@pnpm/crypto.base32-hash': 2.0.0
+      '@pnpm/types': 9.1.0
+      encode-registry: 3.0.0
+      semver: 7.5.1
+
   /@pnpm/error/1.4.0:
     resolution: {integrity: sha512-vxkRrkneBPVmP23kyjnYwVOtipwlSl6UfL+h+Xa3TrABJTz5rYBXemlTsU5BzST8U4pD7YDkTb3SQu+MMuIDKA==}
     engines: {node: '>=10.16'}
@@ -377,6 +395,10 @@ packages:
   /@pnpm/types/8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
+
+  /@pnpm/types/9.1.0:
+    resolution: {integrity: sha512-MMPDMLOY17bfNhLhR9Qmq6/2keoocnR5DWXZfZDC4dKXugrMsE1jB6RnuU8swJIo4zyCsMT/iVSAtl/XK+9Z+A==}
+    engines: {node: '>=16.14'}
 
   /@pnpm/write-project-manifest/1.1.7:
     resolution: {integrity: sha512-OLkDZSqkA1mkoPNPvLFXyI6fb0enCuFji6Zfditi/CLAo9kmIhQFmEUDu4krSB8i908EljG8YwL5Xjxzm5wsWA==}
@@ -468,7 +490,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -496,7 +518,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -636,7 +658,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -657,7 +679,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -678,7 +700,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.0.4
       eslint: 8.7.0
       eslint-scope: 5.1.1
-      semver: 7.3.7
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -698,7 +720,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.9_typescript@4.7.4
       eslint: 8.7.0
       eslint-scope: 5.1.1
-      semver: 7.3.7
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -1883,10 +1905,6 @@ packages:
   /graceful-fs/4.2.4:
     resolution: {integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==}
 
-  /graceful-fs/4.2.6:
-    resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==}
-    dev: true
-
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
@@ -2268,7 +2286,7 @@ packages:
     hasBin: true
 
   /json-buffer/3.0.0:
-    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -2506,6 +2524,11 @@ packages:
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  /minimatch/3.0.8:
+    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
+    dependencies:
+      brace-expansion: 1.1.11
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2890,7 +2913,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.12.13
+      '@babel/code-frame': 7.22.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -3754,7 +3777,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.11
     dev: true
 
   /wcwidth/1.0.1:
@@ -3891,22 +3914,23 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.99.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.99.0.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.99.0.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.100.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.100.1.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.100.1.tgz
     name: '@microsoft/rush-lib'
-    version: 5.99.0
+    version: 5.100.1
     engines: {node: '>=5.6.0'}
     dependencies:
+      '@pnpm/dependency-path': 2.1.2
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz_@types+node@14.18.36
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.27.tgz_@types+node@14.18.36
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.2.14.tgz_@types+node@14.18.36
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.245.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.20.tgz_@types+node@14.18.36
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.31.tgz_@types+node@14.18.36
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.3.0.tgz_@types+node@14.18.36
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.249.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.24.tgz_@types+node@14.18.36
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.15.1.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
       builtin-modules: 3.1.0
@@ -3937,16 +3961,16 @@ packages:
       - encoding
       - supports-color
 
-  file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz
+  file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz
     name: '@rushstack/eslint-config'
-    version: 3.3.1
+    version: 3.3.2
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
-      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz
+      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.2.tgz
       '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
       '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.7.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
       '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.6.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq
@@ -3963,16 +3987,16 @@ packages:
       - supports-color
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz_valmiib6gbzc7jhcbpocdsabay:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz}
-    id: file:../temp/tarballs/rushstack-eslint-config-3.3.1.tgz
+  file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz_valmiib6gbzc7jhcbpocdsabay:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz}
+    id: file:../temp/tarballs/rushstack-eslint-config-3.3.2.tgz
     name: '@rushstack/eslint-config'
-    version: 3.3.1
+    version: 3.3.2
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
-      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz
+      '@rushstack/eslint-patch': file:../temp/tarballs/rushstack-eslint-patch-1.3.2.tgz
       '@rushstack/eslint-plugin': file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_valmiib6gbzc7jhcbpocdsabay
       '@rushstack/eslint-plugin-packlets': file:../temp/tarballs/rushstack-eslint-plugin-packlets-0.7.0.tgz_valmiib6gbzc7jhcbpocdsabay
       '@rushstack/eslint-plugin-security': file:../temp/tarballs/rushstack-eslint-plugin-security-0.6.0.tgz_valmiib6gbzc7jhcbpocdsabay
@@ -3989,10 +4013,10 @@ packages:
       - supports-color
     dev: true
 
-  file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-patch-1.3.1.tgz}
+  file:../temp/tarballs/rushstack-eslint-patch-1.3.2.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-eslint-patch-1.3.2.tgz}
     name: '@rushstack/eslint-patch'
-    version: 1.3.1
+    version: 1.3.2
     dev: true
 
   file:../temp/tarballs/rushstack-eslint-plugin-0.12.0.tgz_ucoohk2w7gukx6ccuul7rl7pnq:
@@ -4091,17 +4115,17 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.53.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.53.1.tgz}
+  file:../temp/tarballs/rushstack-heft-0.55.2.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.55.2.tgz}
     name: '@rushstack/heft'
-    version: 0.53.1
+    version: 0.55.2
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
-      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz
+      '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.15.1.tgz
       '@types/tapable': 1.0.6
       argparse: 1.0.10
       chokidar: 3.4.3
@@ -4115,58 +4139,58 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz}
+  file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz}
     name: '@rushstack/heft-config-file'
-    version: 0.12.4
+    version: 0.12.5
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz}
-    id: file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
+  file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz}
+    id: file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz
     name: '@rushstack/heft-config-file'
-    version: 0.12.4
+    version: 0.12.5
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
-      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
+      '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.6.tgz_@rushstack+heft@0.53.1:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.6.tgz}
-    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.6.tgz
+  file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.10.tgz_@rushstack+heft@0.55.2:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.10.tgz}
+    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.1.10.tgz
     name: '@rushstack/heft-lint-plugin'
-    version: 0.1.6
+    version: 0.1.10
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.53.1.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.55.2.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz
       semver: 7.3.7
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.6.tgz_@rushstack+heft@0.53.1:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.6.tgz}
-    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.6.tgz
+  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.10.tgz_@rushstack+heft@0.55.2:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.10.tgz}
+    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.1.10.tgz
     name: '@rushstack/heft-typescript-plugin'
-    version: 0.1.6
+    version: 0.1.10
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.53.1.tgz
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.4.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.55.2.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.12.5.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz
       '@types/tapable': 1.0.6
       semver: 7.3.7
       tapable: 1.1.3
@@ -4174,10 +4198,10 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz}
+  file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz}
     name: '@rushstack/node-core-library'
-    version: 3.59.3
+    version: 3.59.4
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4193,11 +4217,11 @@ packages:
       z-schema: 5.0.3
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz}
-    id: file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz
+  file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz}
+    id: file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz
     name: '@rushstack/node-core-library'
-    version: 3.59.3
+    version: 3.59.4
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4213,75 +4237,76 @@ packages:
       semver: 7.3.7
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.0.27.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.27.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.27.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.0.31.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.0.31.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.0.31.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.0.27
+    version: 4.0.31
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.2.14.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.2.14.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.2.14.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.3.0.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.3.0.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.3.0.tgz
     name: '@rushstack/package-extractor'
-    version: 0.2.14
+    version: 0.3.0
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.20.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.24.tgz_@types+node@14.18.36
       ignore: 5.1.9
       jszip: 3.8.0
+      minimatch: 3.0.8
       npm-packlist: 2.1.5
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.20.tgz}
+  file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rig-package-0.3.21.tgz}
     name: '@rushstack/rig-package'
-    version: 0.3.20
+    version: 0.3.21
     dependencies:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.99.0.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.99.0.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.99.0.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.100.1.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.100.1.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.100.1.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.99.0
+    version: 5.100.1
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
       '@types/node-fetch': 2.6.2
       tapable: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.0.245.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.245.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.0.245.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.0.249.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.0.249.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.0.249.tgz
     name: '@rushstack/stream-collator'
-    version: 4.0.245
+    version: 4.0.249
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.20.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.24.tgz_@types+node@14.18.36
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.5.20.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.20.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.5.20.tgz
+  file:../temp/tarballs/rushstack-terminal-0.5.24.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.5.24.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.5.24.tgz
     name: '@rushstack/terminal'
-    version: 0.5.20
+    version: 0.5.24
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.3.tgz_@types+node@14.18.36
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.4.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       wordwrap: 1.0.0
 
@@ -4291,10 +4316,10 @@ packages:
     version: 0.2.4
     dev: true
 
-  file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.14.0.tgz}
+  file:../temp/tarballs/rushstack-ts-command-line-4.15.1.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-ts-command-line-4.15.1.tgz}
     name: '@rushstack/ts-command-line'
-    version: 4.14.0
+    version: 4.15.1
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10

--- a/common/changes/@microsoft/api-extractor/IRigConfig_2023-06-19-22-00.json
+++ b/common/changes/@microsoft/api-extractor/IRigConfig_2023-06-19-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Use the `IRigConfig` interface in the `IExtractorConfigLoadForFolderOptions` object insteacd of the `RigConfig` class.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/heft-config-file/IRigConfig_2023-06-19-22-00.json
+++ b/common/changes/@rushstack/heft-config-file/IRigConfig_2023-06-19-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": " Use the `IRigConfig` interface insteacd of the `RigConfig` class in the API.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft/IRigConfig_2023-06-19-22-00.json
+++ b/common/changes/@rushstack/heft/IRigConfig_2023-06-19-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Use the `IRigConfig` interface in the `HeftConfiguration` object insteacd of the `RigConfig` class.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/rig-package/IRigConfig_2023-06-19-22-00.json
+++ b/common/changes/@rushstack/rig-package/IRigConfig_2023-06-19-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rig-package",
+      "comment": "Expose an `IRigConfig` interface that `RigConfig` implements.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rig-package"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -6,10 +6,10 @@
 
 import { EnumMemberOrder } from '@microsoft/api-extractor-model';
 import { INodePackageJson } from '@rushstack/node-core-library';
+import { IRigConfig } from '@rushstack/rig-package';
 import { JsonSchema } from '@rushstack/node-core-library';
 import { NewlineKind } from '@rushstack/node-core-library';
 import { PackageJsonLookup } from '@rushstack/node-core-library';
-import { RigConfig } from '@rushstack/rig-package';
 import * as tsdoc from '@microsoft/tsdoc';
 import { TSDocConfigFile } from '@microsoft/tsdoc-config';
 import { TSDocConfiguration } from '@microsoft/tsdoc';
@@ -241,7 +241,7 @@ export interface IConfigTsdocMetadata {
 // @public
 export interface IExtractorConfigLoadForFolderOptions {
     packageJsonLookup?: PackageJsonLookup;
-    rigConfig?: RigConfig;
+    rigConfig?: IRigConfig;
     startingFolder: string;
 }
 

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
+import type { IRigConfig } from '@rushstack/rig-package';
 import { ITerminal } from '@rushstack/node-core-library';
-import { RigConfig } from '@rushstack/rig-package';
 
 // @beta (undocumented)
 export class ConfigurationFile<TConfigurationFile> {
@@ -14,9 +14,9 @@ export class ConfigurationFile<TConfigurationFile> {
     static _formatPathForLogging: (path: string) => string;
     getObjectSourceFilePath<TObject extends object>(obj: TObject): string | undefined;
     getPropertyOriginalValue<TParentProperty extends object, TValue>(options: IOriginalValueOptions<TParentProperty>): TValue | undefined;
-    loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: RigConfig): Promise<TConfigurationFile>;
+    loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile>;
     readonly projectRelativeFilePath: string;
-    tryLoadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: RigConfig): Promise<TConfigurationFile | undefined>;
+    tryLoadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile | undefined>;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -15,9 +15,9 @@ import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringListParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';
 import { IPackageJson } from '@rushstack/node-core-library';
+import { IRigConfig } from '@rushstack/rig-package';
 import { ITerminal } from '@rushstack/node-core-library';
 import { ITerminalProvider } from '@rushstack/node-core-library';
-import { RigConfig } from '@rushstack/rig-package';
 
 // @beta
 export class CancellationToken {
@@ -67,7 +67,7 @@ export class HeftConfiguration {
     static initialize(options: _IHeftConfigurationInitializationOptions): HeftConfiguration;
     get projectConfigFolderPath(): string;
     get projectPackageJson(): IPackageJson;
-    get rigConfig(): RigConfig;
+    get rigConfig(): IRigConfig;
     get rigPackageResolver(): IRigPackageResolver;
     get tempFolderPath(): string;
     get terminalProvider(): ITerminalProvider;

--- a/common/reviews/api/rig-package.api.md
+++ b/common/reviews/api/rig-package.api.md
@@ -12,13 +12,28 @@ export interface ILoadForProjectFolderOptions {
 }
 
 // @public
+export interface IRigConfig {
+    readonly filePath: string;
+    getResolvedProfileFolder(): string;
+    getResolvedProfileFolderAsync(): Promise<string>;
+    readonly projectFolderOriginalPath: string;
+    readonly projectFolderPath: string;
+    readonly relativeProfileFolderPath: string;
+    readonly rigFound: boolean;
+    readonly rigPackageName: string;
+    readonly rigProfile: string;
+    tryResolveConfigFilePath(configFileRelativePath: string): string | undefined;
+    tryResolveConfigFilePathAsync(configFileRelativePath: string): Promise<string | undefined>;
+}
+
+// @public
 export interface IRigConfigJson {
     rigPackageName: string;
     rigProfile?: string;
 }
 
 // @public
-export class RigConfig {
+export class RigConfig implements IRigConfig {
     readonly filePath: string;
     getResolvedProfileFolder(): string;
     getResolvedProfileFolderAsync(): Promise<string>;

--- a/libraries/heft-config-file/src/ConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ConfigurationFile.ts
@@ -11,7 +11,7 @@ import {
   FileSystem,
   ITerminal
 } from '@rushstack/node-core-library';
-import { RigConfig } from '@rushstack/rig-package';
+import type { IRigConfig } from '@rushstack/rig-package';
 
 interface IConfigurationJson {
   extends?: string;
@@ -329,7 +329,7 @@ export class ConfigurationFile<TConfigurationFile> {
   public async loadConfigurationFileForProjectAsync(
     terminal: ITerminal,
     projectPath: string,
-    rigConfig?: RigConfig
+    rigConfig?: IRigConfig
   ): Promise<TConfigurationFile> {
     const projectConfigurationFilePath: string = this._getConfigurationFilePathForProject(projectPath);
     return await this._loadConfigurationFileInnerWithCacheAsync(
@@ -347,7 +347,7 @@ export class ConfigurationFile<TConfigurationFile> {
   public async tryLoadConfigurationFileForProjectAsync(
     terminal: ITerminal,
     projectPath: string,
-    rigConfig?: RigConfig
+    rigConfig?: IRigConfig
   ): Promise<TConfigurationFile | undefined> {
     try {
       return await this.loadConfigurationFileForProjectAsync(terminal, projectPath, rigConfig);
@@ -401,7 +401,7 @@ export class ConfigurationFile<TConfigurationFile> {
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
-    rigConfig: RigConfig | undefined
+    rigConfig: IRigConfig | undefined
   ): Promise<TConfigurationFile> {
     let cacheEntryPromise: Promise<TConfigurationFile> | undefined = this._configPromiseCache.get(
       resolvedConfigurationFilePath
@@ -440,7 +440,7 @@ export class ConfigurationFile<TConfigurationFile> {
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
-    rigConfig: RigConfig | undefined
+    rigConfig: IRigConfig | undefined
   ): Promise<TConfigurationFile> {
     const resolvedConfigurationFilePathForLogging: string = ConfigurationFile._formatPathForLogging(
       resolvedConfigurationFilePath
@@ -549,7 +549,7 @@ export class ConfigurationFile<TConfigurationFile> {
 
   private async _tryLoadConfigurationFileInRigAsync(
     terminal: ITerminal,
-    rigConfig: RigConfig,
+    rigConfig: IRigConfig,
     visitedConfigurationFilePaths: Set<string>
   ): Promise<TConfigurationFile | undefined> {
     if (rigConfig.rigFound) {

--- a/libraries/rig-package/src/RigConfig.ts
+++ b/libraries/rig-package/src/RigConfig.ts
@@ -72,7 +72,114 @@ export interface ILoadForProjectFolderOptions {
  *
  * @public
  */
-export class RigConfig {
+export interface IRigConfig {
+  /**
+   * The project folder path that was passed to {@link RigConfig.loadForProjectFolder},
+   * which maybe an absolute or relative path.
+   *
+   * @remarks
+   * Example: `.`
+   */
+  readonly projectFolderOriginalPath: string;
+
+  /**
+   * The absolute path for the project folder path that was passed to {@link RigConfig.loadForProjectFolder}.
+   *
+   * @remarks
+   * Example: `/path/to/your-project`
+   */
+  readonly projectFolderPath: string;
+
+  /**
+   * Returns `true` if `config/rig.json` was found, or `false` otherwise.
+   */
+  readonly rigFound: boolean;
+
+  /**
+   * The full path to the `rig.json` file that was found, or `""` if none was found.
+   *
+   * @remarks
+   * Example: `/path/to/your-project/config/rig.json`
+   */
+  readonly filePath: string;
+
+  /**
+   * The `"rigPackageName"` field from `rig.json`, or `""` if the file was not found.
+   *
+   * @remarks
+   * The name must be a valid NPM package name, and must end with the `-rig` suffix.
+   *
+   * Example: `example-rig`
+   */
+  readonly rigPackageName: string;
+
+  /**
+   * The `"rigProfile"` value that was loaded from `rig.json`, or `""` if the file was not found.
+   *
+   * @remarks
+   * The name must consist of lowercase alphanumeric words separated by hyphens, for example `"sample-profile"`.
+   * If the `rig.json` file exists, but the `"rigProfile"` is not specified, then the profile
+   * name will be `"default"`.
+   *
+   * Example: `example-profile`
+   */
+  readonly rigProfile: string;
+
+  /**
+   * The relative path to the rig profile specified by `rig.json`, or `""` if the file was not found.
+   *
+   * @remarks
+   * Example: `profiles/example-profile`
+   */
+  readonly relativeProfileFolderPath: string;
+
+  /**
+   * Performs Node.js module resolution to locate the rig package folder, then returns the absolute path
+   * of the rig profile folder specified by `rig.json`.
+   *
+   * @remarks
+   * If no `rig.json` file was found, then this method throws an error.  The first time this method
+   * is called, the result is cached and will be returned by all subsequent calls.
+   *
+   * Example: `/path/to/your-project/node_modules/example-rig/profiles/example-profile`
+   */
+  getResolvedProfileFolder(): string;
+
+  /**
+   * An async variant of {@link IRigConfig.getResolvedProfileFolder}
+   */
+  getResolvedProfileFolderAsync(): Promise<string>;
+
+  /**
+   * This lookup first checks for the specified relative path under `projectFolderPath`; if it does
+   * not exist there, then it checks in the resolved rig profile folder.  If the file is found,
+   * its absolute path is returned. Otherwise, `undefined` is returned.
+   *
+   * @remarks
+   * For example, suppose the rig profile is:
+   *
+   * `/path/to/your-project/node_modules/example-rig/profiles/example-profile`
+   *
+   * And suppose `configFileRelativePath` is `folder/file.json`. Then the following locations will be checked:
+   *
+   * `/path/to/your-project/folder/file.json`
+   *
+   * `/path/to/your-project/node_modules/example-rig/profiles/example-profile/folder/file.json`
+   */
+  tryResolveConfigFilePath(configFileRelativePath: string): string | undefined;
+
+  /**
+   * An async variant of {@link IRigConfig.tryResolveConfigFilePath}
+   */
+  tryResolveConfigFilePathAsync(configFileRelativePath: string): Promise<string | undefined>;
+}
+
+/**
+ * {@inheritdoc IRigConfig}
+ *
+ * @public
+ */
+export class RigConfig implements IRigConfig {
   // For syntax details, see PackageNameParser from @rushstack/node-core-library
   private static readonly _packageNameRegExp: RegExp = /^(@[A-Za-z0-9\-_\.]+\/)?[A-Za-z0-9\-_\.]+$/;
 
@@ -99,62 +206,37 @@ export class RigConfig {
   private static readonly _configCache: Map<string, RigConfig> = new Map();
 
   /**
-   * The project folder path that was passed to {@link RigConfig.loadForProjectFolder},
-   * which maybe an absolute or relative path.
-   *
-   * @remarks
-   * Example: `.`
+   * {@inheritdoc IRigConfig.projectFolderOriginalPath}
    */
   public readonly projectFolderOriginalPath: string;
 
   /**
-   * The absolute path for the project folder path that was passed to {@link RigConfig.loadForProjectFolder}.
-   *
-   * @remarks
-   * Example: `/path/to/your-project`
+   * {@inheritdoc IRigConfig.projectFolderPath}
    */
   public readonly projectFolderPath: string;
 
   /**
-   * Returns `true` if `config/rig.json` was found, or `false` otherwise.
+   * {@inheritdoc IRigConfig.rigFound}
    */
   public readonly rigFound: boolean;
 
   /**
-   * The full path to the `rig.json` file that was found, or `""` if none was found.
-   *
-   * @remarks
-   * Example: `/path/to/your-project/config/rig.json`
+   * {@inheritdoc IRigConfig.filePath}
    */
   public readonly filePath: string;
 
   /**
-   * The `"rigPackageName"` field from `rig.json`, or `""` if the file was not found.
-   *
-   * @remarks
-   * The name must be a valid NPM package name, and must end with the `-rig` suffix.
-   *
-   * Example: `example-rig`
+   * {@inheritdoc IRigConfig.rigPackageName}
    */
   public readonly rigPackageName: string;
 
   /**
-   * The `"rigProfile"` value that was loaded from `rig.json`, or `""` if the file was not found.
-   *
-   * @remarks
-   * The name must consist of lowercase alphanumeric words separated by hyphens, for example `"sample-profile"`.
-   * If the `rig.json` file exists, but the `"rigProfile"` is not specified, then the profile
-   * name will be `"default"`.
-   *
-   * Example: `example-profile`
+   * {@inheritdoc IRigConfig.rigProfile}
    */
   public readonly rigProfile: string;
 
   /**
-   * The relative path to the rig profile specified by `rig.json`, or `""` if the file was not found.
-   *
-   * @remarks
-   * Example: `profiles/example-profile`
+   * {@inheritdoc IRigConfig.relativeProfileFolderPath}
    */
   public readonly relativeProfileFolderPath: string;
 
@@ -316,14 +398,7 @@ export class RigConfig {
   }
 
   /**
-   * Performs Node.js module resolution to locate the rig package folder, then returns the absolute path
-   * of the rig profile folder specified by `rig.json`.
-   *
-   * @remarks
-   * If no `rig.json` file was found, then this method throws an error.  The first time this method
-   * is called, the result is cached and will be returned by all subsequent calls.
-   *
-   * Example: `/path/to/your-project/node_modules/example-rig/profiles/example-profile`
+   * {@inheritdoc IRigConfig.getResolvedProfileFolder}
    */
   public getResolvedProfileFolder(): string {
     if (this._resolvedRigPackageFolder === undefined) {
@@ -356,7 +431,7 @@ export class RigConfig {
   }
 
   /**
-   * An async variant of {@link RigConfig.getResolvedProfileFolder}
+   * {@inheritdoc IRigConfig.getResolvedProfileFolderAsync}
    */
   public async getResolvedProfileFolderAsync(): Promise<string> {
     if (this._resolvedRigPackageFolder === undefined) {
@@ -389,20 +464,7 @@ export class RigConfig {
   }
 
   /**
-   * This lookup first checks for the specified relative path under `projectFolderPath`; if it does
-   * not exist there, then it checks in the resolved rig profile folder.  If the file is found,
-   * its absolute path is returned. Otherwise, `undefined` is returned.
-   *
-   * @remarks
-   * For example, suppose the rig profile is:
-   *
-   * `/path/to/your-project/node_modules/example-rig/profiles/example-profile`
-   *
-   * And suppose `configFileRelativePath` is `folder/file.json`. Then the following locations will be checked:
-   *
-   * `/path/to/your-project/folder/file.json`
-   *
-   * `/path/to/your-project/node_modules/example-rig/profiles/example-profile/folder/file.json`
+   * {@inheritdoc IRigConfig.tryResolveConfigFilePath}
    */
   public tryResolveConfigFilePath(configFileRelativePath: string): string | undefined {
     if (!Helpers.isDownwardRelative(configFileRelativePath)) {
@@ -423,7 +485,7 @@ export class RigConfig {
   }
 
   /**
-   * An async variant of {@link RigConfig.tryResolveConfigFilePath}
+   * {@inheritdoc IRigConfig.tryResolveConfigFilePathAsync}
    */
   public async tryResolveConfigFilePathAsync(configFileRelativePath: string): Promise<string | undefined> {
     if (!Helpers.isDownwardRelative(configFileRelativePath)) {

--- a/libraries/rig-package/src/index.ts
+++ b/libraries/rig-package/src/index.ts
@@ -12,4 +12,9 @@
  * @packageDocumentation
  */
 
-export { IRigConfigJson, RigConfig, ILoadForProjectFolderOptions } from './RigConfig';
+export {
+  type IRigConfigJson,
+  type IRigConfig,
+  RigConfig,
+  type ILoadForProjectFolderOptions
+} from './RigConfig';


### PR DESCRIPTION
## Summary

Similar to `Terminal` vs `ITerminal`, this PR is creating an `IRigConfig` interface to be used in APIs to avoid issues with mismatched versions of `@rushstack/rig-package`.

## How it was tested

Built.

## Impacted documentation

The `IRigConfig` interface needs to be added to the API docs.