### PR TITLE
[heft-sass-plugin] Fix the 'excludeFiles' configuration option.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
 			"name": "Attach",
 			"type": "node",
 			"request": "attach",
-			"port": 5858
+			"port": 9229
 		}
 	]
 }

--- a/build-tests/heft-sass-test/config/heft.json
+++ b/build-tests/heft-sass-test/config/heft.json
@@ -7,7 +7,12 @@
   // TODO: Add comments
   "phasesByName": {
     "build": {
-      "cleanFiles": [{ "sourcePath": "dist" }, { "sourcePath": "lib" }, { "sourcePath": "lib-commonjs" }],
+      "cleanFiles": [
+        { "sourcePath": "dist" },
+        { "sourcePath": "lib" },
+        { "sourcePath": "lib-commonjs" },
+        { "sourcePath": "temp" }
+      ],
       "tasksByName": {
         "sass": {
           "taskPlugin": {

--- a/build-tests/heft-sass-test/config/rush-project.json
+++ b/build-tests/heft-sass-test/config/rush-project.json
@@ -4,7 +4,7 @@
   "operationSettings": [
     {
       "operationName": "build",
-      "outputFolderNames": ["lib", "dist"]
+      "outputFolderNames": ["lib", "dist", "temp/sass-ts"]
     }
   ]
 }

--- a/build-tests/heft-sass-test/config/sass.json
+++ b/build-tests/heft-sass-test/config/sass.json
@@ -2,5 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft-sass-plugin.schema.json",
 
   "cssOutputFolders": ["lib", "lib-commonjs"],
-  "secondaryGeneratedTsFolders": ["lib"]
+  "secondaryGeneratedTsFolders": ["lib"],
+  "excludeFiles": ["./ignored1.scss", "ignored2.scss"]
 }

--- a/build-tests/heft-sass-test/src/ignored1.scss
+++ b/build-tests/heft-sass-test/src/ignored1.scss
@@ -1,0 +1,3 @@
+.ignoredStyle {
+  color: green;
+}

--- a/build-tests/heft-sass-test/src/ignored2.scss
+++ b/build-tests/heft-sass-test/src/ignored2.scss
@@ -1,0 +1,3 @@
+.otherIgnoredStyle {
+  color: blue;
+}

--- a/common/changes/@rushstack/heft-sass-plugin/fix-excludefiles_2023-07-16-15-18.json
+++ b/common/changes/@rushstack/heft-sass-plugin/fix-excludefiles_2023-07-16-15-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Fix the \"excludeFiles\" configuraiton option.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/fix-excludefiles_2023-07-16-15-18.json
+++ b/common/changes/@rushstack/heft-sass-plugin/fix-excludefiles_2023-07-16-15-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-sass-plugin",
-      "comment": "Fix the \"excludeFiles\" configuraiton option.",
+      "comment": "Fix the \"excludeFiles\" configuration option.",
       "type": "patch"
     }
   ],

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -106,7 +106,13 @@ export class SassProcessor extends StringValuesTypingsGenerator {
 
     const { allFileExtensions, isFileModule } = buildExtensionClassifier(sassConfiguration);
 
-    const { cssOutputFolders, preserveSCSSExtension = false } = sassConfiguration;
+    const {
+      cssOutputFolders,
+      excludeFiles,
+      secondaryGeneratedTsFolders,
+      importIncludePaths,
+      preserveSCSSExtension = false
+    } = sassConfiguration;
 
     const getCssPaths: ((relativePath: string) => string[]) | undefined = cssOutputFolders
       ? (relativePath: string): string[] => {
@@ -125,14 +131,26 @@ export class SassProcessor extends StringValuesTypingsGenerator {
         }
       : undefined;
 
+    let globsToIgnore: string[] | undefined;
+    if (excludeFiles) {
+      globsToIgnore = [];
+      for (const excludedFile of excludeFiles) {
+        if (excludedFile.startsWith('./')) {
+          globsToIgnore.push(excludedFile.substring(2));
+        } else {
+          globsToIgnore.push(excludedFile);
+        }
+      }
+    }
+
     super({
       srcFolder,
       generatedTsFolder,
       exportAsDefault,
       exportAsDefaultInterfaceName,
       fileExtensions: allFileExtensions,
-      filesToIgnore: sassConfiguration.excludeFiles,
-      secondaryGeneratedTsFolders: sassConfiguration.secondaryGeneratedTsFolders,
+      globsToIgnore,
+      secondaryGeneratedTsFolders,
 
       getAdditionalOutputFiles: getCssPaths,
 
@@ -149,7 +167,7 @@ export class SassProcessor extends StringValuesTypingsGenerator {
           fileContents,
           filePath,
           buildFolder,
-          sassConfiguration.importIncludePaths
+          importIncludePaths
         );
 
         let classMap: IClassMap = {};


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/3417

## Details

Updated the `excludeFiles` `config/sass.json` configuration option to map to a normalized value for the `globsToIgnore` option for the `@rushstack/typings-generator` package.

## How it was tested

Introduced a test in `/build-tests/heft-sass-test`.