### PR TITLE
[heft] Fix watch mode

### DIFF
--- a/common/changes/@rushstack/operation-graph/heft-watch-waiting_2023-09-25-22-14.json
+++ b/common/changes/@rushstack/operation-graph/heft-watch-waiting_2023-09-25-22-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Add OperationStatus.Waiting to possible states in watcher loop, add exhaustiveness check.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/libraries/operation-graph/src/Operation.ts
+++ b/libraries/operation-graph/src/Operation.ts
@@ -256,6 +256,7 @@ export class Operation implements IOperationStates {
       requestRun: requestRun
         ? () => {
             switch (this.state?.status) {
+              case OperationStatus.Waiting:
               case OperationStatus.Ready:
               case OperationStatus.Executing:
                 // If current status has not yet resolved to a fixed value,
@@ -278,7 +279,9 @@ export class Operation implements IOperationStates {
                 // to capture here.
                 return requestRun(this.name);
               default:
-                throw new InternalError(`Unexpected status: ${this.state?.status}`);
+                // This line is here to enforce exhaustiveness
+                const currentStatus: undefined = this.state?.status;
+                throw new InternalError(`Unexpected status: ${currentStatus}`);
             }
           }
         : undefined


### PR DESCRIPTION
## Summary
Fixes a build break in watch mode caused by the introduction of the OperationStatus.Waiting status value.

## Details
Also adds a compile-time exhaustiveness check to the offending switch-case statement.

## How it was tested
Manual invocation of `heft test-watch` and changes to files.

Need to add unit tests for the watch mode flow, will investigate after this PR, since it is fixing a critical break and that would delay it.

## Impacted documentation
None.