### PR TITLE
[heft-jest-plugin] Add logHeapUsage

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
+++ b/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/heft-jest-plugin",
       "comment": "Add a `--log-heap-usage` flag that includes memory usage analysis in each test run.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/heft-jest-plugin"

--- a/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
+++ b/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-jest-plugin",
-      "comment": "add log-heap-usage flag",
+      "comment": "Add a `--log-heap-usage` flag that includes memory usage analysis in each test run.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
+++ b/common/changes/@rushstack/heft-jest-plugin/add-jest-log-heap-usage_2023-09-12-12-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "add log-heap-usage flag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/heft-plugin.json
+++ b/heft-plugins/heft-jest-plugin/heft-plugin.json
@@ -37,6 +37,11 @@
           "description": "Find and run the tests that cover a source file that was passed in as an argument.  This corresponds to the \"--findRelatedTests\" parameter in Jest's documentation. This parameter is not compatible with watch mode."
         },
         {
+          "longName": "--log-heap-usage",
+          "parameterKind": "flag",
+          "description": "Logs the heap usage after every test. Useful to debug memory leaks. Use together with --expose-gc in node."
+        },
+        {
           "longName": "--max-workers",
           "parameterKind": "string",
           "argumentName": "COUNT_OR_PERCENTAGE",

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -63,9 +63,15 @@ export default class HeftJestReporter implements Reporter {
     // (ex. jest-junit) only use perfStats:
     // https://github.com/jest-community/jest-junit/blob/12da1a20217a9b6f30858013175319c1256f5b15/utils/buildJsonResults.js#L112
     const duration: string = perfStats ? `${((perfStats.end - perfStats.start) / 1000).toFixed(3)}s` : '?';
+
+    // calculate memoryUsage to MB reference -> https://jestjs.io/docs/cli#--logheapusage
+    const memUsage: string = testResult.memoryUsage
+      ? ` ${Math.floor(testResult.memoryUsage / 1000000)}MB heap size`
+      : '';
+
     const message: string =
       ` ${this._getTestPath(test.path)} ` +
-      `(duration: ${duration}, ${numPassingTests} passed, ${numFailingTests} failed)`;
+      `(duration: ${duration}, ${numPassingTests} passed, ${numFailingTests} failed,${memUsage})`;
 
     if (numFailingTests > 0) {
       this._terminal.writeLine(Colors.redBackground(Colors.black('FAIL')), message);

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -66,12 +66,12 @@ export default class HeftJestReporter implements Reporter {
 
     // calculate memoryUsage to MB reference -> https://jestjs.io/docs/cli#--logheapusage
     const memUsage: string = testResult.memoryUsage
-      ? ` ${Math.floor(testResult.memoryUsage / 1000000)}MB heap size`
+      ? `, ${Math.floor(testResult.memoryUsage / 1000000)}MB heap size`
       : '';
 
     const message: string =
       ` ${this._getTestPath(test.path)} ` +
-      `(duration: ${duration}, ${numPassingTests} passed, ${numFailingTests} failed,${memUsage})`;
+      `(duration: ${duration}, ${numPassingTests} passed, ${numFailingTests} failed${memUsage})`;
 
     if (numFailingTests > 0) {
       this._terminal.writeLine(Colors.redBackground(Colors.black('FAIL')), message);

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -109,6 +109,7 @@ export interface IJestPluginOptions {
   testPathPattern?: string;
   testTimeout?: number;
   updateSnapshots?: boolean;
+  logHeapUsage?: boolean;
 }
 
 export interface IHeftJestConfiguration extends Config.InitialOptions {}
@@ -178,6 +179,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
     const silentParameter: CommandLineFlagParameter = parameters.getFlagParameter('--silent');
     const updateSnapshotsParameter: CommandLineFlagParameter =
       parameters.getFlagParameter('--update-snapshots');
+    const logHeapUsageParameter: CommandLineFlagParameter = parameters.getFlagParameter('--log-heap-usage');
 
     // Strings
     const configParameter: CommandLineStringParameter = parameters.getStringParameter('--config');
@@ -204,6 +206,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       debugHeftReporter: debugHeftReporterParameter.value || pluginOptions?.debugHeftReporter,
       detectOpenHandles: detectOpenHandlesParameter.value || pluginOptions?.detectOpenHandles,
       disableCodeCoverage: disableCodeCoverageParameter.value || pluginOptions?.disableCodeCoverage,
+      logHeapUsage: logHeapUsageParameter.value || pluginOptions?.logHeapUsage,
       findRelatedTests: findRelatedTestsParameter.values.length
         ? Array.from(findRelatedTestsParameter.values)
         : pluginOptions?.findRelatedTests,
@@ -559,6 +562,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       runInBand: taskSession.parameters.debug,
       debug: taskSession.parameters.debug,
       detectOpenHandles: options.detectOpenHandles || false,
+      logHeapUsage: options.logHeapUsage || false,
 
       // Use the temp folder. Cache is unreliable, so we want it cleared on every --clean run
       cacheDirectory: taskSession.tempFolderPath,


### PR DESCRIPTION
## Summary

This PR brings a new flag `--log-heap-usage`, and a corresponding change to the Reporter to show the heap usage for each test.

Jest logHeapUsage documentation is [here](https://jestjs.io/docs/cli#--logheapusage)

## Details

Useful to debug memory leaks. 

## How it was tested

Manual testing.

## Impacted documentation

Comments in the code and `rush change` json are provided.


