### PR TITLE
[heft-webpack4-plugin] Add an option to heft-webpack4-plugin to replace md4 hashes with md5.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
         with:
           node-version: ${{ matrix.NodeVersion }}
 
-      # Workaround for Node 18 incompatibility with Webpack 4
-      - name: Enable Webpack 4 workaround
-        shell: bash
-        run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> "$GITHUB_ENV"
-        if: matrix.NodeVersion == 18
-
       - name: Verify Change Logs
         run: node common/scripts/install-run-rush.js change --verify
 
@@ -67,9 +61,3 @@ jobs:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
-
-      # One of the post run actions apparently uses older Node.js that rejects --openssl-legacy-provider
-      - name: Revert Webpack 4 workaround
-        shell: bash
-        run: echo "NODE_OPTIONS=" >> "$GITHUB_ENV"
-        if: matrix.NodeVersion == 18

--- a/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/config/heft.json
@@ -24,7 +24,10 @@
         "webpack": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-webpack4-plugin"
+            "pluginPackage": "@rushstack/heft-webpack4-plugin",
+            "options": {
+              "patchMd4WithMd5Hash": true
+            }
           }
         },
         "storybook": {

--- a/build-tests/hashed-folder-copy-plugin-webpack4-test/config/heft.json
+++ b/build-tests/hashed-folder-copy-plugin-webpack4-test/config/heft.json
@@ -26,7 +26,10 @@
         "webpack4": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-webpack4-plugin"
+            "pluginPackage": "@rushstack/heft-webpack4-plugin",
+            "options": {
+              "patchMd4WithMd5Hash": true
+            }
           }
         }
       }

--- a/build-tests/heft-sass-test/config/heft.json
+++ b/build-tests/heft-sass-test/config/heft.json
@@ -24,7 +24,10 @@
         "webpack": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-webpack4-plugin"
+            "pluginPackage": "@rushstack/heft-webpack4-plugin",
+            "options": {
+              "patchMd4WithMd5Hash": true
+            }
           }
         },
         "lint": {

--- a/build-tests/heft-webpack4-everything-test/config/heft.json
+++ b/build-tests/heft-webpack4-everything-test/config/heft.json
@@ -24,7 +24,10 @@
         "webpack": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-webpack4-plugin"
+            "pluginPackage": "@rushstack/heft-webpack4-plugin",
+            "options": {
+              "patchMd4WithMd5Hash": true
+            }
           }
         }
       }

--- a/build-tests/set-webpack-public-path-plugin-webpack4-test/config/heft.json
+++ b/build-tests/set-webpack-public-path-plugin-webpack4-test/config/heft.json
@@ -24,7 +24,10 @@
         "webpack": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {
-            "pluginPackage": "@rushstack/heft-webpack4-plugin"
+            "pluginPackage": "@rushstack/heft-webpack4-plugin",
+            "options": {
+              "patchMd4WithMd5Hash": true
+            }
           }
         }
       }

--- a/common/changes/@rushstack/heft-webpack4-plugin/webpack4-compat-patch_2023-09-05-23-55.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/webpack4-compat-patch_2023-09-05-23-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Add a `patchMd4WithMd5Hash` option that monkey-patches Webpack to use md5 instead of md4.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack4-plugin"
+}

--- a/common/reviews/api/heft-webpack4-plugin.api.md
+++ b/common/reviews/api/heft-webpack4-plugin.api.md
@@ -12,6 +12,14 @@ import type { HeftConfiguration } from '@rushstack/heft';
 import type { IHeftTaskSession } from '@rushstack/heft';
 import type * as TWebpack from 'webpack';
 
+// @beta (undocumented)
+export interface IWarningErrorEmitter {
+    // (undocumented)
+    emitError: (error: Error) => void;
+    // (undocumented)
+    emitWarning: (warning: Error) => void;
+}
+
 // @public (undocumented)
 export type IWebpackConfiguration = IWebpackConfigurationWithDevServer | IWebpackConfigurationWithDevServer[];
 
