### PR TITLE
[heft] (BREAKING CHANGE) Put temp folders for tasks in parent for phase

### DIFF
--- a/apps/heft/src/operations/runners/PhaseOperationRunner.ts
+++ b/apps/heft/src/operations/runners/PhaseOperationRunner.ts
@@ -10,7 +10,6 @@ import {
 import { deleteFilesAsync, type IDeleteOperation } from '../../plugins/DeleteFilesPlugin';
 import type { HeftPhase } from '../../pluginFramework/HeftPhase';
 import type { HeftPhaseSession } from '../../pluginFramework/HeftPhaseSession';
-import type { HeftTaskSession } from '../../pluginFramework/HeftTaskSession';
 import type { InternalHeftSession } from '../../pluginFramework/InternalHeftSession';
 
 export interface IPhaseOperationRunnerOptions {
@@ -53,10 +52,14 @@ export class PhaseOperationRunner implements IOperationRunner {
     const deleteOperations: IDeleteOperation[] = Array.from(phase.cleanFiles);
 
     // Delete all temp folders for tasks by default
-    for (const task of phase.tasks) {
-      const taskSession: HeftTaskSession = phaseSession.getSessionForTask(task);
-      deleteOperations.push({ sourcePath: taskSession.tempFolderPath });
-    }
+    const tempFolderGlobs: string[] = [
+      /* heft@>0.60.0 */ phase.phaseName,
+      /* heft@<=0.60.0 */ `${phase.phaseName}.*`
+    ];
+    deleteOperations.push({
+      sourcePath: internalHeftSession.heftConfiguration.tempFolderPath,
+      includeGlobs: tempFolderGlobs
+    });
 
     // Delete the files if any were specified
     if (deleteOperations.length) {

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import { AsyncParallelHook, AsyncSeriesWaterfallHook } from 'tapable';
 
 import type { MetricsCollector } from '../metrics/MetricsCollector';

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -295,7 +295,7 @@ export class HeftTaskSession implements IHeftTaskSession {
     const uniqueTaskFolderName: string = `${phase.phaseName}/${task.taskName}`;
 
     // <projectFolder>/temp/<phaseName>/<taskName>
-    this.tempFolderPath = path.join(tempFolder, uniqueTaskFolderName);
+    this.tempFolderPath = `${tempFolder}/${uniqueTaskFolderName}`;
 
     this._options = options;
   }

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -287,13 +287,14 @@ export class HeftTaskSession implements IHeftTaskSession {
     };
 
     // Guaranteed to be unique since phases are uniquely named, tasks are uniquely named within
-    // phases, and neither can have '.' in their names. We will also use the phase name and
+    // phases, and neither can have '/' in their names. We will also use the phase name and
     // task name as the folder name (instead of the plugin name) since we want to enable re-use
     // of plugins in multiple phases and tasks while maintaining unique temp/cache folders for
     // each task.
-    const uniqueTaskFolderName: string = `${phase.phaseName}.${task.taskName}`;
+    // Having a parent folder for the phase simplifies interaction with the Rush build cache.
+    const uniqueTaskFolderName: string = `${phase.phaseName}/${task.taskName}`;
 
-    // <projectFolder>/temp/<phaseName>.<taskName>
+    // <projectFolder>/temp/<phaseName>/<taskName>
     this.tempFolderPath = path.join(tempFolder, uniqueTaskFolderName);
 
     this._options = options;

--- a/build-tests/heft-parameter-plugin-test/src/test/customParameter.test.ts
+++ b/build-tests/heft-parameter-plugin-test/src/test/customParameter.test.ts
@@ -4,7 +4,7 @@ import { FileSystem } from '@rushstack/node-core-library';
 describe('CustomParameterOutput', () => {
   it('parses command line arguments and prints output.', async () => {
     const outputContent: string = await FileSystem.readFileAsync(
-      `${dirname(dirname(__dirname))}/temp/test.write-parameters/custom_output.txt`
+      `${dirname(dirname(__dirname))}/temp/test/write-parameters/custom_output.txt`
     );
     expect(outputContent).toBe(
       'customIntegerParameter: 5\n' +

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   rush-lib-test:
     dependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.107.0.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.107.0.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.107.1.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.107.1.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
@@ -30,15 +30,15 @@ importers:
   rush-sdk-test:
     dependencies:
       '@rushstack/rush-sdk':
-        specifier: file:rushstack-rush-sdk-5.107.0.tgz
-        version: file:../temp/tarballs/rushstack-rush-sdk-5.107.0.tgz(@types/node@18.17.15)
+        specifier: file:rushstack-rush-sdk-5.107.1.tgz
+        version: file:../temp/tarballs/rushstack-rush-sdk-5.107.1.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.107.0.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.107.0.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.107.1.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.107.1.tgz(@types/node@18.17.15)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -55,14 +55,14 @@ importers:
         specifier: file:rushstack-eslint-config-3.3.4.tgz
         version: file:../temp/tarballs/rushstack-eslint-config-3.3.4.tgz(eslint@8.7.0)(typescript@5.0.4)
       '@rushstack/heft':
-        specifier: file:rushstack-heft-0.59.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-0.59.0.tgz
+        specifier: file:rushstack-heft-0.60.0.tgz
+        version: file:../temp/tarballs/rushstack-heft-0.60.0.tgz
       '@rushstack/heft-lint-plugin':
-        specifier: file:rushstack-heft-lint-plugin-0.2.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.0.tgz(@rushstack/heft@0.59.0)
+        specifier: file:rushstack-heft-lint-plugin-0.2.1.tgz
+        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.1.tgz(@rushstack/heft@0.60.0)
       '@rushstack/heft-typescript-plugin':
-        specifier: file:rushstack-heft-typescript-plugin-0.2.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.0.tgz(@rushstack/heft@0.59.0)
+        specifier: file:rushstack-heft-typescript-plugin-0.2.1.tgz
+        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.1.tgz(@rushstack/heft@0.60.0)
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -79,14 +79,14 @@ importers:
         specifier: file:rushstack-eslint-config-3.3.4.tgz
         version: file:../temp/tarballs/rushstack-eslint-config-3.3.4.tgz(eslint@8.7.0)(typescript@4.7.4)
       '@rushstack/heft':
-        specifier: file:rushstack-heft-0.59.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-0.59.0.tgz
+        specifier: file:rushstack-heft-0.60.0.tgz
+        version: file:../temp/tarballs/rushstack-heft-0.60.0.tgz
       '@rushstack/heft-lint-plugin':
-        specifier: file:rushstack-heft-lint-plugin-0.2.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.0.tgz(@rushstack/heft@0.59.0)
+        specifier: file:rushstack-heft-lint-plugin-0.2.1.tgz
+        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.1.tgz(@rushstack/heft@0.60.0)
       '@rushstack/heft-typescript-plugin':
-        specifier: file:rushstack-heft-typescript-plugin-0.2.0.tgz
-        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.0.tgz(@rushstack/heft@0.59.0)
+        specifier: file:rushstack-heft-typescript-plugin-0.2.1.tgz
+        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.1.tgz(@rushstack/heft@0.60.0)
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -3923,22 +3923,22 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.107.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.107.0.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.107.0.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.107.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.107.1.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.107.1.tgz
     name: '@microsoft/rush-lib'
-    version: 5.107.0
+    version: 5.107.1
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/dependency-path': 2.1.2
       '@pnpm/link-bins': 5.3.25
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.0.tgz(@types/node@18.17.15)
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.1.0.tgz(@types/node@18.17.15)
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.6.1.tgz(@types/node@18.17.15)
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.1.1.tgz(@types/node@18.17.15)
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.6.2.tgz(@types/node@18.17.15)
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.5.0.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.1.1.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.0.tgz(@types/node@18.17.15)
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.1.2.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.1.tgz(@types/node@18.17.15)
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.16.0.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
@@ -4125,16 +4125,16 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.59.0.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.59.0.tgz}
+  file:../temp/tarballs/rushstack-heft-0.60.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.60.0.tgz}
     name: '@rushstack/heft'
-    version: 0.59.0
+    version: 0.60.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.0.tgz(@types/node@18.17.15)
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
-      '@rushstack/operation-graph': file:../temp/tarballs/rushstack-operation-graph-0.0.1.tgz
+      '@rushstack/operation-graph': file:../temp/tarballs/rushstack-operation-graph-0.1.0.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.5.0.tgz
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.16.0.tgz
       '@types/tapable': 1.0.6
@@ -4163,30 +4163,30 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.0.tgz(@rushstack/heft@0.59.0):
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.0.tgz}
-    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.0.tgz
+  file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.1.tgz(@rushstack/heft@0.60.0):
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.1.tgz}
+    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.2.1.tgz
     name: '@rushstack/heft-lint-plugin'
-    version: 0.2.0
+    version: 0.2.1
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.59.0.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.60.0.tgz
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.0.tgz(@rushstack/heft@0.59.0):
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.0.tgz}
-    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.0.tgz
+  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.1.tgz(@rushstack/heft@0.60.0):
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.1.tgz}
+    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.2.1.tgz
     name: '@rushstack/heft-typescript-plugin'
-    version: 0.2.0
+    version: 0.2.1
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.59.0.tgz
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.60.0.tgz
       '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.0.tgz(@types/node@18.17.15)
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
       '@types/tapable': 1.0.6
@@ -4216,10 +4216,10 @@ packages:
       semver: 7.5.4
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-operation-graph-0.0.1.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-operation-graph-0.0.1.tgz}
+  file:../temp/tarballs/rushstack-operation-graph-0.1.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-operation-graph-0.1.0.tgz}
     name: '@rushstack/operation-graph'
-    version: 0.0.1
+    version: 0.1.0
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4229,25 +4229,25 @@ packages:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
     dev: true
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.1.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.1.0.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.1.0.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.1.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.1.1.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.1.1.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.1.0
+    version: 4.1.1
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.6.1.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.6.1.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.6.1.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.6.2.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.6.2.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.6.2.tgz
     name: '@rushstack/package-extractor'
-    version: 0.6.1
+    version: 0.6.2
     dependencies:
       '@pnpm/link-bins': 5.3.25
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.0.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.1.tgz(@types/node@18.17.15)
       ignore: 5.1.9
       jszip: 3.8.0
       minimatch: 3.0.8
@@ -4264,11 +4264,11 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.107.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.107.0.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.107.0.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.107.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.107.1.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.107.1.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.107.0
+    version: 5.107.1
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
       '@types/node-fetch': 2.6.2
@@ -4277,22 +4277,22 @@ packages:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.1.1.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.1.1.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.1.1.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.1.2.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.1.2.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.1.2.tgz
     name: '@rushstack/stream-collator'
-    version: 4.1.1
+    version: 4.1.2
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.60.0.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.0.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.1.tgz(@types/node@18.17.15)
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.7.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.7.0.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.7.0.tgz
+  file:../temp/tarballs/rushstack-terminal-0.7.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.7.1.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.7.1.tgz
     name: '@rushstack/terminal'
-    version: 0.7.0
+    version: 0.7.1
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:

--- a/common/changes/@rushstack/heft/heft-temp-folder-pattern_2023-09-20-00-47.json
+++ b/common/changes/@rushstack/heft/heft-temp-folder-pattern_2023-09-20-00-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "(BREAKING CHANGE): Rename task temp folder from \"<phase>.<task>\" to \"<phase>/<task>\" to simplify caching phase outputs.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary
Changes the naming convention for Heft's task temp folders from `<phase>.<task>` to `<phase>/<task>` so that the Rush build cache (or other tools interested in caching) can select a single well-formed folder to capture the entire phase's temp output.

## Details
Ensures that folders named `temp/<phase>.*` get cleaned.

## How it was tested
Local build.

## Impacted documentation
Any documentation concerning the temp folder path.