### PR TITLE
[rush] Update the functionality that runs external lifecycle processes to be async.

### DIFF
--- a/apps/rush/src/RushVersionSelector.ts
+++ b/apps/rush/src/RushVersionSelector.ts
@@ -48,7 +48,7 @@ export class RushVersionSelector {
       if (installIsValid) {
         console.log('Another process performed the installation.');
       } else {
-        Utilities.installPackageInDirectory({
+        await Utilities.installPackageInDirectoryAsync({
           directory: expectedRushPath,
           packageName: isLegacyRushVersion ? '@microsoft/rush' : '@microsoft/rush-lib',
           version: version,

--- a/common/changes/@microsoft/rush/main_2023-09-24-06-11.json
+++ b/common/changes/@microsoft/rush/main_2023-09-24-06-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the functionality that runs external lifecycle processes to be async.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/config/jest.config.json
+++ b/libraries/rush-lib/config/jest.config.json
@@ -13,5 +13,7 @@
     "!lib-commonjs/**/__tests__/**",
     "!lib-commonjs/**/__fixtures__/**",
     "!lib-commonjs/**/__mocks__/**"
-  ]
+  ],
+
+  "globalTeardown": "<rootDir>/lib-commonjs/utilities/test/global-teardown.js"
 }

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -420,15 +420,7 @@ export class RushPnpmCommandLineParser {
           environment: pnpmEnvironmentMap.toObject(),
           keepEnvironment: true
         },
-        onStdoutStreamChunk,
-        (exitCode: number | null, signal: NodeJS.Signals | null) => {
-          if (typeof exitCode === 'number') {
-            process.exitCode = exitCode;
-          } else {
-            // Terminated by a signal
-            process.exitCode = 1;
-          }
-        }
+        onStdoutStreamChunk
       );
     } catch (e) {
       this._terminal.writeDebugLine(`Error: ${e}`);

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -412,16 +412,14 @@ export class RushPnpmCommandLineParser {
     }
 
     try {
-      await Utilities.executeCommandAndInspectOutputAsync(
-        {
-          command: rushConfiguration.packageManagerToolFilename,
-          args: this._pnpmArgs,
-          workingDirectory: process.cwd(),
-          environment: pnpmEnvironmentMap.toObject(),
-          keepEnvironment: true
-        },
+      await Utilities.executeCommandAsync({
+        command: rushConfiguration.packageManagerToolFilename,
+        args: this._pnpmArgs,
+        workingDirectory: process.cwd(),
+        environment: pnpmEnvironmentMap.toObject(),
+        keepEnvironment: true,
         onStdoutStreamChunk
-      );
+      });
     } catch (e) {
       this._terminal.writeDebugLine(`Error: ${e}`);
     }

--- a/libraries/rush-lib/src/cli/test/Cli.test.ts
+++ b/libraries/rush-lib/src/cli/test/Cli.test.ts
@@ -6,12 +6,12 @@ import * as path from 'path';
 import { Utilities } from '../../utilities/Utilities';
 
 describe('CLI', () => {
-  it('should not fail when there is no rush.json', () => {
+  it('should not fail when there is no rush.json', async () => {
     const workingDir: string = '/';
     const startPath: string = path.resolve(__dirname, '../../../lib-commonjs/start.js');
 
-    expect(() => {
-      Utilities.executeCommand({
+    await expect(async () => {
+      await Utilities.executeCommandAsync({
         command: 'node',
         args: [startPath],
         workingDirectory: workingDir,
@@ -20,12 +20,12 @@ describe('CLI', () => {
     }).not.toThrow();
   });
 
-  it('rushx should pass args to scripts', () => {
+  it('rushx should pass args to scripts', async () => {
     // Invoke "rushx"
     const startPath: string = path.resolve(__dirname, '../../../lib-commonjs/startx.js');
 
     // Run "rushx show-args 1 2 -x" in the "repo/rushx-project" folder
-    const output: string = Utilities.executeCommandAndCaptureOutput(
+    const output: string = await Utilities.executeCommandAndCaptureOutputAsync(
       'node',
       [startPath, 'show-args', '1', '2', '-x'],
       `${__dirname}/repo/rushx-project`
@@ -38,11 +38,11 @@ describe('CLI', () => {
     expect(lastLine).toEqual('build.js: ARGS=["1","2","-x"]');
   });
 
-  it('rushx should fail in un-rush project', () => {
+  it('rushx should fail in un-rush project', async () => {
     // Invoke "rushx"
     const startPath: string = path.resolve(__dirname, '../../../lib-commonjs/startx.js');
 
-    const output = Utilities.executeCommandAndCaptureOutput(
+    const output: string = await Utilities.executeCommandAndCaptureOutputAsync(
       'node',
       [startPath, 'show-args', '1', '2', '-x'],
       `${__dirname}/repo/rushx-not-in-rush-project`

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -301,10 +301,7 @@ describe('RushCommandLineParser', () => {
 
         expect(FileSystem.exists(telemetryFilePath)).toEqual(true);
 
-        let telemetryStore: ITelemetryData[] = [];
-        expect(() => {
-          telemetryStore = JsonFile.load(telemetryFilePath);
-        }).not.toThrowError();
+        const telemetryStore: ITelemetryData[] = await JsonFile.loadAsync(telemetryFilePath);
         expect(telemetryStore?.[0].name).toEqual('build');
         expect(telemetryStore?.[0].result).toEqual('Succeeded');
       });

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -20,11 +20,7 @@ import './mockRushCommandLineParser';
 import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
-import type { IParserTestInstance } from './TestUtils';
-import { getDirnameInLib, getCommandLineParserInstanceAsync } from './TestUtils';
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirnameInLib: string = getDirnameInLib();
+import { getCommandLineParserInstanceAsync } from './TestUtils';
 
 function pathEquals(actual: string, expected: string): void {
   expect(Path.convertToSlashes(actual)).toEqual(Path.convertToSlashes(expected));
@@ -44,64 +40,67 @@ describe('RushCommandLineParser', () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'basicAndRunBuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(repoName, 'build');
 
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_build_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
 
       describe("'rebuild' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'basicAndRunRebuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(
+            repoName,
+            'rebuild'
+          );
 
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_build_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
     });
@@ -110,64 +109,67 @@ describe('RushCommandLineParser', () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'overrideRebuildAndRunBuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(repoName, 'build');
 
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_build_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
 
       describe("'rebuild' action", () => {
         it(`executes the package's 'rebuild' script`, async () => {
           const repoName: string = 'overrideRebuildAndRunRebuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(
+            repoName,
+            'rebuild'
+          );
 
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_REbuild_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
     });
@@ -176,31 +178,31 @@ describe('RushCommandLineParser', () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'overrideAndDefaultBuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(repoName, 'build');
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_build_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
 
@@ -208,31 +210,34 @@ describe('RushCommandLineParser', () => {
         it(`executes the package's 'build' script`, async () => {
           // broken
           const repoName: string = 'overrideAndDefaultRebuildActionRepo';
-          const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
-          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(
+            repoName,
+            'rebuild'
+          );
+          await expect(parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
-          const packageCount: number = instance.spawnMock.mock.calls.length;
+          const packageCount: number = spawnMock.mock.calls.length;
           expect(packageCount).toEqual(2);
 
           // Use regex for task name in case spaces were prepended or appended to spawned command
           const expectedBuildTaskRegexp: RegExp = /fake_build_task_but_works_with_mock/;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const firstSpawn: any[] = instance.spawnMock.mock.calls[0];
+          const firstSpawn: any[] = spawnMock.mock.calls[0];
           expect(firstSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(firstSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/a`);
+          pathEquals(firstSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/a`);
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const secondSpawn: any[] = instance.spawnMock.mock.calls[1];
+          const secondSpawn: any[] = spawnMock.mock.calls[1];
           expect(secondSpawn[SPAWN_ARG_ARGS]).toEqual(
             expect.arrayContaining([expect.stringMatching(expectedBuildTaskRegexp)])
           );
           expect(secondSpawn[SPAWN_ARG_OPTIONS]).toEqual(expect.any(Object));
-          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${__dirnameInLib}/${repoName}/b`);
+          pathEquals(secondSpawn[SPAWN_ARG_OPTIONS].cwd, `${repoPath}/b`);
         });
       });
     });
@@ -288,8 +293,8 @@ describe('RushCommandLineParser', () => {
     describe('in repo plugin custom flushTelemetry', () => {
       it('creates a custom telemetry file', async () => {
         const repoName: string = 'tapFlushTelemetryAndRunBuildActionRepo';
-        const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
-        const telemetryFilePath: string = `${instance.parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
+        const { parser } = await getCommandLineParserInstanceAsync(repoName, 'build');
+        const telemetryFilePath: string = `${parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
         FileSystem.deleteFile(telemetryFilePath);
 
         /**
@@ -297,7 +302,7 @@ describe('RushCommandLineParser', () => {
          */
         jest.spyOn(Autoinstaller.prototype, 'prepareAsync').mockImplementation(async function () {});
 
-        await expect(instance.parser.executeAsync()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
 
         expect(FileSystem.exists(telemetryFilePath)).toEqual(true);
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
@@ -21,7 +21,6 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
 import { FileSystem, JsonFile } from '@rushstack/node-core-library';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
-import type { IParserTestInstance } from './TestUtils';
 import { getCommandLineParserInstanceAsync, setSpawnMock } from './TestUtils';
 
 describe('RushCommandLineParserFailureCases', () => {
@@ -43,15 +42,15 @@ describe('RushCommandLineParserFailureCases', () => {
           }) as any);
         });
 
-        const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
+        const { parser } = await getCommandLineParserInstanceAsync(repoName, 'build');
 
-        const telemetryFilePath: string = `${instance.parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
+        const telemetryFilePath: string = `${parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
         FileSystem.deleteFile(telemetryFilePath);
 
         jest.spyOn(Autoinstaller.prototype, 'prepareAsync').mockImplementation(async function () {});
 
         setSpawnMock({ emitError: false, returnCode: 1 });
-        await instance.parser.executeAsync();
+        await parser.executeAsync();
         await procProm;
         expect(process.exit).toHaveBeenCalledWith(1);
 

--- a/libraries/rush-lib/src/cli/test/TestUtils.ts
+++ b/libraries/rush-lib/src/cli/test/TestUtils.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
-import { FileSystem, PackageJsonLookup } from '@rushstack/node-core-library';
+import { AlreadyExistsBehavior, FileSystem, PackageJsonLookup } from '@rushstack/node-core-library';
 import type { RushCommandLineParser as RushCommandLineParserType } from '../RushCommandLineParser';
 import { FlagFile } from '../../api/FlagFile';
 import { RushConstants } from '../../logic/RushConstants';
@@ -13,6 +12,7 @@ import { RushConstants } from '../../logic/RushConstants';
 export interface IParserTestInstance {
   parser: RushCommandLineParserType;
   spawnMock: jest.Mock;
+  repoPath: string;
 }
 
 /**
@@ -45,20 +45,8 @@ export function setSpawnMock(options?: ISpawnMockConfig): jest.Mock {
   return spawnMock;
 }
 
-export function getDirnameInLib(): string {
-  // Run these tests in the /lib folder because some of them require compiled output
-  const projectRootFolder: string = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname)!;
-  const projectRootRelativeDirnamePath: string = path.relative(projectRootFolder, __dirname);
-  const projectRootRelativeLibDirnamePath: string = projectRootRelativeDirnamePath.replace(
-    /^src/,
-    'lib-commonjs'
-  );
-  const dirnameInLIb: string = `${projectRootFolder}/${projectRootRelativeLibDirnamePath}`;
-  return dirnameInLIb;
-}
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirnameInLib: string = getDirnameInLib();
+const PROJECT_ROOT: string = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname)!;
+export const TEST_REPO_FOLDER_PATH: string = `${PROJECT_ROOT}/temp/test/unit-test-repos`;
 
 /**
  * Helper to set up a test instance for RushCommandLineParser.
@@ -67,15 +55,20 @@ export async function getCommandLineParserInstanceAsync(
   repoName: string,
   taskName: string
 ): Promise<IParserTestInstance> {
-  // Run these tests in the /lib folder because some of them require compiled output
-  // Point to the test repo folder
-  const startPath: string = `${__dirnameInLib}/${repoName}`;
+  // Copy the test repo to a sandbox folder
+  const repoPath: string = `${TEST_REPO_FOLDER_PATH}/${repoName}-${performance.now()}`;
+
+  await FileSystem.copyFilesAsync({
+    sourcePath: `${__dirname}/${repoName}`,
+    destinationPath: repoPath,
+    alreadyExistsBehavior: AlreadyExistsBehavior.Error
+  });
 
   // The `build` task is hard-coded to be incremental. So delete the package-deps file folder in
   // the test repo to guarantee the test actually runs.
   await Promise.all([
-    FileSystem.deleteFolderAsync(`${startPath}/a/.rush/temp`),
-    FileSystem.deleteFolderAsync(`${startPath}/b/.rush/temp`)
+    FileSystem.deleteFolderAsync(`${repoPath}/a/.rush/temp`),
+    FileSystem.deleteFolderAsync(`${repoPath}/b/.rush/temp`)
   ]);
 
   const { RushCommandLineParser } = await import('../RushCommandLineParser');
@@ -84,7 +77,7 @@ export async function getCommandLineParserInstanceAsync(
   // to exit and clear the Rush file lock. So running multiple `it` or `describe` test blocks over the same test
   // repo will fail due to contention over the same lock which is kept until the test runner process
   // ends.
-  const parser: RushCommandLineParserType = new RushCommandLineParser({ cwd: startPath });
+  const parser: RushCommandLineParserType = new RushCommandLineParser({ cwd: repoPath });
 
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid
@@ -100,6 +93,7 @@ export async function getCommandLineParserInstanceAsync(
 
   return {
     parser,
-    spawnMock
+    spawnMock,
+    repoPath
   };
 }

--- a/libraries/rush-lib/src/cli/test/TestUtils.ts
+++ b/libraries/rush-lib/src/cli/test/TestUtils.ts
@@ -73,8 +73,10 @@ export async function getCommandLineParserInstanceAsync(
 
   // The `build` task is hard-coded to be incremental. So delete the package-deps file folder in
   // the test repo to guarantee the test actually runs.
-  FileSystem.deleteFolder(`${startPath}/a/.rush/temp`);
-  FileSystem.deleteFolder(`${startPath}/b/.rush/temp`);
+  await Promise.all([
+    FileSystem.deleteFolderAsync(`${startPath}/a/.rush/temp`),
+    FileSystem.deleteFolderAsync(`${startPath}/b/.rush/temp`)
+  ]);
 
   const { RushCommandLineParser } = await import('../RushCommandLineParser');
 

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -144,7 +144,7 @@ export class Autoinstaller {
           `Installing dependencies under ${autoinstallerFullPath}...\n`
         );
 
-        Utilities.executeCommand({
+        await Utilities.executeCommandAsync({
           command: this._rushConfiguration.packageManagerToolFilename,
           args: ['install', '--frozen-lockfile'],
           workingDirectory: autoinstallerFullPath,
@@ -225,7 +225,7 @@ export class Autoinstaller {
       targetNpmrcFolder: this.folderFullPath
     });
 
-    Utilities.executeCommand({
+    await Utilities.executeCommandAsync({
       command: this._rushConfiguration.packageManagerToolFilename,
       args: ['install'],
       workingDirectory: this.folderFullPath,
@@ -236,7 +236,7 @@ export class Autoinstaller {
 
     if (this._rushConfiguration.packageManager === 'npm') {
       this._logIfConsoleOutputIsNotRestricted(Colorize.bold('Running "npm shrinkwrap"...'));
-      Utilities.executeCommand({
+      await Utilities.executeCommandAsync({
         command: this._rushConfiguration.packageManagerToolFilename,
         args: ['shrinkwrap'],
         workingDirectory: this.folderFullPath,

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as url from 'url';
 
 import { trueCasePathSync } from 'true-case-path';
-import { Executable, AlreadyReportedError, Path } from '@rushstack/node-core-library';
+import { Executable, AlreadyReportedError, Path, Async } from '@rushstack/node-core-library';
 import { Colorize, type ITerminal } from '@rushstack/terminal';
 import { ensureGitMinimumVersion } from '@rushstack/package-deps-hash';
 
@@ -93,8 +93,8 @@ export class Git {
    * If a Git email address is configured and is nonempty, this returns it.
    * Otherwise, undefined is returned.
    */
-  public tryGetGitEmail(): string | undefined {
-    const emailResult: IResultOrError<string> = this._tryGetGitEmail();
+  public async tryGetGitEmailAsync(): Promise<string | undefined> {
+    const emailResult: IResultOrError<string> = await this._tryGetGitEmailAsync();
     if (emailResult.result !== undefined && emailResult.result.length > 0) {
       return emailResult.result;
     }
@@ -106,10 +106,10 @@ export class Git {
    * Otherwise, configuration instructions are printed to the console,
    * and AlreadyReportedError is thrown.
    */
-  public getGitEmail(): string {
+  public async getGitEmailAsync(): Promise<string> {
     // Determine the user's account
     // Ex: "bob@example.com"
-    const emailResult: IResultOrError<string> = this._tryGetGitEmail();
+    const emailResult: IResultOrError<string> = await this._tryGetGitEmailAsync();
     if (emailResult.error) {
       // eslint-disable-next-line no-console
       console.log(
@@ -154,7 +154,7 @@ export class Git {
     return undefined;
   }
 
-  public isHooksPathDefault(): boolean {
+  public async getIsHooksPathDefaultAsync(): Promise<boolean> {
     const repoInfo: gitInfo.GitRepoInfo | undefined = this.getGitInfo();
     if (!repoInfo?.commonGitDir) {
       // This should have never been called in a non-Git environment
@@ -167,7 +167,7 @@ export class Git {
       /* ignore errors from true-case-path */
     }
     const defaultHooksPath: string = path.resolve(commonGitDir, 'hooks');
-    const hooksResult: IResultOrError<string> = this._tryGetGitHooksPath();
+    const hooksResult: IResultOrError<string> = await this._tryGetGitHooksPathAsync();
     if (hooksResult.error) {
       // eslint-disable-next-line no-console
       console.log(
@@ -195,11 +195,13 @@ export class Git {
     return true;
   }
 
-  public getConfigHooksPath(): string {
+  public async getConfigHooksPathAsync(): Promise<string> {
     let configHooksPath: string = '';
     const gitPath: string = this.getGitPathOrThrow();
     try {
-      configHooksPath = this._executeGitCommandAndCaptureOutput(gitPath, ['config', 'core.hooksPath']).trim();
+      configHooksPath = (
+        await this._executeGitCommandAndCaptureOutputAsync(gitPath, ['config', 'core.hooksPath'])
+      ).trim();
     } catch (e) {
       // git config returns error code 1 if core.hooksPath is not set.
     }
@@ -228,14 +230,18 @@ export class Git {
     return this._gitInfo;
   }
 
-  public getMergeBase(targetBranch: string, terminal: ITerminal, shouldFetch: boolean = false): string {
+  public async getMergeBaseAsync(
+    targetBranch: string,
+    terminal: ITerminal,
+    shouldFetch: boolean = false
+  ): Promise<string> {
     if (shouldFetch) {
       this._fetchRemoteBranch(targetBranch, terminal);
     }
 
     const gitPath: string = this.getGitPathOrThrow();
     try {
-      const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
+      const output: string = await this._executeGitCommandAndCaptureOutputAsync(gitPath, [
         '--no-optional-locks',
         'merge-base',
         '--',
@@ -256,9 +262,9 @@ export class Git {
     }
   }
 
-  public getBlobContent({ blobSpec, repositoryRoot }: IGetBlobOptions): string {
+  public async getBlobContentAsync({ blobSpec, repositoryRoot }: IGetBlobOptions): Promise<string> {
     const gitPath: string = this.getGitPathOrThrow();
-    const output: string = this._executeGitCommandAndCaptureOutput(
+    const output: string = await this._executeGitCommandAndCaptureOutputAsync(
       gitPath,
       ['cat-file', 'blob', blobSpec, '--'],
       repositoryRoot
@@ -274,18 +280,18 @@ export class Git {
    * those in the provided {@param targetBranch}. If a {@param pathPrefix} is provided,
    * this function only returns results under the that path.
    */
-  public getChangedFiles(
+  public async getChangedFilesAsync(
     targetBranch: string,
     terminal: ITerminal,
     skipFetch: boolean = false,
     pathPrefix?: string
-  ): string[] {
+  ): Promise<string[]> {
     if (!skipFetch) {
       this._fetchRemoteBranch(targetBranch, terminal);
     }
 
     const gitPath: string = this.getGitPathOrThrow();
-    const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
+    const output: string = await this._executeGitCommandAndCaptureOutputAsync(gitPath, [
       'diff',
       `${targetBranch}...`,
       '--name-only',
@@ -318,11 +324,11 @@ export class Git {
    *
    * @param rushConfiguration - rush configuration
    */
-  public getRemoteDefaultBranch(): string {
+  public async getRemoteDefaultBranchAsync(): Promise<string> {
     const repositoryUrls: string[] = this._rushConfiguration.repositoryUrls;
     if (repositoryUrls.length > 0) {
       const gitPath: string = this.getGitPathOrThrow();
-      const output: string = this._executeGitCommandAndCaptureOutput(gitPath, ['remote']).trim();
+      const output: string = (await this._executeGitCommandAndCaptureOutputAsync(gitPath, ['remote'])).trim();
 
       const normalizedRepositoryUrls: Set<string> = new Set<string>();
       for (const repositoryUrl of repositoryUrls) {
@@ -330,28 +336,31 @@ export class Git {
         normalizedRepositoryUrls.add(Git.normalizeGitUrlForComparison(repositoryUrl).toUpperCase());
       }
 
-      const matchingRemotes: string[] = output.split('\n').filter((remoteName) => {
-        if (remoteName) {
-          const remoteUrl: string = this._executeGitCommandAndCaptureOutput(gitPath, [
-            'remote',
-            'get-url',
-            '--',
-            remoteName
-          ]).trim();
+      const matchingRemotes: string[] = [];
+      await Async.forEachAsync(
+        output.split('\n'),
+        async (remoteName) => {
+          if (remoteName) {
+            const remoteUrl: string = (
+              await this._executeGitCommandAndCaptureOutputAsync(gitPath, [
+                'remote',
+                'get-url',
+                '--',
+                remoteName
+              ])
+            ).trim();
 
-          if (!remoteUrl) {
-            return false;
+            if (remoteUrl) {
+              // Also apply toUpperCase() for a case-insensitive comparison
+              const normalizedRemoteUrl: string = Git.normalizeGitUrlForComparison(remoteUrl).toUpperCase();
+              if (normalizedRepositoryUrls.has(normalizedRemoteUrl)) {
+                matchingRemotes.push(remoteName);
+              }
+            }
           }
-
-          // Also apply toUpperCase() for a case-insensitive comparison
-          const normalizedRemoteUrl: string = Git.normalizeGitUrlForComparison(remoteUrl).toUpperCase();
-          if (normalizedRepositoryUrls.has(normalizedRemoteUrl)) {
-            return true;
-          }
-        }
-
-        return false;
-      });
+        },
+        { concurrency: 10 }
+      );
 
       if (matchingRemotes.length > 0) {
         if (matchingRemotes.length > 1) {
@@ -385,8 +394,8 @@ export class Git {
     }
   }
 
-  public hasUncommittedChanges(): boolean {
-    const gitStatusEntries: Iterable<IGitStatusEntry> = this.getGitStatus();
+  public async hasUncommittedChangesAsync(): Promise<boolean> {
+    const gitStatusEntries: Iterable<IGitStatusEntry> = await this.getGitStatusAsync();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const gitStatusEntry of gitStatusEntries) {
       // If there are any changes, return true. We only need to evaluate the first iterator entry
@@ -396,8 +405,8 @@ export class Git {
     return false;
   }
 
-  public hasUnstagedChanges(): boolean {
-    const gitStatusEntries: Iterable<IGitStatusEntry> = this.getGitStatus();
+  public async hasUnstagedChangesAsync(): Promise<boolean> {
+    const gitStatusEntries: Iterable<IGitStatusEntry> = await this.getGitStatusAsync();
     for (const gitStatusEntry of gitStatusEntries) {
       if (
         gitStatusEntry.kind === 'untracked' ||
@@ -413,9 +422,9 @@ export class Git {
   /**
    * The list of files changed but not committed
    */
-  public getUncommittedChanges(): ReadonlyArray<string> {
+  public async getUncommittedChangesAsync(): Promise<ReadonlyArray<string>> {
     const result: string[] = [];
-    const gitStatusEntries: Iterable<IGitStatusEntry> = this.getGitStatus();
+    const gitStatusEntries: Iterable<IGitStatusEntry> = await this.getGitStatusAsync();
     for (const gitStatusEntry of gitStatusEntries) {
       result.push(gitStatusEntry.path);
     }
@@ -427,10 +436,10 @@ export class Git {
     return this._rushConfiguration.gitTagSeparator || DEFAULT_GIT_TAG_SEPARATOR;
   }
 
-  public getGitStatus(): Iterable<IGitStatusEntry> {
+  public async getGitStatusAsync(): Promise<Iterable<IGitStatusEntry>> {
     const gitPath: string = this.getGitPathOrThrow();
     // See Git.test.ts for example output
-    const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
+    const output: string = await this._executeGitCommandAndCaptureOutputAsync(gitPath, [
       'status',
       '--porcelain=2',
       '--null',
@@ -509,12 +518,14 @@ export class Git {
     return result;
   }
 
-  private _tryGetGitEmail(): IResultOrError<string> {
+  private async _tryGetGitEmailAsync(): Promise<IResultOrError<string>> {
     if (this._gitEmailResult === undefined) {
       const gitPath: string = this.getGitPathOrThrow();
       try {
         this._gitEmailResult = {
-          result: this._executeGitCommandAndCaptureOutput(gitPath, ['config', 'user.email']).trim()
+          result: (
+            await this._executeGitCommandAndCaptureOutputAsync(gitPath, ['config', 'user.email'])
+          ).trim()
         };
       } catch (e) {
         this._gitEmailResult = {
@@ -526,16 +537,14 @@ export class Git {
     return this._gitEmailResult;
   }
 
-  private _tryGetGitHooksPath(): IResultOrError<string> {
+  private async _tryGetGitHooksPathAsync(): Promise<IResultOrError<string>> {
     if (this._gitHooksPath === undefined) {
       const gitPath: string = this.getGitPathOrThrow();
       try {
         this._gitHooksPath = {
-          result: this._executeGitCommandAndCaptureOutput(gitPath, [
-            'rev-parse',
-            '--git-path',
-            'hooks'
-          ]).trim()
+          result: (
+            await this._executeGitCommandAndCaptureOutputAsync(gitPath, ['rev-parse', '--git-path', 'hooks'])
+          ).trim()
         };
       } catch (e) {
         this._gitHooksPath = {
@@ -583,13 +592,13 @@ export class Git {
   /**
    * @internal
    */
-  public _executeGitCommandAndCaptureOutput(
+  public async _executeGitCommandAndCaptureOutputAsync(
     gitPath: string,
     args: string[],
     repositoryRoot: string = this._rushConfiguration.rushJsonFolder
-  ): string {
+  ): Promise<string> {
     try {
-      return Utilities.executeCommandAndCaptureOutput(gitPath, args, repositoryRoot);
+      return await Utilities.executeCommandAndCaptureOutputAsync(gitPath, args, repositoryRoot);
     } catch (e) {
       ensureGitMinimumVersion(gitPath);
       throw e;
@@ -599,19 +608,20 @@ export class Git {
    *
    * @param ref Given a ref which can be branch name, commit hash, tag name, etc, check if it is a commit hash
    */
-  public isRefACommit(ref: string): boolean {
+  public async determineIfRefIsACommitAsync(ref: string): Promise<boolean> {
     const gitPath: string = this.getGitPathOrThrow();
     try {
-      const output: string = this._executeGitCommandAndCaptureOutput(gitPath, ['rev-parse', '--verify', ref]);
+      const output: string = await this._executeGitCommandAndCaptureOutputAsync(gitPath, [
+        'rev-parse',
+        '--verify',
+        ref
+      ]);
       const result: string = output.trim();
 
-      if (result === ref) {
-        return true;
-      }
+      return result === ref;
     } catch (e) {
       // assume not a commit
       return false;
     }
-    return false;
   }
 }

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -666,7 +666,7 @@ export class PackageJsonUpdater {
           commandArgs = ['view', packageName, 'versions', '--json'];
         }
 
-        const allVersions: string = Utilities.executeCommandAndCaptureOutput(
+        const allVersions: string = await Utilities.executeCommandAndCaptureOutputAsync(
           this._rushConfiguration.packageManagerToolFilename,
           commandArgs,
           this._rushConfiguration.commonTempFolder
@@ -727,10 +727,12 @@ export class PackageJsonUpdater {
           commandArgs = ['view', `${packageName}@latest`, 'version'];
         }
 
-        selectedVersion = Utilities.executeCommandAndCaptureOutput(
-          this._rushConfiguration.packageManagerToolFilename,
-          commandArgs,
-          this._rushConfiguration.commonTempFolder
+        selectedVersion = (
+          await Utilities.executeCommandAndCaptureOutputAsync(
+            this._rushConfiguration.packageManagerToolFilename,
+            commandArgs,
+            this._rushConfiguration.commonTempFolder
+          )
         ).trim();
       }
 

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -223,9 +223,10 @@ export class ProjectChangeAnalyzer {
     const repoRoot: string = getRepoRoot(rushConfiguration.rushJsonFolder);
 
     // if the given targetBranchName is a commit, we assume it is the merge base
-    const mergeCommit: string = this._git.isRefACommit(targetBranchName)
+    const IsTargetBranchACommit: boolean = await this._git.determineIfRefIsACommitAsync(targetBranchName);
+    const mergeCommit: string = IsTargetBranchACommit
       ? targetBranchName
-      : this._git.getMergeBase(targetBranchName, terminal, shouldFetch);
+      : await this._git.getMergeBaseAsync(targetBranchName, terminal, shouldFetch);
 
     const repoChanges: Map<string, IFileDiffStatus> = getRepoChanges(repoRoot, mergeCommit, gitPath);
 
@@ -256,7 +257,7 @@ export class ProjectChangeAnalyzer {
             throw new Error(`Unable to obtain current shrinkwrap file.`);
           }
 
-          const oldShrinkwrapText: string = this._git.getBlobContent({
+          const oldShrinkwrapText: string = await this._git.getBlobContentAsync({
             // <ref>:<path> syntax: https://git-scm.com/docs/gitrevisions
             blobSpec: `${mergeCommit}:${shrinkwrapFile}`,
             repositoryRoot: repoRoot

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -253,14 +253,14 @@ export class PublishUtilities {
    * @param secretSubstring -- if specified, a substring to be replaced by `<<SECRET>>` to avoid printing secrets
    * on the console
    */
-  public static execCommand(
+  public static async execCommandAsync(
     shouldExecute: boolean,
     command: string,
     args: string[] = [],
     workingDirectory: string = process.cwd(),
     environment?: IEnvironment,
     secretSubstring?: string
-  ): void {
+  ): Promise<void> {
     let relativeDirectory: string = path.relative(process.cwd(), workingDirectory);
 
     if (relativeDirectory) {
@@ -280,7 +280,7 @@ export class PublishUtilities {
     );
 
     if (shouldExecute) {
-      Utilities.executeCommand({
+      await Utilities.executeCommandAsync({
         command,
         args,
         workingDirectory,

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -177,7 +177,7 @@ export class InstallHelpers {
       );
 
       // note that this will remove the last-install flag from the directory
-      Utilities.installPackageInDirectory({
+      await Utilities.installPackageInDirectoryAsync({
         directory: packageManagerToolFolder,
         packageName: packageManager,
         version: rushConfiguration.packageManagerToolVersion,

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -524,7 +524,7 @@ export class RushInstallManager extends BaseInstallManager {
           const args: string[] = ['prune'];
           this.pushConfigurationArgs(args, this.options, subspace);
 
-          Utilities.executeCommandWithRetry(
+          await Utilities.executeCommandWithRetryAsync(
             {
               command: packageManagerFilename,
               args: args,
@@ -605,7 +605,7 @@ export class RushInstallManager extends BaseInstallManager {
       );
     }
 
-    Utilities.executeCommandWithRetry(
+    await Utilities.executeCommandWithRetryAsync(
       {
         command: packageManagerFilename,
         args: installArgs,
@@ -634,7 +634,7 @@ export class RushInstallManager extends BaseInstallManager {
       console.log('\n' + Colorize.bold('Running "npm shrinkwrap"...'));
       const npmArgs: string[] = ['shrinkwrap'];
       this.pushConfigurationArgs(npmArgs, this.options, subspace);
-      Utilities.executeCommand({
+      await Utilities.executeCommandAsync({
         command: this.rushConfiguration.packageManagerToolFilename,
         args: npmArgs,
         workingDirectory: this.rushConfiguration.commonTempFolder

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -463,16 +463,16 @@ export class WorkspaceInstallManager extends BaseInstallManager {
             }
           : undefined;
       try {
-        await Utilities.executeCommandAndProcessOutputWithRetryAsync(
+        await Utilities.executeCommandWithRetryAsync(
           {
             command: packageManagerFilename,
             args: installArgs,
             workingDirectory: subspace.getSubspaceTempFolder(),
             environment: packageManagerEnv,
-            suppressOutput: false
+            suppressOutput: false,
+            onStdoutStreamChunk: onPnpmStdoutChunk
           },
           this.options.maxInstallAttempts,
-          onPnpmStdoutChunk,
           () => {
             if (this.rushConfiguration.packageManager === 'pnpm') {
               this._terminal.writeWarningLine(`Deleting the "node_modules" folder`);

--- a/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -36,7 +36,7 @@ export async function validateAsync(
 
   let userEmail: string | undefined = await git.tryGetGitEmailAsync();
   // If there isn't a Git policy, then we don't care whether the person configured
-  // a Git email address at all.  This helps people who don't
+  // a Git email address at all.
   if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
     if (userEmail === undefined) {
       return;

--- a/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -34,10 +34,11 @@ export async function validateAsync(
     return;
   }
 
+  let userEmail: string | undefined = await git.tryGetGitEmailAsync();
   // If there isn't a Git policy, then we don't care whether the person configured
   // a Git email address at all.  This helps people who don't
   if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
-    if (git.tryGetGitEmailAsync() === undefined) {
+    if (userEmail === undefined) {
       return;
     }
 
@@ -45,9 +46,8 @@ export async function validateAsync(
     // sanity checks (e.g. no spaces in the address).
   }
 
-  let userEmail: string;
   try {
-    userEmail = await git.getGitEmailAsync();
+    userEmail = git.validateGitEmail(userEmail);
 
     // sanity check; a valid email should not contain any whitespace
     // if this fails, then we have another issue to report

--- a/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -10,7 +10,10 @@ import { Git } from '../Git';
 import { RushConstants } from '../RushConstants';
 import type { IPolicyValidatorOptions } from './PolicyValidator';
 
-export function validate(rushConfiguration: RushConfiguration, options: IPolicyValidatorOptions): void {
+export async function validateAsync(
+  rushConfiguration: RushConfiguration,
+  options: IPolicyValidatorOptions
+): Promise<void> {
   const git: Git = new Git(rushConfiguration);
 
   if (!git.isGitPresent()) {
@@ -34,7 +37,7 @@ export function validate(rushConfiguration: RushConfiguration, options: IPolicyV
   // If there isn't a Git policy, then we don't care whether the person configured
   // a Git email address at all.  This helps people who don't
   if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
-    if (git.tryGetGitEmail() === undefined) {
+    if (git.tryGetGitEmailAsync() === undefined) {
       return;
     }
 
@@ -44,7 +47,7 @@ export function validate(rushConfiguration: RushConfiguration, options: IPolicyV
 
   let userEmail: string;
   try {
-    userEmail = git.getGitEmail();
+    userEmail = await git.getGitEmailAsync();
 
     // sanity check; a valid email should not contain any whitespace
     // if this fails, then we have another issue to report
@@ -97,10 +100,8 @@ export function validate(rushConfiguration: RushConfiguration, options: IPolicyV
   // Ex. "Example Name <name@example.com>"
   let fancyEmail: string = Colorize.cyan(userEmail);
   try {
-    const userName: string = Utilities.executeCommandAndCaptureOutput(
-      git.gitPath!,
-      ['config', 'user.name'],
-      '.'
+    const userName: string = (
+      await Utilities.executeCommandAndCaptureOutputAsync(git.gitPath!, ['config', 'user.name'], '.')
     ).trim();
     if (userName) {
       fancyEmail = `${userName} <${fancyEmail}>`;

--- a/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
+++ b/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
@@ -19,7 +19,7 @@ export async function validatePolicyAsync(
   options: IPolicyValidatorOptions
 ): Promise<void> {
   if (!options.bypassPolicy) {
-    GitEmailPolicy.validate(rushConfiguration, options);
+    await GitEmailPolicy.validateAsync(rushConfiguration, options);
     await EnvironmentPolicy.validateAsync(rushConfiguration, options);
     if (!options.allowShrinkwrapUpdates) {
       // Don't validate the shrinkwrap if updates are allowed, as it's likely to change

--- a/libraries/rush-lib/src/logic/test/Git.test.ts
+++ b/libraries/rush-lib/src/logic/test/Git.test.ts
@@ -35,24 +35,26 @@ describe(Git.name, () => {
     });
   });
 
-  describe(Git.prototype.getGitStatus.name, () => {
-    function getGitStatusEntriesForCommandOutput(outputSections: string[]): IGitStatusEntry[] {
+  describe(Git.prototype.getGitStatusAsync.name, () => {
+    async function getGitStatusEntriesForCommandOutputAsync(
+      outputSections: string[]
+    ): Promise<IGitStatusEntry[]> {
       const gitInstance: Git = new Git({ rushJsonFolder: '/repo/root' } as RushConfiguration);
       jest.spyOn(gitInstance, 'getGitPathOrThrow').mockReturnValue('/git/bin/path');
       jest
-        .spyOn(gitInstance, '_executeGitCommandAndCaptureOutput')
-        .mockImplementation((gitPath: string, args: string[]) => {
+        .spyOn(gitInstance, '_executeGitCommandAndCaptureOutputAsync')
+        .mockImplementation(async (gitPath: string, args: string[]) => {
           expect(gitPath).toEqual('/git/bin/path');
           expect(args).toEqual(['status', '--porcelain=2', '--null', '--ignored=no']);
           return outputSections.join('\0');
         });
 
-      return Array.from(gitInstance.getGitStatus());
+      return Array.from(await gitInstance.getGitStatusAsync());
     }
 
-    it('parses a git status', () => {
-      expect(
-        getGitStatusEntriesForCommandOutput([
+    it('parses a git status', async () => {
+      await expect(
+        getGitStatusEntriesForCommandOutputAsync([
           // Staged add
           '1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 a171a25d2c978ba071959f39dbeaa339fe84f768 path/a.ts',
           // Modifications, some staged and some unstaged
@@ -73,7 +75,7 @@ describe(Git.name, () => {
           '1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 9d9ab4adc79c591c0aa72f7fd29a008c80893e3e path/h.ts',
           ''
         ])
-      ).toMatchInlineSnapshot(`
+      ).resolves.toMatchInlineSnapshot(`
         Array [
           Object {
             "headFileMode": "000000",
@@ -183,39 +185,42 @@ describe(Git.name, () => {
       `);
     });
 
-    it('throws with invalid git output', () => {
-      expect(() =>
-        getGitStatusEntriesForCommandOutput(['1 A. N... 000000 100644 100644 000000000000000000'])
-      ).toThrowErrorMatchingInlineSnapshot(`"Unexpected end of git status output after position 31"`);
+    it('throws with invalid git output', async () => {
+      await expect(() =>
+        getGitStatusEntriesForCommandOutputAsync(['1 A. N... 000000 100644 100644 000000000000000000'])
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Unexpected end of git status output after position 31"`);
     });
   });
 
-  describe(Git.prototype.isRefACommit.name, () => {
+  describe(Git.prototype.determineIfRefIsACommitAsync.name, () => {
     const commit = `d9bc1881959b9e44d846655521cd055fcf713f4d`;
-    function getMockedGitIsRefACommit(ref: string): boolean {
+    async function getMockedGitIsRefACommitAsync(ref: string): Promise<boolean> {
       const gitInstance: Git = new Git({ rushJsonFolder: '/repo/root' } as RushConfiguration);
       jest.spyOn(gitInstance, 'getGitPathOrThrow').mockReturnValue('/git/bin/path');
       jest
-        .spyOn(gitInstance, '_executeGitCommandAndCaptureOutput')
-        .mockImplementation((gitPath: string, args: string[]) => {
+        .spyOn(gitInstance, '_executeGitCommandAndCaptureOutputAsync')
+        .mockImplementation(async (gitPath: string, args: string[]) => {
           expect(gitPath).toEqual('/git/bin/path');
           expect(args).toEqual(['rev-parse', '--verify', ref]);
           return commit;
         });
-      return gitInstance.isRefACommit(ref);
+      return await gitInstance.determineIfRefIsACommitAsync(ref);
     }
 
-    it('Returns true for commit ref', () => {
-      expect(getMockedGitIsRefACommit(commit)).toBe(true);
+    it('Returns true for commit ref', async () => {
+      await expect(getMockedGitIsRefACommitAsync(commit)).resolves.toBe(true);
     });
-    it('Returns false for branch ref', () => {
-      expect(getMockedGitIsRefACommit('kenrick/skip-merge-base')).toBe(false);
+
+    it('Returns false for branch ref', async () => {
+      await expect(getMockedGitIsRefACommitAsync('kenrick/skip-merge-base')).resolves.toBe(false);
     });
-    it('Returns false for ref that is a tag', () => {
-      expect(getMockedGitIsRefACommit('testing-tag-v1.2.3')).toBe(false);
+
+    it('Returns false for ref that is a tag', async () => {
+      await expect(getMockedGitIsRefACommitAsync('testing-tag-v1.2.3')).resolves.toBe(false);
     });
-    it('Returns false for ref that is other string', () => {
-      expect(getMockedGitIsRefACommit('HEAD')).toBe(false);
+
+    it('Returns false for ref that is other string', async () => {
+      await expect(getMockedGitIsRefACommitAsync('HEAD')).resolves.toBe(false);
     });
   });
 });

--- a/libraries/rush-lib/src/logic/test/PublishGit.test.ts
+++ b/libraries/rush-lib/src/logic/test/PublishGit.test.ts
@@ -19,7 +19,7 @@ describe('PublishGit Test', () => {
   });
 
   beforeEach(() => {
-    execCommand = jest.spyOn(PublishUtilities, 'execCommand').mockImplementation(() => {
+    execCommand = jest.spyOn(PublishUtilities, 'execCommandAsync').mockImplementation(async () => {
       /* no-op */
     });
 
@@ -33,8 +33,8 @@ describe('PublishGit Test', () => {
     execCommand.mockClear();
   });
 
-  it('Test git with no command line arg tag', () => {
-    publishGit.addTag(
+  it('Test git with no command line arg tag', async () => {
+    await publishGit.addTagAsync(
       false,
       'project1',
       '2',
@@ -45,8 +45,8 @@ describe('PublishGit Test', () => {
     expect(execCommand).toBeCalledWith(false, gitPath, ['tag', '-a', `project1_v2`, '-m', 'project1 v2']);
   });
 
-  it('Test git with command line arg tag', () => {
-    publishGit.addTag(
+  it('Test git with command line arg tag', async () => {
+    await publishGit.addTagAsync(
       false,
       'project1',
       '2',

--- a/libraries/rush-lib/src/utilities/Npm.ts
+++ b/libraries/rush-lib/src/utilities/Npm.ts
@@ -5,15 +5,15 @@ import { Utilities } from './Utilities';
 import * as semver from 'semver';
 
 export class Npm {
-  public static publishedVersions(
+  public static async getPublishedVersionsAsync(
     packageName: string,
     cwd: string,
     env: { [key: string]: string | undefined },
     extraArgs: string[] = []
-  ): string[] {
+  ): Promise<string[]> {
     const versions: string[] = [];
     try {
-      const packageTime: string = Utilities.executeCommandAndCaptureOutput(
+      const packageTime: string = await Utilities.executeCommandAndCaptureOutputAsync(
         'npm',
         ['view', packageName, 'time', '--json', ...extraArgs],
         cwd,
@@ -30,7 +30,7 @@ export class Npm {
         // eslint-disable-next-line no-console
         console.log(`Package ${packageName} time value does not exist. Fall back to versions.`);
         // time property does not exist. It happens sometimes. Fall back to versions.
-        const packageVersions: string = Utilities.executeCommandAndCaptureOutput(
+        const packageVersions: string = await Utilities.executeCommandAndCaptureOutputAsync(
           'npm',
           ['view', packageName, 'versions', '--json', ...extraArgs],
           cwd,

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -470,12 +470,13 @@ export class Utilities {
     directory
   }: IInstallPackageInDirectoryOptions): Promise<void> {
     directory = path.resolve(directory);
-    if (FileSystem.exists(directory)) {
+    const directoryExists: boolean = await FileSystem.existsAsync(directory);
+    if (directoryExists) {
       // eslint-disable-next-line no-console
       console.log('Deleting old files from ' + directory);
     }
 
-    FileSystem.ensureEmptyFolder(directory);
+    await FileSystem.ensureEmptyFolderAsync(directory);
 
     const npmPackageJson: IPackageJson = {
       dependencies: {
@@ -486,7 +487,7 @@ export class Utilities {
       private: true,
       version: '0.0.0'
     };
-    JsonFile.save(npmPackageJson, path.join(directory, FileConstants.PackageJson));
+    await JsonFile.saveAsync(npmPackageJson, path.join(directory, FileConstants.PackageJson));
 
     if (commonRushConfigFolder) {
       Utilities.syncNpmrc({

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -814,6 +814,10 @@ export class Utilities {
   }): void {
     if (error) {
       error.message += `\n${stderr}`;
+      if (status) {
+        error.message += `\nExited with status ${status}`;
+      }
+
       throw error;
     }
 

--- a/libraries/rush-lib/src/utilities/test/Npm.test.ts
+++ b/libraries/rush-lib/src/utilities/test/Npm.test.ts
@@ -11,7 +11,7 @@ describe(Npm.name, () => {
   let stub: jest.SpyInstance;
 
   beforeEach(() => {
-    stub = jest.spyOn(Utilities, 'executeCommandAndCaptureOutput');
+    stub = jest.spyOn(Utilities, 'executeCommandAndCaptureOutputAsync');
   });
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe(Npm.name, () => {
     stub.mockRestore();
   });
 
-  it('publishedVersions gets versions when package time is available.', () => {
+  it('publishedVersions gets versions when package time is available.', async () => {
     const json: string = `{
       "modified": "2017-03-30T18:37:27.757Z",
       "created": "2017-01-03T20:28:10.342Z",
@@ -28,9 +28,9 @@ describe(Npm.name, () => {
       "1.4.1": "2017-01-09T19:22:00.488Z",
       "2.4.0-alpha.1": "2017-03-30T18:37:27.757Z"
     }`;
-    stub.mockImplementationOnce(() => json);
+    stub.mockImplementationOnce(() => Promise.resolve(json));
 
-    const versions: string[] = Npm.publishedVersions(packageName, __dirname, process.env);
+    const versions: string[] = await Npm.getPublishedVersionsAsync(packageName, __dirname, process.env);
 
     expect(stub).toHaveBeenCalledWith(
       'npm',
@@ -44,17 +44,17 @@ describe(Npm.name, () => {
     expect(versions).toMatchObject(['0.0.0', '1.4.0', '1.4.1', '2.4.0-alpha.1']);
   });
 
-  it('publishedVersions gets versions when package time is not available', () => {
+  it('publishedVersions gets versions when package time is not available', async () => {
     const json: string = `[
       "0.0.0",
       "1.4.0",
       "1.4.1",
       "2.4.0-alpha.1"
     ]`;
-    stub.mockImplementationOnce(() => '');
-    stub.mockImplementationOnce(() => json);
+    stub.mockImplementationOnce(() => Promise.resolve(''));
+    stub.mockImplementationOnce(() => Promise.resolve(json));
 
-    const versions: string[] = Npm.publishedVersions(packageName, __dirname, process.env);
+    const versions: string[] = await Npm.getPublishedVersionsAsync(packageName, __dirname, process.env);
 
     expect(stub).toHaveBeenCalledWith(
       'npm',

--- a/libraries/rush-lib/src/utilities/test/global-teardown.ts
+++ b/libraries/rush-lib/src/utilities/test/global-teardown.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { FileSystem } from '@rushstack/node-core-library';
+import { TEST_REPO_FOLDER_PATH } from '../../cli/test/TestUtils';
+
+export default async function globalTeardown(): Promise<void> {
+  await FileSystem.deleteFolderAsync(TEST_REPO_FOLDER_PATH);
+}


### PR DESCRIPTION
## Summary

This PR refactors the `executeCommand` and related functions to be async. This is in preparation for some follow-up work to merge `executeCommandAndProcessOutputWithRetryAsync` into the `executeCommandAsync` function.

## How it was tested

This change needs some more testing.