### PR TITLE
[rush] Fix filtered installs in pnpm@8

### DIFF
--- a/common/changes/@microsoft/rush/pnpm-install-filter_2023-09-20-18-04.json
+++ b/common/changes/@microsoft/rush/pnpm-install-filter_2023-09-20-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix filtered installs in pnpm@8.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -358,12 +358,12 @@ export class RushConfiguration {
   public readonly currentVariantJsonFilename: string;
 
   /**
-   * The version of the locally installed NPM tool.  (Example: "1.2.3")
+   * The version of the locally package manager tool.  (Example: "1.2.3")
    */
   public readonly packageManagerToolVersion: string;
 
   /**
-   * The absolute path to the locally installed NPM tool.  If "rush install" has not
+   * The absolute path to the locally package manager tool.  If "rush install" has not
    * been run, then this file may not exist yet.
    * Example: `C:\MyRepo\common\temp\npm-local\node_modules\.bin\npm`
    */

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -575,7 +575,7 @@ ${gitLfsHookHandling}
 
         if (
           options.pnpmFilterArguments.length > 0 &&
-          semver.satisfies(this.rushConfiguration.packageManagerToolVersion, '^8')
+          Number.parseInt(this.rushConfiguration.packageManagerToolVersion, 10) >= 8 // PNPM Major version 8+
         ) {
           // On pnpm@8, disable the "dedupe-peer-dependents" feature when doing a filtered CI install so that filters take effect.
           args.push('--config.dedupe-peer-dependents=false');

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -572,6 +572,14 @@ ${gitLfsHookHandling}
 
       if (experiments.usePnpmFrozenLockfileForRushInstall && !options.allowShrinkwrapUpdates) {
         args.push('--frozen-lockfile');
+
+        if (
+          options.pnpmFilterArguments.length > 0 &&
+          semver.satisfies(this.rushConfiguration.packageManagerToolVersion, '^8')
+        ) {
+          // On pnpm@8, disable the "dedupe-peer-dependents" feature when doing a filtered CI install so that filters take effect.
+          args.push('--config.dedupe-peer-dependents=false');
+        }
       } else if (experiments.usePnpmPreferFrozenLockfileForRushUpdate) {
         // In workspaces, we want to avoid unnecessary lockfile churn
         args.push('--prefer-frozen-lockfile');


### PR DESCRIPTION
## Summary
Fixes #4285 

## Details
Sets the `dedupe-peer-dependents=false` option when passing filter arguments and installing with `--frozen-lockfile`.

## How it was tested
Created a second git worktree and used the modified version of rush to run `rush install --to @rushstack/heft`:
```
Running "pnpm install" in /workspaces/rushstack-2/common/temp

Scope: 14 of 130 workspace projects
Lockfile is up to date, resolution step is skipped
.                                        | +507 +++++++++++++++++++++++++++++++++++++++++++++++++++

Downloading registry.npmjs.org/typescript/5.0.4: 7.05 MB/7.05 MB, done
Progress: resolved 507, reused 0, downloaded 497, added 507, done
Done in 2.8s
```


## Impacted documentation
None.