### PR TITLE
[rush-lib] Add support for npm aliases in `PnpmShrinkwrapFile._getPackageId`

### DIFF
--- a/common/changes/@microsoft/rush/pnpmv8_2023-07-24-21-56.json
+++ b/common/changes/@microsoft/rush/pnpmv8_2023-07-24-21-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an issue where PnpmShrinkwrapFile._getPackageId returns incorrect value",
+      "comment": "Add support for npm aliases in `PnpmShrinkwrapFile._getPackageId`.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/pnpmv8_2023-07-24-21-56.json
+++ b/common/changes/@microsoft/rush/pnpmv8_2023-07-24-21-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where PnpmShrinkwrapFile._getPackageId returns incorrect value",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -926,7 +926,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         // This is a github repo reference
         return version;
       } else {
-        return `/${name}@${version}`;
+        return version.indexOf('/') === 0 ? version : `/${name}@${version}`;
       }
     } else {
       // Version can sometimes be in the form of a path that's already in the /name/version format.

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -926,7 +926,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         // This is a github repo reference
         return version;
       } else {
-        return version.indexOf('/') === 0 ? version : `/${name}@${version}`;
+        return version.startsWith('/') ? version : `/${name}@${version}`;
       }
     } else {
       // Version can sometimes be in the form of a path that's already in the /name/version format.


### PR DESCRIPTION
## Summary

This fixes an issue of incorrect package id when aliased package dependency is used.

## Details

It's possible to have package dependencies aliased like below:

```json
  "@_ts/min": "npm:typescript@~4.2.4",
  "@_ts/max": "npm:typescript@latest",
```

in pnpm-lock.yaml (v7), they are stored as

```yaml
    dependencies:
      '@_ts/max': /typescript/5.1.6
      '@_ts/min': /typescript/4.2.4
```

Current logic returns package id of `/@ts/max@/typescript/5.1.6`, which is incorrect.

This PR returns the version string if it has a leading `"/"` already.

## How it was tested

`rush update` is broken in our repo https://github.com/Azure/azure-sdk-for-js when using the latest rush stack.  With the change in this PR it is working again. I have checked all our dependencies and found no other cases of version having a leading `"/"` than the above one .

## Impacted documentation

N/A