### PR TITLE
[rush] Fix interactions between the build cache and watch mode

### DIFF
--- a/common/changes/@microsoft/rush/build-cache-watch_2023-09-07-22-33.json
+++ b/common/changes/@microsoft/rush/build-cache-watch_2023-09-07-22-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Disable build cache writes in watch rebuilds.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/build-cache-watch_2023-09-08-01-36.json
+++ b/common/changes/@microsoft/rush/build-cache-watch_2023-09-08-01-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix the instance of \"ICreateOperationsContext\" passed to the \"beforeExecuteOperations\" hook in watch mode rebuilds to match the instance passed to the \"createOperations\" hook.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -534,7 +534,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         ignoreHooks: true,
         operations,
         stopwatch,
-        executionManagerOptions,
+        executionManagerOptions: {
+          ...executionManagerOptions,
+          beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
+            await this.hooks.beforeExecuteOperations.promise(records, createOperationsContext);
+          }
+        },
         terminal
       };
 

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -93,7 +93,8 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
         recordByOperation: Map<Operation, IOperationExecutionResult>,
         context: ICreateOperationsContext
       ): Promise<void> => {
-        const { isIncrementalBuildAllowed, projectChangeAnalyzer, projectConfigurations } = context;
+        const { isIncrementalBuildAllowed, projectChangeAnalyzer, projectConfigurations, isInitial } =
+          context;
 
         this._createContext = context;
 
@@ -135,8 +136,9 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
             disjointSet?.add(operation);
 
             const buildCacheContext: IOperationBuildCacheContext = {
-              // Supports cache writes by default.
-              isCacheWriteAllowed: true,
+              // Supports cache writes by default for initial operations.
+              // Don't write during watch runs for performance reasons (and to avoid flooding the cache)
+              isCacheWriteAllowed: isInitial,
               isCacheReadAllowed: isIncrementalBuildAllowed,
               projectBuildCache: undefined,
               operationSettings,


### PR DESCRIPTION
## Summary
Fixes a bug in which project versions were incorrectly calculated in watch mode rebuilds.
Disables build cache writes when running in watch mode.

## Details
The instance of `ICreateOperationsContext` passed to the `beforeExecuteOperations` hook was incorrectly pinned to the initial version, rather than being invoked with the incremental instance.

## How it was tested
Local run of `rush start`, validated cache miss on rerun when changing inputs.

## Impacted documentation
Only the note that build cache writes don't occur during watch mode rebuilds (for performance reasons).