### PR TITLE
[heft-storybook-plugin] Run Storybook as a forked Node process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,5 +85,6 @@ lib-esnext
 lib-commonjs
 lib-shim
 dist
+dist-storybook
 *.scss.ts
 *.sass.ts

--- a/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
@@ -7,7 +7,13 @@
   // TODO: Add comments
   "phasesByName": {
     "build": {
-      "cleanFiles": [{ "sourcePath": "dist" }, { "sourcePath": "lib" }, { "sourcePath": "lib-commonjs" }],
+      "cleanFiles": [
+        { "sourcePath": "dist" },
+        { "sourcePath": "dist-storybook" },
+        { "sourcePath": "lib" },
+        { "sourcePath": "lib-commonjs" }
+      ],
+
       "tasksByName": {
         "typescript": {
           "taskPlugin": {

--- a/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
@@ -34,7 +34,7 @@
               "storykitPackageName": "heft-storybook-react-tutorial-storykit",
               "startupModulePath": "@storybook/react/bin/index.js",
               "staticBuildModulePath": "@storybook/react/bin/build.js",
-              "staticBuildOutputFolder": "static-build-dir"
+              "staticBuildOutputFolder": "dist-storybook"
             }
           }
         }

--- a/build-tests-samples/heft-storybook-react-tutorial/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/package.json
@@ -4,11 +4,11 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "heft build --clean",
+    "build": "heft build --clean --storybook",
     "start": "heft build-watch",
     "storybook": "heft build-watch --storybook",
     "build-storybook": "heft build --storybook",
-    "_phase:build": "heft run --only build -- --clean",
+    "_phase:build": "heft run --only build -- --storybook --clean",
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {

--- a/build-tests-samples/heft-storybook-react-tutorial/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/package.json
@@ -8,7 +8,7 @@
     "start": "heft build-watch",
     "storybook": "heft build-watch --storybook",
     "build-storybook": "heft build --storybook",
-    "_phase:build": "heft run --only build -- --storybook --clean",
+    "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {

--- a/common/changes/@rushstack/heft-storybook-plugin/user-danade-StorybookProcess_2023-07-19-06-03.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/user-danade-StorybookProcess_2023-07-19-06-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Run Storybook in a forked Node process, providing various advantages including isolation of the process and encapsulation of all console logging",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}


### PR DESCRIPTION
## Summary

Runs Storybook as a forked Node process.

## Details

Running Storybook as a forked Node process provides us a few advantages over the existing approach:
- Storybook is executed directly as it expects to be run
- Avoids the overhead of loading the module synchronously
- Provides the ability to tweak the CLI args passed to Storybook without tweaking the process.argv of the Heft process
- Encapsulates of the stdout and stderr streams of Storybook, which allows for piping the output through an `ITerminal`
  - Allows for forwarding all stderr output from the forked process to the Heft stdout, since all output is written to stderr in Storybook
- Potential performance improvements sourced from running Storybook as a separate process

## How it was tested

Running the `heft-storybook-react-tutorial` project build
