### PR TITLE
[rush] Fix pnpm's install status printing when pnpm custom tips are defined.

### DIFF
--- a/common/changes/@microsoft/rush/fix-tty_2023-09-19-10-01.json
+++ b/common/changes/@microsoft/rush/fix-tty_2023-09-19-10-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix pnpm's install status printing when pnpm custom tips are defined.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.107.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -493,6 +493,26 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       args.push('--recursive');
       args.push('--link-workspace-packages', 'false');
 
+      if (process.stdout.isTTY) {
+        // If we're on a TTY console and something else didn't set a `--reporter` parameter,
+        // explicitly set the default reporter. This fixes an issue where, when the pnpm
+        // output is being monitored to match custom tips, pnpm will detect a non-TTY
+        // stdout stream and use the `append-only` reporter.
+        //
+        // See docs here: https://pnpm.io/cli/install#--reportername
+        let includesReporterArg: boolean = false;
+        for (const arg of args) {
+          if (arg.startsWith('--reporter')) {
+            includesReporterArg = true;
+            break;
+          }
+        }
+
+        if (!includesReporterArg) {
+          args.push('--reporter', 'default');
+        }
+      }
+
       for (const arg of this.options.pnpmFilterArguments) {
         args.push(arg);
       }


### PR DESCRIPTION
## Summary

This change adds a `--reporter default` parameter to the args passed to pnpm if Rush is running in an environment with a TTY stdout. This fixes an issue where, when the pnpm output is being monitored to match custom tips, pnpm will detect a non-TTY stdout stream and use the `append-only` reporter. This reporter doesn't incrementally update the installation progress line, and instead repeatedly reprints that line down the console.
 
Docs on that parameter: https://pnpm.io/cli/install#--reportername

## How it was tested

Tested in a repo with a nonexistent dependency and a `TIP_PNPM_NO_MATCHING_VERSION` custom tip defined.