### PR TITLE
[rush] Improve accuracy of detecting pnpm shrinkwrap is modified

### DIFF
--- a/common/changes/@microsoft/rush/improve-pnpm-shrinkwrap-modified_2023-07-25-12-11.json
+++ b/common/changes/@microsoft/rush/improve-pnpm-shrinkwrap-modified_2023-07-25-12-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "improve accuracy of detecting pnpm shrinkwrap is modified",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/improve-pnpm-shrinkwrap-modified_2023-07-25-12-11.json
+++ b/common/changes/@microsoft/rush/improve-pnpm-shrinkwrap-modified_2023-07-25-12-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "improve accuracy of detecting pnpm shrinkwrap is modified",
+      "comment": "Reduce false positive detections of the pnpm shrinkwrap file being out of date in the presence of the `globalOverrides` setting in `pnpm-config.json`, or when a dependency is listed in both `dependencies` and `devDependencies` in the same package.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -778,6 +778,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       for (const { dependencyType, name, version } of allDependencies) {
         let isOptional: boolean = false;
         let specifierFromLockfile: IPnpmVersionSpecifier | undefined;
+        let isDevDepFallThrough: boolean = false;
         switch (dependencyType) {
           case DependencyType.Optional: {
             specifierFromLockfile = importer.optionalDependencies?.[name];
@@ -798,6 +799,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
               importerDevDependencies.delete(name);
               break;
             }
+            // If fall through, there is a chance the package declares an inconsistent version, ignore it.
+            isDevDepFallThrough = true;
           }
 
           // eslint-disable-next-line no-fallthrough
@@ -819,7 +822,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
             );
           } else {
             const resolvedVersion: string = this.overrides.get(name) ?? version;
-            if (specifierFromLockfile.specifier !== resolvedVersion && !isOptional) {
+            if (specifierFromLockfile.specifier !== resolvedVersion && !isDevDepFallThrough && !isOptional) {
               return true;
             }
           }

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -821,7 +821,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
                 `"${specifierFromLockfile}" instead of an object.`
             );
           } else {
-            // TODO: Add an error message when someone tries to override a version of something in one of their
+            // TODO: Emit an error message when someone tries to override a version of something in one of their
             // local repo packages.
             const resolvedVersion: string = this.overrides.get(name) ?? version;
             if (specifierFromLockfile.specifier !== resolvedVersion && !isDevDepFallThrough && !isOptional) {

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -821,6 +821,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
                 `"${specifierFromLockfile}" instead of an object.`
             );
           } else {
+            // TODO: Add an error message when someone tries to override a version of something in one of their
+            // local repo packages.
             const resolvedVersion: string = this.overrides.get(name) ?? version;
             if (specifierFromLockfile.specifier !== resolvedVersion && !isDevDepFallThrough && !isOptional) {
               return true;

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
@@ -132,6 +132,14 @@ describe(PnpmShrinkwrapFile.name, () => {
         );
         await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(true);
       });
+
+      it('can detect overrides', async () => {
+        const project = getMockRushProject();
+        const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
+          `${__dirname}/yamlFiles/pnpm-lock-v5/overrides-not-modified.yaml`
+        );
+        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(false);
+      });
     });
 
     describe('pnpm lockfile major version 6', () => {
@@ -149,6 +157,14 @@ describe(PnpmShrinkwrapFile.name, () => {
           `${__dirname}/yamlFiles/pnpm-lock-v6/modified.yaml`
         );
         await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(true);
+      });
+
+      it('can detect overrides', async () => {
+        const project = getMockRushProject();
+        const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
+          `${__dirname}/yamlFiles/pnpm-lock-v6/overrides-not-modified.yaml`
+        );
+        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(false);
       });
     });
   });

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
@@ -166,6 +166,14 @@ describe(PnpmShrinkwrapFile.name, () => {
         );
         await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(false);
       });
+
+      it('can handle the inconsistent version of a package declared in dependencies and devDependencies', async () => {
+        const project = getMockRushProject2();
+        const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
+          `${__dirname}/yamlFiles/pnpm-lock-v6/inconsistent-dep-devDep.yaml`
+        );
+        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project)).resolves.toBe(false);
+      });
     });
   });
 });
