### PR TITLE
[rush-serve] Fix back-compat with HTTP/1

### DIFF
--- a/common/changes/@microsoft/rush/rush-serve-http1_2023-08-15-17-50.json
+++ b/common/changes/@microsoft/rush/rush-serve-http1_2023-08-15-17-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix HTTP/1 backwards compatibility in rush-serve-plugin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes an infinite recursion when a connection to the `@rushstack/rush-serve-plugin` was initiated using HTTP/1.

## Details
Updates the implementation of the `_headers` and `_implicitHeader` properties to only be overridden when using HTTP/2.

## How it was tested
Used the updated server and made network requests to it.

## Impacted documentation
None.