### PR TITLE
[rush] Allow overlapping phase outputs if both phases won't be executed by the project.

### DIFF
--- a/common/changes/@microsoft/rush/overlapping-unused-phases_2023-09-07-23-43.json
+++ b/common/changes/@microsoft/rush/overlapping-unused-phases_2023-09-07-23-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the phase output folders validation to only check for overlapping folders for phases that actually execute an operation in a given project.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -521,6 +521,7 @@ export interface IOperationRunner {
     cacheable: boolean;
     executeAsync(context: IOperationRunnerContext): Promise<OperationStatus>;
     getConfigHash(): string;
+    readonly isNoOp?: boolean;
     readonly name: string;
     reportTiming: boolean;
     silent: boolean;
@@ -1198,8 +1199,8 @@ export class RushProjectConfiguration {
     readonly operationSettingsByOperationName: ReadonlyMap<string, Readonly<IOperationSettings>>;
     // (undocumented)
     readonly project: RushConfigurationProject;
-    static tryLoadAndValidateForProjectsAsync(projects: Iterable<RushConfigurationProject>, phases: ReadonlySet<IPhase>, terminal: ITerminal): Promise<ReadonlyMap<RushConfigurationProject, RushProjectConfiguration>>;
     static tryLoadForProjectAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<RushProjectConfiguration | undefined>;
+    static tryLoadForProjectsAsync(projects: Iterable<RushConfigurationProject>, terminal: ITerminal): Promise<ReadonlyMap<RushConfigurationProject, RushProjectConfiguration>>;
     static tryLoadIgnoreGlobsForProjectAsync(project: RushConfigurationProject, terminal: ITerminal): Promise<ReadonlyArray<string> | undefined>;
     validatePhaseConfiguration(phases: Iterable<IPhase>, terminal: ITerminal): void;
 }

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -392,21 +392,23 @@ export class RushProjectConfiguration {
    * Load the rush-project.json data for all selected projects.
    * Validate compatibility of output folders across all selected phases.
    */
-  public static async tryLoadAndValidateForProjectsAsync(
+  public static async tryLoadForProjectsAsync(
     projects: Iterable<RushConfigurationProject>,
-    phases: ReadonlySet<IPhase>,
     terminal: ITerminal
   ): Promise<ReadonlyMap<RushConfigurationProject, RushProjectConfiguration>> {
     const result: Map<RushConfigurationProject, RushProjectConfiguration> = new Map();
 
-    await Async.forEachAsync(projects, async (project: RushConfigurationProject) => {
-      const projectConfig: RushProjectConfiguration | undefined =
-        await RushProjectConfiguration.tryLoadForProjectAsync(project, terminal);
-      if (projectConfig) {
-        projectConfig.validatePhaseConfiguration(phases, terminal);
-        result.set(project, projectConfig);
-      }
-    });
+    await Async.forEachAsync(
+      projects,
+      async (project: RushConfigurationProject) => {
+        const projectConfig: RushProjectConfiguration | undefined =
+          await RushProjectConfiguration.tryLoadForProjectAsync(project, terminal);
+        if (projectConfig) {
+          result.set(project, projectConfig);
+        }
+      },
+      { concurrency: 50 }
+    );
 
     return result;
   }

--- a/libraries/rush-lib/src/api/test/RushProjectConfiguration.test.ts
+++ b/libraries/rush-lib/src/api/test/RushProjectConfiguration.test.ts
@@ -77,14 +77,9 @@ describe(RushProjectConfiguration.name, () => {
     });
 
     it('throws an error when loading a rush-project.json config that lists an operation twice', async () => {
-      let errorMessage: string | undefined;
-      try {
-        await loadProjectConfigurationAsync('test-project-b');
-      } catch (e) {
-        errorMessage = (e as Error).message;
-      }
-
-      expect(errorMessage).toMatchSnapshot();
+      await expect(
+        async () => await loadProjectConfigurationAsync('test-project-b')
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it('allows outputFolderNames to be inside subfolders', async () => {
@@ -99,14 +94,7 @@ describe(RushProjectConfiguration.name, () => {
       const rushProjectConfiguration: RushProjectConfiguration | undefined =
         await loadProjectConfigurationAsync('test-project-d');
 
-      let errorWasThrown: boolean = false;
-      try {
-        validateConfiguration(rushProjectConfiguration);
-      } catch (e) {
-        errorWasThrown = true;
-      }
-
-      expect(errorWasThrown).toBe(true);
+      expect(() => validateConfiguration(rushProjectConfiguration)).toThrowError();
     });
   });
 
@@ -166,7 +154,7 @@ describe(RushProjectConfiguration.name, () => {
       expect(reason).toMatchSnapshot();
     });
 
-    it('returns undfined if the config is safe', async () => {
+    it('returns undefined if the config is safe', async () => {
       const config: RushProjectConfiguration | undefined = await loadProjectConfigurationAsync(
         'test-project-c'
       );

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -42,6 +42,7 @@ import { CobuildConfiguration } from '../../api/CobuildConfiguration';
 import { CacheableOperationPlugin } from '../../logic/operations/CacheableOperationPlugin';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { LegacySkipPlugin } from '../../logic/operations/LegacySkipPlugin';
+import { ValidateOperationsPlugin } from '../../logic/operations/ValidateOperationsPlugin';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -153,6 +154,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     new PhasedOperationPlugin().apply(this.hooks);
     // Applies the Shell Operation Runner to selected operations
     new ShellOperationRunnerPlugin().apply(this.hooks);
+    new ValidateOperationsPlugin(terminal).apply(this.hooks);
 
     if (this._enableParallelism) {
       this._parallelismParameter = this.defineStringParameter({
@@ -369,11 +371,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this
         ._runsBeforeInstall
         ? new Map()
-        : await RushProjectConfiguration.tryLoadAndValidateForProjectsAsync(
-            projectSelection,
-            this._initialPhases,
-            terminal
-          );
+        : await RushProjectConfiguration.tryLoadForProjectsAsync(projectSelection, terminal);
 
       const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
       const initialCreateOperationsContext: ICreateOperationsContext = {

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -98,6 +98,12 @@ export interface IOperationRunner {
   warningsAreAllowed: boolean;
 
   /**
+   * If set to true, this operation is considered a no-op and can be considered always skipped for
+   * analysis purposes.
+   */
+  readonly isNoOp?: boolean;
+
+  /**
    * Method to be executed for the operation.
    */
   executeAsync(context: IOperationRunnerContext): Promise<OperationStatus>;

--- a/libraries/rush-lib/src/logic/operations/NullOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/NullOperationRunner.ts
@@ -35,6 +35,7 @@ export class NullOperationRunner implements IOperationRunner {
   public cacheable: boolean = false;
   // Nothing will get logged, no point allowing warnings
   public readonly warningsAreAllowed: boolean = false;
+  public readonly isNoOp: boolean = true;
 
   public readonly result: OperationStatus;
 

--- a/libraries/rush-lib/src/logic/operations/ValidateOperationsPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ValidateOperationsPlugin.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { Operation } from './Operation';
+import type {
+  ICreateOperationsContext,
+  IPhasedCommandPlugin,
+  PhasedCommandHooks
+} from '../../pluginFramework/PhasedCommandHooks';
+import type { IOperationExecutionResult } from './IOperationExecutionResult';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import type { ITerminal } from '@rushstack/node-core-library';
+import type { IPhase } from '../../api/CommandLineConfiguration';
+
+const PLUGIN_NAME: 'ValidateOperationsPlugin' = 'ValidateOperationsPlugin';
+
+/**
+ * Core phased command plugin that provides the functionality for generating a base operation graph
+ * from the set of selected projects and phases.
+ */
+export class ValidateOperationsPlugin implements IPhasedCommandPlugin {
+  private readonly _terminal: ITerminal;
+
+  public constructor(terminal: ITerminal) {
+    this._terminal = terminal;
+  }
+
+  public apply(hooks: PhasedCommandHooks): void {
+    hooks.beforeExecuteOperations.tap(PLUGIN_NAME, this._validateOperations.bind(this));
+  }
+
+  private _validateOperations(
+    records: Map<Operation, IOperationExecutionResult>,
+    context: ICreateOperationsContext
+  ): void {
+    const phasesByProject: Map<RushConfigurationProject, Set<IPhase>> = new Map();
+    for (const { associatedPhase, associatedProject, runner } of records.keys()) {
+      if (associatedProject && associatedPhase && !runner?.isNoOp) {
+        // Ignore operations that aren't associated with a project or phase, or that
+        // use the NullOperationRunner (i.e. - the phase doesn't do anything)
+        let projectPhases: Set<IPhase> | undefined = phasesByProject.get(associatedProject);
+        if (!projectPhases) {
+          projectPhases = new Set();
+          phasesByProject.set(associatedProject, projectPhases);
+        }
+
+        projectPhases.add(associatedPhase);
+      }
+    }
+
+    for (const [project, phases] of phasesByProject) {
+      const projectConfiguration: RushProjectConfiguration | undefined =
+        context.projectConfigurations.get(project);
+      if (projectConfiguration) {
+        projectConfiguration.validatePhaseConfiguration(phases, this._terminal);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This allows for an edge case where a Rush command runs multiple phases that projects may use one of and that cache the same folders. For example `_phase:build` and `_phase:tool-build` that take different arguments..

## Details

This change moves the `rush-project.json` validation out of the function that loads those files and introduces a `ValidateOperationsPlugin` that performs validation during the `beforeExecuteOperations` hook, after the operation graph has been generated. It sorts operations into projects, ignoring no-op operations, and each project's set of phases.

## How it was tested

Tested in a repo with overlapping `_phase:build` and `_phase:tool-build`, and validated that a project that defines both still produces an error.