### PR TITLE
Update our CI pipelines to include Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           node-version: ${{ matrix.NodeVersion }}
 
+      # Workaround for Node 18 incompatibility with Webpack 4
+      - name: Enable Webpack4 workaround
+        run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $GITHUB_ENV
+        if: matrix.NodeVersion == 18
+
       - name: Verify Change Logs
         run: node common/scripts/install-run-rush.js change --verify
 
@@ -54,9 +59,6 @@ jobs:
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
 
-          # Workaround for Node 18 incompatibility with Webpack 4
-          NODE_OPTIONS: --openssl-legacy-provider
-
       - name: Ensure repo README is up-to-date
         run: node repo-scripts/repo-toolbox/lib/start.js readme --verify
 
@@ -66,6 +68,3 @@ jobs:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
-
-          # Workaround for Node 18 incompatibility with Webpack 4
-          NODE_OPTIONS: --openssl-legacy-provider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.NodeVersion }}
 
       # Workaround for Node 18 incompatibility with Webpack 4
-      - name: Enable Webpack4 workaround
+      - name: Enable Webpack 4 workaround
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $GITHUB_ENV
         if: matrix.NodeVersion == 18
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.NodeVersion }}
 
       # Workaround for Node 18 incompatibility with Webpack 4
-      - name: Enable Webpack 4 workaround
+      - name: Set environment for Webpack 4 workaround
         shell: bash
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> "$GITHUB_ENV"
         if: matrix.NodeVersion == 18
@@ -67,3 +67,9 @@ jobs:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
+
+      # One of the post run actions apparently uses older Node.js that rejects --openssl-legacy-provider
+      - name: Unset environment for Webpack 4 workaround
+        shell: bash
+        run: echo "NODE_OPTIONS=" >> "$GITHUB_ENV"
+        if: matrix.NodeVersion == 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
       # Workaround for Node 18 incompatibility with Webpack 4
       - name: Enable Webpack 4 workaround
+        shell: bash
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> "$GITHUB_ENV"
         if: matrix.NodeVersion == 18
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
         include:
           - NodeVersion: 14
             OS: ubuntu-latest
-          - NodeVersion: 16
-            OS: ubuntu-latest
           - NodeVersion: 18
             OS: ubuntu-latest
           - NodeVersion: 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Workaround for Node 18 incompatibility with Webpack 4
       - name: Enable Webpack 4 workaround
-        run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $GITHUB_ENV
+        run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> "$GITHUB_ENV"
         if: matrix.NodeVersion == 18
 
       - name: Verify Change Logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
             OS: ubuntu-latest
           - NodeVersion: 16
             OS: ubuntu-latest
+          - NodeVersion: 18
+            OS: ubuntu-latest
           - NodeVersion: 16
+            OS: windows-latest
+          - NodeVersion: 18
             OS: windows-latest
     name: Node.js v${{ matrix.NodeVersion }} (${{ matrix.OS }})
     runs-on: ${{ matrix.OS }}
@@ -50,11 +54,18 @@ jobs:
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
 
+          # Workaround for Node 18 incompatibility with Webpack 4
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Ensure repo README is up-to-date
+        run: node repo-scripts/repo-toolbox/lib/start.js readme --verify
+
       - name: Rush test (rush-lib)
         run: node apps/rush/lib/start-dev.js test --verbose --production --timeline
         env:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
-      - name: Ensure repo README is up-to-date
-        run: node repo-scripts/repo-toolbox/lib/start.js readme --verify
+
+          # Workaround for Node 18 incompatibility with Webpack 4
+          NODE_OPTIONS: --openssl-legacy-provider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.NodeVersion }}
 
       # Workaround for Node 18 incompatibility with Webpack 4
-      - name: Set environment for Webpack 4 workaround
+      - name: Enable Webpack 4 workaround
         shell: bash
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> "$GITHUB_ENV"
         if: matrix.NodeVersion == 18
@@ -69,7 +69,7 @@ jobs:
           BROWSERSLIST_IGNORE_OLD_DATA: 1
 
       # One of the post run actions apparently uses older Node.js that rejects --openssl-legacy-provider
-      - name: Unset environment for Webpack 4 workaround
+      - name: Revert Webpack 4 workaround
         shell: bash
         run: echo "NODE_OPTIONS=" >> "$GITHUB_ENV"
         if: matrix.NodeVersion == 18

