### PR TITLE
CertificateManager issues when CertUtil fails to set friendly name

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/patch-2_2023-09-12-15-44.json
+++ b/common/changes/@rushstack/debug-certificate-manager/patch-2_2023-09-12-15-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fixes issues with CertificateManager when setting the certificate friendly name fails.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -700,7 +700,8 @@ export class CertificateManager {
       ]);
 
       if (repairStoreResult.code !== 0) {
-        terminal.writeErrorLine(`CertUtil Error: ${repairStoreResult.stderr.join('')}`);
+        terminal.writeVerboseLine(`CertUtil Error: ${repairStoreResult.stderr.join('')}`);
+        terminal.writeVerboseLine(`CertUtil: ${repairStoreResult.stdout.join('')}`);
         return false;
       } else {
         terminal.writeVerboseLine('Successfully set certificate name.');
@@ -743,7 +744,7 @@ export class CertificateManager {
       subjectAltNames = generatedCertificate.subjectAltNames;
 
       // Try to set the friendly name, and warn if we can't
-      if (!this._trySetFriendlyNameAsync(tempCertificatePath, terminal)) {
+      if (!await this._trySetFriendlyNameAsync(tempCertificatePath, terminal)) {
         terminal.writeWarningLine("Unable to set the certificate's friendly name.");
       }
     } else {


### PR DESCRIPTION
## Summary
Fixes three issues in Certificate Manager:

1. `certutil.exe` appears to not write to stderr when it fails, so we should also log stdout.
2. Writing this as an error doesn't make sense, since this is an optional step (note the warning in the location where this is called). It is causing SPFx to detect this is a total task failure.
3. We are not awaiting the result of this call, so the above warning is not appearing.

## Details

See: https://github.com/SharePoint/sp-dev-docs/issues/9201#issuecomment-1715957297

## How it was tested

This was tested by making these changes directly to installed versions of `@rushstack/debug-certificate-manager` inside a sample SPFx project.

## Impacted documentation

N/A
