### PR TITLE
[rush] Initial SelectorExpressionParser implementation

### DIFF
--- a/common/changes/@microsoft/rush/enelson-expressions_2023-07-30-19-26.json
+++ b/common/changes/@microsoft/rush/enelson-expressions_2023-07-30-19-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add selector expressions to Rush CLI",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushProjectSelector.ts
+++ b/libraries/rush-lib/src/api/RushProjectSelector.ts
@@ -18,6 +18,18 @@ import { ExpressionJson, ISelectorJson, IFilterJson, IOperatorJson } from './Sel
 import { SelectorExpressionParser } from './SelectorExpressionParser';
 
 /**
+ * When preparing to select projects in a Rush monorepo, some selector scopes
+ * require additional configuration in order to control their behavior. This
+ * options interface allows the caller to provide these properties.
+ */
+export interface IProjectSelectionOptions {
+  /**
+   * Options required for configuring the git selector scope.
+   */
+  gitSelectorParserOptions: IGitSelectorParserOptions;
+}
+
+/**
  * A central interface for selecting a subset of Rush projects from a given monorepo,
  * using standardized selector expressions. Note that the types of selectors available
  * in a monorepo may be influenced in the future by plugins, so project selection
@@ -26,12 +38,17 @@ import { SelectorExpressionParser } from './SelectorExpressionParser';
 export class RushProjectSelector {
   private _rushConfig: RushConfiguration;
   private _scopes: Map<string, ISelectorParser<RushConfigurationProject>> = new Map();
+  private _options: IProjectSelectionOptions;
 
-  public constructor(rushConfig: RushConfiguration) {
+  public constructor(rushConfig: RushConfiguration, options: IProjectSelectionOptions) {
     this._rushConfig = rushConfig;
+    this._options = options;
 
     this._scopes.set('name', new NamedProjectSelectorParser(this._rushConfig));
-    //this._scopes.set('git', new GitChangedProjectSelectorParser(this._rushConfig, gitOptions));
+    this._scopes.set(
+      'git',
+      new GitChangedProjectSelectorParser(this._rushConfig, this._options.gitSelectorParserOptions)
+    );
     this._scopes.set('tag', new TagProjectSelectorParser(this._rushConfig));
     this._scopes.set('version-policy', new VersionPolicyProjectSelectorParser(this._rushConfig));
   }

--- a/libraries/rush-lib/src/api/RushProjectSelector.ts
+++ b/libraries/rush-lib/src/api/RushProjectSelector.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { RushConfiguration } from './RushConfiguration';
+import { RushConfigurationProject } from './RushConfigurationProject';
+import { Selection } from '../logic/Selection';
+import type { ISelectorParser } from '../logic/selectors/ISelectorParser';
+import type { ITerminal } from '@rushstack/node-core-library';
+import {
+  GitChangedProjectSelectorParser,
+  IGitSelectorParserOptions
+} from '../logic/selectors/GitChangedProjectSelectorParser';
+import { NamedProjectSelectorParser } from '../logic/selectors/NamedProjectSelectorParser';
+import { TagProjectSelectorParser } from '../logic/selectors/TagProjectSelectorParser';
+import { VersionPolicyProjectSelectorParser } from '../logic/selectors/VersionPolicyProjectSelectorParser';
+
+import { ExpressionJson, ISelectorJson, IFilterJson, IOperatorJson } from './SelectorExpressionJson';
+import { SelectorExpressionParser } from './SelectorExpressionParser';
+
+/**
+ * A central interface for selecting a subset of Rush projects from a given monorepo,
+ * using standardized selector expressions. Note that the types of selectors available
+ * in a monorepo may be influenced in the future by plugins, so project selection
+ * is always done in the context of a particular Rush configuration.
+ */
+export class RushProjectSelector {
+  private _rushConfig: RushConfiguration;
+  private _scopes: Map<string, ISelectorParser<RushConfigurationProject>> = new Map();
+
+  public constructor(rushConfig: RushConfiguration) {
+    this._rushConfig = rushConfig;
+
+    this._scopes.set('name', new NamedProjectSelectorParser(this._rushConfig));
+    //this._scopes.set('git', new GitChangedProjectSelectorParser(this._rushConfig, gitOptions));
+    this._scopes.set('tag', new TagProjectSelectorParser(this._rushConfig));
+    this._scopes.set('version-policy', new VersionPolicyProjectSelectorParser(this._rushConfig));
+  }
+
+  public async selectExpression(expr: ExpressionJson): Promise<RushConfigurationProject[]> {
+    if (RushProjectSelector.isSelector(expr)) {
+      return this._evaluateSelector(expr);
+    } else if (RushProjectSelector.isFilter(expr)) {
+      return this._evaluateFilter(expr);
+    } else if (RushProjectSelector.isOperator(expr)) {
+      return this._evaluateOperator(expr);
+    } else {
+      throw new Error(`Unexpected object in selector expression.`);
+    }
+  }
+
+  public async selectExpressionString(exprString: string): Promise<RushConfigurationProject[]> {
+    // Allowed filters can be influenced by Rush plugins in the future.
+    const allowedFilters: string[] = ['to', 'from', 'impacted-by', 'only'];
+
+    const expr: ExpressionJson = SelectorExpressionParser.parse(exprString, allowedFilters);
+    return this.selectExpression(expr);
+  }
+
+  private async _evaluateSelector(selector: ISelectorJson): Promise<RushConfigurationProject[]> {
+    const parser: ISelectorParser<RushConfigurationProject> | undefined = this._scopes.get(selector.scope);
+    if (!parser) {
+      throw new Error(`Unknown selector scope '${selector.scope}' for value '${selector.value}'.`);
+    }
+    return [
+      ...(await parser.evaluateSelectorAsync({
+        unscopedSelector: selector.value,
+        terminal: undefined as unknown as ITerminal,
+        parameterName: 'blah'
+      }))
+    ];
+  }
+
+  private async _evaluateFilter(expr: IFilterJson): Promise<RushConfigurationProject[]> {
+    if (expr.filter === 'to') {
+      const arg: RushConfigurationProject[] = await this.selectExpression(expr.arg);
+      return [...Selection.expandAllDependencies(arg)];
+    } else if (expr.filter === 'from') {
+      const arg: RushConfigurationProject[] = await this.selectExpression(expr.arg);
+      return [...Selection.expandAllDependencies(Selection.expandAllConsumers(arg))];
+    } else if (expr.filter === 'only') {
+      // "only" is sort of a no-op in a generic selector expression
+      const arg: RushConfigurationProject[] = await this.selectExpression(expr.arg);
+      return arg;
+    } else {
+      throw new Error(`Unknown filter '${expr.filter}' encountered in selector expression.`);
+    }
+  }
+
+  private async _evaluateOperator(expr: IOperatorJson): Promise<RushConfigurationProject[]> {
+    if (expr.op === 'not') {
+      // Built-in operator
+      const result: RushConfigurationProject[] = await this.selectExpression(expr.args[0]);
+      return this._rushConfig.projects.filter((p) => !result.includes(p));
+    } else if (expr.op === 'and') {
+      // Built-in operator
+      return [
+        ...Selection.intersection(
+          new Set(await this.selectExpression(expr.args[0])),
+          new Set(await this.selectExpression(expr.args[1]))
+        )
+      ];
+    } else if (expr.op === 'or') {
+      // Built-in operator
+      return [
+        ...Selection.union(
+          new Set(await this.selectExpression(expr.args[0])),
+          new Set(await this.selectExpression(expr.args[1]))
+        )
+      ];
+    } else {
+      throw new Error(`Unknown operator '${expr.op}' in selector expression.`);
+    }
+  }
+
+  public static isSelector(expr: ExpressionJson): expr is ISelectorJson {
+    return !!(expr as ISelectorJson).scope;
+  }
+
+  public static isFilter(expr: ExpressionJson): expr is IFilterJson {
+    return !!(expr as IFilterJson).filter;
+  }
+
+  public static isOperator(expr: ExpressionJson): expr is IOperatorJson {
+    return !!(expr as IOperatorJson).op;
+  }
+}

