### PR TITLE
feat(rush-lib): Expose more tip IDs

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -7,13 +7,13 @@ importers:
 
   rush-lib-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.104.1.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.105.0.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~5.0.4
     dependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.104.1.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.105.0.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
       '@types/node': 14.18.36
@@ -22,17 +22,17 @@ importers:
 
   rush-sdk-test:
     specifiers:
-      '@microsoft/rush-lib': file:microsoft-rush-lib-5.104.1.tgz
-      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.104.1.tgz
+      '@microsoft/rush-lib': file:microsoft-rush-lib-5.105.0.tgz
+      '@rushstack/rush-sdk': file:rushstack-rush-sdk-5.105.0.tgz
       '@types/node': 14.18.36
       colors: ^1.4.0
       rimraf: ^4.1.2
       typescript: ~5.0.4
     dependencies:
-      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.104.1.tgz_@types+node@14.18.36
+      '@rushstack/rush-sdk': file:../temp/tarballs/rushstack-rush-sdk-5.105.0.tgz_@types+node@14.18.36
       colors: 1.4.0
     devDependencies:
-      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.104.1.tgz_@types+node@14.18.36
+      '@microsoft/rush-lib': file:../temp/tarballs/microsoft-rush-lib-5.105.0.tgz_@types+node@14.18.36
       '@types/node': 14.18.36
       rimraf: 4.4.1
       typescript: 5.0.4
@@ -3913,11 +3913,11 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.104.1.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.104.1.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.104.1.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.105.0.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.105.0.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.105.0.tgz
     name: '@microsoft/rush-lib'
-    version: 5.104.1
+    version: 5.105.0
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/dependency-path': 2.1.2
@@ -3925,7 +3925,7 @@ packages:
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.13.3.tgz_@types+node@14.18.36
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.7.tgz_@types+node@14.18.36
       '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.0.44.tgz_@types+node@14.18.36
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.5.1.tgz_@types+node@14.18.36
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.5.3.tgz_@types+node@14.18.36
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.4.1.tgz
       '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.0.263.tgz_@types+node@14.18.36
       '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.5.38.tgz_@types+node@14.18.36
@@ -4247,11 +4247,11 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.5.1.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.5.1.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.5.1.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.5.3.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.5.3.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.5.3.tgz
     name: '@rushstack/package-extractor'
-    version: 0.5.1
+    version: 0.5.3
     dependencies:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.7.tgz_@types+node@14.18.36
@@ -4272,11 +4272,11 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.104.1.tgz_@types+node@14.18.36:
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.104.1.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.104.1.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.105.0.tgz_@types+node@14.18.36:
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.105.0.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.105.0.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.104.1
+    version: 5.105.0
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.59.7.tgz_@types+node@14.18.36
       '@types/node-fetch': 2.6.2

