### PR TITLE
Don't strip out `@alpha` items from generated reports

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -173,7 +173,9 @@ export class MarkdownDocumenter {
     }
 
     if (ApiReleaseTagMixin.isBaseClassOf(apiItem)) {
-      if (apiItem.releaseTag === ReleaseTag.Beta) {
+      if (apiItem.releaseTag === ReleaseTag.Alpha) {
+        this._writeAlphaWarning(output);
+      } else if (apiItem.releaseTag === ReleaseTag.Beta) {
         this._writeBetaWarning(output);
       }
     }
@@ -1000,10 +1002,13 @@ export class MarkdownDocumenter {
     const section: DocSection = new DocSection({ configuration });
 
     if (ApiReleaseTagMixin.isBaseClassOf(apiItem)) {
-      if (apiItem.releaseTag === ReleaseTag.Beta) {
+      if (apiItem.releaseTag === ReleaseTag.Alpha || apiItem.releaseTag === ReleaseTag.Beta) {
         section.appendNodesInParagraph([
           new DocEmphasisSpan({ configuration, bold: true, italic: true }, [
-            new DocPlainText({ configuration, text: '(BETA)' })
+            new DocPlainText({
+              configuration,
+              text: `(${apiItem.releaseTag === ReleaseTag.Alpha ? 'ALPHA' : 'BETA'})`
+            })
           ]),
           new DocPlainText({ configuration, text: ' ' })
         ]);
@@ -1152,10 +1157,22 @@ export class MarkdownDocumenter {
     }
   }
 
+  private _writeAlphaWarning(output: DocSection): void {
+    const configuration: TSDocConfiguration = this._tsdocConfiguration;
+    const betaWarning: string =
+      'This API is provided as an alpha preview for developers and may change' +
+      ' based on feedback that we receive.  Do not use this API in a production environment.';
+    output.appendNode(
+      new DocNoteBox({ configuration }, [
+        new DocParagraph({ configuration }, [new DocPlainText({ configuration, text: betaWarning })])
+      ])
+    );
+  }
+
   private _writeBetaWarning(output: DocSection): void {
     const configuration: TSDocConfiguration = this._tsdocConfiguration;
     const betaWarning: string =
-      'This API is provided as a preview for developers and may change' +
+      'This API is provided as a beta preview for developers and may change' +
       ' based on feedback that we receive.  Do not use this API in a production environment.';
     output.appendNode(
       new DocNoteBox({ configuration }, [

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -425,7 +425,7 @@ export class YamlDocumenter {
     }
 
     if (ApiReleaseTagMixin.isBaseClassOf(apiItem)) {
-      if (apiItem.releaseTag === ReleaseTag.Beta) {
+      if (apiItem.releaseTag === ReleaseTag.Alpha || apiItem.releaseTag === ReleaseTag.Beta) {
         yamlItem.isPreview = true;
       }
     }

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -176,8 +176,8 @@ export class ApiModelGenerator {
 
     const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
     const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
-    if (releaseTag === ReleaseTag.Internal || releaseTag === ReleaseTag.Alpha) {
-      return; // trim out items marked as "@internal" or "@alpha"
+    if (releaseTag === ReleaseTag.Internal) {
+      return; // trim out items marked as "@internal"
     }
 
     switch (astDeclaration.declaration.kind) {

--- a/common/changes/@microsoft/api-documenter/patch-1_2023-09-20-22-22.json
+++ b/common/changes/@microsoft/api-documenter/patch-1_2023-09-20-22-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Add notes for @alpha items when encountered. Mimics the existing behavior for @beta items.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor/patch-1_2023-09-20-22-22.json
+++ b/common/changes/@microsoft/api-extractor/patch-1_2023-09-20-22-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Don't strip out @alpha items when generating API reports.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
It is useful for `@alpha` items to appear in metadata and generated documentation. The system currently unconditionally strips all `@alpha` items out.

I don't know how important it is to preserve existing behavior. If it is, perhaps this should be configurable somehow? Any feedback / suggestions would be appreciated.

I posted a question in the chatroom about this but have not yet heard back. I'll link to this PR from there as well.