### PR TITLE
[rush-lib] add pause functionality to PhasedScriptAction

### DIFF
--- a/common/changes/@microsoft/rush/user-bharatmiddha-project-watcher-pause_2023-09-14-02-19.json
+++ b/common/changes/@microsoft/rush/user-bharatmiddha-project-watcher-pause_2023-09-14-02-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add pause/resume option to project watcher",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

Add functionality to pause the project watcher when running `rush start`.

## Details

Added keyboard hook to listen for key presses. If `w` is pressed, toggle pause/resume. If `b` is pressed and the project watcher is paused, build once (by resuming then pausing again).

## How it was tested

Tested by running `node ./apps/rush/lib/start-dev.js start ` in this repo
