### PR TITLE
[rush] Fix failures not blocking

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-09-21-22-56.json
+++ b/common/changes/@microsoft/rush/main_2023-09-21-22-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a bug in which an operation failing incorrectly does not block its consumers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -76,14 +76,17 @@ export class AsyncOperationQueue
     this._completedOperations.add(record);
 
     // Apply status changes to direct dependents
-    for (const item of record.consumers) {
-      // Remove this operation from the dependencies, to unblock the scheduler
-      if (
-        item.dependencies.delete(record) &&
-        item.dependencies.size === 0 &&
-        item.status === OperationStatus.Waiting
-      ) {
-        item.status = OperationStatus.Ready;
+    if (record.status !== OperationStatus.Failure && record.status !== OperationStatus.Blocked) {
+      // Only do so if the operation did not fail or get blocked
+      for (const item of record.consumers) {
+        // Remove this operation from the dependencies, to unblock the scheduler
+        if (
+          item.dependencies.delete(record) &&
+          item.dependencies.size === 0 &&
+          item.status === OperationStatus.Waiting
+        ) {
+          item.status = OperationStatus.Ready;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes a bug in which an operation failing does not block its consumers.

## Details
Fallout from adding the "Waiting" state to the operation graph. The code to cascade "blocked" status checked the wrong state, and there wasn't a test case.

## How it was tested
Added unit test coverage.

## Impacted documentation
None