### PR TITLE
[extension] Generate a .vscodeignore dynamically.

### DIFF
--- a/common/changes/@rushstack/package-extractor/main_2023-08-04-01-56.json
+++ b/common/changes/@rushstack/package-extractor/main_2023-08-04-01-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Include an API for getting files that are included in a npm package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -192,7 +192,7 @@
     },
     {
       "name": "@rushstack/package-extractor",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "vscode-extensions" ]
     },
     {
       "name": "@rushstack/rig-package",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1267,7 +1267,7 @@ importers:
       '@rushstack/heft-lint-plugin': link:../../heft-plugins/heft-lint-plugin
       '@rushstack/heft-typescript-plugin': link:../../heft-plugins/heft-typescript-plugin
       '@types/jest': 29.5.3
-      '@types/node': 20.4.6
+      '@types/node': 20.4.7
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.9.5
       tslint-microsoft-contrib: 6.2.0_uwqr5pcif4g7c56scrk6kqzf7i
@@ -2872,6 +2872,7 @@ importers:
       '@rushstack/heft-node-rig': workspace:*
       '@rushstack/heft-webpack5-plugin': workspace:*
       '@rushstack/node-core-library': workspace:*
+      '@rushstack/package-extractor': workspace:*
       '@rushstack/rush-sdk': workspace:*
       '@rushstack/rush-vscode-command-webview': workspace:*
       '@rushstack/ts-command-line': workspace:*
@@ -2896,6 +2897,7 @@ importers:
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
       '@rushstack/heft-webpack5-plugin': link:../../heft-plugins/heft-webpack5-plugin
+      '@rushstack/package-extractor': link:../../libraries/package-extractor
       '@rushstack/webpack-preserve-dynamic-require-plugin': link:../../webpack/preserve-dynamic-require-plugin
       '@types/glob': 7.1.1
       '@types/mocha': 9.1.1
@@ -10365,8 +10367,8 @@ packages:
     resolution: {integrity: sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==}
     dev: true
 
-  /@types/node/20.4.6:
-    resolution: {integrity: sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA==}
+  /@types/node/20.4.7:
+    resolution: {integrity: sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ded1d9e0e7cd7f6e59d31ca9182f4cc993c6cba0",
+  "pnpmShrinkwrapHash": "a26b57eff121575687c2e9c78c2246ffa0842333",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -59,6 +59,8 @@ export interface IProjectInfoJson {
 // @public
 export class PackageExtractor {
     extractAsync(options: IExtractorOptions): Promise<void>;
+    // @beta
+    static getPackageIncludedFilesAsync(packageRootPath: string): Promise<string[]>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/vscode-extensions/rush-vscode-extension/.gitignore
+++ b/vscode-extensions/rush-vscode-extension/.gitignore
@@ -1,3 +1,4 @@
 webview/
 .vscode-test/
 *.vsix
+.vscodeignore

--- a/vscode-extensions/rush-vscode-extension/.npmignore
+++ b/vscode-extensions/rush-vscode-extension/.npmignore
@@ -14,4 +14,7 @@
 /dist/*.stats.*
 /lib/**/test/
 /lib-*/**/test/
+lib/scripts/
+lib-*/scripts/
 *.test.js
+*.map

--- a/vscode-extensions/rush-vscode-extension/config/heft.json
+++ b/vscode-extensions/rush-vscode-extension/config/heft.json
@@ -33,6 +33,16 @@
               ]
             }
           }
+        },
+        "generate-vscodeignore": {
+          "taskDependencies": ["copy-webview", "typescript", "webpack"],
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
+            "options": {
+              "scriptPath": "lib/scripts/generate-vscodeignore.js"
+            }
+          }
         }
       }
     }

--- a/vscode-extensions/rush-vscode-extension/package.json
+++ b/vscode-extensions/rush-vscode-extension/package.json
@@ -204,9 +204,10 @@
   "devDependencies": {
     "@microsoft/rush-lib": "workspace:*",
     "@rushstack/eslint-config": "workspace:*",
-    "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
     "@rushstack/heft-webpack5-plugin": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@rushstack/package-extractor": "workspace:*",
     "@rushstack/webpack-preserve-dynamic-require-plugin": "workspace:*",
     "@types/glob": "7.1.1",
     "@types/mocha": "^9.0.0",

--- a/vscode-extensions/rush-vscode-extension/src/scripts/generate-vscodeignore.ts
+++ b/vscode-extensions/rush-vscode-extension/src/scripts/generate-vscodeignore.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IRunScriptOptions } from '@rushstack/heft';
+import { FileSystem } from '@rushstack/node-core-library';
+import { PackageExtractor } from '@rushstack/package-extractor';
+
+export async function runAsync({
+  heftConfiguration: { buildFolderPath },
+  heftTaskSession: { logger }
+}: IRunScriptOptions): Promise<void> {
+  const includedFilePaths: string[] = await PackageExtractor.getPackageIncludedFilesAsync(buildFolderPath);
+  includedFilePaths.sort();
+  const vscodeIgnoreLines: string[] = ['**'];
+  for (const folderItemPath of includedFilePaths) {
+    vscodeIgnoreLines.push(`!${folderItemPath}`);
+  }
+
+  const vscodeignorePath: string = `${buildFolderPath}/.vscodeignore`;
+  await FileSystem.writeFileAsync(vscodeignorePath, vscodeIgnoreLines.join('\n') + '\n');
+}

--- a/vscode-extensions/rush-vscode-extension/webpack.config.js
+++ b/vscode-extensions/rush-vscode-extension/webpack.config.js
@@ -39,7 +39,10 @@ function createExtensionConfig({ production, webpack }) {
       new webpack.DefinePlugin({
         ___DEV___: JSON.stringify(!production)
       })
-    ]
+    ],
+    optimization: {
+      minimize: false // Ensure licenses are included in the bundle
+    }
   };
   return extensionConfig;
 }


### PR DESCRIPTION
The `.vscodeignore` file does not follow the same semantics as `.npmignore`. This change generates a `.vscodeignore` file during build that explicitly lists all files that should be included in the package. As of this PR, that `.vscodeignore` file looks like:

```
**
!LICENSE
!dist/extension.js
!lib/extension.d.ts
!lib/extension.js
!lib/logic/RushCommandWebViewPanel.d.ts
!lib/logic/RushCommandWebViewPanel.js
!lib/logic/RushWorkspace.d.ts
!lib/logic/RushWorkspace.js
!lib/logic/logger.d.ts
!lib/logic/logger.js
!lib/providers/RushCommandsProvider.d.ts
!lib/providers/RushCommandsProvider.js
!lib/providers/RushProjectsProvider.d.ts
!lib/providers/RushProjectsProvider.js
!lib/providers/TaskProvider.d.ts
!lib/providers/TaskProvider.js
!package.json
!resources/rushstack.png
!resources/rushstack.svg
!webview/rush-command-webview/bundle.js
!webview/rush-command-webview/index.html

```