### PR TITLE
[terminal] Fix a minor logic issue for TextRewriterTransform cleanup

### DIFF
--- a/common/changes/@rushstack/terminal/octogonz-text-rewriter-transform_2023-08-24-04-44.json
+++ b/common/changes/@rushstack/terminal/octogonz-text-rewriter-transform_2023-08-24-04-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Fix a minor logic issue for TextRewriterTransform cleanup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/libraries/terminal/src/TextRewriterTransform.ts
+++ b/libraries/terminal/src/TextRewriterTransform.ts
@@ -140,7 +140,7 @@ export class TextRewriterTransform extends TerminalTransform {
 
   protected onClose(): void {
     this._closeRewriters(this._stderrStates, TerminalChunkKind.Stderr);
-    this._closeRewriters(this._stderrStates, TerminalChunkKind.Stdout);
+    this._closeRewriters(this._stdoutStates, TerminalChunkKind.Stdout);
 
     this.autocloseDestination();
   }

--- a/libraries/terminal/src/test/TextRewriterTransform.test.ts
+++ b/libraries/terminal/src/test/TextRewriterTransform.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import colors from 'colors';
+
+import { TerminalChunkKind } from '../ITerminalChunk';
+import { MockWritable } from '../MockWritable';
+import { TextRewriterTransform } from '../TextRewriterTransform';
+import { NewlineKind, Text } from '@rushstack/node-core-library';
+
+describe(TextRewriterTransform.name, () => {
+  it('should apply standard rewriters', () => {
+    const mockWritable: MockWritable = new MockWritable();
+    const transform: TextRewriterTransform = new TextRewriterTransform({
+      destination: mockWritable,
+      removeColors: true,
+      ensureNewlineAtEnd: true,
+      normalizeNewlines: NewlineKind.Lf
+    });
+
+    // This color code will be removed
+    transform.writeChunk({ text: colors.red('RED'), kind: TerminalChunkKind.Stderr });
+    // These newlines will be converted to \n
+    transform.writeChunk({ text: 'stderr 1\r\nstderr 2\r\n', kind: TerminalChunkKind.Stderr });
+
+    // The incomplete color code will be passed through
+    // The incomplete line will have \n appended
+    transform.writeChunk({ text: 'stdout 3\r\nstdout 4\x1b[1', kind: TerminalChunkKind.Stdout });
+
+    transform.close();
+
+    expect(
+      mockWritable.chunks.map((x) => ({
+        kind: x.kind,
+        text: Text.replaceAll(x.text, '\n', '[n]')
+      }))
+    ).toMatchSnapshot();
+  });
+});

--- a/libraries/terminal/src/test/__snapshots__/TextRewriterTransform.test.ts.snap
+++ b/libraries/terminal/src/test/__snapshots__/TextRewriterTransform.test.ts.snap
@@ -14,5 +14,9 @@ Array [
     "kind": "O",
     "text": "stdout 3[n]stdout 4",
   },
+  Object {
+    "kind": "O",
+    "text": "[1[n]",
+  },
 ]
 `;

--- a/libraries/terminal/src/test/__snapshots__/TextRewriterTransform.test.ts.snap
+++ b/libraries/terminal/src/test/__snapshots__/TextRewriterTransform.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextRewriterTransform should apply standard rewriters 1`] = `
+Array [
+  Object {
+    "kind": "E",
+    "text": "RED",
+  },
+  Object {
+    "kind": "E",
+    "text": "stderr 1[n]stderr 2[n]",
+  },
+  Object {
+    "kind": "O",
+    "text": "stdout 3[n]stdout 4",
+  },
+]
+`;


### PR DESCRIPTION
## Summary

Fix a typo in the `onClose()` method for `TextRewriterTransform`.

## Details

I noticed this problem while helping to debug PR https://github.com/microsoft/rushstack/pull/3949.

## How it was tested

The code is obviously wrong, but the effect is generally only noticeable in edge cases where the last line is of STDOUT is incomplete.

I added a unit test and confirmed that the edge case is fixed.

@iclanton @chengcyber 