### PR TITLE
[api-extractor] Support customizing defaults when loading config

### DIFF
--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -454,3 +454,21 @@ export interface IConfigFile {
    */
   messages?: IExtractorMessagesConfig;
 }
+
+/**
+ * Helper type for partial config.
+ *
+ * @public
+ */
+export type DeepPartial<T> = T extends object
+  ? {
+      [K in keyof T]?: DeepPartial<T[K]>;
+    }
+  : T;
+
+/**
+ * The data type for custom defaults.
+ *
+ * @public
+ */
+export type IDeepPartialConfigFile = DeepPartial<IConfigFile>;

--- a/apps/api-extractor/src/api/test/ExtractorConfig-lookup.test.ts
+++ b/apps/api-extractor/src/api/test/ExtractorConfig-lookup.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { Path } from '@rushstack/node-core-library';
 
 import { ExtractorConfig } from '../ExtractorConfig';
+import type { IConfigFile } from '../IConfigFile';
 
 const testDataFolder: string = path.join(__dirname, 'test-data');
 
@@ -16,22 +17,40 @@ function expectEqualPaths(path1: string, path2: string): void {
 
 // Tests for expanding the "<lookup>" token for the "projectFolder" setting in api-extractor.json
 describe(`${ExtractorConfig.name}.${ExtractorConfig.loadFileAndPrepare.name}`, () => {
-  it.only('config-lookup1: looks up ./api-extractor.json', () => {
+  it('config-lookup1: looks up ./api-extractor.json', () => {
     const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
       path.join(testDataFolder, 'config-lookup1/api-extractor.json')
     );
     expectEqualPaths(extractorConfig.projectFolder, path.join(testDataFolder, 'config-lookup1'));
   });
-  it.only('config-lookup2: looks up ./config/api-extractor.json', () => {
+  it('config-lookup2: looks up ./config/api-extractor.json', () => {
     const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
       path.join(testDataFolder, 'config-lookup2/config/api-extractor.json')
     );
     expectEqualPaths(extractorConfig.projectFolder, path.join(testDataFolder, 'config-lookup2'));
   });
-  it.only('config-lookup3a: looks up ./src/test/config/api-extractor.json', () => {
+  it('config-lookup3a: looks up ./src/test/config/api-extractor.json', () => {
     const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
       path.join(testDataFolder, 'config-lookup3/src/test/config/api-extractor.json')
     );
     expectEqualPaths(extractorConfig.projectFolder, path.join(testDataFolder, 'config-lookup3/src/test/'));
+  });
+});
+
+describe(`${ExtractorConfig.name}.${ExtractorConfig.loadFile.name}`, () => {
+  it('config-lookup1: respects customDefaults', () => {
+    const extractorConfig: IConfigFile = ExtractorConfig.loadFile(
+      path.join(testDataFolder, 'config-lookup1/api-extractor.json'),
+      {
+        apiReport: {
+          enabled: false,
+          reportTempFolder: '/foo'
+        }
+      }
+    );
+
+    expect(extractorConfig.apiReport?.enabled).toEqual(true);
+    expect(extractorConfig.apiReport?.reportTempFolder).toEqual('/foo');
+    expect(extractorConfig.apiReport?.reportFolder).toEqual('<projectFolder>/etc/');
   });
 });

--- a/apps/api-extractor/src/index.ts
+++ b/apps/api-extractor/src/index.ts
@@ -40,5 +40,7 @@ export {
   IConfigMessageReportingRule,
   IConfigMessageReportingTable,
   IExtractorMessagesConfig,
-  IConfigFile
+  IConfigFile,
+  DeepPartial,
+  IDeepPartialConfigFile
 } from './api/IConfigFile';

--- a/common/changes/@microsoft/api-extractor/api-extractor-temp-path_2023-09-20-19-59.json
+++ b/common/changes/@microsoft/api-extractor/api-extractor-temp-path_2023-09-20-19-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add the ability for tools to customize the default values when loading api-extractor.json files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/api-extractor-temp-path_2023-09-20-20-02.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/api-extractor-temp-path_2023-09-20-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "Move temp path for api report into task temp folder.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -37,6 +37,11 @@ export const enum ConsoleMessageId {
 }
 
 // @public
+export type DeepPartial<T> = T extends object ? {
+    [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+// @public
 export class Extractor {
     static invoke(extractorConfig: ExtractorConfig, options?: IExtractorInvokeOptions): ExtractorResult;
     static loadConfigAndInvoke(configFilePath: string, options?: IExtractorInvokeOptions): ExtractorResult;
@@ -61,7 +66,7 @@ export class ExtractorConfig {
     _getShortFilePath(absolutePath: string): string;
     static hasDtsFileExtension(filePath: string): boolean;
     static readonly jsonSchema: JsonSchema;
-    static loadFile(jsonFilePath: string): IConfigFile;
+    static loadFile(jsonFilePath: string, customDefaults?: IDeepPartialConfigFile): IConfigFile;
     static loadFileAndPrepare(configJsonFilePath: string): ExtractorConfig;
     readonly mainEntryPointFilePath: string;
     readonly messages: IExtractorMessagesConfig;
@@ -237,6 +242,9 @@ export interface IConfigTsdocMetadata {
     enabled: boolean;
     tsdocMetadataFilePath?: string;
 }
+
+// @public
+export type IDeepPartialConfigFile = DeepPartial<IConfigFile>;
 
 // @public
 export interface IExtractorConfigLoadForFolderOptions {

--- a/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
+++ b/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
@@ -122,7 +122,11 @@ export default class ApiExtractorPlugin implements IHeftTaskPlugin {
       heftConfiguration
     );
     const apiExtractorConfigurationObject: TApiExtractor.IConfigFile =
-      apiExtractorPackage.ExtractorConfig.loadFile(apiExtractorConfigurationFilePath);
+      apiExtractorPackage.ExtractorConfig.loadFile(apiExtractorConfigurationFilePath, {
+        apiReport: {
+          reportTempFolder: taskSession.tempFolderPath
+        }
+      });
 
     // Load the configuration file. Always load from scratch.
     const apiExtractorConfiguration: TApiExtractor.ExtractorConfig =


### PR DESCRIPTION
## Summary
Adds the ability for tools consuming API-Extractor to customize the default values when loading config files.

## Details
Provided custom defaults override global defaults, then the config file values are written on top of them.
 
Uses this ability in heft-api-extractor-plugin to change the default API report temp folder in the Heft task temp folder.

## How it was tested
Added unit test for config file custom defaults.
Validated new location for temp api.md file in rushstack projects.

## Impacted documentation
Currently none, unless something mentions the path to which heft-api-extractor-plugin writes its temp files.