### PR TITLE
[rush] Fix an issue where a pnpm-lock file would fail to parse if a project used a package alias in a repo using pnpm 8.

### DIFF
--- a/common/changes/@microsoft/rush/pnpm8-non-workspace-alias_2023-08-15-08-06.json
+++ b/common/changes/@microsoft/rush/pnpm8-non-workspace-alias_2023-08-15-08-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where a pnpm-lock file would fail to parse if a project used a package alias in a repo using pnpm 8.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -158,12 +158,14 @@ export function parsePnpmDependencyKey(
   // Example: "path.pkgs.visualstudio.com/@scope/depame/1.4.0"  --> 0="@scope/depame" 1="1.4.0"
   // Example: "/isarray/2.0.1"                                  --> 0="isarray"       1="2.0.1"
   // Example: "/sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7"       --> 0="sinon-chai"    1="2.8.0/chai@3.5.0+sinon@1.17.7"
+  // Example: "/typescript@5.1.6"                               --> 0=typescript      1="5.1.6"
   // Example: 1.2.3_peer-dependency@.4.5.6                      --> no match
   // Example: 1.2.3_@scope+peer-dependency@.4.5.6               --> no match
   // Example: 1.2.3(peer-dependency@.4.5.6)                     --> no match
   // Example: 1.2.3(@scope/peer-dependency@.4.5.6)              --> no match
-  const packageNameMatch: RegExpMatchArray | null =
-    /^[^\/]*(?<!\([^\(]*)\/((?:@[^\/]+\/)?[^\/]+)\/(.*)$/.exec(dependencyKey);
+  const packageNameMatch: RegExpMatchArray | null = /^[^\/(]*\/((?:@[^\/(]+\/)?[^\/(]+)[\/@](.*)$/.exec(
+    dependencyKey
+  );
   if (packageNameMatch) {
     parsedPackageName = packageNameMatch[1];
     parsedInstallPath = packageNameMatch[2];

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
@@ -80,7 +80,7 @@ describe(PnpmShrinkwrapFile.name, () => {
       );
     });
 
-    it('Supports aliased package specifiers', () => {
+    it('Supports aliased package specifiers (v5)', () => {
       const parsedSpecifier: DependencySpecifier | undefined = parsePnpmDependencyKey(
         SCOPED_DEPENDENCY_NAME,
         `/${DEPENDENCY_NAME}/${VERSION}`
@@ -88,7 +88,18 @@ describe(PnpmShrinkwrapFile.name, () => {
       expect(parsedSpecifier).toBeDefined();
       expect(parsedSpecifier!.specifierType).toBe(DependencySpecifierType.Alias);
       expect(parsedSpecifier!.packageName).toBe(SCOPED_DEPENDENCY_NAME);
-      expect(parsedSpecifier!.versionSpecifier).toMatchInlineSnapshot(`"npm:dependency_name@1.4.0"`);
+      expect(parsedSpecifier!.versionSpecifier).toMatchInlineSnapshot(`"npm:${DEPENDENCY_NAME}@${VERSION}"`);
+    });
+
+    it('Supports aliased package specifiers (v6)', () => {
+      const parsedSpecifier: DependencySpecifier | undefined = parsePnpmDependencyKey(
+        SCOPED_DEPENDENCY_NAME,
+        `/${DEPENDENCY_NAME}@${VERSION}`
+      );
+      expect(parsedSpecifier).toBeDefined();
+      expect(parsedSpecifier!.specifierType).toBe(DependencySpecifierType.Alias);
+      expect(parsedSpecifier!.packageName).toBe(SCOPED_DEPENDENCY_NAME);
+      expect(parsedSpecifier!.versionSpecifier).toMatchInlineSnapshot(`"npm:${DEPENDENCY_NAME}@${VERSION}"`);
     });
 
     it('Supports URL package specifiers', () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/4274

## Details

There is an issue with the way `parsePnpmDependencyKey` in `PnpmShrinkwrapFile.ts` parses package aliases in repos that don't use workspaces. A partial V6 `pnpm-lock-yaml` file in such a repo looks like this:

```YAML
lockfileVersion: '6.1'

settings:
  autoInstallPeers: true
  excludeLinksFromLockfile: false

dependencies:
  '@_ts/max':
    specifier: npm:typescript@latest
    version: /typescript@5.1.6

packages:
  /typescript@5.1.6:
    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
    engines: {node: '>=14.17'}
    hasBin: true
    dev: false

  file:projects/project3.tgz:
    resolution: {integrity: sha512-JzgaFd56J57GFwjddbjJr1tMBOUZrnjWGEs2OOEfjOG6F2201KOIod7kdBfwOsJf7yHrpEHqx8T7Khm21YsxVg==, tarball: file:projects/project3.tgz}
    name: '@rush-temp/project3'
    version: 0.0.0
    dependencies:
      '@_ts/max': /typescript@5.1.6 # <-- This version line fails to parse
    dev: false

```

This PR adds a test for this case and simplifies the regexp that parses these.

## How it was tested

Tested by running `rush update` and `rush install --purge` on:

- this repo
- https://github.com/iclanton/rush-test-repo
- a large internal repo