### PR TITLE
[Heft] Reorganize lifecycle operation runner and support watch-mode cleaning

### DIFF
--- a/apps/heft/src/cli/actions/CleanAction.ts
+++ b/apps/heft/src/cli/actions/CleanAction.ts
@@ -106,7 +106,10 @@ export class CleanAction extends CommandLineAction implements IHeftAction {
     }
 
     // Delete the files
-    await deleteFilesAsync(deleteOperations, this._terminal);
+    if (deleteOperations.length > 0) {
+      const rootFolderPath: string = this._internalHeftSession.heftConfiguration.buildFolderPath;
+      await deleteFilesAsync(rootFolderPath, deleteOperations, this._terminal);
+    }
 
     return deleteOperations.length === 0 ? OperationStatus.NoOp : OperationStatus.Success;
   }

--- a/apps/heft/src/operations/runners/PhaseOperationRunner.ts
+++ b/apps/heft/src/operations/runners/PhaseOperationRunner.ts
@@ -20,6 +20,7 @@ export class PhaseOperationRunner implements IOperationRunner {
   public readonly silent: boolean = true;
 
   private readonly _options: IPhaseOperationRunnerOptions;
+  private _isClean: boolean = false;
 
   public get name(): string {
     return `Phase ${JSON.stringify(this._options.phase.phaseName)}`;
@@ -31,40 +32,40 @@ export class PhaseOperationRunner implements IOperationRunner {
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
     const { internalHeftSession, phase } = this._options;
-    const { clean, watch } = internalHeftSession.parameterManager.defaultParameters;
+    const { clean } = internalHeftSession.parameterManager.defaultParameters;
 
     // Load and apply the plugins for this phase only
     const phaseSession: HeftPhaseSession = internalHeftSession.getSessionForPhase(phase);
     const { phaseLogger, cleanLogger } = phaseSession;
-    phaseLogger.terminal.writeVerboseLine('Applying task plugins');
-    await phaseSession.applyPluginsAsync();
+    await phaseSession.applyPluginsAsync(phaseLogger.terminal);
 
-    if (watch) {
-      // Avoid running the phase operation when in watch mode
+    if (this._isClean || !clean) {
       return OperationStatus.NoOp;
     }
 
     // Run the clean hook
-    if (clean) {
-      const startTime: number = performance.now();
+    const startTime: number = performance.now();
 
-      // Grab the additional clean operations from the phase
-      cleanLogger.terminal.writeVerboseLine('Starting clean');
-      const deleteOperations: IDeleteOperation[] = Array.from(phase.cleanFiles);
+    // Grab the additional clean operations from the phase
+    cleanLogger.terminal.writeVerboseLine('Starting clean');
+    const deleteOperations: IDeleteOperation[] = Array.from(phase.cleanFiles);
 
-      // Delete all temp folders for tasks by default
-      for (const task of phase.tasks) {
-        const taskSession: HeftTaskSession = phaseSession.getSessionForTask(task);
-        deleteOperations.push({ sourcePath: taskSession.tempFolderPath });
-      }
-
-      // Delete the files if any were specified
-      if (deleteOperations.length) {
-        await deleteFilesAsync(deleteOperations, cleanLogger.terminal);
-      }
-
-      cleanLogger.terminal.writeVerboseLine(`Finished clean (${performance.now() - startTime}ms)`);
+    // Delete all temp folders for tasks by default
+    for (const task of phase.tasks) {
+      const taskSession: HeftTaskSession = phaseSession.getSessionForTask(task);
+      deleteOperations.push({ sourcePath: taskSession.tempFolderPath });
     }
+
+    // Delete the files if any were specified
+    if (deleteOperations.length) {
+      const rootFolderPath: string = internalHeftSession.heftConfiguration.buildFolderPath;
+      await deleteFilesAsync(rootFolderPath, deleteOperations, cleanLogger.terminal);
+    }
+
+    // Ensure we only run the clean operation once
+    this._isClean = true;
+
+    cleanLogger.terminal.writeVerboseLine(`Finished clean (${performance.now() - startTime}ms)`);
 
     // Return success and allow for the TaskOperationRunner to execute tasks
     return OperationStatus.Success;

--- a/apps/heft/src/operations/runners/TaskOperationRunner.ts
+++ b/apps/heft/src/operations/runners/TaskOperationRunner.ts
@@ -177,17 +177,21 @@ export class TaskOperationRunner implements IOperationRunner {
         OperationStatus.Success;
 
     if (this._fileOperations) {
+      const rootFolderPath: string = this._options.internalHeftSession.heftConfiguration.buildFolderPath;
       const { copyOperations, deleteOperations } = this._fileOperations;
 
       await Promise.all([
         copyOperations.size > 0
           ? copyFilesAsync(
+              rootFolderPath,
               copyOperations,
               logger.terminal,
               isWatchMode ? getWatchFileSystemAdapter() : undefined
             )
           : Promise.resolve(),
-        deleteOperations.size > 0 ? deleteFilesAsync(deleteOperations, logger.terminal) : Promise.resolve()
+        deleteOperations.size > 0
+          ? deleteFilesAsync(rootFolderPath, deleteOperations, logger.terminal)
+          : Promise.resolve()
       ]);
     }
 

--- a/apps/heft/src/pluginFramework/HeftLifecycle.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycle.ts
@@ -21,6 +21,8 @@ import {
   type IHeftLifecycleToolFinishHookOptions,
   type IHeftLifecycleSession
 } from './HeftLifecycleSession';
+import type { ScopedLogger } from './logging/ScopedLogger';
+import type { LifecycleOperationRunnerType } from '../operations/runners/LifecycleOperationRunner';
 
 export interface IHeftLifecycleContext {
   lifecycleSession?: HeftLifecycleSession;
@@ -37,6 +39,7 @@ export class HeftLifecycle extends HeftPluginHost {
     HeftLifecyclePluginDefinition,
     IHeftLifecyclePlugin<object | void>
   > = new Map();
+  private readonly _lifecycleLoggersByType: Map<string | undefined, ScopedLogger> = new Map();
 
   private _isInitialized: boolean = false;
 
@@ -176,6 +179,17 @@ export class HeftLifecycle extends HeftPluginHost {
         this._lifecycleContextByDefinition.set(pluginDefinition, lifecycleContext);
       }
     }
+  }
+
+  public getLifecycleLoggerByType(type: LifecycleOperationRunnerType | undefined): ScopedLogger {
+    let logger: ScopedLogger | undefined = this._lifecycleLoggersByType.get(type);
+    if (!logger) {
+      logger = this._internalHeftSession.loggingManager.requestScopedLogger(
+        `lifecycle${type === undefined ? '' : `:${type}`}`
+      );
+      this._lifecycleLoggersByType.set(type, logger);
+    }
+    return logger;
   }
 
   public async getSessionForPluginDefinitionAsync(

--- a/apps/heft/src/pluginFramework/HeftPluginHost.ts
+++ b/apps/heft/src/pluginFramework/HeftPluginHost.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { SyncHook } from 'tapable';
-import { InternalError } from '@rushstack/node-core-library';
+import { InternalError, type ITerminal } from '@rushstack/node-core-library';
 
 import type { HeftPluginDefinitionBase } from '../configuration/HeftPluginDefinition';
 import type { IHeftPlugin } from './IHeftPlugin';
@@ -12,11 +12,12 @@ export abstract class HeftPluginHost {
   private readonly _pluginAccessRequestHooks: Map<string, SyncHook<any>> = new Map();
   private _pluginsApplied: boolean = false;
 
-  public async applyPluginsAsync(): Promise<void> {
+  public async applyPluginsAsync(terminal: ITerminal): Promise<void> {
     if (this._pluginsApplied) {
       // No need to apply them a second time.
       return;
     }
+    terminal.writeVerboseLine('Applying plugins');
     await this.applyPluginsInternalAsync();
     this._pluginsApplied = true;
   }

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -67,11 +67,13 @@ interface ICopyDescriptor {
 }
 
 export async function copyFilesAsync(
+  rootFolderPath: string,
   copyOperations: Iterable<ICopyOperation>,
   terminal: ITerminal,
   watchFileSystemAdapter?: WatchFileSystemAdapter
 ): Promise<void> {
   const copyDescriptorByDestination: Map<string, ICopyDescriptor> = await _getCopyDescriptorsAsync(
+    rootFolderPath,
     copyOperations,
     watchFileSystemAdapter
   );
@@ -80,6 +82,7 @@ export async function copyFilesAsync(
 }
 
 async function _getCopyDescriptorsAsync(
+  rootFolderPath: string,
   copyConfigurations: Iterable<ICopyOperation>,
   fs: WatchFileSystemAdapter | undefined
 ): Promise<Map<string, ICopyDescriptor>> {
@@ -92,6 +95,7 @@ async function _getCopyDescriptorsAsync(
     async (copyConfiguration: ICopyOperation) => {
       // "sourcePath" is required to be a folder. To copy a single file, put the parent folder in "sourcePath"
       // and the filename in "includeGlobs"
+      copyConfiguration.sourcePath = path.resolve(rootFolderPath, copyConfiguration.sourcePath);
       const sourceFolder: string | undefined = copyConfiguration.sourcePath;
       const sourceFilePaths: Set<string> | undefined = await getFilePathsAsync(copyConfiguration, fs);
 

--- a/apps/heft/src/plugins/DeleteFilesPlugin.ts
+++ b/apps/heft/src/plugins/DeleteFilesPlugin.ts
@@ -25,11 +25,15 @@ interface IDeleteFilesPluginOptions {
   deleteOperations: IDeleteOperation[];
 }
 
-async function _getPathsToDeleteAsync(deleteOperations: Iterable<IDeleteOperation>): Promise<Set<string>> {
+async function _getPathsToDeleteAsync(
+  rootFolderPath: string,
+  deleteOperations: Iterable<IDeleteOperation>
+): Promise<Set<string>> {
   const pathsToDelete: Set<string> = new Set();
   await Async.forEachAsync(
     deleteOperations,
     async (deleteOperation: IDeleteOperation) => {
+      deleteOperation.sourcePath = path.resolve(rootFolderPath, deleteOperation.sourcePath);
       if (
         !deleteOperation.fileExtensions?.length &&
         !deleteOperation.includeGlobs?.length &&
@@ -53,10 +57,11 @@ async function _getPathsToDeleteAsync(deleteOperations: Iterable<IDeleteOperatio
 }
 
 export async function deleteFilesAsync(
+  rootFolderPath: string,
   deleteOperations: Iterable<IDeleteOperation>,
   terminal: ITerminal
 ): Promise<void> {
-  const pathsToDelete: Set<string> = await _getPathsToDeleteAsync(deleteOperations);
+  const pathsToDelete: Set<string> = await _getPathsToDeleteAsync(rootFolderPath, deleteOperations);
   await _deleteFilesInnerAsync(pathsToDelete, terminal);
 }
 

--- a/common/changes/@rushstack/heft/user-danade-WatchModeClean_2023-07-12-21-17.json
+++ b/common/changes/@rushstack/heft/user-danade-WatchModeClean_2023-07-12-21-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Support `--clean` in watch mode. Cleaning in watch mode is now performed only during the first-pass of lifecycle or phase operations. Once the clean has been completed, `--clean` will be ignored until the command is restarted",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary

This PR does two things:
- Moves lifecycle cleaning to it's own operation, instead of piggybacking on the existing `start` lifecycle operation
- Adds support for the `--clean` flag in `heft *-watch` commands

Fixes #4228

## Details

Cleaning in watch mode is now performed only during the first-pass of the watch-mode operations. Once the clean has been completed, the clean will be ignored until the command is restarted. This allows starting from a fresh state during watch mode

## How it was tested

Tested locally using `heft build`, `heft build --clean`, `heft build-watch` and `heft build-watch --clean`

## Impacted documentation

Docs may need to be updated to indicate that `--clean` is now possible in watch mode.