### PR TITLE
[rush] rush scan package name with dot

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-scan_2023-08-11-01-24.json
+++ b/common/changes/@microsoft/rush/fix-rush-scan_2023-08-11-01-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-rush-scan_2023-08-11-01-24.json
+++ b/common/changes/@microsoft/rush/fix-rush-scan_2023-08-11-01-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "",
+      "comment": "Improve \"rush scan\" to recognize module patterns such as \"import get from 'lodash.get'\"",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/cli/actions/ScanAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ScanAction.ts
@@ -101,12 +101,13 @@ export class ScanAction extends BaseConfiglessRushAction {
 
     // Example: "my-package/lad/dee/dah" --> "my-package"
     // Example: "@ms/my-package" --> "@ms/my-package"
-    const packageRegExp: RegExp = /^((@[a-z\-0-9!_]+\/)?[a-z\-0-9!_]+)\/?/;
+    // Example: "lodash.get" --> "lodash.get"
+    const packageRegExp: RegExp = /^((@[a-z\-0-9!_]+\/)?[a-z\-0-9!_][a-z\-0-9!_.]*)\/?/;
 
     const requireMatches: Set<string> = new Set<string>();
 
     const { default: glob } = await import('fast-glob');
-    const scanResults: string[] = await glob('{./*.{ts,js,tsx,jsx},./{src,lib}/**/*.{ts,js,tsx,jsx}}');
+    const scanResults: string[] = await glob(['./*.{ts,js,tsx,jsx}', './{src,lib}/**/*.{ts,js,tsx,jsx}']);
     for (const filename of scanResults) {
       try {
         const contents: string = FileSystem.readFile(filename);


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fix a edge case when scanning package name with dot

## Details

Assuming the project imports `lodash.get`. Now the log is 

```
Starting "rush scan"

Possible phantom dependencies - these seem to be imported but aren't listed in package.json:
  lodash         // <--- lodash instead of lodash.get
```

This PR fixes the log to print correct package name

```
Starting "rush scan"

Possible phantom dependencies - these seem to be imported but aren't listed in package.json:
  lodash.get
```

## How it was tested

Test it in a local repo by adding a line `import get from 'lodash.get'` to `src/index.ts`

## Impacted documentation

No

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
