### PR TITLE
[rush] Rename the PnpmStoreOptions type to PnpmStoreLocation.

### DIFF
--- a/common/changes/@microsoft/rush/rename-PnpmStoreOptions_2023-09-11-00-45.json
+++ b/common/changes/@microsoft/rush/rename-PnpmStoreOptions_2023-09-11-00-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Rename the `PnpmStoreOptions` type to `PnpmStoreLocation`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -608,7 +608,7 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     globalPatchedDependencies?: Record<string, string>;
     // Warning: (ae-forgotten-export) The symbol "IPnpmPeerDependencyRules" needs to be exported by the entry point index.d.ts
     globalPeerDependencyRules?: IPnpmPeerDependencyRules;
-    pnpmStore?: PnpmStoreOptions;
+    pnpmStore?: PnpmStoreLocation;
     preventManualShrinkwrapChanges?: boolean;
     strictPeerDependencies?: boolean;
     unsupportedPackageJsonSettings?: unknown;
@@ -924,7 +924,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     static loadFromJsonFileOrThrow(jsonFilename: string, commonTempFolder: string): PnpmOptionsConfiguration;
     // @internal (undocumented)
     static loadFromJsonObject(json: _IPnpmOptionsJson, commonTempFolder: string): PnpmOptionsConfiguration;
-    readonly pnpmStore: PnpmStoreOptions;
+    readonly pnpmStore: PnpmStoreLocation;
     readonly pnpmStorePath: string;
     readonly preventManualShrinkwrapChanges: boolean;
     readonly strictPeerDependencies: boolean;
@@ -934,7 +934,10 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
 }
 
 // @public
-export type PnpmStoreOptions = 'local' | 'global';
+export type PnpmStoreLocation = 'local' | 'global';
+
+// @public @deprecated (undocumented)
+export type PnpmStoreOptions = PnpmStoreLocation;
 
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from './logic/yarn/YarnOptionsConfiguration';
 export {
   IPnpmOptionsJson as _IPnpmOptionsJson,
+  PnpmStoreLocation,
   PnpmStoreOptions,
   PnpmOptionsConfiguration
 } from './logic/pnpm/PnpmOptionsConfiguration';

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -14,7 +14,13 @@ import schemaJson from '../../schemas/pnpm-config.schema.json';
  * This represents the available PNPM store options
  * @public
  */
-export type PnpmStoreOptions = 'local' | 'global';
+export type PnpmStoreLocation = 'local' | 'global';
+
+/**
+ * @deprecated Use {@link PnpmStoreLocation} instead
+ * @public
+ */
+export type PnpmStoreOptions = PnpmStoreLocation;
 
 /**
  * @beta
@@ -46,7 +52,7 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
   /**
    * {@inheritDoc PnpmOptionsConfiguration.pnpmStore}
    */
-  pnpmStore?: PnpmStoreOptions;
+  pnpmStore?: PnpmStoreLocation;
   /**
    * {@inheritDoc PnpmOptionsConfiguration.strictPeerDependencies}
    */
@@ -114,7 +120,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
    *  - local: Use the standard Rush store path: common/temp/pnpm-store
    *  - global: Use PNPM's global store path
    */
-  public readonly pnpmStore: PnpmStoreOptions;
+  public readonly pnpmStore: PnpmStoreLocation;
 
   /**
    * The path for PNPM to use as the store directory.


### PR DESCRIPTION
Renaming the `PnpmStoreOptions` type to `PnpmStoreLocation` because it isn't an options object.