--- a/.gitignore
+++ b/.gitignore
@@ -63,18 +63,19 @@ jspm_packages/
 .idea/
 *.iml
 
-# Visual Studio Code
-.vscode
-
 # Rush temporary files
 common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
 **/.rush/temp/
+*.lock
 
 # Heft temporary files
 .cache
 .heft
+
+# Visual Studio Code
+.vscode
 
 # Common toolchain intermediate files
 temp

--- a/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-49.json
+++ b/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update Node.js version checks to support the new LTS release",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-50.json
+++ b/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update \"rush init\" template to use PNPM 7.33.5",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-51.json
+++ b/common/changes/@microsoft/rush/octogonz-node-18_2023-08-11-18-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the \"rush init\" template's .gitignore to avoid spurious diffs for files such as \"autoinstaller.lock\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft-webpack4-plugin/octogonz-node-18_2023-08-11-18-32.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/octogonz-node-18_2023-08-11-18-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Display a warning if Node.js 17 or newer is used without the \"--openssl-legacy-provider\" workaround",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin"
+}

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -189,6 +189,12 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     if (versionMatch) {
       const nodejsMajorVersion: number = parseInt(versionMatch[1]);
       if (nodejsMajorVersion >= 16) {
+        // Match strings like this:
+        //   "--max-old-space-size=4096 --openssl-legacy-provider"
+        //   "--openssl-legacy-provider=true"
+        // Do not accidentally match strings like this:
+        //   "--openssl-legacy-provider-unrelated"
+        //   "---openssl-legacy-provider"
         if (!/(^|[^a-z\-])--openssl-legacy-provider($|[^a-z\-])/.test(process.env.NODE_OPTIONS ?? '')) {
           taskSession.logger.emitWarning(
             new Error(

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -188,7 +188,7 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     const versionMatch: RegExpExecArray | null = /^([0-9]+)\./.exec(process.versions.node); // parse the SemVer MAJOR part
     if (versionMatch) {
       const nodejsMajorVersion: number = parseInt(versionMatch[1]);
-      if (nodejsMajorVersion >= 16) {
+      if (nodejsMajorVersion > 16) {
         // Match strings like this:
         //   "--max-old-space-size=4096 --openssl-legacy-provider"
         //   "--openssl-legacy-provider=true"

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -101,22 +101,6 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     heftConfiguration: HeftConfiguration,
     options: IWebpackPluginOptions = {}
   ): void {
-    const versionMatch: RegExpExecArray | null = /^([0-9]+)\./.exec(process.versions.node); // parse the SemVer MAJOR part
-    if (versionMatch) {
-      const nodejsMajorVersion: number = parseInt(versionMatch[1]);
-      if (nodejsMajorVersion >= 16) {
-        if (!/(^|[^a-z\-])--openssl-legacy-provider($|[^a-z\-])/.test(process.env.NODE_OPTIONS ?? '')) {
-          taskSession.logger.emitWarning(
-            new Error(
-              `Node.js version ${nodejsMajorVersion} is incompatible with Webpack 4. To work around this problem, use the environment variable NODE_OPTIONS="--openssl-legacy-provider"`
-            )
-          );
-        }
-      }
-    } else {
-      taskSession.logger.emitWarning(new Error(`Unable to parse Node.js version "${process.versions.node}"`));
-    }
-
     this._isServeMode = taskSession.parameters.getFlagParameter(SERVE_PARAMETER_LONG_NAME).value;
     if (!taskSession.parameters.watch && this._isServeMode) {
       throw new Error(
@@ -200,11 +184,31 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     return this._webpackCompiler;
   }
 
+  private _warnAboutNodeJsIncompatibility(taskSession: IHeftTaskSession): void {
+    const versionMatch: RegExpExecArray | null = /^([0-9]+)\./.exec(process.versions.node); // parse the SemVer MAJOR part
+    if (versionMatch) {
+      const nodejsMajorVersion: number = parseInt(versionMatch[1]);
+      if (nodejsMajorVersion >= 16) {
+        if (!/(^|[^a-z\-])--openssl-legacy-provider($|[^a-z\-])/.test(process.env.NODE_OPTIONS ?? '')) {
+          taskSession.logger.emitWarning(
+            new Error(
+              `Node.js ${nodejsMajorVersion} is incompatible with Webpack 4. To work around this problem, use the environment variable NODE_OPTIONS="--openssl-legacy-provider"`
+            )
+          );
+        }
+      }
+    } else {
+      taskSession.logger.emitWarning(new Error(`Unable to parse Node.js version "${process.versions.node}"`));
+    }
+  }
+
   private async _runWebpackAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
     options: IWebpackPluginOptions
   ): Promise<void> {
+    this._warnAboutNodeJsIncompatibility(taskSession);
+
     this._validateEnvironmentVariable(taskSession);
     if (taskSession.parameters.watch || this._isServeMode) {
       // Should never happen, but just in case
@@ -252,6 +256,8 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     options: IWebpackPluginOptions,
     requestRun: () => void
   ): Promise<void> {
+    this._warnAboutNodeJsIncompatibility(taskSession);
+
     // Save a handle to the original promise, since the this-scoped promise will be replaced whenever
     // the compilation completes.
     let webpackCompilationDonePromise: Promise<void> | undefined = this._webpackCompilationDonePromise;

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -101,6 +101,22 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     heftConfiguration: HeftConfiguration,
     options: IWebpackPluginOptions = {}
   ): void {
+    const versionMatch: RegExpExecArray | null = /^([0-9]+)\./.exec(process.versions.node); // parse the SemVer MAJOR part
+    if (versionMatch) {
+      const nodejsMajorVersion: number = parseInt(versionMatch[1]);
+      if (nodejsMajorVersion >= 16) {
+        if (!/(^|[^a-z\-])--openssl-legacy-provider($|[^a-z\-])/.test(process.env.NODE_OPTIONS ?? '')) {
+          taskSession.logger.emitWarning(
+            new Error(
+              `Node.js version ${nodejsMajorVersion} is incompatible with Webpack 4. To work around this problem, use the environment variable NODE_OPTIONS="--openssl-legacy-provider"`
+            )
+          );
+        }
+      }
+    } else {
+      taskSession.logger.emitWarning(new Error(`Unable to parse Node.js version "${process.versions.node}"`));
+    }
+
     this._isServeMode = taskSession.parameters.getFlagParameter(SERVE_PARAMETER_LONG_NAME).value;
     if (!taskSession.parameters.watch && this._isServeMode) {
       throw new Error(

--- a/libraries/rush-lib/assets/rush-init/[dot]gitignore
+++ b/libraries/rush-lib/assets/rush-init/[dot]gitignore
@@ -68,6 +68,8 @@ common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
 **/.rush/temp/
+*.lock
 
 # Heft temporary files
+.cache
 .heft

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "6.7.1",
+  "pnpmVersion": "7.33.5",
 
   /*[LINE "HYPOTHETICAL"]*/ "npmVersion": "6.14.15",
   /*[LINE "HYPOTHETICAL"]*/ "yarnVersion": "1.9.4",

--- a/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -15,7 +15,7 @@ import type { RushConfiguration } from '../api/RushConfiguration';
  * LTS schedule: https://nodejs.org/en/about/releases/
  * LTS versions: https://nodejs.org/en/download/releases/
  */
-const UPCOMING_NODE_LTS_VERSION: number = 18;
+const UPCOMING_NODE_LTS_VERSION: number = 20;
 const nodeVersion: string = process.versions.node;
 const nodeMajorVersion: number = semver.major(nodeVersion);
 

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "7.26.1",
+  "pnpmVersion": "7.33.5",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.15.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.15.0 <19.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current

--- a/rush.json
+++ b/rush.json
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.15.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary


Node 18 has been LTS since 2022-10-25, but our CI pipelines have not been building it because of incompatibility with Webpack 4.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

- `heft-webpack4-plugin` now prints a warning if Node 18 is used without the `NODE_OPTIONS=--openssl-legacy-provider` workaround
- Enable this workaround in our CI pipelines
- Update `NodeJsCompatibility.ts` to specify 18 as the new LTS
- Upgrade rush.json to use PNPM 7.33.5
- I noticed that `autoinstaller.lock` sometimes appears in my Git diff view, so I've added `*.lock` to .gitignore and synced up the `rush init` template


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

- [x] Confirm that CI build passes for this PR

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

@TheLarkInn @iclanton 