### PR TITLE
[heft] Fix some incorrect TSDoc

### DIFF
--- a/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
@@ -46,7 +46,7 @@ export interface IHeftLifecycleSession {
 
   /**
    * The scoped logger for the lifecycle plugin. Messages logged with this logger will be prefixed
-   * with the plugin name, in the format "[lifecycle:<pluginName>]". It is highly recommended that
+   * with the plugin name, in the format `[lifecycle:<pluginName>]`. It is highly recommended that
    * writing to the console be performed via the logger, as it will ensure that logging messages
    * are labeled with the source of the message.
    *

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -106,7 +106,7 @@ export interface IHeftTaskSession {
 
   /**
    * The scoped logger for the task. Messages logged with this logger will be prefixed with
-   * the phase and task name, in the format "[<phaseName>:<taskName>]". It is highly recommended
+   * the phase and task name, in the format `[<phaseName>:<taskName>]`. It is highly recommended
    * that writing to the console be performed via the logger, as it will ensure that logging messages
    * are labeled with the source of the message.
    *

--- a/common/changes/@rushstack/heft/octogonz-tsdoc-fix_2023-07-12-06-06.json
+++ b/common/changes/@rushstack/heft/octogonz-tsdoc-fix_2023-07-12-06-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
@dmichon-msft this syntax was breaking the API website MDX because an unquoted `<pluginName>` is interpreted as an HTML tag.