### PR TITLE
[rush-lib] Make the project watcher status and keyboard commands message more visible

### DIFF
--- a/common/changes/@microsoft/rush/watch-mode-option_2023-09-23-03-02.json
+++ b/common/changes/@microsoft/rush/watch-mode-option_2023-09-23-03-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "make project watcher pause status and keybinds message more visible",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/watch-mode-option_2023-09-23-03-02.json
+++ b/common/changes/@microsoft/rush/watch-mode-option_2023-09-23-03-02.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "make project watcher pause status and keybinds message more visible",
+      "comment": "Make the project watcher status and keyboard commands message more visible.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -164,7 +164,7 @@ export class ProjectWatcher {
 
           try {
             if (this.isPaused) {
-              this._setStatus(`Project watcher paused. Press 'w' to toggle. Press 'b' to build once.`);
+              this._setStatus(`Project watcher paused.`);
               return;
             }
             this._setStatus(`Evaluating changes to tracked files...`);
@@ -315,7 +315,16 @@ export class ProjectWatcher {
     } else {
       this._hasRenderedStatus = true;
     }
-    this._terminal.write(Colors.bold(Colors.cyan(`Watch Status: ${status}`)));
+
+    this._terminal.write(
+      Colors.bold(
+        Colors.cyan(
+          `[${this.isPaused ? 'PAUSED' : 'WATCHING'}] Watch Status: ${status} ${
+            this.isPaused ? 'Press <w> to resume. Press <b> to build once.' : 'Press <w> to pause.'
+          }`
+        )
+      )
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Make project watcher pause status and keybinds message show as part of watch status.

## Details

Before: `Watch Status: No changes detected to tracked files.`
After: `[WATCHING] Watch Status: No changes detected to tracked files. Press <w> to pause.`

![image](https://github.com/microsoft/rushstack/assets/5100938/9f320179-800d-4d1c-ad23-47b9efc815cc)

## How it was tested

Tested by running `node ../rushstack/apps/rush/lib/start-dev.js start`, making changes, toggling watch mode.