@@ -184,6 +192,16 @@ function getMockRushProject(): RushConfigurationProject {
   const project = rushConfiguration.projectsByName.get('foo');
   if (!project) {
     throw new Error(`Can not get project "foo"`);
+  }
+  return project;
+}
+
+function getMockRushProject2(): RushConfigurationProject {
+  const rushFilename: string = `${__dirname}/repo/rush2.json`;
+  const rushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+  const project = rushConfiguration.projectsByName.get('bar');
+  if (!project) {
+    throw new Error(`Can not get project "bar"`);
   }
   return project;
 }

--- a/libraries/rush-lib/src/logic/pnpm/test/repo/apps/bar/package.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/repo/apps/bar/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bar",
+  "version": "1.0.0",
+  "dependencies": {
+    "prettier": "~2.3.0"
+  },
+  "devDependencies": {
+    "prettier": "~2.7.1"
+  }
+}

--- a/libraries/rush-lib/src/logic/pnpm/test/repo/rush2.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/repo/rush2.json
@@ -1,0 +1,13 @@
+{
+  "pnpmVersion": "7.0.0",
+  "rushVersion": "5.46.1",
+  "projectFolderMinDepth": 1,
+  "projectFolderMaxDepth": 99,
+
+  "projects": [
+    {
+      "packageName": "bar",
+      "projectFolder": "apps/bar"
+    }
+  ]
+}

--- a/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v5/overrides-not-modified.yaml
+++ b/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v5/overrides-not-modified.yaml
@@ -1,0 +1,32 @@
+lockfileVersion: 5.3
+
+overrides:
+  typescript: 5.0.4
+
+importers:
+  .:
+    specifiers: {}
+
+  ../../apps/foo:
+    specifiers:
+      tslib: ~2.3.1
+      typescript: 5.0.4
+    dependencies:
+      tslib: 2.3.1
+    devDependencies:
+      typescript: 5.0.4
+
+packages:
+  /typescript/5.0.4:
+    resolution:
+      {
+        integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+      }
+    engines: { node: '>=12.20' }
+    hasBin: true
+
+  /tslib/2.3.1:
+    resolution:
+      {
+        integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+      }

--- a/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v6/inconsistent-dep-devDep.yaml
+++ b/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v6/inconsistent-dep-devDep.yaml
@@ -1,0 +1,20 @@
+lockfileVersion: '6.0'
+
+importers:
+  .: {}
+
+  ../../apps/bar:
+    dependencies:
+      prettier:
+        specifier: ~2.3.0
+        version: 2.3.0
+    devDependencies:
+
+packages:
+  /prettier/2.3.0:
+    resolution:
+      {
+        integrity: sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+      }
+    engines: { node: '>=10.13.0' }
+    hasBin: true

--- a/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v6/overrides-not-modified.yaml
+++ b/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v6/overrides-not-modified.yaml
@@ -1,0 +1,32 @@
+lockfileVersion: '6.0'
+
+overrides:
+  typescript: 5.0.4
+
+importers:
+  .: {}
+
+  ../../apps/foo:
+    dependencies:
+      tslib:
+        specifier: ~2.3.1
+        version: 2.3.1
+    devDependencies:
+      typescript:
+        specifier: 5.0.4
+        version: 5.0.4
+
+packages:
+  /typescript/5.0.4:
+    resolution:
+      {
+        integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+      }
+    engines: { node: '>=12.20' }
+    hasBin: true
+
+  /tslib/2.3.1:
+    resolution:
+      {
+        integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+      }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Improve accuracy of detecting pnpm shrinkwrap modified

## Details

### Case 1: pnpm.overrides

With `pnpm.overrides`, the version in package.json is different from the specifier in pnpm lockfile. This MR changes the logic to compare the overrided version with specifier in lockfile when necessary.

### Case 2: duplicated inconsistent version in dep and devDep.

There is a chance that one package declared both in `dependencies` and `devDependencies` with inconsistent versions (absurd). This MR ignores the version in devDependencies when detecting for pnpm lockfile v6

NOTE: when detecting pnpm lockfile v5, the implementation iterates `specifiers` in lockfile where dev dependencies' versions never show up.


## How it was tested

Test cases are added

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

No

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
