### PR TITLE
[typings-generator] Support custom readFile

### DIFF
--- a/common/changes/@rushstack/typings-generator/typings-generator-read-file_2023-08-03-21-57.json
+++ b/common/changes/@rushstack/typings-generator/typings-generator-read-file_2023-08-03-21-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "Allow customization of how the TypingsGenerator reads files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator"
+}

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -7,9 +7,23 @@
 import { ITerminal } from '@rushstack/node-core-library';
 
 // @public (undocumented)
-export interface IStringValuesTypingsGeneratorOptions extends ITypingsGeneratorOptions<IStringValueTypings | undefined> {
+export interface IReadFile<TFileContents = string> {
+    // (undocumented)
+    (filePath: string, relativePath: string): Promise<TFileContents> | TFileContents;
+}
+
+// @public (undocumented)
+export interface IStringValuesTypingsGeneratorBaseOptions {
     exportAsDefault?: boolean;
     exportAsDefaultInterfaceName?: string;
+}
+
+// @public (undocumented)
+export interface IStringValuesTypingsGeneratorOptions<TFileContents extends string = string> extends ITypingsGeneratorOptions<IStringValueTypings | undefined, TFileContents>, IStringValuesTypingsGeneratorBaseOptions {
+}
+
+// @public (undocumented)
+export interface IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents = string> extends ITypingsGeneratorOptionsWithCustomReadFile<IStringValueTypings | undefined, TFileContents>, IStringValuesTypingsGeneratorBaseOptions {
 }
 
 // @public (undocumented)
@@ -41,7 +55,19 @@ export interface ITypingsGeneratorBaseOptions {
 }
 
 // @public (undocumented)
-export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> extends ITypingsGeneratorBaseOptions {
+export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined, TFileContents extends string = string> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
+    // (undocumented)
+    readFile?: IReadFile<TFileContents>;
+}
+
+// @public
+export interface ITypingsGeneratorOptionsWithCustomReadFile<TTypingsResult = string | undefined, TFileContents = string> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
+    // (undocumented)
+    readFile: IReadFile<TFileContents>;
+}
+
+// @public (undocumented)
+export interface ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult = string | undefined, TFileContents = string> extends ITypingsGeneratorBaseOptions {
     // (undocumented)
     fileExtensions: string[];
     // @deprecated (undocumented)
@@ -49,24 +75,26 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined> e
     // (undocumented)
     getAdditionalOutputFiles?: (relativePath: string) => string[];
     // (undocumented)
-    parseAndGenerateTypings: (fileContents: string, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
+    parseAndGenerateTypings: (fileContents: TFileContents, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
 }
 
 // @public
-export class StringValuesTypingsGenerator extends TypingsGenerator {
-    constructor(options: IStringValuesTypingsGeneratorOptions);
+export class StringValuesTypingsGenerator<TFileContents = string> extends TypingsGenerator<TFileContents> {
+    constructor(options: TFileContents extends string ? IStringValuesTypingsGeneratorOptions<TFileContents> : never);
+    constructor(options: IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents>);
 }
 
 // @public
-export class TypingsGenerator {
-    constructor(options: ITypingsGeneratorOptions);
+export class TypingsGenerator<TFileContents = string> {
+    constructor(options: TFileContents extends string ? ITypingsGeneratorOptions<string | undefined, TFileContents> : never);
+    constructor(options: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents>);
     generateTypingsAsync(relativeFilePaths?: string[]): Promise<void>;
     // (undocumented)
     getOutputFilePaths(relativePath: string): string[];
     readonly ignoredFileGlobs: readonly string[];
     readonly inputFileGlob: string;
     // (undocumented)
-    protected _options: ITypingsGeneratorOptions;
+    protected _options: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents>;
     registerDependency(consumer: string, rawDependency: string): void;
     // (undocumented)
     runWatcherAsync(): Promise<void>;

--- a/common/reviews/api/typings-generator.api.md
+++ b/common/reviews/api/typings-generator.api.md
@@ -7,12 +7,6 @@
 import { ITerminal } from '@rushstack/node-core-library';
 
 // @public (undocumented)
-export interface IReadFile<TFileContents = string> {
-    // (undocumented)
-    (filePath: string, relativePath: string): Promise<TFileContents> | TFileContents;
-}
-
-// @public (undocumented)
 export interface IStringValuesTypingsGeneratorBaseOptions {
     exportAsDefault?: boolean;
     exportAsDefaultInterfaceName?: string;
@@ -57,13 +51,13 @@ export interface ITypingsGeneratorBaseOptions {
 // @public (undocumented)
 export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined, TFileContents extends string = string> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
     // (undocumented)
-    readFile?: IReadFile<TFileContents>;
+    readFile?: ReadFile<TFileContents>;
 }
 
 // @public
 export interface ITypingsGeneratorOptionsWithCustomReadFile<TTypingsResult = string | undefined, TFileContents = string> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
     // (undocumented)
-    readFile: IReadFile<TFileContents>;
+    readFile: ReadFile<TFileContents>;
 }
 
 // @public (undocumented)
@@ -77,6 +71,9 @@ export interface ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult = string
     // (undocumented)
     parseAndGenerateTypings: (fileContents: TFileContents, filePath: string, relativePath: string) => TTypingsResult | Promise<TTypingsResult>;
 }
+
+// @public (undocumented)
+export type ReadFile<TFileContents = string> = (filePath: string, relativePath: string) => Promise<TFileContents> | TFileContents;
 
 // @public
 export class StringValuesTypingsGenerator<TFileContents = string> extends TypingsGenerator<TFileContents> {

--- a/libraries/typings-generator/README.md
+++ b/libraries/typings-generator/README.md
@@ -33,6 +33,29 @@ await typingsGenerator.generateTypings();
 await typingsGenerator.runWatcher();
 ```
 
+```TypeScript
+import { TypingsGenerator } from '@rushstack/typings-generator';
+
+const assetTypingsGenerator: TypingsGenerator = new TypingsGenerator({
+  srcFolder: '/repo/package/src',
+  generatedTsFolder: '/repo/package/temp/generated-typings',
+  fileExtensions: ['.jpg'],
+  parseAndGenerateTypings: (fileContents: false, filePath: string) => {
+    const parsedFile = parseFile(fileContents);
+    const typings: string = 'declare const path: string;\nexport default path;';
+    return typings;
+  },
+  // Don't read files at all
+  readFile: (filePath: string, relativePath: string) => false
+});
+
+// To run once before a compilation:
+await typingsGenerator.generateTypings();
+
+// To start a watcher:
+await typingsGenerator.runWatcher();
+```
+
 ## Options
 
 ### `srcFolder = '...'`
@@ -50,11 +73,19 @@ that this be a folder parallel to the source folder, specified in addition to th
 
 This property enumerates the file extensions that should be handled.
 
-### `parseAndGenerateTypings = (fileContents: string, filePath: string) => string | Promise<string>`
+### `parseAndGenerateTypings = (fileContents: TFileContents, filePath: string, relativePath: string) => string | Promise<string>`
 
 This property is used to specify the function that should be called on every file for which typings
 are being generated. In watch mode, this is called on every file creation and file update. It should
 return TypeScript declarations for the file it is called with.
+
+### `readFile = (filePath: string, relativePath: string) => TFileContents | Promise<TFileContents>`
+
+This property allows customizing the process by which files are read from the specified paths.
+Use cases include:
+- Disabling reads altogether, if the typings don't depend on file content
+- Reading from an alternate data source
+- Reading files with a different encoding than 'utf-8'
 
 ### `terminal`
 

--- a/libraries/typings-generator/src/StringValuesTypingsGenerator.ts
+++ b/libraries/typings-generator/src/StringValuesTypingsGenerator.ts
@@ -3,7 +3,11 @@
 
 import { EOL } from 'os';
 
-import { ITypingsGeneratorOptions, TypingsGenerator } from './TypingsGenerator';
+import {
+  type ITypingsGeneratorOptions,
+  TypingsGenerator,
+  type ITypingsGeneratorOptionsWithCustomReadFile
+} from './TypingsGenerator';
 
 /**
  * @public
@@ -23,8 +27,7 @@ export interface IStringValueTypings {
 /**
  * @public
  */
-export interface IStringValuesTypingsGeneratorOptions
-  extends ITypingsGeneratorOptions<IStringValueTypings | undefined> {
+export interface IStringValuesTypingsGeneratorBaseOptions {
   /**
    * Setting this option wraps the typings export in a default property.
    */
@@ -37,7 +40,82 @@ export interface IStringValuesTypingsGeneratorOptions
   exportAsDefaultInterfaceName?: string;
 }
 
+/**
+ * @public
+ */
+export interface IStringValuesTypingsGeneratorOptions<TFileContents extends string = string>
+  extends ITypingsGeneratorOptions<IStringValueTypings | undefined, TFileContents>,
+    IStringValuesTypingsGeneratorBaseOptions {
+  // Nothing added.
+}
+
+/**
+ * @public
+ */
+export interface IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents = string>
+  extends ITypingsGeneratorOptionsWithCustomReadFile<IStringValueTypings | undefined, TFileContents>,
+    IStringValuesTypingsGeneratorBaseOptions {
+  // Nothing added.
+}
+
 const EXPORT_AS_DEFAULT_INTERFACE_NAME: string = 'IExport';
+
+function convertToTypingsGeneratorOptions<TFileContents>(
+  options: IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents>
+): ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents> {
+  async function parseAndGenerateTypings(
+    fileContents: TFileContents,
+    filePath: string,
+    relativePath: string
+  ): Promise<string | undefined> {
+    const stringValueTypings: IStringValueTypings | undefined = await options.parseAndGenerateTypings(
+      fileContents,
+      filePath,
+      relativePath
+    );
+
+    if (stringValueTypings === undefined) {
+      return;
+    }
+
+    const outputLines: string[] = [];
+    const interfaceName: string = options.exportAsDefaultInterfaceName
+      ? options.exportAsDefaultInterfaceName
+      : EXPORT_AS_DEFAULT_INTERFACE_NAME;
+    let indent: string = '';
+    if (options.exportAsDefault) {
+      outputLines.push(`export interface ${interfaceName} {`);
+      indent = '  ';
+    }
+
+    for (const stringValueTyping of stringValueTypings.typings) {
+      const { exportName, comment } = stringValueTyping;
+
+      if (comment && comment.trim() !== '') {
+        outputLines.push(`${indent}/**`, `${indent} * ${comment.replace(/\*\//g, '*\\/')}`, `${indent} */`);
+      }
+
+      if (options.exportAsDefault) {
+        outputLines.push(`${indent}'${exportName}': string;`, '');
+      } else {
+        outputLines.push(`export declare const ${exportName}: string;`, '');
+      }
+    }
+
+    if (options.exportAsDefault) {
+      outputLines.push('}', '', `declare const strings: ${interfaceName};`, '', 'export default strings;');
+    }
+
+    return outputLines.join(EOL);
+  }
+
+  const convertedOptions: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents> = {
+    ...options,
+    parseAndGenerateTypings
+  };
+
+  return convertedOptions;
+}
 
 /**
  * This is a simple tool that generates .d.ts files for non-TS files that can be represented as
@@ -45,61 +123,12 @@ const EXPORT_AS_DEFAULT_INTERFACE_NAME: string = 'IExport';
  *
  * @public
  */
-export class StringValuesTypingsGenerator extends TypingsGenerator {
-  public constructor(options: IStringValuesTypingsGeneratorOptions) {
-    super({
-      ...options,
-      parseAndGenerateTypings: async (fileContents: string, filePath: string, relativePath: string) => {
-        const stringValueTypings: IStringValueTypings | undefined = await options.parseAndGenerateTypings(
-          fileContents,
-          filePath,
-          relativePath
-        );
-
-        if (stringValueTypings === undefined) {
-          return;
-        }
-
-        const outputLines: string[] = [];
-        const interfaceName: string = options.exportAsDefaultInterfaceName
-          ? options.exportAsDefaultInterfaceName
-          : EXPORT_AS_DEFAULT_INTERFACE_NAME;
-        let indent: string = '';
-        if (options.exportAsDefault) {
-          outputLines.push(`export interface ${interfaceName} {`);
-          indent = '  ';
-        }
-
-        for (const stringValueTyping of stringValueTypings.typings) {
-          const { exportName, comment } = stringValueTyping;
-
-          if (comment && comment.trim() !== '') {
-            outputLines.push(
-              `${indent}/**`,
-              `${indent} * ${comment.replace(/\*\//g, '*\\/')}`,
-              `${indent} */`
-            );
-          }
-
-          if (options.exportAsDefault) {
-            outputLines.push(`${indent}'${exportName}': string;`, '');
-          } else {
-            outputLines.push(`export declare const ${exportName}: string;`, '');
-          }
-        }
-
-        if (options.exportAsDefault) {
-          outputLines.push(
-            '}',
-            '',
-            `declare const strings: ${interfaceName};`,
-            '',
-            'export default strings;'
-          );
-        }
-
-        return outputLines.join(EOL);
-      }
-    });
+export class StringValuesTypingsGenerator<TFileContents = string> extends TypingsGenerator<TFileContents> {
+  public constructor(
+    options: TFileContents extends string ? IStringValuesTypingsGeneratorOptions<TFileContents> : never
+  );
+  public constructor(options: IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents>);
+  public constructor(options: IStringValuesTypingsGeneratorOptionsWithCustomReadFile<TFileContents>) {
+    super(convertToTypingsGeneratorOptions(options));
   }
 }

--- a/libraries/typings-generator/src/TypingsGenerator.ts
+++ b/libraries/typings-generator/src/TypingsGenerator.ts
@@ -51,9 +51,10 @@ export interface ITypingsGeneratorOptionsWithoutReadFile<
 /**
  * @public
  */
-export interface IReadFile<TFileContents = string> {
-  (filePath: string, relativePath: string): Promise<TFileContents> | TFileContents;
-}
+export type ReadFile<TFileContents = string> = (
+  filePath: string,
+  relativePath: string
+) => Promise<TFileContents> | TFileContents;
 
 /**
  * @public
@@ -62,7 +63,7 @@ export interface ITypingsGeneratorOptions<
   TTypingsResult = string | undefined,
   TFileContents extends string = string
 > extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
-  readFile?: IReadFile<TFileContents>;
+  readFile?: ReadFile<TFileContents>;
 }
 
 /**
@@ -74,7 +75,7 @@ export interface ITypingsGeneratorOptionsWithCustomReadFile<
   TTypingsResult = string | undefined,
   TFileContents = string
 > extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
-  readFile: IReadFile<TFileContents>;
+  readFile: ReadFile<TFileContents>;
 }
 
 /**

--- a/libraries/typings-generator/src/TypingsGenerator.ts
+++ b/libraries/typings-generator/src/TypingsGenerator.ts
@@ -29,11 +29,13 @@ export interface ITypingsGeneratorBaseOptions {
 /**
  * @public
  */
-export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined>
-  extends ITypingsGeneratorBaseOptions {
+export interface ITypingsGeneratorOptionsWithoutReadFile<
+  TTypingsResult = string | undefined,
+  TFileContents = string
+> extends ITypingsGeneratorBaseOptions {
   fileExtensions: string[];
   parseAndGenerateTypings: (
-    fileContents: string,
+    fileContents: TFileContents,
     filePath: string,
     relativePath: string
   ) => TTypingsResult | Promise<TTypingsResult>;
@@ -47,11 +49,40 @@ export interface ITypingsGeneratorOptions<TTypingsResult = string | undefined>
 }
 
 /**
+ * @public
+ */
+export interface IReadFile<TFileContents = string> {
+  (filePath: string, relativePath: string): Promise<TFileContents> | TFileContents;
+}
+
+/**
+ * @public
+ */
+export interface ITypingsGeneratorOptions<
+  TTypingsResult = string | undefined,
+  TFileContents extends string = string
+> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
+  readFile?: IReadFile<TFileContents>;
+}
+
+/**
+ * Options for a TypingsGenerator that needs to customize how files are read.
+ *
+ * @public
+ */
+export interface ITypingsGeneratorOptionsWithCustomReadFile<
+  TTypingsResult = string | undefined,
+  TFileContents = string
+> extends ITypingsGeneratorOptionsWithoutReadFile<TTypingsResult, TFileContents> {
+  readFile: IReadFile<TFileContents>;
+}
+
+/**
  * This is a simple tool that generates .d.ts files for non-TS files.
  *
  * @public
  */
-export class TypingsGenerator {
+export class TypingsGenerator<TFileContents = string> {
   // Map of resolved consumer file path -> Set<resolved dependency file path>
   private readonly _dependenciesOfFile: Map<string, Set<string>>;
 
@@ -61,7 +92,7 @@ export class TypingsGenerator {
   // Map of resolved file path -> relative file path
   private readonly _relativePaths: Map<string, string>;
 
-  protected _options: ITypingsGeneratorOptions;
+  protected _options: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents>;
 
   /**
    * The folder path that contains all input source files.
@@ -78,43 +109,53 @@ export class TypingsGenerator {
    */
   public readonly ignoredFileGlobs: readonly string[];
 
-  public constructor(options: ITypingsGeneratorOptions) {
+  public constructor(
+    options: TFileContents extends string
+      ? ITypingsGeneratorOptions<string | undefined, TFileContents>
+      : never
+  );
+  public constructor(options: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents>);
+  public constructor(options: ITypingsGeneratorOptionsWithCustomReadFile<string | undefined, TFileContents>) {
     this._options = {
-      ...options
+      ...options,
+      readFile:
+        options.readFile ??
+        ((filePath: string, relativePath: string): Promise<TFileContents> =>
+          FileSystem.readFileAsync(filePath) as Promise<TFileContents>)
     };
 
     if (options.filesToIgnore) {
       throw new Error('The filesToIgnore option is no longer supported. Please use globsToIgnore instead.');
     }
 
-    if (!this._options.generatedTsFolder) {
+    if (!options.generatedTsFolder) {
       throw new Error('generatedTsFolder must be provided');
     }
 
-    if (!this._options.srcFolder) {
+    if (!options.srcFolder) {
       throw new Error('srcFolder must be provided');
     }
-    this.sourceFolderPath = this._options.srcFolder;
+    this.sourceFolderPath = options.srcFolder;
 
-    if (Path.isUnder(this._options.srcFolder, this._options.generatedTsFolder)) {
+    if (Path.isUnder(options.srcFolder, options.generatedTsFolder)) {
       throw new Error('srcFolder must not be under generatedTsFolder');
     }
 
-    if (Path.isUnder(this._options.generatedTsFolder, this._options.srcFolder)) {
+    if (Path.isUnder(options.generatedTsFolder, options.srcFolder)) {
       throw new Error('generatedTsFolder must not be under srcFolder');
     }
 
-    if (!this._options.fileExtensions || this._options.fileExtensions.length === 0) {
+    if (!options.fileExtensions || options.fileExtensions.length === 0) {
       throw new Error('At least one file extension must be provided.');
     }
 
-    this.ignoredFileGlobs = this._options.globsToIgnore || [];
+    this.ignoredFileGlobs = options.globsToIgnore || [];
 
-    if (!this._options.terminal) {
+    if (!options.terminal) {
       this._options.terminal = new Terminal(new ConsoleTerminalProvider({ verboseEnabled: true }));
     }
 
-    this._options.fileExtensions = this._normalizeFileExtensions(this._options.fileExtensions);
+    this._options.fileExtensions = this._normalizeFileExtensions(options.fileExtensions);
 
     this._dependenciesOfFile = new Map();
     this._consumersOfFile = new Map();
@@ -140,7 +181,7 @@ export class TypingsGenerator {
       });
     }
 
-    await this._reprocessFiles(relativeFilePaths, checkFilePaths);
+    await this._reprocessFiles(relativeFilePaths!, checkFilePaths);
   }
 
   public async runWatcherAsync(): Promise<void> {
@@ -290,7 +331,7 @@ export class TypingsGenerator {
     this._clearDependencies(resolvedPath);
 
     try {
-      const fileContents: string = await FileSystem.readFileAsync(resolvedPath);
+      const fileContents: TFileContents = await this._options.readFile(resolvedPath, relativePath);
       const typingsData: string | undefined = await this._options.parseAndGenerateTypings(
         fileContents,
         resolvedPath,

--- a/libraries/typings-generator/src/index.ts
+++ b/libraries/typings-generator/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 export {
-  type IReadFile,
+  type ReadFile,
   type ITypingsGeneratorBaseOptions,
   type ITypingsGeneratorOptionsWithoutReadFile,
   type ITypingsGeneratorOptions,

--- a/libraries/typings-generator/src/index.ts
+++ b/libraries/typings-generator/src/index.ts
@@ -9,11 +9,20 @@
  * @packageDocumentation
  */
 
-export { ITypingsGeneratorBaseOptions, ITypingsGeneratorOptions, TypingsGenerator } from './TypingsGenerator';
+export {
+  type IReadFile,
+  type ITypingsGeneratorBaseOptions,
+  type ITypingsGeneratorOptionsWithoutReadFile,
+  type ITypingsGeneratorOptions,
+  type ITypingsGeneratorOptionsWithCustomReadFile,
+  TypingsGenerator
+} from './TypingsGenerator';
 
 export {
-  IStringValueTyping,
-  IStringValueTypings,
-  IStringValuesTypingsGeneratorOptions,
+  type IStringValueTyping,
+  type IStringValueTypings,
+  type IStringValuesTypingsGeneratorBaseOptions,
+  type IStringValuesTypingsGeneratorOptions,
+  type IStringValuesTypingsGeneratorOptionsWithCustomReadFile,
   StringValuesTypingsGenerator
 } from './StringValuesTypingsGenerator';


### PR DESCRIPTION
## Summary
Adds the ability for consumers of `TypingsGenerator` to customize how files are read. Possible use cases include:
 - Skipping reading files altogether, such as when generating .d.ts files that don't depend on the file content
 - Reading from somewhere other than the file system
 - Reading files as `Buffer` rather than `string`, or with alternate encoding

## Details
Figuring out the options interfaces for backwards compatibility was the toughest part of making this work. The `readFile` property needs to be optional if its return type is `string`, and required otherwise.

## How it was tested
Local build.
Lab build.
Manual validation that the `readFile` property is required if the type of `fileContents` is not `string`.

## Impacted documentation
Docs for TypingsGenerator.