### PR TITLE
[heft-lint-plugin] Handle malformed cache

### DIFF
--- a/common/changes/@rushstack/heft-lint-plugin/lint-handle-malformed-file_2023-07-14-01-40.json
+++ b/common/changes/@rushstack/heft-lint-plugin/lint-handle-malformed-file_2023-07-14-01-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "Treat a malformed cache file the same as no cache file (i.e. recheck everything) instead of throwing an error..",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}


### PR DESCRIPTION
## Summary
Handle the scenario where the lint cache file exists but is not valid JSON by treating it the same as when no cache file is present, rather than throwing.

## Details

## How it was tested
Deliberately corrupted the cache file and ran an incremental build. Confirmed (when running with --verbose) that it detected the malformed cache file, and ran all rules on all files.

## Impacted documentation
None