### PR TITLE
fix(eslint-patch): fix for VS Code eslint extension with flat config enabled

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-flat-config-support_2023-08-07-03-59.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-flat-config-support_2023-08-07-03-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix patching for running eslint via eslint/use-at-your-own-risk, which VS Code's eslint extension does when enabling flat config support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -68,7 +68,7 @@ for (let currentModule = module; ; ) {
 
       // Make sure we actually resolved the module in our call path
       // and not some other spurious dependency.
-      if (path.join(eslintCandidateFolder, 'lib/cli-engine/cli-engine.js') === currentModule.filename) {
+      if (currentModule.filename.startsWith(eslintCandidateFolder + path.sep)) {
         eslintFolder = eslintCandidateFolder;
         break;
       }


### PR DESCRIPTION
## Summary

Fixes a bug where VS Code's eslint extension + eslint-patch confuse each other

## Details

### Problem

If all of the following apply to you:
- You're using VS Code with the eslint extension from Microsoft
- One of your eslint packages uses eslint-patch
- You're using the new flat config eslint has
- You've followed the instructions for the VS Code eslint extension and set `"eslint.experimental.useFlatConfig": true` in your VS Code settings (required, otherwise you get an error)

Eslint still won't work inside VS Code. This MR fixes that.

### Root cause

1. VS Code's eslint extension [uses `eslint/use-at-your-own-risk`](https://github.com/microsoft/vscode-eslint/blob/release/2.4.2/server/src/eslint.ts#L872) when you turn on flat config
2. eslint's `use-at-your-own-risk` [maps to `lib/unsupported-api.js`](https://github.com/eslint/eslint/blob/v8.46.0/package.json#L13)
3. `lib/unsupported-api.js` [loads `lib/cli-engine/file-enumerator.js`](https://github.com/eslint/eslint/blob/v8.46.0/lib/unsupported-api.js#L14), not `lib/cli-engine/cli-engine.js`
4. eslint-patch prior to this commit specifically searched for `lib/cli-engine/cli-engine.js` in the import stack (see the diff) and if it wasn't found, it would assume an older version of eslint, and that would cause an error

### The fix

This commit allows for any file inside the eslint package to count when searching for an eslint package, allowing VS Code's eslint extension to work when you use eslint's flat config.

### Alternatives considered
I considered is to allow `lib/cli-engine/file-enumerator.js`, or `lib/cli-engine/*`, or `lib/unsupported-api.js` instead. However, I decided to consider what the original purpose of this code was. The comment right above the code said this:

> Make sure we actually resolved the module in our call path and not some other spurious dependency.

Based on that comment, it shouldn't matter which exact file in eslint is being used; one of them is being used, and that's all that matters. Eslint's implementation details shouldn't matter.

### Performance

Personally, I believe this performs well enough. However, a micro optimizer could make the case that it would be more efficient to check for `lib/cli-engine/file-enumerator.js` specifically. I'll make that change if requested, but personally I believe the right trade-off has been made in this MR as is.

## How it was tested

Looking at the links mentioned in the details, I think it's clear that this works. There was no algorithmic code here, and there are no unit tests for this library, so I simply patched the file locally, quit VS Code, and restarted it to see if it would work in my test repo.

## Impacted documentation

None.