--- a/libraries/rush-lib/src/api/SelectorExpressionJson.ts
+++ b/libraries/rush-lib/src/api/SelectorExpressionJson.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * JSON Project Selector Expressions provide a canonical way to represent a
+ * complex selection of projects. In the future, Rush may use such expressions
+ * within configuration files to control certain behaviors. Users can create
+ * and save these expressions in JSON files and select them on the command line.
+ *
+ * Any string-based project selector can also be expressed in JSON format.
+ */
+export type ExpressionJson = ISelectorJson | IFilterJson | IOperatorJson;
+
+/**
+ * A selector has a scope and a value. On the command-line this is represented as
+ * a pair separated by a colon, for example, "tag:app" is a selector with scope `tag`
+ * and value `app`. An individual project name, often specified on the command-line
+ * with no scope, is represented by the scope `name`.
+ *
+ * In the future, Rush plugins may implement additional selector scopes. In JSON
+ * form, it's possible certain scopes might even support additional field properties
+ * to customize the selection.
+ */
+export interface ISelectorJson {
+  scope: string;
+  value: string;
+}
+
+/**
+ * A filter is a type of transformer, which takes one set of projects and transforms
+ * them into a new set. Classic Rush parameters like "--to" and "--from" are examples
+ * of filters.
+ *
+ * In the future, Rush plugins may implement additional filter types.
+ */
+export interface IFilterJson {
+  filter: string;
+  arg: ExpressionJson;
+}
+
+/**
+ * An operator is a built-in type of transformer that takes one or more sets of projects
+ * and applies a logical operation to them.
+ *
+ * Today, the binary operators "and" and "or", and the unary operator "not", are built into
+ * the expression selector. Other operators may be implemented in the future.
+ */
+export interface IOperatorJson {
+  op: string;
+  args: ExpressionJson[];
+}

