### PR TITLE
[webpack-module-minifier] Fix units for rendered positions

### DIFF
--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/fix-module-minifier-length_2023-07-18-20-30.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/fix-module-minifier-length_2023-07-18-20-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "Fix calculation of rendered module positions to properly reflect character codes, not raw bytes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/fix-module-minifier-length_2023-07-18-20-30.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/fix-module-minifier-length_2023-07-18-20-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "Fix calculation of rendered module positions to properly reflect character codes, not raw bytes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/webpack/webpack4-module-minifier-plugin/src/RehydrateAsset.ts
+++ b/webpack/webpack4-module-minifier-plugin/src/RehydrateAsset.ts
@@ -46,7 +46,8 @@ export function rehydrateAsset(
   const validIdRegex: RegExp = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
   const source: ConcatSource = new ConcatSource(banner, prefix);
-  let charOffset: number = source.size();
+  // Source.size() is in bytes, we want characters
+  let charOffset: number = source.source().length;
 
   const firstModuleId: string | number = modules[0];
   const lastModuleId: string | number = modules[modules.length - 1];
@@ -108,7 +109,9 @@ export function rehydrateAsset(
 
       const item: IModuleInfo | undefined = moduleMap.get(id);
       const moduleCode: Source | string = item ? item.source : emptyFunction;
-      const charLength: number = typeof moduleCode === 'string' ? moduleCode.length : moduleCode.size();
+      // Source.size() is in bytes, we want characters
+      const charLength: number =
+        typeof moduleCode === 'string' ? moduleCode.length : moduleCode.source().toString().length;
 
       if (emitRenderInfo) {
         asset.renderInfo.set(id, {
@@ -141,7 +144,9 @@ export function rehydrateAsset(
 
       const item: IModuleInfo | undefined = moduleMap.get(id);
       const moduleCode: Source | string = item ? item.source : emptyFunction;
-      const charLength: number = typeof moduleCode === 'string' ? moduleCode.length : moduleCode.size();
+      // Source.size() is in bytes, we want characters
+      const charLength: number =
+        typeof moduleCode === 'string' ? moduleCode.length : moduleCode.source().toString().length;
 
       if (useConcat && delta + 1 > fillerArrayThreshold) {
         if (concatInserted) {

--- a/webpack/webpack5-module-minifier-plugin/src/RehydrateAsset.ts
+++ b/webpack/webpack5-module-minifier-plugin/src/RehydrateAsset.ts
@@ -67,7 +67,7 @@ export function rehydrateAsset(
     lastStart = CHUNK_MODULE_REGEX.lastIndex;
 
     if (moduleSource) {
-      const charLength: number = moduleSource.source.size();
+      const charLength: number = moduleSource.source.source().length;
 
       if (emitRenderInfo) {
         asset.renderInfo.set(moduleSource.id, {

--- a/webpack/webpack5-module-minifier-plugin/src/test/AmdExternals.test.ts
+++ b/webpack/webpack5-module-minifier-plugin/src/test/AmdExternals.test.ts
@@ -18,7 +18,7 @@ async function amdExternalsTest(minifier: IModuleMinifier): Promise<void> {
     {
       '/package.json': '{}',
       '/entry.js': `// A comment\nconsole.log("Do stuff");import(/* webpackChunkName: 'async' */ './async.js').then(mod => mod.foo());`,
-      '/async.js': `// @license MIT\nimport bar from 'bar';\nimport baz from 'baz';\nexport function foo() { bar.a(); baz.b(); }`
+      '/async.js': `// @license MIT\nimport bar from 'bar';\nimport baz from 'baz';\nexport function foo() { bar.a(); baz.b(); }console.log("Test character lengths: \ufeff\uffef")`
     },
     '/src'
   );

--- a/webpack/webpack5-module-minifier-plugin/src/test/__snapshots__/AmdExternals.test.ts.snap
+++ b/webpack/webpack5-module-minifier-plugin/src/test/__snapshots__/AmdExternals.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`ModuleMinifierPlugin Handles AMD externals (mock): Content 1`] = `
 Object {
   "/release/async.js": "/*! For license information please see async.js.LICENSE.txt */
-// Begin Asset Hash=1ae78808fac7117a5df587de32cb0a5dee132b58e7e47a7b63a98988b705dd2d
+// Begin Asset Hash=9cea223c5b52c3d2d453434504be210b33d1d8257f6a701509abfe7888323dcb
 \\"use strict\\";
 (self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[931],{
 
 /***/ 417:
 
-// Begin Module Hash=28dcea527403bc33391ab136fc2a6cb6b86954eee7151ce9026985cfd93e297a
+// Begin Module Hash=094ab5223af3c15d458c0cef66f228ac5ef757e87c865e83b0c812f6e36777ae
 
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
@@ -24,7 +24,7 @@ __webpack_require__.r(__webpack_exports__);
 // @license MIT
 
 
-function foo() { bar__WEBPACK_IMPORTED_MODULE_0___default().a(); baz__WEBPACK_IMPORTED_MODULE_1___default().b(); }
+function foo() { bar__WEBPACK_IMPORTED_MODULE_0___default().a(); baz__WEBPACK_IMPORTED_MODULE_1___default().b(); }console.log(\\"Test character lengths: ﻿￯\\")
 
 /***/ })
 
@@ -344,7 +344,7 @@ Object {
     "async.js" => Object {
       "positionByModuleId": Map {
         417 => Object {
-          "charLength": 965,
+          "charLength": 1006,
           "charOffset": 240,
         },
       },
@@ -352,7 +352,7 @@ Object {
   },
   "byModule": Map {
     417 => Map {
-      931 => 965,
+      931 => 1010,
     },
   },
 }
@@ -363,7 +363,7 @@ exports[`ModuleMinifierPlugin Handles AMD externals (mock): Warnings 1`] = `Arra
 exports[`ModuleMinifierPlugin Handles AMD externals (terser): Content 1`] = `
 Object {
   "/release/async.js": "/*! For license information please see async.js.LICENSE.txt */
-\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[931],{417:((e,t,n)=>{n.r(t),n.d(t,{foo:()=>s});var a=n(791),i=n.n(a),r=n(506),o=n.n(r);function s(){i().a(),o().b()}})
+\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[931],{417:((e,t,n)=>{n.r(t),n.d(t,{foo:()=>s});var a=n(791),i=n.n(a),r=n(506),o=n.n(r);function s(){i().a(),o().b()}console.log(\\"Test character lengths: \\\\ufeff￯\\")})
 }]);",
   "/release/async.js.LICENSE.txt": "// @license MIT
 ",
@@ -382,7 +382,7 @@ Object {
     "async.js" => Object {
       "positionByModuleId": Map {
         417 => Object {
-          "charLength": 108,
+          "charLength": 154,
           "charOffset": 135,
         },
       },
@@ -390,7 +390,7 @@ Object {
   },
   "byModule": Map {
     417 => Map {
-      931 => 108,
+      931 => 156,
     },
   },
 }


### PR DESCRIPTION
## Summary
Ensures that the metadata about rendered positions and lengths of modules is accurately in character code counts, not UTF-8 bytes.

## Details
Needed to switch from Source.size() (which is in bytes) to Source.source().length.

## How it was tested
Inspection of emitted snapshots.

## Impacted documentation
None