@@ -48,6 +56,9 @@ export interface IWebpackPluginAccessorHooks {
 export interface IWebpackPluginAccessorParameters {
     readonly isServeMode: boolean;
 }
+
+// @beta (undocumented)
+export function loadWebpackAsync(logger: IWarningErrorEmitter, patchMd4WithMd5Hash: boolean | undefined): Promise<typeof TWebpack>;
 
 // @public (undocumented)
 export const PluginName: 'webpack4-plugin';

--- a/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/Webpack4Plugin.ts
@@ -131,6 +131,12 @@ export default class Webpack4Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
     requestRun?: () => void
   ): Promise<IWebpackConfiguration | undefined> {
     if (this._webpackConfiguration === false) {
+      if (options.patchMd4WithMd5Hash) {
+        // Ensure webpack is patched before we try to load the webpack config in case the config
+        // also loads webpack
+        await loadWebpackAsync(taskSession.logger, options.patchMd4WithMd5Hash);
+      }
+
       const webpackConfiguration: IWebpackConfiguration | undefined = await tryLoadWebpackConfigurationAsync(
         {
           taskSession,

--- a/heft-plugins/heft-webpack4-plugin/src/index.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 export { PLUGIN_NAME as PluginName, STAGE_LOAD_LOCAL_CONFIG } from './shared';
+export { loadWebpackAsync, type IWarningErrorEmitter } from './webpackPackageUtilities';
 
 export type {
   IWebpackConfigurationWithDevServer,

--- a/heft-plugins/heft-webpack4-plugin/src/schemas/heft-webpack4-plugin.schema.json
+++ b/heft-plugins/heft-webpack4-plugin/src/schemas/heft-webpack4-plugin.schema.json
@@ -20,6 +20,11 @@
     "configurationPath": {
       "description": "Specifies a relative path to the Webpack configuration. The default value is \"./webpack.config.js\".",
       "type": "string"
+    },
+
+    "patchMd4WithMd5Hash": {
+      "description": "Specifies whether to patch the md4 hash with the md5 hash. This is useful to support Node version >= 18 without setting the `--openssl-legacy-provider` env variable. The default value is false.",
+      "type": "boolean"
     }
   }
 }

--- a/heft-plugins/heft-webpack4-plugin/src/webpackPackageUtilities.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/webpackPackageUtilities.ts
@@ -74,10 +74,9 @@ async function _patchWebpackCreateHashModule(logger: IWarningErrorEmitter): Prom
 
   type HashFunction = (algorithm?: string | (new () => import('crypto').Hash)) => import('crypto').Hash;
   const webpackCreateHashModule: HashFunction | { default: HashFunction } = await import(createHashFullPath);
-  const webpackCreateHashFunction: HashFunction = (webpackCreateHashModule as { default: HashFunction })
-    .default
-    ? (webpackCreateHashModule as { default: HashFunction }).default
-    : (webpackCreateHashModule as HashFunction);
+  const webpackCreateHashFunction: HashFunction =
+    (webpackCreateHashModule as { default: HashFunction }).default ??
+    (webpackCreateHashModule as HashFunction);
 
   const patchedWebpackCreateHash: typeof webpackCreateHashModule = (algorithm) =>
     webpackCreateHashFunction(algorithm === 'md4' ? 'md5' : algorithm);

--- a/heft-plugins/heft-webpack4-plugin/src/webpackPackageUtilities.ts
+++ b/heft-plugins/heft-webpack4-plugin/src/webpackPackageUtilities.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type * as TWebpack from 'webpack';
+import type { IScopedLogger } from '@rushstack/heft';
+import { FileSystem, Import } from '@rushstack/node-core-library';
+import { PATCH_MD4_WITH_MD5_HASH_OPTION_NAME, WEBPACK_PACKAGE_NAME } from './Webpack4Plugin';
+import path from 'path';
+
+let _loadWebpackAsyncPromise: Promise<typeof TWebpack> | undefined;
+
+export async function loadWebpackAsync(
+  logger: IScopedLogger,
+  patchMd4WithMd5Hash: boolean | undefined
+): Promise<typeof TWebpack> {
+  if (!_loadWebpackAsyncPromise) {
+    _loadWebpackAsyncPromise = _loadWebpackAsyncInner(logger, patchMd4WithMd5Hash);
+  }
+
+  return await _loadWebpackAsyncPromise;
+}
+
+async function _loadWebpackAsyncInner(
+  logger: IScopedLogger,
+  patchMd4WithMd5Hash: boolean | undefined
+): Promise<typeof TWebpack> {
+  // Allow this to fail if webpack is not installed
+  if (patchMd4WithMd5Hash) {
+    await _patchWebpackCreateHashModule(logger);
+    await _patchWebpackModuleAsync('lib/optimize/SplitChunksPlugin', logger, (existingCode) =>
+      existingCode.replace(/\.createHash\(['"]md4['"]\)/g, '.createHash("md5")')
+    );
+  }
+
+  return await import(WEBPACK_PACKAGE_NAME);
+}
+
+interface IWebpackModule {
+  default: unknown;
+}
+
+async function _patchWebpackCreateHashModule(logger: IScopedLogger): Promise<void> {
+  const createHashFullPath: string = await Import.resolveModuleAsync({
+    modulePath: `${WEBPACK_PACKAGE_NAME}/lib/util/createHash`,
+    baseFolderPath: __dirname
+  });
+
+  if (createHashFullPath in require.cache) {
+    logger.emitWarning(
+      new Error(
+        `The ${createHashFullPath} module is already loaded and the ` +
+          `${PATCH_MD4_WITH_MD5_HASH_OPTION_NAME} option was set. Webpack may not be patched correctly.`
+      )
+    );
+  }
+
+  type HashFunction = (algorithm?: string | (new () => import('crypto').Hash)) => import('crypto').Hash;
+  const webpackCreateHashModule: HashFunction | { default: HashFunction } = await import(createHashFullPath);
+  const webpackCreateHashFunction: HashFunction = (webpackCreateHashModule as { default: HashFunction })
+    .default
+    ? (webpackCreateHashModule as { default: HashFunction }).default
+    : (webpackCreateHashModule as HashFunction);
+
+  const patchedWebpackCreateHash: typeof webpackCreateHashModule = (algorithm) =>
+    webpackCreateHashFunction(algorithm === 'md4' ? 'md5' : algorithm);
+  (patchedWebpackCreateHash as unknown as { default: typeof webpackCreateHashModule }).default =
+    patchedWebpackCreateHash;
+
+  require.cache[createHashFullPath]!.exports = patchedWebpackCreateHash;
+}
+
+async function _patchWebpackModuleAsync(
+  webpackPackageRelativeModulePath: string,
+  logger: IScopedLogger,
+  patchFn: (existingCode: string) => string
+): Promise<void> {
+  // TODO: Consider deduplicating this with the code in heft-jest-plugin/patches/jestWorkerPatch.ts
+  try {
+    const modulePath: string = await Import.resolveModuleAsync({
+      modulePath: `${WEBPACK_PACKAGE_NAME}/${webpackPackageRelativeModulePath}`,
+      baseFolderPath: __dirname
+    });
+
+    if (modulePath in require.cache) {
+      logger.emitError(
+        new Error(`The ${modulePath} module is already loaded and may not be patched successfully.`)
+      );
+    }
+
+    const normalizedModulePathFilename: string = path.basename(modulePath).toUpperCase();
+
+    // Load the module
+    await import(modulePath);
+
+    // Obtain the metadata for the module
+    let webpackModuleMetadata: NodeModule | undefined = undefined;
+    for (const childModule of module.children) {
+      if (path.basename(childModule.filename || '').toUpperCase() === normalizedModulePathFilename) {
+        if (webpackModuleMetadata) {
+          throw new Error('More than one child module matched while detecting Node.js module metadata');
+        }
+        webpackModuleMetadata = childModule;
+      }
+    }
+
+    if (!webpackModuleMetadata) {
+      throw new Error(`Failed to detect the Node.js module metadata for ${modulePath}`);
+    }
+
+    // Load the original file contents
+    const originalFileContent: string = await FileSystem.readFileAsync(modulePath);
+
+    const patchedFileContent: string = patchFn(originalFileContent);
+    // Add boilerplate so that eval() will return the exports
+    const patchedCode: string =
+      '// PATCHED BY HEFT USING eval()\n\nmodule.exports = {}\nexports = module.exports;' +
+      patchedFileContent +
+      '\n// return value:\nmodule.exports';
+
+    function evalInContext(): IWebpackModule {
+      // Remap the require() function for the eval() context
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      function require<TResult>(modulePath: string): TResult {
+        return webpackModuleMetadata!.require(modulePath);
+      }
+
+      // eslint-disable-next-line no-eval
+      return eval(patchedCode);
+    }
+
+    const patchedModule: IWebpackModule = evalInContext();
+
+    // eslint-disable-next-line require-atomic-updates
+    webpackModuleMetadata.exports = patchedModule;
+  } catch (e) {
+    logger.emitError(
+      new Error(
+        `Failed to patch the "${webpackPackageRelativeModulePath}" module from the "${WEBPACK_PACKAGE_NAME}" package: ${e}`
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds an option called `patchMd4WithMd5Hash` to `@rushstack/heft-webpack4-plugin` that patches Webpack to replace MD4 hashes with MD5.

## Details

This specifically performs these patches in-memory when Webpack is loaded by the plugin:
- wraps the [`createHash`](https://github.com/webpack/webpack/blob/webpack-4/lib/util/createHash.js#L126-L137) function with a function that conditionally replaces the argument's value with `"md5"` if `"md4"` was passed in
- Replaces `crypto.createHash("md4")` with `crypto.createHash("md5")` in [`SplitChunksPlugin`](https://github.com/webpack/webpack/blob/webpack-4/lib/optimize/SplitChunksPlugin.js#L25C21-L25C21).

## How it was tested

Tested in a large internal repo that uses Webpack 4 under Node 18 and by removing the `--openssl-legacy-provider=true` env var workaround in this repo.