### PR TITLE
[rush] Bundle rush-http-build-cache-plugin

### DIFF
--- a/common/changes/@microsoft/rush/enelson-prepublish_2023-07-31-17-14.json
+++ b/common/changes/@microsoft/rush/enelson-prepublish_2023-07-31-17-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Enable the \"http\" option for build-cache providers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/scripts/plugins-prepublish.js
+++ b/libraries/rush-lib/scripts/plugins-prepublish.js
@@ -7,5 +7,6 @@ const packageJson = JsonFile.load(packageJsonPath);
 delete packageJson['publishOnlyDependencies'];
 packageJson.dependencies['@rushstack/rush-amazon-s3-build-cache-plugin'] = packageJson.version;
 packageJson.dependencies['@rushstack/rush-azure-storage-build-cache-plugin'] = packageJson.version;
+packageJson.dependencies['@rushstack/rush-http-build-cache-plugin'] = packageJson.version;
 
 JsonFile.save(packageJson, packageJsonPath, { updateExistingFile: true });


### PR DESCRIPTION
## Summary

The internal plugin `rush-http-build-cache-plugin` was added to the list of internal plugins, but not added to the prepublish script.

This PR should correctly bundle the plugin with Rush, similar to Azure and Amazon plugins.

## Details

 - Update prepublish script

## How it was tested

N/A

## Impacted documentation
