### PR TITLE
[rush] Support splitting `rush update` into "update lockfile" and "install from lockfile"

### DIFF
--- a/common/changes/@microsoft/rush/shrinkwrap-only_2023-08-15-01-41.json
+++ b/common/changes/@microsoft/rush/shrinkwrap-only_2023-08-15-01-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add experiment \"usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate\" that, when running `rush update`, performs first a `--lockfile-only` update to the lockfile, then a `--frozen-lockfile` installation.",
+      "comment": "Add experiment \"usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate\" that, when running `rush update`, performs first a `--lockfile-only` update to the lockfile, then a `--frozen-lockfile` installation. This mitigates issues that may arise when using the `afterAllResolved` hook in `.pnpmfile.cjs`.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/shrinkwrap-only_2023-08-15-01-41.json
+++ b/common/changes/@microsoft/rush/shrinkwrap-only_2023-08-15-01-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add experiment \"usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate\" that, when running `rush update`, performs first a `--lockfile-only` update to the lockfile, then a `--frozen-lockfile` installation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -333,6 +333,7 @@ export interface IExperimentsJson {
     phasedCommands?: boolean;
     printEventHooksOutputToConsole?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;
+    usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate?: boolean;
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 }
 

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -18,6 +18,13 @@
   /*[LINE "HYPOTHETICAL"]*/ "usePnpmPreferFrozenLockfileForRushUpdate": true,
 
   /**
+   * By default, 'rush update' runs as a single operation.
+   * Set this option to true to instead update the lockfile with `--lockfile-only`, then perform a `--frozen-lockfile` install.
+   * Necessary when using the `afterAllResolved` hook in .pnpmfile.cjs.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate": true,
+
+  /**
    * If using the 'preventManualShrinkwrapChanges' option, restricts the hash to only include the layout of external dependencies.
    * Used to allow links between workspace projects or the addition/removal of references to existing dependency versions to not
    * cause hash changes.

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -24,6 +24,13 @@ export interface IExperimentsJson {
   usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 
   /**
+   * By default, 'rush update' runs as a single operation.
+   * Set this option to true to instead update the lockfile with `--lockfile-only`, then perform a `--frozen-lockfile` install.
+   * Necessary when using the `afterAllResolved` hook in .pnpmfile.cjs.
+   */
+  usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate?: boolean;
+
+  /**
    * If using the 'preventManualShrinkwrapChanges' option, restricts the hash to only include the layout of external dependencies.
    * Used to allow links between workspace projects or the addition/removal of references to existing dependency versions to not
    * cause hash changes.

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -568,7 +568,7 @@ ${gitLfsHookHandling}
 
       const { configuration: experiments } = this.rushConfiguration.experimentsConfiguration;
 
-      if (experiments.usePnpmFrozenLockfileForRushInstall && !this.options.allowShrinkwrapUpdates) {
+      if (experiments.usePnpmFrozenLockfileForRushInstall && !options.allowShrinkwrapUpdates) {
         args.push('--frozen-lockfile');
       } else if (experiments.usePnpmPreferFrozenLockfileForRushUpdate) {
         // In workspaces, we want to avoid unnecessary lockfile churn
@@ -577,6 +577,10 @@ ${gitLfsHookHandling}
         // Ensure that Rush's tarball dependencies get synchronized properly with the pnpm-lock.yaml file.
         // See this GitHub issue: https://github.com/pnpm/pnpm/issues/1342
         args.push('--no-prefer-frozen-lockfile');
+      }
+
+      if (options.onlyShrinkwrap) {
+        args.push(`--lockfile-only`);
       }
 
       if (options.collectLogFile) {

--- a/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
@@ -40,6 +40,11 @@ export interface IInstallManagerOptions {
   fullUpgrade: boolean;
 
   /**
+   * If set, only update the shrinkwrap file; do not create node_modules.
+   */
+  onlyShrinkwrap?: boolean;
+
+  /**
    * Whether to force an update to the shrinkwrap file even if it appears to be unnecessary.
    * Normally Rush uses heuristics to determine when "pnpm install" can be skipped,
    * but sometimes the heuristics can be inaccurate due to external influences

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -303,53 +303,78 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
     }
 
-    // Run "npm install" in the common folder
-    const installArgs: string[] = ['install'];
-    this.pushConfigurationArgs(installArgs, this.options);
+    const doInstall = (options: IInstallManagerOptions): void => {
+      // Run "npm install" in the common folder
+      const installArgs: string[] = ['install'];
+      this.pushConfigurationArgs(installArgs, options);
 
-    console.log(
-      '\n' +
-        colors.bold(
-          `Running "${this.rushConfiguration.packageManager} install" in` +
-            ` ${this.rushConfiguration.commonTempFolder}`
-        ) +
-        '\n'
-    );
-
-    // If any diagnostic options were specified, then show the full command-line
-    if (this.options.debug || this.options.collectLogFile || this.options.networkConcurrency) {
       console.log(
         '\n' +
-          colors.green('Invoking package manager: ') +
-          FileSystem.getRealPath(packageManagerFilename) +
-          ' ' +
-          installArgs.join(' ') +
+          colors.bold(
+            `Running "${this.rushConfiguration.packageManager} install" in` +
+              ` ${this.rushConfiguration.commonTempFolder}`
+          ) +
           '\n'
       );
-    }
 
-    Utilities.executeCommandWithRetry(
-      {
-        command: packageManagerFilename,
-        args: installArgs,
-        workingDirectory: this.rushConfiguration.commonTempFolder,
-        environment: packageManagerEnv,
-        suppressOutput: false
-      },
-      this.options.maxInstallAttempts,
-      () => {
-        if (this.rushConfiguration.packageManager === 'pnpm') {
-          console.log(colors.yellow(`Deleting the "node_modules" folder`));
-          this.installRecycler.moveFolder(commonNodeModulesFolder);
-
-          // Leave the pnpm-store as is for the retry. This ensures that packages that have already
-          // been downloaded need not be downloaded again, thereby potentially increasing the chances
-          // of a subsequent successful install.
-
-          Utilities.createFolderWithRetry(commonNodeModulesFolder);
-        }
+      // If any diagnostic options were specified, then show the full command-line
+      if (
+        this.options.debug ||
+        this.options.collectLogFile ||
+        this.options.networkConcurrency ||
+        this.options.onlyShrinkwrap
+      ) {
+        console.log(
+          '\n' +
+            colors.green('Invoking package manager: ') +
+            FileSystem.getRealPath(packageManagerFilename) +
+            ' ' +
+            installArgs.join(' ') +
+            '\n'
+        );
       }
-    );
+
+      Utilities.executeCommandWithRetry(
+        {
+          command: packageManagerFilename,
+          args: installArgs,
+          workingDirectory: this.rushConfiguration.commonTempFolder,
+          environment: packageManagerEnv,
+          suppressOutput: false
+        },
+        this.options.maxInstallAttempts,
+        () => {
+          if (this.rushConfiguration.packageManager === 'pnpm') {
+            console.log(colors.yellow(`Deleting the "node_modules" folder`));
+            this.installRecycler.moveFolder(commonNodeModulesFolder);
+
+            // Leave the pnpm-store as is for the retry. This ensures that packages that have already
+            // been downloaded need not be downloaded again, thereby potentially increasing the chances
+            // of a subsequent successful install.
+
+            Utilities.createFolderWithRetry(commonNodeModulesFolder);
+          }
+        }
+      );
+    };
+
+    const { configuration: experiments } = this.rushConfiguration.experimentsConfiguration;
+    if (
+      this.options.allowShrinkwrapUpdates &&
+      experiments.usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate
+    ) {
+      doInstall({
+        ...this.options,
+        onlyShrinkwrap: true
+      });
+
+      doInstall({
+        ...this.options,
+        allowShrinkwrapUpdates: false
+      });
+    } else {
+      doInstall(this.options);
+    }
 
     // If all attempts fail we just terminate. No special handling needed.
 

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -18,6 +18,10 @@
       "description": "By default, 'rush update' passes --no-prefer-frozen-lockfile to 'pnpm install'. Set this option to true to pass '--prefer-frozen-lockfile' instead.",
       "type": "boolean"
     },
+    "usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate": {
+      "description": "By default, 'rush update' runs as a single operation. Set this option to true to instead update the lockfile with `--lockfile-only`, then perform a `--frozen-lockfile` install. Necessary when using the `afterAllResolved` hook in .pnpmfile.cjs.",
+      "type": "boolean"
+    },
     "omitImportersFromPreventManualShrinkwrapChanges": {
       "description": "If using the 'preventManualShrinkwrapChanges' option, only prevent manual changes to the total set of external dependencies referenced by the repository, not which projects reference which dependencies. This offers a balance between lockfile integrity and merge conflicts.",
       "type": "boolean"


### PR DESCRIPTION
## Summary
Adds a new experiment flag "usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate" that causes two separate invocations of `pnpm install` when running `rush update`: the first with `--lockfile-only`, and the second with `--frozen-lockfile`. This is intended to support repositories that leverage the `afterAllResolved` hook in `.pnpmfile.cjs` to alter the shape of the lockfile following dependency resolution.

## Details
Addresses an issue wherein rewriting the lockfile during `afterAllResolved` would result in broken symbolic links.

## How it was tested
Running `rush update` against the local version and validating that `pnpm install` was invoked twice, the first time with `--lockfile-only --prefer-frozen-lockfile` and the second with `--frozen-lockfile`.

## Impacted documentation
Only the experiment flag. Or guidance for when using the `afterAllResolved` hook.