### PR TITLE
[heft-jest-plugin] Make `jest-environment-jsdom` and `jest-environment-node` optional peerDependencies.

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/fix-jest-environment-dep_2023-07-30-03-41.json
+++ b/common/changes/@rushstack/heft-jest-plugin/fix-jest-environment-dep_2023-07-30-03-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Make `jest-environment-jsdom` and `jest-environment-node` peerDependencies.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/fix-jest-environment-dep_2023-07-30-03-41.json
+++ b/common/changes/@rushstack/heft-jest-plugin/fix-jest-environment-dep_2023-07-30-03-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "Make `jest-environment-jsdom` and `jest-environment-node` peerDependencies.",
+      "comment": "Make `jest-environment-jsdom` and `jest-environment-node` optional peerDependencies.",
       "type": "minor"
     }
   ],

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -16,7 +16,17 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "peerDependencies": {
-    "@rushstack/heft": "^0.58.1"
+    "@rushstack/heft": "^0.58.1",
+    "jest-environment-jsdom": "^29.5.0",
+    "jest-environment-node": "^29.5.0"
+  },
+  "peerDependenciesMeta": {
+    "jest-environment-jsdom": {
+      "optional": true
+    },
+    "jest-environment-node": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@jest/core": "~29.5.0",


### PR DESCRIPTION
`heft-jest-plugin` currently declares `testEnvironment` properties (`jest-environment-jsdom` for Web and `jest-environment-node` for Node), but isn't able to resolve those packages because they're devDependencies, meaning that a consumer extending that built-in Jest configs needs to declare its own dependency on one of those and re-declare a `testEnvironment` property.

This PR adds an optional peerDependency on those two packages, allowing a consumer (either a project or a rig) to just declare a dependency on the `jest-environment-` package.