### PR TITLE
[rush] Fix an issue where changefiles would not be correctly discovered when running on Windows and add a Windows run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,17 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    name: Node.js v${{ matrix.NodeVersion }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        NodeVersion: [14, 16]
+        include:
+          - NodeVersion: 14
+            OS: ubuntu-latest
+          - NodeVersion: 16
+            OS: ubuntu-latest
+          - NodeVersion: 16
+            OS: windows-latest
+    name: Node.js v${{ matrix.NodeVersion }} (${{ matrix.OS }})
+    runs-on: ${{ matrix.OS }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/common/changes/@microsoft/rush/fix-paths-changes-paths_2023-08-11-08-09.json
+++ b/common/changes/@microsoft/rush/fix-paths-changes-paths_2023-08-11-08-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an issue where changefiles would not be correctly discovered when running on Windows.",
+      "comment": "Fix a regression from 5.101.0 where publishing features did not detect changes properly when running on  Windows OS (GitHub #4277)",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-paths-changes-paths_2023-08-11-08-09.json
+++ b/common/changes/@microsoft/rush/fix-paths-changes-paths_2023-08-11-08-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where changefiles would not be correctly discovered when running on Windows.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.101.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/rush-lib/src/logic/ChangeFiles.ts
+++ b/libraries/rush-lib/src/logic/ChangeFiles.ts
@@ -104,7 +104,7 @@ export class ChangeFiles {
   public async getFilesAsync(): Promise<string[]> {
     if (!this._files) {
       const { default: glob } = await import('fast-glob');
-      this._files = (await glob(`${this._changesPath}/**/*.json`)) || [];
+      this._files = (await glob('**/*.json', { cwd: this._changesPath, absolute: true })) || [];
     }
 
     return this._files;


### PR DESCRIPTION
## Summary

`rush-lib`'s unit tests are currently failing on Windows after https://github.com/microsoft/rushstack/pull/4264. This PR fixes the introduced issue and adds a Windows PR pipeline.

## How it was tested

Ran `heft test` in `rush-lib` on Windows.