### PR TITLE
[rush-serve-plugin] Support cors, compression, http2

### DIFF
--- a/common/changes/@microsoft/rush/rush-serve-compression_2023-08-08-18-20.json
+++ b/common/changes/@microsoft/rush/rush-serve-compression_2023-08-08-18-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support in rush-serve-plugin for HTTP/2, gzip compression, and CORS preflight requests.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -55,10 +55,6 @@
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "cors",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
       "name": "dependency-path",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -395,6 +395,14 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "compression",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "cors",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "constructs",
       "allowedCategories": [ "tests" ]
     },
@@ -517,6 +525,10 @@
     {
       "name": "http-proxy",
       "allowedCategories": [ "tests" ]
+    },
+    {
+      "name": "http2-express-bridge",
+      "allowedCategories": [ "libraries" ]
     },
     {
       "name": "https-proxy-agent",

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -216,6 +216,12 @@
       }
     },
 
+    "@types/compression": {
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
+
     "@types/webpack": {
       "dependencies": {
         "anymatch": "^3"
@@ -236,6 +242,12 @@
 
     "http-proxy-middleware": {
       "dependencies": {
+        "@types/express": "*"
+      }
+    },
+
+    "http2-express-bridge": {
+      "peerDependencies": {
         "@types/express": "*"
       }
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,7 @@ lockfileVersion: 5.4
 overrides:
   package-json: ^7
 
-packageExtensionsChecksum: 41333d2d0915bdc80c909c31c409a3a2
+packageExtensionsChecksum: 95336a192bb9f5ec1f70f6e0bed88a4b
 
 importers:
 
@@ -1267,7 +1267,7 @@ importers:
       '@rushstack/heft-lint-plugin': link:../../heft-plugins/heft-lint-plugin
       '@rushstack/heft-typescript-plugin': link:../../heft-plugins/heft-typescript-plugin
       '@types/jest': 29.5.3
-      '@types/node': 20.4.7
+      '@types/node': 20.4.8
       eslint: 8.7.0
       tslint: 5.20.1_typescript@4.9.5
       tslint-microsoft-contrib: 6.2.0_uwqr5pcif4g7c56scrk6kqzf7i
@@ -2793,10 +2793,15 @@ importers:
       '@rushstack/rig-package': workspace:*
       '@rushstack/rush-sdk': workspace:*
       '@rushstack/ts-command-line': workspace:*
+      '@types/compression': ~1.7.2
+      '@types/cors': ~2.8.12
       '@types/express': 4.17.13
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
+      compression: ~1.7.4
+      cors: ~2.8.5
       express: 4.18.1
+      http2-express-bridge: ~1.0.7
     dependencies:
       '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
@@ -2804,11 +2809,16 @@ importers:
       '@rushstack/rig-package': link:../../libraries/rig-package
       '@rushstack/rush-sdk': link:../../libraries/rush-sdk
       '@rushstack/ts-command-line': link:../../libraries/ts-command-line
+      compression: 1.7.4
+      cors: 2.8.5
       express: 4.18.1
+      http2-express-bridge: 1.0.7_@types+express@4.17.13
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-node-rig': link:../../rigs/heft-node-rig
+      '@types/compression': 1.7.2_@types+express@4.17.13
+      '@types/cors': 2.8.13
       '@types/express': 4.17.13
       '@types/heft-jest': 1.0.1
       '@types/node': 14.18.36
@@ -10104,6 +10114,14 @@ packages:
     resolution: {integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==}
     dev: true
 
+  /@types/compression/1.7.2_@types+express@4.17.13:
+    resolution: {integrity: sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==}
+    peerDependencies:
+      '@types/express': '*'
+    dependencies:
+      '@types/express': 4.17.13
+    dev: true
+
   /@types/configstore/6.0.0:
     resolution: {integrity: sha512-GUvNiia85zTDDIx0iPrtF3pI8dwrQkfuokEqxqPDE55qxH0U5SZz4awVZjiJLWN2ZZRkXCUqgsMUbygXY+kytA==}
     dev: true
@@ -10367,8 +10385,8 @@ packages:
     resolution: {integrity: sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==}
     dev: true
 
-  /@types/node/20.4.7:
-    resolution: {integrity: sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==}
+  /@types/node/20.4.8:
+    resolution: {integrity: sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -13793,6 +13811,10 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
+  /destroy/1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+    dev: false
+
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -16445,6 +16467,17 @@ packages:
       statuses: 1.5.0
     dev: false
 
+  /http-errors/1.8.1:
+    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      toidentifier: 1.0.1
+    dev: false
+
   /http-errors/2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -16506,6 +16539,18 @@ packages:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+
+  /http2-express-bridge/1.0.7_@types+express@4.17.13:
+    resolution: {integrity: sha512-bmzZSyn3nuzXRqs/+WgH7IGOQYMCIZNJeqTJ/1AoDgMPTSP5wXQCxPGsdUbGzzxwiHrMwyT4Z7t8ccbsKqiHrw==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      '@types/express': '*'
+    dependencies:
+      '@types/express': 4.17.13
+      merge-descriptors: 1.0.1
+      send: 0.17.2
+      setprototypeof: 1.2.0
+    dev: false
 
   /http2-wrapper/1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -19271,6 +19316,13 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: false
 
+  /on-finished/2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
   /on-finished/2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -21811,6 +21863,25 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /send/0.17.2:
+    resolution: {integrity: sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.8.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    dev: false
 
   /send/0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a26b57eff121575687c2e9c78c2246ffa0842333",
+  "pnpmShrinkwrapHash": "4cfef707a58cfebf1748defd16d0ba994df96319",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/rush-plugins/rush-serve-plugin/README.md
+++ b/rush-plugins/rush-serve-plugin/README.md
@@ -1,8 +1,8 @@
 # @rushstack/rush-serve-plugin
 
-UNDER DEVELOPMENT
-
 A Rush plugin that hooks into action execution and runs an express server to serve project outputs. Meant for use with watch-mode commands.
+
+Supports HTTP/2, compression, CORS, and the new Access-Control-Allow-Private-Network header.
 
 ```
 # The user invokes this command

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -22,12 +22,17 @@
     "@rushstack/rig-package": "workspace:*",
     "@rushstack/rush-sdk": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",
-    "express": "4.18.1"
+    "compression": "~1.7.4",
+    "cors": "~2.8.5",
+    "express": "4.18.1",
+    "http2-express-bridge": "~1.0.7"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
+    "@types/compression": "~1.7.2",
+    "@types/cors": "~2.8.12",
     "@types/express": "4.17.13",
     "@types/heft-jest": "1.0.1",
     "@types/node": "14.18.36"

--- a/rush-plugins/rush-serve-plugin/tsconfig.json
+++ b/rush-plugins/rush-serve-plugin/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "./node_modules/@rushstack/heft-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "types": ["heft-jest", "node"]
+    "types": ["heft-jest", "node"],
+    // express hackery makes this necessary
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary
Updates the rush-serve-plugin to support the following additional capabilities:
- HTTP/2
- GZip or Deflate compression of responses
- CORS Preflight Requests
- Access-Control-Allow-Private-Network (https://developer.chrome.com/blog/private-network-access-preflight/)

## Details
Leverages various existing middelware to support these features.

## How it was tested
Local run of the server.

## Impacted documentation
Only the docs for the plugin.