--- a/libraries/rush-lib/src/api/SelectorExpressionParser.ts
+++ b/libraries/rush-lib/src/api/SelectorExpressionParser.ts
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+export type Expression = Selector | Operator;
+
+export type Selector = {
+  selector: string;
+};
+
+export type Operator = {
+  op: string;
+  args: Expression[];
+};
+
+export type Token = LeftParenToken | RightParenToken | UnaryToken | BinaryToken | SelectorToken;
+
+export type LeftParenToken = {
+  type: '(';
+};
+
+export type RightParenToken = {
+  type: ')';
+};
+
+export type UnaryToken = {
+  type: 'unary';
+  op: string;
+};
+
+export type BinaryToken = {
+  type: 'binary';
+  op: string;
+};
+
+export type SelectorToken = {
+  type: 'selector';
+  selector: string;
+};
+/* eslint-enable @typescript-eslint/consistent-type-definitions */
+
+/**
+ * The SelectorExpressionParser is a small, stand-alone parser designed to take a string-based selector expression
+ * and turn it into a JSON-based selector expression. This selector expression is repo-agnostic, and should
+ * be something that a Rush project selector would eventually interpret to produce a list of projects.
+ *
+ * The parser intentionally does not dive into the internal implementation of selector parameters or implementations.
+ * For example, "git:origin/main" is not validated as a valid selector, or resolved into a GitChangedProjectSelector.
+ * That's because we want the output of this parser to also be a valid input (in a future configuration file, for
+ * example) into the Project Selector API.
+ */
+export class SelectorExpressionParser {
+  private _tokens: Token[];
+  private _keywords: string[];
+  private _pLevel: number;
+
+  public constructor(tokens: Token[], keywords: string[]) {
+    this._tokens = tokens;
+    this._keywords = keywords;
+    this._pLevel = 0;
+  }
+
+  private _eof(): boolean {
+    return this._tokens.length === 0;
+  }
+
+  private _peek(): Token {
+    if (this._eof()) throw new Error('eof');
+    return this._tokens[0]!;
+  }
+
+  private _consume(type: '('): LeftParenToken;
+  private _consume(type: ')'): RightParenToken;
+  private _consume(type: 'selector'): SelectorToken;
+  private _consume(type: 'unary'): UnaryToken;
+  private _consume(type: 'binary'): BinaryToken;
+  private _consume(type: string): Token {
+    if (this._eof()) throw new Error('eof');
+    if (type && this._tokens[0].type !== type) {
+      throw new Error(`Expected ${type} but got ${this._tokens[0].type}`);
+    }
+    return this._tokens.shift()!;
+  }
+
+  private _parseSelector(): Expression {
+    const token: SelectorToken = this._consume('selector');
+    return {
+      selector: token.selector
+    };
+  }
+
+  private _parseUnaryOperator(): Expression {
+    const op: UnaryToken = this._consume('unary');
+    const arg: Expression = this._parseLeftSideExpression();
+
+    return {
+      op: op.op,
+      args: [arg]
+    };
+  }
+
+  private _parseLeftSideExpression(): Expression {
+    const token: Token = this._peek();
+
+    if (token.type === '(') {
+      this._consume('(');
+      this._pLevel++;
+      return this._parseExpression();
+    } else if (token.type === 'unary') {
+      return this._parseUnaryOperator();
+    } else if (token.type === 'selector') {
+      return this._parseSelector();
+    } else {
+      throw new Error(`Expected token good, but saw ${JSON.stringify(token)}`);
+    }
+  }
+
+  private _parseExpression(): Expression {
+    const components: Array<Expression | Token> = [];
+
+    // All unary operators (including "not") are handled while parsing left-side
+    // expression blocks.
+
+    components.push(this._parseLeftSideExpression());
+
+    while (!this._eof()) {
+      const token: Token = this._peek();
+
+      if (token.type === ')') {
+        if (this._pLevel > 0) {
+          this._pLevel--;
+          this._consume(')');
+          break;
+        }
+        throw new Error('unexpected )');
+      }
+
+      if (token.type === 'binary') {
+        components.push(this._consume('binary'));
+      }
+
+      components.push(this._parseLeftSideExpression());
+    }
+
+    // Once all unary operators are complete, apply all "and" operators
+    this._combineInlineBinaryOperators(components, 'and');
+
+    // Last, apply all "or" operators
+    this._combineInlineBinaryOperators(components, 'or');
+
+    if (components.length !== 1) {
+      throw new Error('should be exactly 1');
+    }
+
+    return components[0] as Expression;
+  }
+
+  private _combineInlineBinaryOperators(components: Array<Expression | Token>, op: string): void {
+    for (let i: number = 0; i < components.length; i++) {
+      // Here we are looking for not-yet-consumed binary tokens, and turning them
+      // into consumed binary expressions.
+      if ((components[i] as BinaryToken).type === 'binary' && (components[i] as BinaryToken).op === op) {
+        components.splice(i - 1, 3, {
+          op: op,
+          args: [components[i - 1] as Expression, components[i + 1] as Expression]
+        });
+        i = 0;
+      }
+    }
+  }
+
+  public parse(): Expression {
+    return this._parseExpression();
+  }
+
+  /**
+   * Take an input string, in selector expression format, and turn it into a list of
+   * internal tokens. This simple tokenizer/lexer pass is performed before turning
+   * the list of tokens into an expression tree.
+   *
+   * By default, the internal binary operators "and" and "or" and the internal unary
+   * operator "not" are supported; any other keywords that you wish to be interpreted
+   * as unary operators must be provided.
+   */
+  public static tokenize(expr: string, keywords: string[]): Token[] {
+    const tokens: Token[] = [];
+    let token: string = '';
+
+    const operators: Record<string, 'unary' | 'binary'> = {
+      and: 'binary',
+      or: 'binary',
+      not: 'unary'
+    };
+
+    for (const keyword of keywords) {
+      operators[keyword] = 'unary';
+    }
+
+    let state: 'flat' | 'selector' = 'flat';
+
+    for (const c of expr) {
+      switch (state) {
+        case 'flat':
+          if (c === '[') {
+            if (token !== '') {
+              throw new Error('found [ in middle of some other expr');
+            }
+            state = 'selector';
+          } else if (c === ']') {
+            throw new Error('found ] in middle of some other expr');
+          } else if (c === '(' || c === ')') {
+            if (token) {
+              if (operators[token]) {
+                tokens.push({ type: operators[token], op: token });
+              } else {
+                tokens.push({ type: 'selector', selector: token });
+              }
+              token = '';
+            }
+            tokens.push({ type: c });
+          } else if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+            if (token) {
+              if (operators[token]) {
+                tokens.push({ type: operators[token], op: token });
+              } else {
+                tokens.push({ type: 'selector', selector: token });
+              }
+              token = '';
+            }
+          } else {
+            token += c;
+          }
+          break;
+        case 'selector':
+          if (c === '[') {
+            throw new Error('found [ in selector');
+          } else if (c === ']') {
+            console.log('a' + token);
+            tokens.push({ type: 'selector', selector: token });
+            token = '';
+            state = 'flat';
+          } else {
+            token += c;
+          }
+          break;
+      }
+    }
+    if (token) {
+      tokens.push({ type: 'selector', selector: token });
+    }
+
+    return tokens;
+  }
+
+  public static parse(expr: string): Expression {
+    // This list of keywords is, essentially, the list of Rush selector parameters.
+    // Maybe plugins can inject more?
+    const keywords: string[] = ['to', 'from', 'impacted-by'];
+    const tokens: Token[] = SelectorExpressionParser.tokenize(expr, keywords);
+    return new SelectorExpressionParser(tokens, keywords).parse();
+  }
+}

