### PR TITLE
[rush] Fix issue where "rush update-autoinstaller" doesn't perform a full upgrade

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-update-autoinstaller-fix_2023-08-29-20-22.json
+++ b/common/changes/@microsoft/rush/octogonz-update-autoinstaller-fix_2023-08-29-20-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"rush update-installer\" sometimes did not fully upgrade the lockfile",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/octogonz-update-autoinstaller-fix_2023-08-29-20-23.json
+++ b/common/changes/@microsoft/rush/octogonz-update-autoinstaller-fix_2023-08-29-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where \"undefined\" was sometimes printed instead of a blank line",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -254,7 +254,7 @@ export class Autoinstaller {
 
   private _logIfConsoleOutputIsNotRestricted(message?: string): void {
     if (!this._restrictConsoleOutput) {
-      console.log(message);
+      console.log(message ?? '');
     }
   }
 }

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -168,7 +168,7 @@ export class Autoinstaller {
 
     const autoinstallerPackageJsonPath: string = path.join(this.folderFullPath, 'package.json');
 
-    if (!FileSystem.exists(autoinstallerPackageJsonPath)) {
+    if (!(await FileSystem.existsAsync(autoinstallerPackageJsonPath))) {
       throw new Error(`The specified autoinstaller path does not exist: ` + autoinstallerPackageJsonPath);
     }
 
@@ -178,10 +178,10 @@ export class Autoinstaller {
 
     let oldFileContents: string = '';
 
-    if (FileSystem.exists(this.shrinkwrapFilePath)) {
+    if (await FileSystem.existsAsync(this.shrinkwrapFilePath)) {
       oldFileContents = FileSystem.readFile(this.shrinkwrapFilePath, { convertLineEndings: NewlineKind.Lf });
       this._logIfConsoleOutputIsNotRestricted('Deleting ' + this.shrinkwrapFilePath);
-      FileSystem.deleteFile(this.shrinkwrapFilePath);
+      await FileSystem.deleteFileAsync(this.shrinkwrapFilePath);
       if (this._rushConfiguration.packageManager === 'pnpm') {
         // Workaround for https://github.com/pnpm/pnpm/issues/1890
         //
@@ -191,7 +191,7 @@ export class Autoinstaller {
         // Deleting both files ensures that a new lockfile will always be generated.
         const pnpmPackageManager: PnpmPackageManager = this._rushConfiguration
           .packageManagerWrapper as PnpmPackageManager;
-        FileSystem.deleteFile(
+        await FileSystem.deleteFileAsync(
           path.join(this.folderFullPath, pnpmPackageManager.internalShrinkwrapRelativePath)
         );
       }
@@ -232,13 +232,13 @@ export class Autoinstaller {
       this._logIfConsoleOutputIsNotRestricted();
     }
 
-    if (!FileSystem.exists(this.shrinkwrapFilePath)) {
+    if (!(await FileSystem.existsAsync(this.shrinkwrapFilePath))) {
       throw new Error(
         'The package manager did not create the expected shrinkwrap file: ' + this.shrinkwrapFilePath
       );
     }
 
-    const newFileContents: string = FileSystem.readFile(this.shrinkwrapFilePath, {
+    const newFileContents: string = await FileSystem.readFileAsync(this.shrinkwrapFilePath, {
       convertLineEndings: NewlineKind.Lf
     });
     if (oldFileContents !== newFileContents) {

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -185,11 +185,10 @@ export class Autoinstaller {
       if (this._rushConfiguration.packageManager === 'pnpm') {
         // Workaround for https://github.com/pnpm/pnpm/issues/1890
         //
-        // When "rush update --full" is run, rush deletes common/temp/pnpm-lock.yaml so that
-        // a new lockfile can be generated. However "pnpm install" by design will try to recover
-        // pnpm-lock.yaml from "common/temp/node_modules/.pnpm-lock.yaml" and thus will not generate
-        // a new lockfile. Deleting this file in addition to deleting common/temp/pnpm-lock.yaml
-        // ensures that a new lockfile will be generated with "rush update --full".
+        // When "rush update-autoinstaller" is run, Rush deletes "common/autoinstallers/my-task/pnpm-lock.yaml"
+        // so that a new lockfile will be generated. However "pnpm install" by design will try to recover
+        // "pnpm-lock.yaml" from "my-task/node_modules/.pnpm/lock.yaml", which may prevent a full upgrade.
+        // Deleting both files ensures that a new lockfile will always be generated.
         const pnpmPackageManager: PnpmPackageManager = this._rushConfiguration
           .packageManagerWrapper as PnpmPackageManager;
         FileSystem.deleteFile(

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -755,11 +755,10 @@ ${gitLfsHookHandling}
       if (this.rushConfiguration.packageManager === 'pnpm') {
         // Workaround for https://github.com/pnpm/pnpm/issues/1890
         //
-        // When "rush update --full" is run, rush deletes common/temp/pnpm-lock.yaml so that
-        // a new lockfile can be generated. However "pnpm install" by design will try to recover
-        // pnpm-lock.yaml from "common/temp/node_modules/.pnpm-lock.yaml" and thus will not generate
-        // a new lockfile. Deleting this file in addition to deleting common/temp/pnpm-lock.yaml
-        // ensures that a new lockfile will be generated with "rush update --full".
+        // When "rush update --full" is run, Rush deletes "common/temp/pnpm-lock.yaml"
+        // so that a new lockfile will be generated. However "pnpm install" by design will try to recover
+        // "pnpm-lock.yaml" from "common/temp/node_modules/.pnpm/lock.yaml", which may prevent a full upgrade.
+        // Deleting both files ensures that a new lockfile will always be generated.
         const pnpmPackageManager: PnpmPackageManager = this.rushConfiguration
           .packageManagerWrapper as PnpmPackageManager;
 

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -756,11 +756,10 @@ ${gitLfsHookHandling}
         // Workaround for https://github.com/pnpm/pnpm/issues/1890
         //
         // When "rush update --full" is run, rush deletes common/temp/pnpm-lock.yaml so that
-        // a new lockfile can be generated. But because of the above bug "pnpm install" would
-        // respect "common/temp/node_modules/.pnpm-lock.yaml" and thus would not generate a
-        // new lockfile. Deleting this file in addition to deleting common/temp/pnpm-lock.yaml
+        // a new lockfile can be generated. However "pnpm install" by design will try to recover
+        // pnpm-lock.yaml from "common/temp/node_modules/.pnpm-lock.yaml" and thus will not generate
+        // a new lockfile. Deleting this file in addition to deleting common/temp/pnpm-lock.yaml
         // ensures that a new lockfile will be generated with "rush update --full".
-
         const pnpmPackageManager: PnpmPackageManager = this.rushConfiguration
           .packageManagerWrapper as PnpmPackageManager;
 


### PR DESCRIPTION
## Summary

While trying to resolve https://github.com/microsoft/rushstack-websites/pull/193, I encountered a problem where `rush update-autoinstaller` was not performing a full upgrade, because it does not implement `rush install`'s workaround for https://github.com/pnpm/pnpm/issues/1890.

## Details

`rush update-autoinstaller`  tries to force a clean reinstall by deleting `pnpm-lock.yaml`, but PNPM has an unusual behavior where it tries to recover the deleted file using a backup copy from the `node_modules` folder. (Other package managers don't do that, but [the issue notes ](https://github.com/pnpm/pnpm/issues/1890) explains an obscure use case that justifies it.)  Rush works around this problem by deleting the backup file as well, but `rush update-autoinstaller` is missing that logic.

I also fixed a minor regression from PR #3391 where `_logIfConsoleOutputIsNotRestricted()` was printing `undefined` instead of a blank line.

## How it was tested

How I reproed the issue:

1. Clone https://github.com/microsoft/rushstack-websites/commit/516e8304c95827771df8230dcce19704ed32c3c8
2. Invoke `rush prettier` to install the `rush-prettier` autoinstaller
3. Then invoke `rush update-autoinstaller --name rush-prettier`.  The lockfile version number is incremented, but no dependencies are upgraded.  (Whereas if we skipped step 2, then a full upgrade would be performed.)

Redoing step 3 with my PR build, the upgrade is performed successfully.

## Impacted documentation

None.
