### PR TITLE
[rush] Fix an issue where the error message printed when two phases defined in `rush-project.json` have overlapping output folders didn't include the second phase's name.

### DIFF
--- a/common/changes/@microsoft/rush/fix-error-message_2023-09-07-21-37.json
+++ b/common/changes/@microsoft/rush/fix-error-message_2023-09-07-21-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the error message printed when two phases have overlapping output folders did not mention both phases.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -251,10 +251,11 @@ export class RushProjectConfiguration {
       if (operationSettings) {
         if (operationSettings.outputFolderNames) {
           for (const outputFolderName of operationSettings.outputFolderNames) {
-            const overlappingOperationNames: string[] | undefined =
+            const otherOverlappingOperationNames: string[] | undefined =
               overlappingPathAnalyzer.addPathAndGetFirstEncounteredLabels(outputFolderName, operationName);
-            if (overlappingOperationNames) {
-              const overlapsWithOwnOperation: boolean = overlappingOperationNames?.includes(operationName);
+            if (otherOverlappingOperationNames) {
+              const overlapsWithOwnOperation: boolean =
+                otherOverlappingOperationNames?.includes(operationName);
               if (overlapsWithOwnOperation) {
                 terminal.writeErrorLine(
                   `The project "${project.packageName}" has a ` +
@@ -267,10 +268,9 @@ export class RushProjectConfiguration {
                   `The project "${project.packageName}" has a ` +
                     `"${RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath}" configuration that defines ` +
                     'two operations in the same command whose "outputFolderNames" would overlap. ' +
-                    'Operations outputs in the same command must be disjoint so that they can be independently cached.' +
-                    `\n\n` +
+                    'Operations outputs in the same command must be disjoint so that they can be independently cached. ' +
                     `The "${outputFolderName}" path overlaps between these operations: ` +
-                    overlappingOperationNames.map((operationName) => `"${operationName}"`).join(', ')
+                    `"${operationName}", "${otherOverlappingOperationNames.join('", "')}"`
                 );
               }
 

--- a/libraries/rush-lib/src/api/test/__snapshots__/RushProjectConfiguration.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/RushProjectConfiguration.test.ts.snap
@@ -34,7 +34,7 @@ exports[`RushProjectConfiguration operationSettingsByOperationName allows output
 
 exports[`RushProjectConfiguration operationSettingsByOperationName allows outputFolderNames to be inside subfolders: validation: terminal warning 1`] = `""`;
 
-exports[`RushProjectConfiguration operationSettingsByOperationName does not allow one outputFolderName to be under another: validation: terminal error 1`] = `"The project \\"test-project-d\\" has a \\"config/rush-project.json\\" configuration that defines two operations in the same command whose \\"outputFolderNames\\" would overlap. Operations outputs in the same command must be disjoint so that they can be independently cached.[n][n]The \\"a/b\\" path overlaps between these operations: \\"_phase:a\\"[n]"`;
+exports[`RushProjectConfiguration operationSettingsByOperationName does not allow one outputFolderName to be under another: validation: terminal error 1`] = `"The project \\"test-project-d\\" has a \\"config/rush-project.json\\" configuration that defines two operations in the same command whose \\"outputFolderNames\\" would overlap. Operations outputs in the same command must be disjoint so that they can be independently cached. The \\"a/b\\" path overlaps between these operations: \\"_phase:b\\", \\"_phase:a\\"[n]"`;
 
 exports[`RushProjectConfiguration operationSettingsByOperationName does not allow one outputFolderName to be under another: validation: terminal output 1`] = `""`;
 


### PR DESCRIPTION
## Summary

Fixes the error message printed when two phases defined in `rush-project.json` have overlapping output folders didn't include the second phase's name.

## How it was tested

Covered by unit test.