--- a/common/changes/@microsoft/rush/jiawen-expose-more-ids_2023-09-14-02-29.json
+++ b/common/changes/@microsoft/rush/jiawen-expose-more-ids_2023-09-14-02-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Expose more customizable tip ids. ",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/jiawen-expose-more-ids_2023-09-14-02-29.json
+++ b/common/changes/@microsoft/rush/jiawen-expose-more-ids_2023-09-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Expose more customizable tip ids. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -149,7 +149,21 @@ export class CredentialCache {
 // @beta
 export enum CustomTipId {
     // (undocumented)
+    TIP_PNPM_INVALID_NODE_VERSION = "TIP_PNPM_INVALID_NODE_VERSION",
+    // (undocumented)
+    TIP_PNPM_MISMATCHED_RELEASE_CHANNEL = "TIP_PNPM_MISMATCHED_RELEASE_CHANNEL",
+    // (undocumented)
     TIP_PNPM_NO_MATCHING_VERSION = "TIP_PNPM_NO_MATCHING_VERSION",
+    // (undocumented)
+    TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE = "TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE",
+    // (undocumented)
+    TIP_PNPM_OUTDATED_LOCKFILE = "TIP_PNPM_OUTDATED_LOCKFILE",
+    // (undocumented)
+    TIP_PNPM_PEER_DEP_ISSUES = "TIP_PNPM_PEER_DEP_ISSUES",
+    // (undocumented)
+    TIP_PNPM_TARBALL_INTEGRITY = "TIP_PNPM_TARBALL_INTEGRITY",
+    // (undocumented)
+    TIP_PNPM_UNEXPECTED_STORE = "TIP_PNPM_UNEXPECTED_STORE",
     // (undocumented)
     TIP_RUSH_INCONSISTENT_VERSIONS = "TIP_RUSH_INCONSISTENT_VERSIONS"
 }
@@ -158,7 +172,7 @@ export enum CustomTipId {
 export class CustomTipsConfiguration {
     constructor(configFilename: string);
     readonly configuration: Readonly<ICustomTipsJson>;
-    static customTipRegistry: Record<CustomTipId, ICustomTipInfo>;
+    static customTipRegistry: Readonly<Record<CustomTipId, ICustomTipInfo>>;
     // @internal
     _showErrorTip(terminal: ITerminal, tipId: CustomTipId): void;
     // @internal

--- a/libraries/rush-lib/src/api/CustomTipsConfiguration.ts
+++ b/libraries/rush-lib/src/api/CustomTipsConfiguration.ts
@@ -50,8 +50,15 @@ export interface ICustomTipItemJson {
  * @beta
  */
 export enum CustomTipId {
+  TIP_PNPM_UNEXPECTED_STORE = 'TIP_PNPM_UNEXPECTED_STORE',
   TIP_RUSH_INCONSISTENT_VERSIONS = 'TIP_RUSH_INCONSISTENT_VERSIONS',
-  TIP_PNPM_NO_MATCHING_VERSION = 'TIP_PNPM_NO_MATCHING_VERSION'
+  TIP_PNPM_NO_MATCHING_VERSION = 'TIP_PNPM_NO_MATCHING_VERSION',
+  TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE = 'TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE',
+  TIP_PNPM_PEER_DEP_ISSUES = 'TIP_PNPM_PEER_DEP_ISSUES',
+  TIP_PNPM_OUTDATED_LOCKFILE = 'TIP_PNPM_OUTDATED_LOCKFILE',
+  TIP_PNPM_TARBALL_INTEGRITY = 'TIP_PNPM_TARBALL_INTEGRITY',
+  TIP_PNPM_MISMATCHED_RELEASE_CHANNEL = 'TIP_PNPM_MISMATCHED_RELEASE_CHANNEL',
+  TIP_PNPM_INVALID_NODE_VERSION = 'TIP_PNPM_INVALID_NODE_VERSION'
 }
 
 /**
@@ -150,18 +157,89 @@ export class CustomTipsConfiguration {
    * See {@link CustomTipId} for the list of custom tip IDs.
    * See {@link ICustomTipInfo} for the structure of the metadata.
    */
-  public static customTipRegistry: Record<CustomTipId, ICustomTipInfo> = {
+  public static customTipRegistry: Readonly<Record<CustomTipId, ICustomTipInfo>> = {
     [CustomTipId.TIP_RUSH_INCONSISTENT_VERSIONS]: {
       tipId: CustomTipId.TIP_RUSH_INCONSISTENT_VERSIONS,
       severity: CustomTipSeverity.Error,
       type: CustomTipType.rush
+    },
+
+    [CustomTipId.TIP_PNPM_UNEXPECTED_STORE]: {
+      tipId: CustomTipId.TIP_PNPM_UNEXPECTED_STORE,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        return str.includes('ERR_PNPM_UNEXPECTED_STORE');
+      }
     },
     [CustomTipId.TIP_PNPM_NO_MATCHING_VERSION]: {
       tipId: CustomTipId.TIP_PNPM_NO_MATCHING_VERSION,
       severity: CustomTipSeverity.Error,
       type: CustomTipType.pnpm,
       isMatch: (str: string) => {
-        return str.includes('No matching version found for') || str.includes('ERR_PNPM_NO_MATCHING_VERSION');
+        // Example message: (do notice the difference between this one and the TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE)
+
+        // Error Message: ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @babel/types@^7.22.5
+        // The latest release of @babel/types is "7.22.4".
+        // Other releases are:
+        // * esm: 7.21.4-esm.4
+
+        return str.includes('No matching version found for') && str.includes('The latest release of');
+      }
+    },
+    [CustomTipId.TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE]: {
+      tipId: CustomTipId.TIP_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        return str.includes('ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE');
+      }
+    },
+    [CustomTipId.TIP_PNPM_PEER_DEP_ISSUES]: {
+      tipId: CustomTipId.TIP_PNPM_PEER_DEP_ISSUES,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        return str.includes('ERR_PNPM_PEER_DEP_ISSUES');
+      }
+    },
+    [CustomTipId.TIP_PNPM_OUTDATED_LOCKFILE]: {
+      tipId: CustomTipId.TIP_PNPM_OUTDATED_LOCKFILE,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        // Todo: verify this
+        return str.includes('ERR_PNPM_OUTDATED_LOCKFILE');
+      }
+    },
+
+    [CustomTipId.TIP_PNPM_TARBALL_INTEGRITY]: {
+      tipId: CustomTipId.TIP_PNPM_TARBALL_INTEGRITY,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        // Todo: verify this
+        return str.includes('ERR_PNPM_TARBALL_INTEGRITY');
+      }
+    },
+
+    [CustomTipId.TIP_PNPM_MISMATCHED_RELEASE_CHANNEL]: {
+      tipId: CustomTipId.TIP_PNPM_MISMATCHED_RELEASE_CHANNEL,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        // Todo: verify this
+        return str.includes('ERR_PNPM_MISMATCHED_RELEASE_CHANNEL');
+      }
+    },
+
+    [CustomTipId.TIP_PNPM_INVALID_NODE_VERSION]: {
+      tipId: CustomTipId.TIP_PNPM_INVALID_NODE_VERSION,
+      severity: CustomTipSeverity.Error,
+      type: CustomTipType.pnpm,
+      isMatch: (str: string) => {
+        // Todo: verify this
+        return str.includes('ERR_PNPM_INVALID_NODE_VERSION');
       }
     }
   };


### PR DESCRIPTION
In previous MR #4292, we support custom tips for pnpm-printed messages. 

In this MR we simply expose more IDs. The matching logic is based on pnpm's error code documents (https://pnpm.io/next/errors). 