### PR TITLE
[rushx-command-line] Add telemetry to rushx

### DIFF
--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -230,7 +230,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private async _wrapOnExecuteAsync(): Promise<void> {
     if (this.rushConfiguration) {
-      this.telemetry = new Telemetry(this.rushConfiguration, this.rushSession);
+      this.telemetry = new Telemetry('rush', this.rushConfiguration, this.rushSession.hooks.flushTelemetry);
     }
 
     await super.onExecute();

--- a/libraries/rush-lib/src/logic/test/Telemetry.test.ts
+++ b/libraries/rush-lib/src/logic/test/Telemetry.test.ts
@@ -32,7 +32,7 @@ describe(Telemetry.name, () => {
       terminalProvider: new ConsoleTerminalProvider(),
       getIsDebugMode: () => false
     });
-    const telemetry: Telemetry = new Telemetry(rushConfig, rushSession);
+    const telemetry: Telemetry = new Telemetry('test', rushConfig, rushSession.hooks.flushTelemetry);
     const logData1: ITelemetryData = {
       name: 'testData1',
       durationInSeconds: 100,
@@ -65,7 +65,7 @@ describe(Telemetry.name, () => {
       terminalProvider: new ConsoleTerminalProvider(),
       getIsDebugMode: () => false
     });
-    const telemetry: Telemetry = new Telemetry(rushConfig, rushSession);
+    const telemetry: Telemetry = new Telemetry('test', rushConfig, rushSession.hooks.flushTelemetry);
     const logData: ITelemetryData = {
       name: 'testData',
       durationInSeconds: 100,
@@ -86,7 +86,7 @@ describe(Telemetry.name, () => {
       terminalProvider: new ConsoleTerminalProvider(),
       getIsDebugMode: () => false
     });
-    const telemetry: Telemetry = new Telemetry(rushConfig, rushSession);
+    const telemetry: Telemetry = new Telemetry('test', rushConfig, rushSession.hooks.flushTelemetry);
     const logData: ITelemetryData = {
       name: 'testData1',
       durationInSeconds: 100,
@@ -115,7 +115,7 @@ describe(Telemetry.name, () => {
       terminalProvider: new ConsoleTerminalProvider(),
       getIsDebugMode: () => false
     });
-    const telemetry: Telemetry = new Telemetry(rushConfig, rushSession);
+    const telemetry: Telemetry = new Telemetry('test', rushConfig, rushSession.hooks.flushTelemetry);
     const logData: ITelemetryData = {
       name: 'testData1',
       durationInSeconds: 100,
@@ -139,8 +139,9 @@ describe(Telemetry.name, () => {
     const customFlushTelemetry: jest.Mock = jest.fn();
     rushSession.hooks.flushTelemetry.tap('test', customFlushTelemetry);
     const telemetry: ITelemetryPrivateMembers = new Telemetry(
+      'test',
       rushConfig,
-      rushSession
+      rushSession.hooks.flushTelemetry
     ) as unknown as ITelemetryPrivateMembers;
     const logData: ITelemetryData = {
       name: 'testData1',
@@ -169,8 +170,9 @@ describe(Telemetry.name, () => {
     const customFlushTelemetry: jest.Mock = jest.fn();
     rushSession.hooks.flushTelemetry.tap('test', customFlushTelemetry);
     const telemetry: ITelemetryPrivateMembers = new Telemetry(
+      'test',
       rushConfig,
-      rushSession
+      rushSession.hooks.flushTelemetry
     ) as unknown as ITelemetryPrivateMembers;
     const logData: ITelemetryData = {
       name: 'testData1',


### PR DESCRIPTION
## Summary

Reuse the telemetry code in rush to record telemetry for rush x

## Details

Changes:
* Added telemetry initialization and logging to rushx
* Refactored telemetry to take a hook instead of a rush session to prevent code creep from rush to rushx
* Refactored telemetry to allow an undefined hook (rushx does not support this hook)
* Refactored telemetry to take an executable name to distinquish telemetry output by file name. (This is a breaking change for downstream implementations that depend on the file name having a particular structure.  This seems like a safer change than added an exeName property to the data because that can be missed and cause data processing errors by including the wrong files)

## How it was tested

* Invoked `rushx build` and `rush update` to verify that in both cases, the correct filename is written with correct data.
* Invoked `rushx not_exist` and verified correct error data was logged in the telemetry output 

## Impacted documentation

* https://rushjs.io/pages/advanced/rush_files_and_folders/