--- a/libraries/rush-lib/src/api/SelectorExpressionParser.ts
+++ b/libraries/rush-lib/src/api/SelectorExpressionParser.ts
@@ -44,7 +44,7 @@ export type SelectorToken = {
 /* eslint-enable @typescript-eslint/consistent-type-definitions */
 
 export class ParseError extends Error {
-  constructor(message: string, expr: string) {
+  public constructor(message: string, expr: string) {
     super(`${message} (parsing expression '${expr}').`);
   }
 }
@@ -377,7 +377,7 @@ export class SelectorExpressionParser {
     return tokens;
   }
 
-  private _tokenToString(token: Token) {
+  private _tokenToString(token: Token): string {
     return (
       (token as UnaryOperatorToken).op ||
       (token as FilterToken).filter ||

--- a/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
+++ b/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { SelectorExpressionParser } from '../SelectorExpressionParser';
+
+describe(SelectorExpressionParser.name, () => {
+  describe('parse', () => {
+    it('parses one project name', () => {
+      expect(SelectorExpressionParser.parse('@acme/dynamite')).toEqual({
+        selector: '@acme/dynamite'
+      });
+    });
+
+    it('parses a generic selector', () => {
+      expect(SelectorExpressionParser.parse('animal:zebra')).toEqual({
+        selector: 'animal:zebra'
+      });
+    });
+
+    it('parses an expression with parentheses and operators', () => {
+      expect(SelectorExpressionParser.parse('(A or B or C) and tag:XYZ')).toEqual({
+        op: 'and',
+        args: [
+          {
+            op: 'or',
+            args: [
+              {
+                op: 'or',
+                args: [{ selector: 'A' }, { selector: 'B' }]
+              },
+              {
+                selector: 'C'
+              }
+            ]
+          },
+          {
+            selector: 'tag:XYZ'
+          }
+        ]
+      });
+    });
+
+    it('applies operator precedence correctly', () => {
+      expect(SelectorExpressionParser.parse('A and not B or not C and D')).toEqual({
+        op: 'or',
+        args: [
+          {
+            op: 'and',
+            args: [
+              {
+                selector: 'A'
+              },
+              {
+                op: 'not',
+                args: [
+                  {
+                    selector: 'B'
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            op: 'and',
+            args: [
+              {
+                op: 'not',
+                args: [
+                  {
+                    selector: 'C'
+                  }
+                ]
+              },
+              {
+                selector: 'D'
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('treats selector parameter keywords as unary operators', () => {
+      expect(SelectorExpressionParser.parse('to (A or B) and not from git:origin/main')).toEqual({
+        op: 'and',
+        args: [
+          {
+            op: 'to',
+            args: [
+              {
+                op: 'or',
+                args: [{ selector: 'A' }, { selector: 'B' }]
+              }
+            ]
+          },
+          {
+            op: 'not',
+            args: [
+              {
+                op: 'from',
+                args: [
+                  {
+                    selector: 'git:origin/main'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      });
+    });
+  });
+});

--- a/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
+++ b/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
@@ -8,108 +8,172 @@ const KEYWORDS = ['to', 'from'];
 describe(SelectorExpressionParser.name, () => {
   describe('parse', () => {
     it('parses one project name', () => {
-      expect(SelectorExpressionParser.parse('@acme/dynamite', KEYWORDS)).toEqual({
-        selector: '@acme/dynamite'
-      });
+      expect(SelectorExpressionParser.parse('@acme/dynamite', KEYWORDS)).toMatchInlineSnapshot(`
+Object {
+  "scope": "name",
+  "value": "@acme/dynamite",
+}
+`);
     });
 
     it('parses a generic selector', () => {
-      expect(SelectorExpressionParser.parse('animal:zebra', KEYWORDS)).toEqual({
-        selector: 'animal:zebra'
-      });
+      expect(SelectorExpressionParser.parse('animal:zebra', KEYWORDS)).toMatchInlineSnapshot(`
+Object {
+  "scope": "animal",
+  "value": "zebra",
+}
+`);
     });
 
     it('parses an expression with parentheses and operators', () => {
-      expect(SelectorExpressionParser.parse('(A or B or C) and tag:XYZ', KEYWORDS)).toEqual({
-        op: 'and',
-        args: [
-          {
-            op: 'or',
-            args: [
-              {
-                op: 'or',
-                args: [{ selector: 'A' }, { selector: 'B' }]
-              },
-              {
-                selector: 'C'
-              }
-            ]
-          },
-          {
-            selector: 'tag:XYZ'
-          }
-        ]
-      });
+      expect(SelectorExpressionParser.parse('(A or B or C) and tag:XYZ', KEYWORDS)).toMatchInlineSnapshot(`
+Object {
+  "args": Array [
+    Object {
+      "args": Array [
+        Object {
+          "args": Array [
+            Object {
+              "scope": "name",
+              "value": "A",
+            },
+            Object {
+              "scope": "name",
+              "value": "B",
+            },
+          ],
+          "op": "or",
+        },
+        Object {
+          "scope": "name",
+          "value": "C",
+        },
+      ],
+      "op": "or",
+    },
+    Object {
+      "scope": "tag",
+      "value": "XYZ",
+    },
+  ],
+  "op": "and",
+}
+`);
     });
 
     it('applies operator precedence correctly', () => {
-      expect(SelectorExpressionParser.parse('A and not B or not C and D', KEYWORDS)).toEqual({
-        op: 'or',
-        args: [
-          {
-            op: 'and',
-            args: [
-              {
-                selector: 'A'
-              },
-              {
-                op: 'not',
-                args: [
-                  {
-                    selector: 'B'
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            op: 'and',
-            args: [
-              {
-                op: 'not',
-                args: [
-                  {
-                    selector: 'C'
-                  }
-                ]
-              },
-              {
-                selector: 'D'
-              }
-            ]
-          }
-        ]
-      });
+      expect(SelectorExpressionParser.parse('A and not B or not C and D', KEYWORDS)).toMatchInlineSnapshot(`
+Object {
+  "args": Array [
+    Object {
+      "args": Array [
+        Object {
+          "scope": "name",
+          "value": "A",
+        },
+        Object {
+          "args": Array [
+            Object {
+              "scope": "name",
+              "value": "B",
+            },
+          ],
+          "op": "not",
+        },
+      ],
+      "op": "and",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "args": Array [
+            Object {
+              "scope": "name",
+              "value": "C",
+            },
+          ],
+          "op": "not",
+        },
+        Object {
+          "scope": "name",
+          "value": "D",
+        },
+      ],
+      "op": "and",
+    },
+  ],
+  "op": "or",
+}
+`);
     });
 
     it('treats selector parameter keywords as unary operators', () => {
-      expect(SelectorExpressionParser.parse('to (A or B) and not from git:origin/main', KEYWORDS)).toEqual({
-        op: 'and',
-        args: [
-          {
-            op: 'to',
-            args: [
-              {
-                op: 'or',
-                args: [{ selector: 'A' }, { selector: 'B' }]
-              }
-            ]
+      expect(SelectorExpressionParser.parse('to (A or B) and not from git:origin/main', KEYWORDS))
+        .toMatchInlineSnapshot(`
+Object {
+  "args": Array [
+    Object {
+      "arg": Object {
+        "args": Array [
+          Object {
+            "scope": "name",
+            "value": "A",
           },
-          {
-            op: 'not',
-            args: [
-              {
-                op: 'from',
-                args: [
-                  {
-                    selector: 'git:origin/main'
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      });
+          Object {
+            "scope": "name",
+            "value": "B",
+          },
+        ],
+        "op": "or",
+      },
+      "filter": "to",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "arg": Object {
+            "scope": "git",
+            "value": "origin/main",
+          },
+          "filter": "from",
+        },
+      ],
+      "op": "not",
+    },
+  ],
+  "op": "and",
+}
+`);
+    });
+
+    it('raises error if string starts with binary operator', () => {
+      expect(() => SelectorExpressionParser.parse('and foobar', KEYWORDS)).toThrowError(
+        `Expected partial expression (unary operator, filter, or selector) but encountered 'and' instead (parsing expression 'and foobar').`
+      );
+    });
+
+    it('raises error if binary operator missing final operand', () => {
+      expect(() => SelectorExpressionParser.parse('foo or ', KEYWORDS)).toThrowError(
+        `Expected partial expression (unary operator, filter, or selector) but encountered end of expression (parsing expression 'foo or ').`
+      );
+    });
+
+    it('raises error on unmatched left parentheses', () => {
+      expect(() => SelectorExpressionParser.parse('(foo or bar', KEYWORDS)).toThrowError(
+        `Expected ')' somewhere in expression but encountered end of expression (parsing expression '(foo or bar').`
+      );
+    });
+
+    it('raises error on unmatched right parentheses', () => {
+      expect(() => SelectorExpressionParser.parse('(foo or bar))', KEYWORDS)).toThrowError(
+        `Encountered unmatched ')' in selector expression (parsing expression '(foo or bar))').`
+      );
+    });
+
+    it('raises error if filter is missing an argument', () => {
+      expect(() => SelectorExpressionParser.parse('(tag:A and not)', KEYWORDS)).toThrowError(
+        `Expected partial expression (unary operator, filter, or selector) but encountered ')' instead (parsing expression '(tag:A and not)').`
+      );
     });
   });
 });

--- a/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
+++ b/libraries/rush-lib/src/api/test/SelectorExpressionParser.test.ts
@@ -3,22 +3,24 @@
 
 import { SelectorExpressionParser } from '../SelectorExpressionParser';
 
+const KEYWORDS = ['to', 'from'];
+
 describe(SelectorExpressionParser.name, () => {
   describe('parse', () => {
     it('parses one project name', () => {
-      expect(SelectorExpressionParser.parse('@acme/dynamite')).toEqual({
+      expect(SelectorExpressionParser.parse('@acme/dynamite', KEYWORDS)).toEqual({
         selector: '@acme/dynamite'
       });
     });
 
     it('parses a generic selector', () => {
-      expect(SelectorExpressionParser.parse('animal:zebra')).toEqual({
+      expect(SelectorExpressionParser.parse('animal:zebra', KEYWORDS)).toEqual({
         selector: 'animal:zebra'
       });
     });
 
     it('parses an expression with parentheses and operators', () => {
-      expect(SelectorExpressionParser.parse('(A or B or C) and tag:XYZ')).toEqual({
+      expect(SelectorExpressionParser.parse('(A or B or C) and tag:XYZ', KEYWORDS)).toEqual({
         op: 'and',
         args: [
           {
@@ -41,7 +43,7 @@ describe(SelectorExpressionParser.name, () => {
     });
 
     it('applies operator precedence correctly', () => {
-      expect(SelectorExpressionParser.parse('A and not B or not C and D')).toEqual({
+      expect(SelectorExpressionParser.parse('A and not B or not C and D', KEYWORDS)).toEqual({
         op: 'or',
         args: [
           {
@@ -81,7 +83,7 @@ describe(SelectorExpressionParser.name, () => {
     });
 
     it('treats selector parameter keywords as unary operators', () => {
-      expect(SelectorExpressionParser.parse('to (A or B) and not from git:origin/main')).toEqual({
+      expect(SelectorExpressionParser.parse('to (A or B) and not from git:origin/main', KEYWORDS)).toEqual({
         op: 'and',
         args: [
           {

--- a/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
+++ b/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
@@ -31,6 +31,7 @@ import { RushProjectSelector } from '../../api/RushProjectSelector';
  */
 export class SelectionParameterSet {
   private readonly _rushConfiguration: RushConfiguration;
+  private readonly _gitOptions: IGitSelectorParserOptions;
 
   private readonly _fromProject: CommandLineStringListParameter;
   private readonly _impactedByProject: CommandLineStringListParameter;
@@ -42,8 +43,8 @@ export class SelectionParameterSet {
   private readonly _fromVersionPolicy: CommandLineStringListParameter;
   private readonly _toVersionPolicy: CommandLineStringListParameter;
 
-  private readonly _selectString: CommandLineStringListParameter;
-  private readonly _selectJsonFile: CommandLineStringListParameter;
+  private readonly _selectByString: CommandLineStringListParameter;
+  private readonly _selectByJsonFile: CommandLineStringListParameter;
 
   private readonly _selectorParserByScope: Map<string, ISelectorParser<RushConfigurationProject>>;
 
@@ -53,6 +54,7 @@ export class SelectionParameterSet {
     gitOptions: IGitSelectorParserOptions
   ) {
     this._rushConfiguration = rushConfiguration;
+    this._gitOptions = gitOptions;
 
     const selectorParsers: Map<string, ISelectorParser<RushConfigurationProject>> = new Map<
       string,
@@ -187,14 +189,14 @@ export class SelectionParameterSet {
         ' For details, refer to the website article "Selecting subsets of projects".'
     });
 
-    this._selectString = action.defineStringListParameter({
+    this._selectByString = action.defineStringListParameter({
       parameterLongName: '--select',
       argumentName: 'EXPRESSION',
       description:
         'Select projects using a string selector expression. ' +
         'This is going to require some pretty good documentation.'
     });
-    this._selectJsonFile = action.defineStringListParameter({
+    this._selectByJsonFile = action.defineStringListParameter({
       parameterLongName: '--select-json-file',
       argumentName: 'EXPRESSION',
       description:
@@ -229,8 +231,8 @@ export class SelectionParameterSet {
     // Check if any of the selection parameters have a value specified on the command line
     const isSelectionSpecified: boolean =
       selectors.some((param: CommandLineStringListParameter) => param.values.length > 0) ||
-      this._selectString.values.length > 0 ||
-      this._selectJsonFile.values.length > 0;
+      this._selectByString.values.length > 0 ||
+      this._selectByJsonFile.values.length > 0;
 
     // If no selection parameters are specified, return everything
     if (!isSelectionSpecified) {
@@ -257,9 +259,11 @@ export class SelectionParameterSet {
     );
 
     // New Selector Expression Parsing Stuff
-    const projectSelector: RushProjectSelector = new RushProjectSelector(this._rushConfiguration);
+    const projectSelector: RushProjectSelector = new RushProjectSelector(this._rushConfiguration, {
+      gitSelectorParserOptions: this._gitOptions
+    });
     let selectedByExpression: RushConfigurationProject[] = [];
-    for (const value of this._selectString.values) {
+    for (const value of this._selectByString.values) {
       selectedByExpression = selectedByExpression.concat(await projectSelector.selectExpressionString(value));
     }
     // End New Selector Expression Parsing Stuff

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -128,8 +128,9 @@ exports[`CommandLineHelp prints the help for each action: build 1`] = `
 "usage: rush build [-h] [-p COUNT] [--timeline] [-t PROJECT] [-T PROJECT]
                   [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                   [--to-version-policy VERSION_POLICY_NAME]
-                  [--from-version-policy VERSION_POLICY_NAME] [-v] [-c]
-                  [--ignore-hooks] [-s] [-m]
+                  [--from-version-policy VERSION_POLICY_NAME]
+                  [--select EXPRESSION] [--select-json-file EXPRESSION] [-v]
+                  [-c] [--ignore-hooks] [-s] [-m]
                   
 
 This command is similar to \\"rush rebuild\\", except that \\"rush build\\" performs 
@@ -237,6 +238,13 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --select EXPRESSION   Select projects using a string selector expression. 
+                        This is going to require some pretty good 
+                        documentation.
+  --select-json-file EXPRESSION
+                        Select projects using a JSON selector expression read 
+                        from the specified file. This is going to require 
+                        some pretty good documentation too.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   -c, --changed-projects-only
@@ -392,7 +400,9 @@ exports[`CommandLineHelp prints the help for each action: import-strings 1`] = `
                            [-T PROJECT] [-f PROJECT] [-o PROJECT] [-i PROJECT]
                            [-I PROJECT]
                            [--to-version-policy VERSION_POLICY_NAME]
-                           [--from-version-policy VERSION_POLICY_NAME] [-v]
+                           [--from-version-policy VERSION_POLICY_NAME]
+                           [--select EXPRESSION]
+                           [--select-json-file EXPRESSION] [-v]
                            [--ignore-hooks]
                            [--locale {en-us,fr-fr,es-es,zh-cn}]
                            
@@ -493,6 +503,13 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --select EXPRESSION   Select projects using a string selector expression. 
+                        This is going to require some pretty good 
+                        documentation.
+  --select-json-file EXPRESSION
+                        Select projects using a JSON selector expression read 
+                        from the specified file. This is going to require 
+                        some pretty good documentation too.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 
@@ -573,7 +590,9 @@ exports[`CommandLineHelp prints the help for each action: install 1`] = `
                     [--variant VARIANT] [-t PROJECT] [-T PROJECT] [-f PROJECT]
                     [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME] [--check-only]
+                    [--from-version-policy VERSION_POLICY_NAME]
+                    [--select EXPRESSION] [--select-json-file EXPRESSION]
+                    [--check-only]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -694,6 +713,13 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --select EXPRESSION   Select projects using a string selector expression. 
+                        This is going to require some pretty good 
+                        documentation.
+  --select-json-file EXPRESSION
+                        Select projects using a JSON selector expression read 
+                        from the specified file. This is going to require 
+                        some pretty good documentation too.
   --check-only          Only check the validity of the shrinkwrap file 
                         without performing an install.
 "
@@ -721,6 +747,7 @@ exports[`CommandLineHelp prints the help for each action: list 1`] = `
                  [-i PROJECT] [-I PROJECT]
                  [--to-version-policy VERSION_POLICY_NAME]
                  [--from-version-policy VERSION_POLICY_NAME]
+                 [--select EXPRESSION] [--select-json-file EXPRESSION]
                  
 
 List package names, and optionally version (--version) and path (--path) or 
@@ -818,6 +845,13 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --select EXPRESSION   Select projects using a string selector expression. 
+                        This is going to require some pretty good 
+                        documentation.
+  --select-json-file EXPRESSION
+                        Select projects using a JSON selector expression read 
+                        from the specified file. This is going to require 
+                        some pretty good documentation too.
 "
 `;
 
@@ -938,7 +972,8 @@ exports[`CommandLineHelp prints the help for each action: rebuild 1`] = `
 "usage: rush rebuild [-h] [-p COUNT] [--timeline] [-t PROJECT] [-T PROJECT]
                     [-f PROJECT] [-o PROJECT] [-i PROJECT] [-I PROJECT]
                     [--to-version-policy VERSION_POLICY_NAME]
-                    [--from-version-policy VERSION_POLICY_NAME] [-v]
+                    [--from-version-policy VERSION_POLICY_NAME]
+                    [--select EXPRESSION] [--select-json-file EXPRESSION] [-v]
                     [--ignore-hooks] [-s] [-m]
                     
 
@@ -1044,6 +1079,13 @@ Optional arguments:
                         each of the projects belonging to VERSION_POLICY_NAME.
                          For details, refer to the website article \\"Selecting 
                         subsets of projects\\".
+  --select EXPRESSION   Select projects using a string selector expression. 
+                        This is going to require some pretty good 
+                        documentation.
+  --select-json-file EXPRESSION
+                        Select projects using a JSON selector expression read 
+                        from the specified file. This is going to require 
+                        some pretty good documentation too.
   -v, --verbose         Display the logs during the build, rather than just 
                         displaying the build status summary
   --ignore-hooks        Skips execution of the \\"eventHooks\\" scripts defined 

--- a/libraries/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
+++ b/libraries/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
@@ -22,10 +22,10 @@ export class TagProjectSelectorParser implements ISelectorParser<RushConfigurati
     const selection: ReadonlySet<RushConfigurationProject> | undefined =
       this._rushConfiguration.projectsByTag.get(unscopedSelector);
     if (!selection) {
-      terminal.writeErrorLine(
+      throw new Error(
         `The tag "${unscopedSelector}" passed to "${parameterName}" is not specified for any projects in rush.json.`
       );
-      throw new AlreadyReportedError();
+      //throw new AlreadyReportedError();
     }
     return selection;
   }

--- a/libraries/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
+++ b/libraries/rush-lib/src/logic/selectors/TagProjectSelectorParser.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AlreadyReportedError } from '@rushstack/node-core-library';
-
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
@@ -25,7 +23,6 @@ export class TagProjectSelectorParser implements ISelectorParser<RushConfigurati
       throw new Error(
         `The tag "${unscopedSelector}" passed to "${parameterName}" is not specified for any projects in rush.json.`
       );
-      //throw new AlreadyReportedError();
     }
     return selection;
   }

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <19.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION
## Summary

 - Introduce "Selector Expression JSON" syntax.
 - Introduce "Selector Expression String" syntax.
 - Implement a robust project selector at the API layer (instead of the CLI layer).

This PR is related to #3327 (but maybe doesn't close it).

## Details

### Introduction

Today, we select projects with a command like `rush build --to rush-lib --from tag:App`.

 - This command uses two different _selectors_ (selector scopes): the implicit scope `name:` and `tag:`.
 - It uses two different _parameters_ (which I like to refer to as "filters"): `to` and `from`.
 - Finally, there's an implicit _operator_, logical OR (aka set union), which is what we always use in CLI today.

The idea behind selector _expressions_ is to combine these selectors, filters, and operators in a more formal way that allows more complex selection sets.

### Selector Expression JSON

The JSON for expressions come in small blocks, 3 flavors, one for each type above:

 - `{ scope: 'git', value: 'origin/main' }` is a selector, the equivalent of `git:origin/main`
 - `{ filter: 'to', arg: <expr> }` is a filter which operates on sub-expression, the equivalent of `--to`
 - `{ op: 'and', args: [<expr>, <expr>] }` is an operator, which takes one or more sub-expression operands (args)

We can now express a concept like "the set of all projects impacted by project XYZ _and_ tagged `sdk`", like so:

```json
{
  "op": "and"
  "args": [
    {
      "filter": "to",
      "arg": {"scope": "name", "value": "XYZ" }
    },
    { "scope": "tag", "value": "sdk" }
  ]
}
```

This JSON syntax could be generated on the fly and passed in via a file param, or it could even be used for more permanent arrangements, such as saved in Rush configuration files to filter certain future features by project in a configurable way.

### Selector Expression Strings

For ad-hoc project selection on the command line, it would be convenient to express the JSON structure above in a standardized _string format_ as well. This PR proposes a simple parser for such a string, with the following rules:

 - The operators "and", "or", and "not" are expressed as space-separated words.
 - Filter names (like "to" and "from") act just like "not" (i.e. like unary operators).
 - Operator precedence AND > OR > NOT/FILTER > SELECTOR.
 - Parentheses can be used anywhere to group expressions.
 - For project names or selectors that could be misinterpreted (e.g. a project named "and" or other symbols in it), use square brackets to wrap the name - `[and]`.

Thus, the JSON expression in the section above would be expressed as `to XYZ and tag:sdk`. On the command line:

```console
rush build --select 'to XYZ and tag:sdk'

# All of the above are also totally valid and equivalent:
rush build --select 'to(XYZ) and (tag:sdk)'
rush build --select '(to XYZ) and (tag:sdk)'
rush build --select '((to XYZ) and tag:sdk)'

# The following is NOT equivalent (it is more like a --to CLI filter):
rush build --select 'to(XYZ and tag:sdk)'
```

### API Layer

Because the new objects are built at API layer, they should be equally usable outside of the Rush CLI context, e.g.:

```node
// a custom node utility
import { RushProjectSelector } from '@microsoft/rush-lib';

const projects = await new RushProjectSelector(rushConfiguration).selectExpressionString('....... some expression string .......');

for (const project of projects) {
  // custom processing
}
```

### Future extensions

@dmichon-msft originally suggested that the concept of "selector expressions" could be a plugin for the selector types (essentially making it a complex selector type). I am proposing a different approach, which would be instead to make the concept of a selector expression a core feature of Rush, that is _not_ extendable -- for example, there is no way to introduce new core keywords like "and".

However, future Rush plugin types could introduce new selector _scopes_ (e.g. "tag"). Or, they could introduce new selector _filters_ (e.g. "to"). The implementation proposed in this PR would support new scopes and filters, but not new operators or changes to the JSON syntax overall.

## How it was tested

A few unit tests added for documentation.

## Impacted documentation

 - Document the new `--select` parameter
 - Document the concept of selector expressions
 - Document the concept of JSON selector expressions
