### PR TITLE
[rush-lib] Improve version resolution logic in install-run.js

### DIFF
--- a/common/changes/@microsoft/rush/raihle-patch-4256_2023-08-03-15-04.json
+++ b/common/changes/@microsoft/rush/raihle-patch-4256_2023-08-03-15-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve version resolution logic in common/scripts/install-run.js (#4256)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/raihle-patch-4256_2023-08-03-15-04.json
+++ b/common/changes/@microsoft/rush/raihle-patch-4256_2023-08-03-15-04.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Improve version resolution logic in common/scripts/install-run.js (#4256)",
-      "type": "patch"
+      "comment": "Improve version resolution logic in common/scripts/install-run.js (see https://github.com/microsoft/rushstack/issues/4256)",
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -124,6 +124,24 @@ export interface IPackageSpecifier {
 }
 
 /**
+ * Compare version strings according to semantic versioning.
+ * Returns a positive integer if "a" is a later version than "b",
+ * a negative integer if "b" is later than "a",
+ * and 0 otherwise.
+ */
+function _compareVersionStrings(a: string, b: string): number {
+  const aParts: string[] = a.split(/[.-]/);
+  const bParts: string[] = b.split(/[.-]/);
+  const numberOfParts: number = Math.max(aParts.length, bParts.length);
+  for (let i: number = 0; i < numberOfParts; i++) {
+    if (aParts[i] !== bParts[i]) {
+      return (Number(aParts[i]) || 0) - (Number(bParts[i]) || 0);
+    }
+  }
+  return 0;
+}
+
+/**
  * Resolve a package specifier to a static version
  */
 function _resolvePackageVersion(
@@ -150,14 +168,15 @@ function _resolvePackageVersion(
       const npmPath: string = getNpmPath();
 
       // This returns something that looks like:
-      //  @microsoft/rush@3.0.0 '3.0.0'
-      //  @microsoft/rush@3.0.1 '3.0.1'
-      //  ...
-      //  @microsoft/rush@3.0.20 '3.0.20'
-      //  <blank line>
+      // [
+      //   "3.0.0",
+      //   "3.0.1",
+      //   ...
+      //   "3.0.20"
+      // ]
       const npmVersionSpawnResult: childProcess.SpawnSyncReturns<Buffer> = childProcess.spawnSync(
         npmPath,
-        ['view', `${name}@${version}`, 'version', '--no-update-notifier'],
+        ['view', `${name}@${version}`, 'version', '--no-update-notifier', '--json'],
         {
           cwd: rushTempFolder,
           stdio: []
@@ -169,18 +188,18 @@ function _resolvePackageVersion(
       }
 
       const npmViewVersionOutput: string = npmVersionSpawnResult.stdout.toString();
-      const versionLines: string[] = npmViewVersionOutput.split('\n').filter((line) => !!line);
-      const latestVersion: string | undefined = versionLines[versionLines.length - 1];
+      const parsedVersionOutput: string | string[] = JSON.parse(npmViewVersionOutput);
+      const versions: string[] = Array.isArray(parsedVersionOutput)
+        ? parsedVersionOutput
+        : [parsedVersionOutput];
+      versions.sort(_compareVersionStrings);
+      const latestVersion: string | undefined = versions[versions.length - 1];
+
       if (!latestVersion) {
         throw new Error('No versions found for the specified version range.');
       }
 
-      const versionMatches: string[] | null = latestVersion.match(/^.+\s\'(.+)\'$/);
-      if (!versionMatches) {
-        throw new Error(`Invalid npm output ${latestVersion}`);
-      }
-
-      return versionMatches[1];
+      return latestVersion;
     } catch (e) {
       throw new Error(`Unable to resolve version ${version} of package ${name}: ${e}`);
     }

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -180,7 +180,7 @@ function _resolvePackageVersion(
       // if multiple versions match the selector, or
       //
       // ```
-      // "3.0.0
+      // "3.0.0"
       // ```
       //
       // if only a single version matches.


### PR DESCRIPTION
## Summary

Resolves #4256

Fixes install-run.js behavior when there is only one version that matches the version query, or when the registry returns versions out of order.

## Details

As discussed in the issue, I added logic to sort the returned version numbers. There is no handling for pre-releases, but registries should only return them when they exactly match the query, meaning sorting is unnecessary.

This should not break backwards compatibility.
There may be some performance impact in cases where there are very many matching versions, but this is not exactly a hot code-path.

## How it was tested

I compiled the script (`rush build --to @microsoft/rush-lib`) and then ran it (`node common/scripts/install-run.js ...`) with a few example packages.

## Impacted documentation

This change should not impact documentation