### PR TITLE
[rush-lib] Add experiment flag to allow skipping build with warning

### DIFF
--- a/common/changes/@microsoft/rush/feat-skip-build-with-warning-status_2023-09-20-06-34.json
+++ b/common/changes/@microsoft/rush/feat-skip-build-with-warning-status_2023-09-20-06-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add experiment `buildSkipWithAllowWarningsInSuccessfulBuild` to allow skipping builds that succeeded with warnings in the previous run.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -37,6 +37,12 @@
   // "buildCacheWithAllowWarningsInSuccessfulBuild": true,
 
   /**
+   * If true, build skipping will respect the allowWarningsInSuccessfulBuild flag and skip builds with warnings.
+   * This will not replay warnings from the skipped build.
+   */
+  // "buildSkipWithAllowWarningsInSuccessfulBuild": true,
+
+  /**
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -444,6 +444,7 @@ export interface IExecutionResult {
 // @beta
 export interface IExperimentsJson {
     buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
+    buildSkipWithAllowWarningsInSuccessfulBuild?: boolean;
     cleanInstallAfterNpmrcChanges?: boolean;
     forbidPhantomResolvableNodeModulesFolders?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -50,6 +50,12 @@ export interface IExperimentsJson {
   buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
 
   /**
+   * If true, build skipping will respect the allowWarningsInSuccessfulBuild flag and skip builds with warnings.
+   * This will not replay warnings from the skipped build.
+   */
+  buildSkipWithAllowWarningsInSuccessfulBuild?: boolean;
+
+  /**
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -363,6 +363,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       } else if (!this._disableBuildCache) {
         // Explicitly disabling the build cache also disables legacy skip detection.
         new LegacySkipPlugin({
+          allowWarningsInSuccessfulBuild:
+            !!this.rushConfiguration.experimentsConfiguration.configuration
+              .buildSkipWithAllowWarningsInSuccessfulBuild,
           terminal,
           changedProjectsOnly,
           isIncrementalBuildAllowed: this._isIncrementalBuildAllowed

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -364,7 +364,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         // Explicitly disabling the build cache also disables legacy skip detection.
         new LegacySkipPlugin({
           allowWarningsInSuccessfulBuild:
-            !!this.rushConfiguration.experimentsConfiguration.configuration
+            this.rushConfiguration.experimentsConfiguration.configuration
               .buildSkipWithAllowWarningsInSuccessfulBuild,
           terminal,
           changedProjectsOnly,

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -55,6 +55,7 @@ export interface ILegacySkipPluginOptions {
   terminal: ITerminal;
   changedProjectsOnly: boolean;
   isIncrementalBuildAllowed: boolean;
+  allowWarningsInSuccessfulBuild: boolean;
 }
 
 /**
@@ -72,7 +73,8 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
     let projectChangeAnalyzer!: ProjectChangeAnalyzer;
 
-    const { terminal, changedProjectsOnly, isIncrementalBuildAllowed } = this._options;
+    const { terminal, changedProjectsOnly, isIncrementalBuildAllowed, allowWarningsInSuccessfulBuild } =
+      this._options;
 
     hooks.createOperations.tap(
       PLUGIN_NAME,
@@ -257,7 +259,14 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
         const { packageDeps, packageDepsPath } = skipRecord;
 
-        if ((packageDeps && status === OperationStatus.Success) || status === OperationStatus.NoOp) {
+        if (
+          (packageDeps && status === OperationStatus.Success) ||
+          (packageDeps &&
+            status === OperationStatus.SuccessWithWarning &&
+            record.operation.runner!.warningsAreAllowed &&
+            allowWarningsInSuccessfulBuild) ||
+          status === OperationStatus.NoOp
+        ) {
           // Write deps on success.
           await JsonFile.saveAsync(packageDeps, packageDepsPath, {
             ensureFolderExists: true

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -260,12 +260,12 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
         const { packageDeps, packageDepsPath } = skipRecord;
 
         if (
-          (packageDeps && status === OperationStatus.Success) ||
+          status === OperationStatus.NoOp ||
           (packageDeps &&
-            status === OperationStatus.SuccessWithWarning &&
-            record.operation.runner!.warningsAreAllowed &&
-            allowWarningsInSuccessfulBuild) ||
-          status === OperationStatus.NoOp
+            (status === OperationStatus.Success ||
+              (status === OperationStatus.SuccessWithWarning &&
+                record.operation.runner!.warningsAreAllowed &&
+                allowWarningsInSuccessfulBuild)))
         ) {
           // Write deps on success.
           await JsonFile.saveAsync(packageDeps, packageDepsPath, {

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -55,7 +55,7 @@ export interface ILegacySkipPluginOptions {
   terminal: ITerminal;
   changedProjectsOnly: boolean;
   isIncrementalBuildAllowed: boolean;
-  allowWarningsInSuccessfulBuild: boolean;
+  allowWarningsInSuccessfulBuild?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -34,6 +34,10 @@
       "description": "If true, build caching will respect the allowWarningsInSuccessfulBuild flag and cache builds with warnings. This will not replay warnings from the cached build.",
       "type": "boolean"
     },
+    "buildSkipWithAllowWarningsInSuccessfulBuild": {
+      "description": "If true, build skipping will respect the allowWarningsInSuccessfulBuild flag and skip builds with warnings. This will not replay warnings from the skipped build.",
+      "type": "boolean"
+    },
     "phasedCommands": {
       "description": "If true, the phased commands feature is enabled. To use this feature, create a \"phased\" command in common/config/rush/command-line.json.",
       "type": "boolean"


### PR DESCRIPTION

## Summary

The problem: currently a build operation with warning is not allowed to use the incremental build (build skipping) feature. Consequently, the `package-deps_build.json` is not saved to disk which prevents further change detection in future runs. Preventing this is understandably a good default for discouraging build with warning, however, there are cases in which frameworks like Angular write to stderr for logs, which creates the warning. This make even newly generated projects non-skippable by default.

Just like the existing `buildCacheWithAllowWarningsInSuccessfulBuild` flag, it would be great to provide this flexibility to projects that conciously accept the risk or is hard to alter the default behaviours.

The proposed change:
- add a flag to support skipping build with status `sucess with warning`
- persist `package-deps_build.json` when the flag is enabled and the commands are configured to allow warnings.

## How it was tested

- test default experiments.json file
  - `buildSkipWithAllowWarningsInSuccessfulBuild` is disabled
  - build an angular project for 3 times, none of them skipped build
- test with flag on
  - configure a custom command with  `allowWarningsInSuccessfulBuild` and `incremental` on
  - enable `buildSkipWithAllowWarningsInSuccessfulBuild`
  - build an angular project for 3 times, warm runs skipped build
  - modify the project, the next build is not skipped
  -  `package-deps_build.json` was updated
  - subsequent runs are skipped again


## Impacted documentation[

https://rushjs.io/pages/advanced/incremental_builds/
