### PR TITLE
[rush] Support "disableBuildCache" option in phased command schema

### DIFF
--- a/common/changes/@microsoft/rush/run-before-install_2023-09-01-20-06.json
+++ b/common/changes/@microsoft/rush/run-before-install_2023-09-01-20-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add the \"disableBuildCache\" option to the schema for phased commands (it is already present for bulk commands). Update the behavior of the \"disableBuildCache\" flag to also disable the legacy skip detection, in the event that the build cache is not configured.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -259,7 +259,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
 
     if (!this._runsBeforeInstall) {
-      // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are deprecated
+      // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are removed
       const lastLinkFlag: LastLinkFlag = LastLinkFlagFactory.getCommonTempFlag(this.rushConfiguration);
       if (!lastLinkFlag.isValid()) {
         const useWorkspaces: boolean =

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -103,6 +103,10 @@ interface IPhasedCommandTelemetry {
  * "build" script for each project.
  */
 export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
+  /**
+   * @internal
+   */
+  public _runsBeforeInstall: boolean | undefined;
   public readonly hooks: PhasedCommandHooks;
 
   private readonly _enableParallelism: boolean;
@@ -137,6 +141,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     this._watchDebounceMs = options.watchDebounceMs ?? RushConstants.defaultWatchDebounceMs;
     this._alwaysWatch = options.alwaysWatch;
     this._alwaysInstall = options.alwaysInstall;
+    this._runsBeforeInstall = false;
     this._knownPhases = options.phases;
 
     this.hooks = new PhasedCommandHooks();
@@ -253,15 +258,17 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       });
     }
 
-    // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are deprecated
-    const lastLinkFlag: LastLinkFlag = LastLinkFlagFactory.getCommonTempFlag(this.rushConfiguration);
-    if (!lastLinkFlag.isValid()) {
-      const useWorkspaces: boolean =
-        this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
-      if (useWorkspaces) {
-        throw new Error('Link flag invalid.\nDid you run "rush install" or "rush update"?');
-      } else {
-        throw new Error('Link flag invalid.\nDid you run "rush link"?');
+    if (!this._runsBeforeInstall) {
+      // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are deprecated
+      const lastLinkFlag: LastLinkFlag = LastLinkFlagFactory.getCommonTempFlag(this.rushConfiguration);
+      if (!lastLinkFlag.isValid()) {
+        const useWorkspaces: boolean =
+          this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
+        if (useWorkspaces) {
+          throw new Error('Link flag invalid.\nDid you run "rush install" or "rush update"?');
+        } else {
+          throw new Error('Link flag invalid.\nDid you run "rush link"?');
+        }
       }
     }
 
@@ -350,7 +357,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           cobuildConfiguration,
           terminal
         }).apply(this.hooks);
-      } else {
+      } else if (!this._disableBuildCache) {
+        // Explicitly disabling the build cache also disables legacy skip detection.
         new LegacySkipPlugin({
           terminal,
           changedProjectsOnly,
@@ -358,12 +366,14 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         }).apply(this.hooks);
       }
 
-      const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> =
-        await RushProjectConfiguration.tryLoadAndValidateForProjectsAsync(
-          projectSelection,
-          this._initialPhases,
-          terminal
-        );
+      const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this
+        ._runsBeforeInstall
+        ? new Map()
+        : await RushProjectConfiguration.tryLoadAndValidateForProjectsAsync(
+            projectSelection,
+            this._initialPhases,
+            terminal
+          );
 
       const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
       const initialCreateOperationsContext: ICreateOperationsContext = {

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -93,7 +93,7 @@
             },
             "disableBuildCache": {
               "title": "Disable build cache.",
-              "description": "Disable build cache for this action. This may be useful if this command affects state outside of projects' own folders.",
+              "description": "Disable build cache for this action. This may be useful if this command affects state outside of projects' own folders. If the build cache is not configured, this also disables the legacy skip detection logic.",
               "type": "boolean"
             }
           }
@@ -193,6 +193,11 @@
               "items": {
                 "type": "string"
               }
+            },
+            "disableBuildCache": {
+              "title": "Disable build cache.",
+              "description": "Disable build cache for this action. This may be useful if this command affects state outside of projects' own folders. If the build cache is not configured, this also disables the legacy skip detection logic.",
+              "type": "boolean"
             },
             "watchOptions": {
               "title": "Watch Options",


### PR DESCRIPTION
## Summary
Adds the `disableBuildCache` option to the schema for phased commands (it is already present for bulk commands). Setting this flag opts out of both the build cache and the legacy skip logic.

## Details
Also adds an internal property `_runsBeforeInstall` on `PhasedScriptAction`. Intended use case is for, e.g., #4229

## How it was tested
Temporarily set up a custom command with the flag enabled and disabled and stepped through in the debugger to validate the code paths.

## Impacted documentation
Docs for `command-line.json` for phased commands.

@chengcyber 