### PR TITLE
[package-extractor] Fix package extractor filter for subdirectories of non-matching folders

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-FixPackageExtractorFilter_2023-06-26-21-41.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-FixPackageExtractorFilter_2023-06-26-21-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Fix patternsToInclude and patternsToExclude filters when provided patterns target subdirectories of folders that do not match the provided patterns",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -729,16 +729,18 @@ export class PackageExtractor {
         queue,
         async ([sourcePath, callback]: [string, () => void]) => {
           const relativeSourcePath: string = path.relative(sourceFolderPath, sourcePath);
-          if (
-            relativeSourcePath !== '' &&
-            (ignoreFilter.ignores(relativeSourcePath) || isFileExcluded(relativeSourcePath))
-          ) {
+          if (relativeSourcePath !== '' && ignoreFilter.ignores(relativeSourcePath)) {
             callback();
             return;
           }
 
           const sourcePathNode: PathNode = await state.symlinkAnalyzer.analyzePathAsync(sourcePath);
           if (sourcePathNode.kind === 'file') {
+            if (relativeSourcePath !== '' && isFileExcluded(relativeSourcePath)) {
+              callback();
+              return;
+            }
+
             const targetPath: string = path.join(targetFolderPath, relativeSourcePath);
             if (!options.createArchiveOnly) {
               // Manually call fs.copyFile to avoid unnecessary stat calls.


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Package extractor allows for providing filters to modify the list of files to extract. However, because the file system traversal analyzes both folders and files, patterns that specified a subfolder of a non-matching parent folder would not be traversed and would be excluded from the generated extraction. This change ensures that all folders are traversed and only files are matched against the filters.

For example, if `patternsToInclude` is `src/**/*`, files within the `src` folder would not actually be collected, since `src` does not match the pattern `src/**/*` itself, even though the files and folders within do match.

## How it was tested

Tested locally against the project that the issue was encountered in.

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
