### PR TITLE
[node-core-library] Resolve self-referencing modules and packages to their real-path

### DIFF
--- a/common/changes/@rushstack/node-core-library/user-danade-FixSelfReferenceResolving_2023-07-05-22-43.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-FixSelfReferenceResolving_2023-07-05-22-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix Import.resolveModule* and Import.resolvePackage* methods to return real-paths when resolving self-referencing specs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/Import.ts
+++ b/libraries/node-core-library/src/Import.ts
@@ -276,7 +276,7 @@ export class Import {
     }
 
     if (allowSelfReference === true) {
-      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(baseFolderPath);
+      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(normalizedRootPath);
       if (
         ownPackage &&
         (modulePath === ownPackage.packageName || modulePath.startsWith(`${ownPackage.packageName}/`))
@@ -332,7 +332,7 @@ export class Import {
     }
 
     if (allowSelfReference === true) {
-      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(baseFolderPath);
+      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(normalizedRootPath);
       if (
         ownPackage &&
         (modulePath === ownPackage.packageName || modulePath.startsWith(`${ownPackage.packageName}/`))
@@ -418,7 +418,7 @@ export class Import {
     const normalizedRootPath: string = (getRealPath || FileSystem.getRealPath)(baseFolderPath);
 
     if (allowSelfReference) {
-      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(baseFolderPath);
+      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(normalizedRootPath);
       if (ownPackage && ownPackage.packageName === packageName) {
         return ownPackage.packageRootPath;
       }
@@ -471,7 +471,7 @@ export class Import {
     );
 
     if (allowSelfReference) {
-      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(baseFolderPath);
+      const ownPackage: IPackageDescriptor | undefined = Import._getPackageName(normalizedRootPath);
       if (ownPackage && ownPackage.packageName === packageName) {
         return ownPackage.packageRootPath;
       }

--- a/libraries/node-core-library/src/test/Import.test.ts
+++ b/libraries/node-core-library/src/test/Import.test.ts
@@ -129,6 +129,18 @@ describe(Import.name, () => {
         ).toEqual(nodeJsPath.join(packageRoot, 'lib', 'Constants.js'));
       });
 
+      it('resolves the real path inside a package with allowSelfReference turned on', () => {
+        const heftPackageRoot: string = nodeJsPath.join(packageRoot, 'node_modules', '@rushstack', 'heft');
+        const heftPackageJsonRealPath: string = require.resolve('@rushstack/heft/package.json');
+        expect(
+          Import.resolveModule({
+            modulePath: '@rushstack/heft/package.json',
+            baseFolderPath: heftPackageRoot,
+            allowSelfReference: true
+          })
+        ).toEqual(heftPackageJsonRealPath);
+      });
+
       it('throws on an attempt to reference this package without allowSelfReference turned on', () => {
         expectToThrowNormalizedErrorMatchingSnapshot(() =>
           Import.resolveModule({
@@ -232,6 +244,20 @@ describe(Import.name, () => {
             allowSelfReference: true
           })
         ).toEqual(packageRoot);
+      });
+
+      it('resolves the real path of a package with allowSelfReference turned on', () => {
+        const heftPackageRoot: string = nodeJsPath.join(packageRoot, 'node_modules', '@rushstack', 'heft');
+        const resolvedHeftPackageRoot: string = nodeJsPath.dirname(
+          require.resolve('@rushstack/heft/package.json')
+        );
+        expect(
+          Import.resolvePackage({
+            packageName: '@rushstack/heft',
+            baseFolderPath: heftPackageRoot,
+            allowSelfReference: true
+          })
+        ).toEqual(resolvedHeftPackageRoot);
       });
 
       it('fails to resolve a path inside this package with allowSelfReference turned on', () => {


### PR DESCRIPTION
## Summary

The `Import.resolvePackage*` and `Import.resolveModule*` methods currently resolve the returned path without determining the real path to the package IFF using self-referencing and the path was found to exist. This causes the resolved but non-real path to be returned. This is unexpected, since these methods will resolve to the real-path in all other successful resolution scenarios.

This change fixes this issue and ensures that the real-path to the self-referenced module or package is returned.

Fixes #4221

## How it was tested

- Added unit tests
- Verified locally
- Verified against issue specified in #4221 
