### PR TITLE
[rush-serve-plugin] Add build status monitoring via WebSocket

### DIFF
--- a/common/changes/@microsoft/rush/rush-serve-socket_2023-09-14-20-17.json
+++ b/common/changes/@microsoft/rush/rush-serve-socket_2023-09-14-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add \"Waiting\" operation status for operations that have one or more dependencies still pending. Ensure that the `onOperationStatusChanged` hook fires for every status change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/rush-serve-socket_2023-09-14-20-58.json
+++ b/common/changes/@microsoft/rush/rush-serve-socket_2023-09-14-20-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for optional build status notifications over a web socket connection to `@rushstack/rush-serve-plugin`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -407,12 +407,12 @@
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "cors",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
       "name": "constructs",
       "allowedCategories": [ "tests" ]
+    },
+    {
+      "name": "cors",
+      "allowedCategories": [ "libraries" ]
     },
     {
       "name": "css-loader",
@@ -824,6 +824,10 @@
     },
     {
       "name": "wordwrap",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "ws",
       "allowedCategories": [ "libraries" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2866,10 +2866,12 @@ importers:
       '@types/express': 4.17.13
       '@types/heft-jest': 1.0.1
       '@types/node': 18.17.15
+      '@types/ws': 8.5.5
       compression: ~1.7.4
       cors: ~2.8.5
       express: 4.18.1
       http2-express-bridge: ~1.0.7
+      ws: ~8.14.1
     dependencies:
       '@rushstack/debug-certificate-manager': link:../../libraries/debug-certificate-manager
       '@rushstack/heft-config-file': link:../../libraries/heft-config-file
@@ -2881,6 +2883,7 @@ importers:
       cors: 2.8.5
       express: 4.18.1
       http2-express-bridge: 1.0.7_@types+express@4.17.13
+      ws: 8.14.1
     devDependencies:
       '@rushstack/eslint-config': link:../../eslint/eslint-config
       '@rushstack/heft': link:../../apps/heft
@@ -2890,6 +2893,7 @@ importers:
       '@types/express': 4.17.13
       '@types/heft-jest': 1.0.1
       '@types/node': 18.17.15
+      '@types/ws': 8.5.5
 
   ../../vscode-extensions/rush-vscode-command-webview:
     specifiers:
@@ -9711,7 +9715,7 @@ packages:
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.47.0
-      ws: 8.13.0
+      ws: 8.14.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -9784,7 +9788,7 @@ packages:
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.47.0
-      ws: 8.13.0
+      ws: 8.14.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -10720,6 +10724,9 @@ packages:
     resolution: {integrity: sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==}
     dev: true
 
+  /@types/node/14.18.36:
+    resolution: {integrity: sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==}
+
   /@types/node/14.18.59:
     resolution: {integrity: sha512-NWJMpBL2Xs3MY93yrD6YrrTKep8eIA6iMnfG4oIc6LrTRlBZgiSCGiY3V/Owlp6umIBLyKb4F8Q7hxWatjYH5A==}
     dev: true
@@ -10963,8 +10970,7 @@ packages:
   /@types/ws/8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 18.17.15
-    dev: false
+      '@types/node': 14.18.36
 
   /@types/xmldoc/1.1.4:
     resolution: {integrity: sha512-a/ONNCf9itbmzEz1ohx0Fv5TLJzXIPQTapxFu+DlYlDtn9UcAa1OhnrOOMwbU8125hFjrkJKL3qllD7vO5Bivw==}
@@ -18379,7 +18385,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.13.0
+      ws: 8.14.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -24710,7 +24716,7 @@ packages:
       webpack: 4.47.0_webpack-cli@3.3.12
       webpack-cli: 3.3.12_webpack@4.47.0
       webpack-dev-middleware: 5.3.3_webpack@4.47.0
-      ws: 8.13.0
+      ws: 8.14.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -24764,7 +24770,7 @@ packages:
       spdy: 4.0.2
       webpack: 4.47.0
       webpack-dev-middleware: 5.3.3_bs575e6uz6qqyriedrrkqiwy2m
-      ws: 8.13.0
+      ws: 8.14.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -24817,7 +24823,7 @@ packages:
       spdy: 4.0.2
       webpack: 5.82.1
       webpack-dev-middleware: 5.3.3_webpack@5.82.1
-      ws: 8.13.0
+      ws: 8.14.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -25206,8 +25212,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws/8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+  /ws/8.14.1:
+    resolution: {integrity: sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "5ee5e5b7fa262ef5096e77b7d86ef24ade887c5b",
+  "pnpmShrinkwrapHash": "af97ead68ee0632cb19c93ef203e84fc0c1e1375",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -877,7 +877,8 @@ export enum OperationStatus {
     RemoteExecuting = "REMOTE EXECUTING",
     Skipped = "SKIPPED",
     Success = "SUCCESS",
-    SuccessWithWarning = "SUCCESS WITH WARNINGS"
+    SuccessWithWarning = "SUCCESS WITH WARNINGS",
+    Waiting = "WAITING"
 }
 
 // @public (undocumented)

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -75,6 +75,7 @@ const TIMELINE_WIDTH: number = 109;
  * Timeline - symbols representing each operation status
  */
 const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
+  [OperationStatus.Waiting]: '?',
   [OperationStatus.Ready]: '?',
   [OperationStatus.Queued]: '?',
   [OperationStatus.Executing]: '?',
@@ -92,6 +93,7 @@ const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
  * Timeline - colorizer for each operation status
  */
 const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => string> = {
+  [OperationStatus.Waiting]: colors.yellow,
   [OperationStatus.Ready]: colors.yellow,
   [OperationStatus.Queued]: colors.yellow,
   [OperationStatus.Executing]: colors.yellow,

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -394,12 +394,6 @@ export class OperationExecutionManager {
     if (record.status !== OperationStatus.RemoteExecuting) {
       // If the operation was not remote, then we can notify queue that it is complete
       this._executionQueue.complete(record);
-
-      // Apply status changes to direct dependents
-      for (const item of record.consumers) {
-        // Remove this operation from the dependencies, to unblock the scheduler
-        item.dependencies.delete(record);
-      }
     }
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -7,9 +7,13 @@
  */
 export enum OperationStatus {
   /**
-   * The Operation is on the queue, ready to execute (but may be waiting for dependencies)
+   * The Operation is ready to execute. All its dependencies have succeeded.
    */
   Ready = 'READY',
+  /**
+   * The Operation is waiting for one or more dependencies to complete.
+   */
+  Waiting = 'WAITING',
   /**
    * The Operation is Queued
    */

--- a/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
@@ -16,6 +16,7 @@ import { Async } from '@rushstack/node-core-library';
 function addDependency(consumer: OperationExecutionRecord, dependency: OperationExecutionRecord): void {
   consumer.dependencies.add(dependency);
   dependency.consumers.add(consumer);
+  consumer.status = OperationStatus.Waiting;
 }
 
 function nullSort(a: OperationExecutionRecord, b: OperationExecutionRecord): number {
@@ -50,9 +51,6 @@ describe(AsyncOperationQueue.name, () => {
         hasUnassignedOperation = true;
         continue;
       }
-      for (const consumer of operation.consumers) {
-        consumer.dependencies.delete(operation);
-      }
       operation.status = OperationStatus.Success;
       queue.complete(operation);
     }
@@ -81,9 +79,6 @@ describe(AsyncOperationQueue.name, () => {
       if (operation === UNASSIGNED_OPERATION) {
         hasUnassignedOperation = true;
         continue;
-      }
-      for (const consumer of operation.consumers) {
-        consumer.dependencies.delete(operation);
       }
       operation.status = OperationStatus.Success;
       queue.complete(operation);
@@ -151,10 +146,6 @@ describe(AsyncOperationQueue.name, () => {
 
           await Promise.resolve();
 
-          for (const consumer of operation.consumers) {
-            consumer.dependencies.delete(operation);
-          }
-
           --concurrency;
           operation.status = OperationStatus.Success;
           queue.complete(operation);
@@ -212,9 +203,6 @@ describe(AsyncOperationQueue.name, () => {
           remoteExecuted = true;
           continue;
         }
-      }
-      for (const consumer of record.consumers) {
-        consumer.dependencies.delete(record);
       }
       record.status = OperationStatus.Success;
       queue.complete(record);

--- a/rush-plugins/rush-serve-plugin/README.md
+++ b/rush-plugins/rush-serve-plugin/README.md
@@ -14,3 +14,77 @@ What happens:
 - Rush uses the configuration in the aforementioned files to configure an Express server to serve project outputs as static (but not cached) content
 - When a change happens to a source file, Rush's normal watch-mode machinery will rebuild all affected project phases, resulting in new files on disk
 - The next time one of these files is requested, Rush will serve the new version. Optionally, may support signals for automatic refresh.
+
+## Live Build Status via Web Socket
+
+This plugin also provides a web socket server that notifies clients of the build status in real time. To use the server, configure the `buildStatusWebSocketPath` option in `common/config/rush-plugins/rush-serve-plugin.json`. Specifying `/` will make the web socket server available at `wss://localhost:<port>/`.
+
+The recommended way to connect to the web socket is to serve a static HTML page from the serve plugin using the `globalRouting` configuration.
+
+To use the socket:
+```ts
+import type {
+  IWebSocketEventMessage,
+  IOperationInfo,
+  IRushSessionInfo,
+  ReadableOperationStatus
+} from '@rushstack/rush-serve-plugin/api';
+
+const socket: WebSocket = new WebSocket(`wss://${self.location.host}${buildStatusWebSocketPath}`);
+
+const operationsByName: Map<string, IOperationInfo> = new Map();
+let buildStatus: ReadableOperationStatus = 'Ready';
+
+function updateOperations(operations): void {
+  for (const operation of operations) {
+    operationsByName.set(operation.name, operation);
+  }
+
+  for (const [operationName, operation] of operationsByName) {
+    // Do something with the operation
+  }
+}
+
+function updateSessionInfo(sessionInfo: IRushSessionInfo): void {
+  const { actionName, repositoryIdentifier } = sessionInfo;
+}
+
+function updateBuildStatus(newStatus: ReadableOperationStatus): void {
+  buildStatus = newStatus;
+  // Render
+}
+
+socket.addEventListener('message', (ev) => {
+  const message: IWebSocketEventMessage = JSON.parse(ev.data);
+
+  switch (message.event) {
+    case 'before-execute': {
+      const { operations } = message;
+      updateOperations(operations);
+      updateBuildStatus('Executing');
+      break;
+    }
+
+    case 'status-change': {
+      const { operations } = message;
+      updateOperations(operations);
+      break;
+    }
+
+    case 'after-execute': {
+      const { status } = message;
+      updateBuildStatus(status);
+      break;
+    }
+
+    case 'sync': {
+      operationsByName.clear();
+      const { operations, status, sessionInfo } = message;
+      updateOperations(operations);
+      updateSessionInfo(sessionInfo);
+      updateBuildStatus(status);
+      break;
+    }
+  }
+});
+```

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "directory": "rush-plugins/rush-serve-plugin"
   },
-  "main": "lib/index.js",
+  "main": "lib-commonjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "heft test --clean",
@@ -25,7 +25,8 @@
     "compression": "~1.7.4",
     "cors": "~2.8.5",
     "express": "4.18.1",
-    "http2-express-bridge": "~1.0.7"
+    "http2-express-bridge": "~1.0.7",
+    "ws": "~8.14.1"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "workspace:*",
@@ -35,6 +36,26 @@
     "@types/cors": "~2.8.12",
     "@types/express": "4.17.13",
     "@types/heft-jest": "1.0.1",
-    "@types/node": "18.17.15"
+    "@types/node": "18.17.15",
+    "@types/ws": "8.5.5"
+  },
+  "exports": {
+    ".": {
+      "require": "./lib/index.js",
+      "types": "./dist/rush-serve-plugin.d.ts"
+    },
+    "./api": {
+      "types": "./lib/api.types.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/rush-serve-plugin.d.ts"
+      ],
+      "api": [
+        "lib/api.types.d.ts"
+      ]
+    }
   }
 }

--- a/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
@@ -25,12 +25,21 @@ export interface IRushServePluginOptions {
    * The names of phased commands to which the plugin should be applied.
    */
   phasedCommands: ReadonlyArray<string>;
+
+  /**
+   * The URL path at which to host the web socket connection for monitoring build status. If not specified, the web socket interface will not be enabled.
+   */
+  buildStatusWebSocketPath?: string;
+
   /**
    * The name of a parameter that Rush is configured to use to pass a port number to underlying operations.
    * If specified, the plugin will ensure the value is synchronized with the port used for its server.
    */
   portParameterLongName?: string | undefined;
 
+  /**
+   * Routing rules for files that are associated with the entire workspace, rather than a single project (e.g. files output by Rush plugins).
+   */
   globalRouting?: IGlobalRoutingRuleJson[];
 }
 
@@ -43,11 +52,13 @@ export class RushServePlugin implements IRushPlugin {
   private readonly _phasedCommands: Set<string>;
   private readonly _portParameterLongName: string | undefined;
   private readonly _globalRoutingRules: IGlobalRoutingRuleJson[];
+  private readonly _buildStatusWebSocketPath: string | undefined;
 
   public constructor(options: IRushServePluginOptions) {
     this._phasedCommands = new Set(options.phasedCommands);
     this._portParameterLongName = options.portParameterLongName;
     this._globalRoutingRules = options.globalRouting ?? [];
+    this._buildStatusWebSocketPath = options.buildStatusWebSocketPath;
   }
 
   public apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void {
@@ -73,7 +84,8 @@ export class RushServePlugin implements IRushPlugin {
         rushConfiguration,
         command,
         portParameterLongName: this._portParameterLongName,
-        globalRoutingRules
+        globalRoutingRules,
+        buildStatusWebSocketPath: this._buildStatusWebSocketPath
       });
     };
 

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { OperationStatus } from '@rushstack/rush-sdk';
+
+/**
+ * Human readable status values. These are the PascalCase keys of the `OperationStatus` enumeration.
+ */
+export type ReadableOperationStatus = keyof typeof OperationStatus;
+
+/**
+ * Information about an operation in the graph.
+ */
+export interface IOperationInfo {
+  /**
+   * The display name of the operation.
+   */
+  name: string;
+
+  /**
+   * The npm package name of the containing Rush Project.
+   */
+  packageName: string;
+
+  /**
+   * The name of the containing phase.
+   */
+  phaseName: string;
+
+  /**
+   * If true, this operation is configured to be silent and is included for completeness.
+   */
+  silent: boolean;
+  /**
+   * If true, this operation is configured to be a noop and is included for graph completeness.
+   */
+  noop: boolean;
+
+  /**
+   * The current status of the operation. This value is in PascalCase and is the key of the corresponding `OperationStatus` constant.
+   */
+  status: ReadableOperationStatus;
+
+  /**
+   * The start time of the operation, if it has started, in milliseconds. Not wall clock time.
+   */
+  startTime: number | undefined;
+
+  /**
+   * The end time of the operation, if it has finished, in milliseconds. Not wall clock time.
+   */
+  endTime: number | undefined;
+}
+
+/**
+ * Information about the current Rush session.
+ */
+export interface IRushSessionInfo {
+  /**
+   * The name of the command being run.
+   */
+  actionName: string;
+
+  /**
+   * A unique identifier for the repository in which this Rush is running.
+   */
+  repositoryIdentifier: string;
+}
+
+/**
+ * Message sent to a WebSocket client at the start of an execution pass.
+ */
+export interface IWebSocketBeforeExecuteEventMessage {
+  event: 'before-execute';
+  operations: IOperationInfo[];
+}
+
+/**
+ * Message sent to a WebSocket client at the end of an execution pass.
+ */
+export interface IWebSocketAfterExecuteEventMessage {
+  event: 'after-execute';
+  status: ReadableOperationStatus;
+}
+
+/**
+ * Message sent to a WebSocket client when one or more operations change status.
+ *
+ * Batched to reduce noise and improve throughput.
+ */
+export interface IWebSocketBatchStatusChangeEventMessage {
+  event: 'status-change';
+  operations: IOperationInfo[];
+}
+
+/**
+ * Message sent to a WebSocket client upon initial connection, or when explicitly requested.
+ *
+ * @see IWebSocketSyncCommandMessage
+ */
+export interface IWebSocketSyncEventMessage {
+  event: 'sync';
+  operations: IOperationInfo[];
+  sessionInfo: IRushSessionInfo;
+  status: ReadableOperationStatus;
+}
+
+/**
+ * The set of possible messages sent to a WebSocket client.
+ */
+export type IWebSocketEventMessage =
+  | IWebSocketBeforeExecuteEventMessage
+  | IWebSocketAfterExecuteEventMessage
+  | IWebSocketBatchStatusChangeEventMessage
+  | IWebSocketSyncEventMessage;
+
+/**
+ * Message received from a WebSocket client to request a sync.
+ */
+export interface IWebSocketSyncCommandMessage {
+  command: 'sync';
+}
+
+/**
+ * The set of possible messages received from a WebSocket client.
+ */
+export type IWebSocketCommandMessage = IWebSocketSyncCommandMessage;

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -2,29 +2,47 @@
 // See LICENSE in the project root for license information.
 
 import { once } from 'node:events';
-import http2 from 'node:http2';
+import type { Server as HTTPSecureServer } from 'node:https';
+import http2, { Http2SecureServer } from 'node:http2';
 import type { AddressInfo } from 'node:net';
+import os from 'node:os';
 
 import express, { type Application } from 'express';
 import http2express from 'http2-express-bridge';
 import cors from 'cors';
 import compression from 'compression';
+import { WebSocketServer, type WebSocket, type MessageEvent } from 'ws';
 
 import { CertificateManager, ICertificate } from '@rushstack/debug-certificate-manager';
-import { AlreadyReportedError } from '@rushstack/node-core-library';
-import type {
+import { AlreadyReportedError, Sort } from '@rushstack/node-core-library';
+import {
   ILogger,
   RushConfiguration,
   RushConfigurationProject,
   RushSession,
   IPhasedCommand,
   Operation,
-  ICreateOperationsContext
+  ICreateOperationsContext,
+  IOperationExecutionResult,
+  OperationStatus,
+  IExecutionResult
 } from '@rushstack/rush-sdk';
 import type { CommandLineStringParameter } from '@rushstack/ts-command-line';
 
 import { PLUGIN_NAME } from './constants';
 import { IRoutingRule, RushServeConfiguration } from './RushProjectServeConfigFile';
+
+import type {
+  IOperationInfo,
+  IWebSocketAfterExecuteEventMessage,
+  IWebSocketBeforeExecuteEventMessage,
+  IWebSocketEventMessage,
+  IWebSocketBatchStatusChangeEventMessage,
+  IWebSocketSyncEventMessage,
+  ReadableOperationStatus,
+  IWebSocketCommandMessage,
+  IRushSessionInfo
+} from './api.types';
 
 export interface IPhasedCommandHandlerOptions {
   rushSession: RushSession;
@@ -32,6 +50,7 @@ export interface IPhasedCommandHandlerOptions {
   command: IPhasedCommand;
   portParameterLongName: string | undefined;
   globalRoutingRules: IRoutingRule[];
+  buildStatusWebSocketPath: string | undefined;
 }
 
 export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions): Promise<void> {
@@ -53,6 +72,9 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
       );
     }
   }
+
+  const webSocketServerUpgrader: WebSocketServerUpgrader | undefined =
+    tryEnableBuildStatusWebSocketServer(options);
 
   command.hooks.createOperations.tapPromise(
     {
@@ -194,6 +216,8 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
         app
       );
 
+      webSocketServerUpgrader?.(server);
+
       server.listen(requestedPort);
       await once(server, 'listening');
 
@@ -215,4 +239,200 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
   );
 
   command.hooks.waitingForChanges.tap(PLUGIN_NAME, logHost);
+}
+
+type WebSocketServerUpgrader = (server: Http2SecureServer) => void;
+
+/**
+ *
+ */
+function tryEnableBuildStatusWebSocketServer(
+  options: IPhasedCommandHandlerOptions
+): WebSocketServerUpgrader | undefined {
+  const { buildStatusWebSocketPath } = options;
+  if (!buildStatusWebSocketPath) {
+    return;
+  }
+
+  let operationStates: Map<Operation, IOperationExecutionResult> | undefined;
+  let buildStatus: ReadableOperationStatus = 'Ready';
+
+  const webSockets: Set<WebSocket> = new Set();
+
+  // Map from OperationStatus enum values back to the names of the constants
+  const readableStatusFromStatus: { [K in OperationStatus]: ReadableOperationStatus } = {
+    [OperationStatus.Waiting]: 'Waiting',
+    [OperationStatus.Ready]: 'Ready',
+    [OperationStatus.Queued]: 'Queued',
+    [OperationStatus.Executing]: 'Executing',
+    [OperationStatus.RemoteExecuting]: 'RemoteExecuting',
+    [OperationStatus.Success]: 'Success',
+    [OperationStatus.SuccessWithWarning]: 'SuccessWithWarning',
+    [OperationStatus.Skipped]: 'Skipped',
+    [OperationStatus.FromCache]: 'FromCache',
+    [OperationStatus.Failure]: 'Failure',
+    [OperationStatus.Blocked]: 'Blocked',
+    [OperationStatus.NoOp]: 'NoOp'
+  };
+
+  /**
+   * Maps the internal Rush record down to a subset that is JSON-friendly and human readable.
+   */
+  function convertToOperationInfo(record: IOperationExecutionResult): IOperationInfo | undefined {
+    const { operation } = record;
+    const { name, associatedPhase, associatedProject, runner } = operation;
+
+    if (!name || !associatedPhase || !associatedProject || !runner) {
+      return;
+    }
+
+    return {
+      name,
+      packageName: associatedProject.packageName,
+      phaseName: associatedPhase.name,
+
+      silent: !!runner.silent,
+      noop: !!runner.isNoOp,
+
+      status: readableStatusFromStatus[record.status],
+      startTime: record.stopwatch.startTime,
+      endTime: record.stopwatch.endTime
+    };
+  }
+
+  function convertToOperationInfoArray(records: Iterable<IOperationExecutionResult>): IOperationInfo[] {
+    const operations: IOperationInfo[] = [];
+
+    for (const record of records) {
+      const info: IOperationInfo | undefined = convertToOperationInfo(record);
+
+      if (info) {
+        operations.push(info);
+      }
+    }
+
+    Sort.sortBy(operations, (x) => x.name);
+    return operations;
+  }
+
+  function sendWebSocketMessage(message: IWebSocketEventMessage): void {
+    const stringifiedMessage: string = JSON.stringify(message);
+    for (const socket of webSockets) {
+      socket.send(stringifiedMessage);
+    }
+  }
+
+  const { command } = options;
+  const sessionInfo: IRushSessionInfo = {
+    actionName: command.actionName,
+    repositoryIdentifier: getRepositoryIdentifier(options.rushConfiguration)
+  };
+
+  function sendSyncMessage(webSocket: WebSocket): void {
+    const syncMessage: IWebSocketSyncEventMessage = {
+      event: 'sync',
+      operations: convertToOperationInfoArray(operationStates?.values() ?? []),
+      sessionInfo,
+      status: buildStatus
+    };
+
+    webSocket.send(JSON.stringify(syncMessage));
+  }
+
+  const { hooks } = command;
+
+  hooks.beforeExecuteOperations.tap(
+    PLUGIN_NAME,
+    (operationsToExecute: Map<Operation, IOperationExecutionResult>): void => {
+      operationStates = operationsToExecute;
+
+      const beforeExecuteMessage: IWebSocketBeforeExecuteEventMessage = {
+        event: 'before-execute',
+        operations: convertToOperationInfoArray(operationsToExecute.values())
+      };
+      buildStatus = 'Executing';
+      sendWebSocketMessage(beforeExecuteMessage);
+    }
+  );
+
+  hooks.afterExecuteOperations.tap(PLUGIN_NAME, (result: IExecutionResult): void => {
+    buildStatus = readableStatusFromStatus[result.status];
+    const afterExecuteMessage: IWebSocketAfterExecuteEventMessage = {
+      event: 'after-execute',
+      status: buildStatus
+    };
+    sendWebSocketMessage(afterExecuteMessage);
+  });
+
+  const pendingStatusChanges: Map<Operation, IOperationExecutionResult> = new Map();
+  let statusChangeTimeout: NodeJS.Immediate | undefined;
+  function sendBatchedStatusChange(): void {
+    statusChangeTimeout = undefined;
+    const infos: IOperationInfo[] = convertToOperationInfoArray(pendingStatusChanges.values());
+    pendingStatusChanges.clear();
+    const message: IWebSocketBatchStatusChangeEventMessage = {
+      event: 'status-change',
+      operations: infos
+    };
+    sendWebSocketMessage(message);
+  }
+
+  hooks.onOperationStatusChanged.tap(PLUGIN_NAME, (record: IOperationExecutionResult): void => {
+    pendingStatusChanges.set(record.operation, record);
+    if (!statusChangeTimeout) {
+      statusChangeTimeout = setImmediate(sendBatchedStatusChange);
+    }
+  });
+
+  const connector: WebSocketServerUpgrader = (server: Http2SecureServer) => {
+    const wss: WebSocketServer = new WebSocketServer({
+      server: server as unknown as HTTPSecureServer,
+      path: buildStatusWebSocketPath
+    });
+    wss.addListener('connection', (webSocket: WebSocket): void => {
+      webSockets.add(webSocket);
+
+      sendSyncMessage(webSocket);
+
+      webSocket.addEventListener('message', (ev: MessageEvent) => {
+        const parsedMessage: IWebSocketCommandMessage = JSON.parse(ev.data.toString());
+        switch (parsedMessage.command) {
+          case 'sync': {
+            sendSyncMessage(webSocket);
+            break;
+          }
+
+          default: {
+            // Unknown message. Ignore.
+          }
+        }
+      });
+
+      webSocket.addEventListener(
+        'close',
+        () => {
+          webSockets.delete(webSocket);
+        },
+        { once: true }
+      );
+    });
+  };
+
+  return connector;
+}
+
+function getRepositoryIdentifier(rushConfiguration: RushConfiguration): string {
+  const { env } = process;
+  const { CODESPACE_NAME: codespaceName, GITHUB_USER: githubUserName } = env;
+
+  if (codespaceName) {
+    const usernamePrefix: string | undefined = githubUserName?.replace(/_|$/g, '-');
+    const startIndex: number =
+      usernamePrefix && codespaceName.startsWith(usernamePrefix) ? usernamePrefix.length : 0;
+    const endIndex: number = codespaceName.lastIndexOf('-');
+    const normalizedName: string = codespaceName.slice(startIndex, endIndex).replace(/-/g, ' ');
+    return `Codespace "${normalizedName}"`;
+  }
+
+  return `${os.hostname()} - ${rushConfiguration.rushJsonFolder}`;
 }

--- a/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
+++ b/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
@@ -27,6 +27,12 @@
       "pattern": "^--(?:[a-z0-9]+)(?:-[a-z0-9]+)*$"
     },
 
+    "buildStatusWebSocketPath": {
+      "type": "string",
+      "description": "The URL path at which to host the web socket connection for monitoring build status. If not specified, the web socket interface will not be enabled.",
+      "pattern": "^/(?:[a-zA-Z0-9_$-]+(?:/[a-zA-Z0-9_$-]+)*)?$"
+    },
+
     "globalRouting": {
       "type": "array",
       "description": "Routing rules for files that are associated with the entire workspace, rather than a single project (e.g. files output by Rush plugins).",


### PR DESCRIPTION
## Summary
Adds a new configuration option `buildStatusWebSocketPath` to `@rushstack/rush-serve-plugin` that, when configured, enables a secure web socket server at `wss://localhost:${port}${buildStatusWebSocketPath}`.

A client can connect a `WebSocket` at the aforementioned path to receive information about the status of the current watch-mode build command.

## Details
Upon connecting a `WebSocket` to the server, the plugin will send a `sync` message that lists all current operations and their statuses, the overall status of the build, and some metadata about the current session (the name of the command, the machine the command is running on).

Whenever the status of one or more operations in the build graph changes, a `status-change` message will be sent with the new states of the affected operations.

Upon completion of the build, an `after-execute` message will be sent, containing the final aggregate build status.

## Future Work
Add support for fetching build logs and streaming log content.

## How it was tested
Temporarily connected `rush-serve-plugin` to be one of the default Rush plugins in `start-dev.js`.
Configured a global rule to host a static HTML page that connected to the web socket server and monitored for live updates.

## Impacted documentation
The list of `OperationStatus` values in Rush. The package documentation and schema for `@rushstack/rush-serve-plugin`.