### PR TITLE
[eslint-patch] Allow for extended shareable ESLint configurations to use any name

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ These GitHub repositories provide supplementary resources for Rush Stack:
 | [/build-tests/api-extractor-test-03](./build-tests/api-extractor-test-03/) | Building this project is a regression test for api-extractor |
 | [/build-tests/api-extractor-test-04](./build-tests/api-extractor-test-04/) | Building this project is a regression test for api-extractor |
 | [/build-tests/eslint-7-test](./build-tests/eslint-7-test/) | This project contains a build test to validate ESLint 7 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
+| [/build-tests/eslint-8-test](./build-tests/eslint-8-test/) | This project contains a build test to validate ESLint 8 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
 | [/build-tests/hashed-folder-copy-plugin-webpack4-test](./build-tests/hashed-folder-copy-plugin-webpack4-test/) | Building this project exercises @rushstack/hashed-folder-copy-plugin with Webpack 4. |
 | [/build-tests/hashed-folder-copy-plugin-webpack5-test](./build-tests/hashed-folder-copy-plugin-webpack5-test/) | Building this project exercises @rushstack/hashed-folder-copy-plugin with Webpack 5. NOTE - THIS TEST IS CURRENTLY EXPECTED TO BE BROKEN |
 | [/build-tests/heft-copy-files-test](./build-tests/heft-copy-files-test/) | Building this project tests copying files with Heft |

--- a/build-tests/eslint-8-test/.eslintrc.js
+++ b/build-tests/eslint-8-test/.eslintrc.js
@@ -1,0 +1,25 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: [
+    '@rushstack/eslint-config/profile/node-trusted-tool',
+    '@rushstack/eslint-config/mixins/friendly-locals'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname },
+
+  overrides: [
+    /**
+     * Override the parser from @rushstack/eslint-config. Since the config is coming
+     * from the workspace instead of the external NPM package, the versions of ESLint
+     * and TypeScript that the config consumes will be resolved from the devDependencies
+     * of the config instead of from the eslint-7-test package. Overriding the parser
+     * ensures that the these dependencies come from the eslint-7-test package. See:
+     * https://github.com/microsoft/rushstack/issues/3021
+     */
+    {
+      files: ['*.ts', '*.tsx'],
+      parser: '@typescript-eslint/parser'
+    }
+  ]
+};

--- a/build-tests/eslint-8-test/README.md
+++ b/build-tests/eslint-8-test/README.md
@@ -1,0 +1,6 @@
+# eslint-7-test
+
+This project folder is one of the **build-tests** for the Rushstack [ESLint configuration](https://www.npmjs.com/package/@rushstack/eslint-config) (and by extension, the [ESLint plugin](https://www.npmjs.com/package/@rushstack/eslint-plugin))
+package. This project builds using ESLint v7 and contains a simple index file to ensure that the build runs ESLint successfully against source code.
+
+Please see the [ESLint Heft task documentation](https://rushstack.io/pages/heft_tasks/eslint/) for documentation and tutorials.

--- a/build-tests/eslint-8-test/config/rig.json
+++ b/build-tests/eslint-8-test/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "local-node-rig"
+}

--- a/build-tests/eslint-8-test/package.json
+++ b/build-tests/eslint-8-test/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "eslint-8-test",
+  "description": "This project contains a build test to validate ESLint 8 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin)",
+  "version": "1.0.0",
+  "private": true,
+  "main": "lib/index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean"
+  },
+  "devDependencies": {
+    "@rushstack/eslint-config": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "local-node-rig": "workspace:*",
+    "@types/node": "18.17.15",
+    "@typescript-eslint/parser": "~5.59.2",
+    "eslint": "~8.7.0",
+    "typescript": "~5.0.4"
+  }
+}

--- a/build-tests/eslint-8-test/src/index.ts
+++ b/build-tests/eslint-8-test/src/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export class Foo {
+  private _bar: string = 'bar';
+  public baz: string = this._bar;
+}

--- a/build-tests/eslint-8-test/tsconfig.json
+++ b/build-tests/eslint-8-test/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es5",
+    "lib": ["es5"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/common/changes/@rushstack/eslint-config/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-config",
-      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
+      "comment": "Add an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/eslint-config/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/eslint-config/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-patch/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/eslint-patch/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-patch/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/eslint-patch/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-patch",
-      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
+      "comment": "Add an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-node-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/heft-node-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This change also includes the ESLint configurations sourced from \"@rushstack/eslint-config\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-node-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/heft-node-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-node-rig",
-      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This change also includes the ESLint configurations sourced from \"@rushstack/eslint-config\"",
+      "comment": "Add an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This change also includes the ESLint configurations sourced from \"@rushstack/eslint-config\"",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-web-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/heft-web-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-web-rig",
-      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This chang",
+      "comment": "Add an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This change also includes the ESLint configurations sourced from \"@rushstack/eslint-config\"",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/heft-web-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
+++ b/common/changes/@rushstack/heft-web-rig/user-danade-EslintResolverTweaks2_2023-09-25-23-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Adds an optional patch which can be used to allow ESLint to extend configurations from packages that do not have the \"eslint-config-\" prefix. This chang",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1072,6 +1072,30 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
 
+  ../../build-tests/eslint-8-test:
+    devDependencies:
+      '@rushstack/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config
+      '@rushstack/heft':
+        specifier: workspace:*
+        version: link:../../apps/heft
+      '@types/node':
+        specifier: 18.17.15
+        version: 18.17.15
+      '@typescript-eslint/parser':
+        specifier: ~5.59.2
+        version: 5.59.11(eslint@8.7.0)(typescript@5.0.4)
+      eslint:
+        specifier: ~8.7.0
+        version: 8.7.0
+      local-node-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-node-rig
+      typescript:
+        specifier: ~5.0.4
+        version: 5.0.4
+
   ../../build-tests/hashed-folder-copy-plugin-webpack4-test:
     devDependencies:
       '@rushstack/hashed-folder-copy-plugin':
@@ -16029,7 +16053,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.0.8
       natural-compare: 1.4.0
       optionator: 0.9.3
       regexpp: 3.2.0
@@ -25697,7 +25721,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
 
   /widest-line@3.1.0:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1713,7 +1713,7 @@ importers:
         version: 29.5.5
       '@types/node':
         specifier: ts4.9
-        version: 20.6.2
+        version: 20.7.0
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -3528,6 +3528,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: workspace:*
         version: link:../../apps/api-extractor
+      '@rushstack/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config
       '@rushstack/heft-api-extractor-plugin':
         specifier: workspace:*
         version: link:../../heft-plugins/heft-api-extractor-plugin
@@ -3562,6 +3565,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: workspace:*
         version: link:../../apps/api-extractor
+      '@rushstack/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config
       '@rushstack/heft-api-extractor-plugin':
         specifier: workspace:*
         version: link:../../heft-plugins/heft-api-extractor-plugin
@@ -11455,6 +11461,11 @@ packages:
 
   /@types/node@20.6.2:
     resolution: {integrity: sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==}
+    dev: false
+
+  /@types/node@20.7.0:
+    resolution: {integrity: sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==}
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d51a09f515584d6959a8837c0df5200d2d8856f7",
+  "pnpmShrinkwrapHash": "92561e650a0b5a0ffde5b5dcc107d597c755b413",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "92561e650a0b5a0ffde5b5dcc107d597c755b413",
+  "pnpmShrinkwrapHash": "00aeb975643cac9bd71b0f5af110395618d2eedf",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/eslint/eslint-config/patch/custom-config-package-names.js
+++ b/eslint/eslint-config/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-patch/custom-config-package-names');

--- a/eslint/eslint-patch/src/_patch-base.ts
+++ b/eslint/eslint-patch/src/_patch-base.ts
@@ -108,8 +108,8 @@ if (!eslintFolder) {
         );
         if (resolvedConfigArrayFactoryPath === currentModule.filename) {
           configArrayFactoryPath = resolvedConfigArrayFactoryPath;
-          moduleResolverPath = path.join(eslintrcFolder, 'lib/shared/relative-module-resolver');
-          namingPath = path.join(eslintrcFolder, 'lib/shared/naming');
+          moduleResolverPath = `${eslintrcFolder}/lib/shared/relative-module-resolver`;
+          namingPath = `${eslintrcFolder}/lib/shared/naming`;
         }
       } catch (ex: unknown) {
         // Module resolution failures are expected, as we're walking
@@ -157,9 +157,9 @@ if (!eslintFolder) {
     //   .../eslint/lib/cli-engine/config-array-factory.js
     if (/[\\/]eslint[\\/]lib[\\/]cli-engine[\\/]config-array-factory\.js$/i.test(currentModule.filename)) {
       eslintFolder = path.join(path.dirname(currentModule.filename), '../..');
-      configArrayFactoryPath = path.join(eslintFolder, 'lib/cli-engine/config-array-factory');
-      moduleResolverPath = path.join(eslintFolder, 'lib/shared/relative-module-resolver');
-      namingPath = path.join(eslintFolder, 'lib/shared/naming');
+      configArrayFactoryPath = `${eslintFolder}/lib/cli-engine/config-array-factory`;
+      moduleResolverPath = `${eslintFolder}/lib/shared/relative-module-resolver`;
+      namingPath = `${eslintFolder}/lib/shared/naming`;
       break;
     }
 
@@ -176,10 +176,10 @@ if (!eslintFolder) {
 }
 
 // Detect the ESLint package version
-const eslintPackageJson = fs.readFileSync(path.join(eslintFolder, 'package.json')).toString();
+const eslintPackageJson = fs.readFileSync(`${eslintFolder}/package.json`).toString();
 const eslintPackageObject = JSON.parse(eslintPackageJson);
 const eslintPackageVersion = eslintPackageObject.version;
-const versionMatch = /^([0-9]+)\./.exec(eslintPackageVersion); // parse the SemVer MAJOR part
+const versionMatch = parseInt(eslintPackageVersion, 10);
 if (!versionMatch) {
   throw new Error('Unable to parse ESLint version: ' + eslintPackageVersion);
 }

--- a/eslint/eslint-patch/src/_patch-base.ts
+++ b/eslint/eslint-patch/src/_patch-base.ts
@@ -176,14 +176,15 @@ if (!eslintFolder) {
 }
 
 // Detect the ESLint package version
-const eslintPackageJson = fs.readFileSync(`${eslintFolder}/package.json`).toString();
+const eslintPackageJsonPath: string = `${eslintFolder}/package.json`;
+const eslintPackageJson = fs.readFileSync(eslintPackageJsonPath).toString();
 const eslintPackageObject = JSON.parse(eslintPackageJson);
 const eslintPackageVersion = eslintPackageObject.version;
-let eslintMajorVersion: number;
-try {
-  eslintMajorVersion = parseInt(eslintPackageVersion, 10);
-} catch (e) {
-  throw new Error(`Unable to parse ESLint version "${eslintPackageVersion}": ${e}`);
+const eslintMajorVersion: number = parseInt(eslintPackageVersion, 10);
+if (isNaN(eslintMajorVersion)) {
+  throw new Error(
+    `Unable to parse ESLint version "${eslintPackageVersion}" in file "${eslintPackageJsonPath}"`
+  );
 }
 
 if (!(eslintMajorVersion >= 6 && eslintMajorVersion <= 8)) {

--- a/eslint/eslint-patch/src/_patch-base.ts
+++ b/eslint/eslint-patch/src/_patch-base.ts
@@ -193,7 +193,7 @@ if (!(eslintMajorVersion >= 6 && eslintMajorVersion <= 8)) {
   );
 }
 
-let ConfigArrayFactory;
+let ConfigArrayFactory: any;
 if (eslintMajorVersion === 8) {
   ConfigArrayFactory = require(eslintrcBundlePath!).Legacy.ConfigArrayFactory;
 } else {

--- a/eslint/eslint-patch/src/_patch-base.ts
+++ b/eslint/eslint-patch/src/_patch-base.ts
@@ -35,26 +35,28 @@ let eslintFolder: string | undefined = undefined;
 
 // Probe for the ESLint >=8.0.0 layout:
 for (let currentModule = module; ; ) {
-  if (!eslintrcBundlePath && currentModule.filename.endsWith('eslintrc.cjs')) {
-    // For ESLint >=8.0.0, all @eslint/eslintrc code is bundled at this path:
-    //   .../@eslint/eslintrc/dist/eslintrc.cjs
-    try {
-      const eslintrcFolder = path.dirname(
-        require.resolve('@eslint/eslintrc/package.json', { paths: [currentModule.path] })
-      );
+  if (!eslintrcBundlePath) {
+    if (currentModule.filename.endsWith('eslintrc.cjs')) {
+      // For ESLint >=8.0.0, all @eslint/eslintrc code is bundled at this path:
+      //   .../@eslint/eslintrc/dist/eslintrc.cjs
+      try {
+        const eslintrcFolder = path.dirname(
+          require.resolve('@eslint/eslintrc/package.json', { paths: [currentModule.path] })
+        );
 
-      // Make sure we actually resolved the module in our call path
-      // and not some other spurious dependency.
-      const resolvedEslintrcBundlePath: string = path.join(eslintrcFolder, 'dist/eslintrc.cjs');
-      if (resolvedEslintrcBundlePath === currentModule.filename) {
-        eslintrcBundlePath = resolvedEslintrcBundlePath;
-      }
-    } catch (ex: unknown) {
-      // Module resolution failures are expected, as we're walking
-      // up our require stack to look for eslint. All other errors
-      // are rethrown.
-      if (!isModuleResolutionError(ex)) {
-        throw ex;
+        // Make sure we actually resolved the module in our call path
+        // and not some other spurious dependency.
+        const resolvedEslintrcBundlePath: string = path.join(eslintrcFolder, 'dist/eslintrc.cjs');
+        if (resolvedEslintrcBundlePath === currentModule.filename) {
+          eslintrcBundlePath = resolvedEslintrcBundlePath;
+        }
+      } catch (ex: unknown) {
+        // Module resolution failures are expected, as we're walking
+        // up our require stack to look for eslint. All other errors
+        // are rethrown.
+        if (!isModuleResolutionError(ex)) {
+          throw ex;
+        }
       }
     }
   } else {

--- a/eslint/eslint-patch/src/_patch-base.ts
+++ b/eslint/eslint-patch/src/_patch-base.ts
@@ -179,14 +179,16 @@ if (!eslintFolder) {
 const eslintPackageJson = fs.readFileSync(`${eslintFolder}/package.json`).toString();
 const eslintPackageObject = JSON.parse(eslintPackageJson);
 const eslintPackageVersion = eslintPackageObject.version;
-const versionMatch = parseInt(eslintPackageVersion, 10);
-if (!versionMatch) {
-  throw new Error('Unable to parse ESLint version: ' + eslintPackageVersion);
+let eslintMajorVersion: number;
+try {
+  eslintMajorVersion = parseInt(eslintPackageVersion, 10);
+} catch (e) {
+  throw new Error(`Unable to parse ESLint version "${eslintPackageVersion}": ${e}`);
 }
-const eslintMajorVersion = Number(versionMatch[1]);
+
 if (!(eslintMajorVersion >= 6 && eslintMajorVersion <= 8)) {
   throw new Error(
-    'The patch-eslint.js script has only been tested with ESLint version 6.x, 7.x, and 8.x.' +
+    'The ESLint patch script has only been tested with ESLint version 6.x, 7.x, and 8.x.' +
       ` (Your version: ${eslintPackageVersion})\n` +
       'Consider reporting a GitHub issue:\n' +
       'https://github.com/microsoft/rushstack/issues'
@@ -214,6 +216,6 @@ export {
   ConfigArrayFactory,
   ModuleResolver,
   Naming,
-  eslintMajorVersion as EslintMajorVersion,
+  eslintMajorVersion as ESLINT_MAJOR_VERSION,
   isModuleResolutionError
 };

--- a/eslint/eslint-patch/src/custom-config-package-names.ts
+++ b/eslint/eslint-patch/src/custom-config-package-names.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// This is a workaround for ESLint's requirement to consume shareable configurations from package names prefixed
+// with "eslint-config".
+//
+// To remove this requirement, add this line to the top of your project's .eslintrc.js file:
+//
+//    require("@rushstack/eslint-patch/custom-config-package-names");
+//
+import { ConfigArrayFactory, ModuleResolver, Naming } from './_patch-base';
+
+if (!ConfigArrayFactory.__loadExtendedShareableConfigPatched) {
+  ConfigArrayFactory.__loadExtendedShareableConfigPatched = true;
+  const originalLoadExtendedShareableConfig = ConfigArrayFactory.prototype._loadExtendedShareableConfig;
+
+  // Common between ESLint versions
+  // https://github.com/eslint/eslintrc/blob/242d569020dfe4f561e4503787b99ec016337457/lib/config-array-factory.js#L910
+  ConfigArrayFactory.prototype._loadExtendedShareableConfig = function (extendName: string) {
+    const originalResolve = ModuleResolver.resolve;
+    try {
+      ModuleResolver.resolve = function (moduleName: string, relativeToPath: string) {
+        try {
+          return originalResolve.call(this, moduleName, relativeToPath);
+        } catch (e) {
+          // Only change the name we resolve if we cannot find the normalized module, since it is
+          // valid to rely on the normalized package name. Use the originally provided module path
+          // instead of the normalized module path.
+          if (
+            (e as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND' &&
+            moduleName !== extendName &&
+            moduleName === Naming.normalizePackageName(extendName, 'eslint-config')
+          ) {
+            return originalResolve.call(this, extendName, relativeToPath);
+          } else {
+            throw e;
+          }
+        }
+      };
+      return originalLoadExtendedShareableConfig.apply(this, arguments);
+    } finally {
+      ModuleResolver.resolve = originalResolve;
+    }
+  };
+}

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 //
 // To correct how ESLint searches for plugin packages, add this line to the top of your project's .eslintrc.js file:

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -9,10 +9,10 @@
 //
 
 import {
-  EslintMajorVersion,
   ConfigArrayFactory,
   ModuleResolver,
-  isModuleResolutionError
+  isModuleResolutionError,
+  ESLINT_MAJOR_VERSION
 } from './_patch-base';
 
 // error: "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ''"
@@ -23,7 +23,7 @@ if (!ConfigArrayFactory.__loadPluginPatched) {
   ConfigArrayFactory.__loadPluginPatched = true;
   const originalLoadPlugin = ConfigArrayFactory.prototype._loadPlugin;
 
-  if (EslintMajorVersion === 6) {
+  if (ESLINT_MAJOR_VERSION === 6) {
     // ESLint 6.x
     // https://github.com/eslint/eslint/blob/9738f8cc864d769988ccf42bb70f524444df1349/lib/cli-engine/config-array-factory.js#L915
     ConfigArrayFactory.prototype._loadPlugin = function (

--- a/eslint/eslint-patch/src/modern-module-resolution.ts
+++ b/eslint/eslint-patch/src/modern-module-resolution.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+//
+// To correct how ESLint searches for plugin packages, add this line to the top of your project's .eslintrc.js file:
+//
+//    require("@rushstack/eslint-patch/modern-module-resolution");
+//
+
+import {
+  EslintMajorVersion,
+  ConfigArrayFactory,
+  ModuleResolver,
+  isModuleResolutionError
+} from './_patch-base';
+
+// error: "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ''"
+const isInvalidImporterPath: (ex: unknown) => boolean = (ex) =>
+  (ex as { code: unknown } | undefined)?.code === 'ERR_INVALID_ARG_VALUE';
+
+if (!ConfigArrayFactory.__loadPluginPatched) {
+  ConfigArrayFactory.__loadPluginPatched = true;
+  const originalLoadPlugin = ConfigArrayFactory.prototype._loadPlugin;
+
+  if (EslintMajorVersion === 6) {
+    // ESLint 6.x
+    // https://github.com/eslint/eslint/blob/9738f8cc864d769988ccf42bb70f524444df1349/lib/cli-engine/config-array-factory.js#L915
+    ConfigArrayFactory.prototype._loadPlugin = function (
+      name: string,
+      importerPath: string,
+      importerName: string
+    ) {
+      const originalResolve = ModuleResolver.resolve;
+      try {
+        ModuleResolver.resolve = function (moduleName: string, relativeToPath: string) {
+          try {
+            // resolve using importerPath instead of relativeToPath
+            return originalResolve.call(this, moduleName, importerPath);
+          } catch (e) {
+            if (isModuleResolutionError(e) || isInvalidImporterPath(e)) {
+              return originalResolve.call(this, moduleName, relativeToPath);
+            }
+            throw e;
+          }
+        };
+        return originalLoadPlugin.apply(this, arguments);
+      } finally {
+        ModuleResolver.resolve = originalResolve;
+      }
+    };
+  } else {
+    // ESLint 7.x || 8.x
+    // https://github.com/eslint/eslintrc/blob/242d569020dfe4f561e4503787b99ec016337457/lib/config-array-factory.js#L1023
+    ConfigArrayFactory.prototype._loadPlugin = function (name: string, ctx: Record<string, unknown>) {
+      const originalResolve = ModuleResolver.resolve;
+      try {
+        ModuleResolver.resolve = function (moduleName: string, relativeToPath: string) {
+          try {
+            // resolve using ctx.filePath instead of relativeToPath
+            return originalResolve.call(this, moduleName, ctx.filePath);
+          } catch (e) {
+            if (isModuleResolutionError(e) || isInvalidImporterPath(e)) {
+              return originalResolve.call(this, moduleName, relativeToPath);
+            }
+            throw e;
+          }
+        };
+        return originalLoadPlugin.apply(this, arguments);
+      } finally {
+        ModuleResolver.resolve = originalResolve;
+      }
+    };
+  }
+}

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
+    "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft-api-extractor-plugin": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@rushstack/heft-lint-plugin": "workspace:*",

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/friendly-locals']
+};

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/packlets.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/packlets']
+};

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/react.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/react']
+};

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/todoc.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/todoc']
+};

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/custom-config-package-names');

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/modern-module-resolution');

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/profile/node-trusted-tool']
+};

--- a/rigs/heft-node-rig/profiles/default/includes/eslint/profile/node.js
+++ b/rigs/heft-node-rig/profiles/default/includes/eslint/profile/node.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/profile/node']
+};

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
+    "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft-api-extractor-plugin": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",
     "@rushstack/heft-lint-plugin": "workspace:*",

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/friendly-locals']
+};

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/packlets.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/packlets']
+};

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/react.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/react']
+};

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/todoc.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/todoc']
+};

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/custom-config-package-names');

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/modern-module-resolution');

--- a/rigs/heft-web-rig/profiles/app/includes/eslint/profile/web-app.js
+++ b/rigs/heft-web-rig/profiles/app/includes/eslint/profile/web-app.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/profile/web-app']
+};

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/friendly-locals']
+};

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/packlets.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/packlets']
+};

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/react.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/react']
+};

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/todoc.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/mixins/todoc']
+};

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/custom-config-package-names');

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-config/patch/modern-module-resolution');

--- a/rigs/heft-web-rig/profiles/library/includes/eslint/profile/web-app.js
+++ b/rigs/heft-web-rig/profiles/library/includes/eslint/profile/web-app.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/profile/web-app']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/mixins/friendly-locals']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/mixins/packlets.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/mixins/packlets']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/mixins/react.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/mixins/react']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/mixins/todoc.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/mixins/todoc']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names');

--- a/rigs/local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');

--- a/rigs/local-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool']
+};

--- a/rigs/local-node-rig/profiles/default/includes/eslint/profile/node.js
+++ b/rigs/local-node-rig/profiles/default/includes/eslint/profile/node.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-node-rig/profiles/default/includes/eslint/profile/node']
+};

--- a/rigs/local-web-rig/profiles/app/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/friendly-locals']
+};

--- a/rigs/local-web-rig/profiles/app/includes/eslint/mixins/packlets.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/packlets']
+};

--- a/rigs/local-web-rig/profiles/app/includes/eslint/mixins/react.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/react']
+};

--- a/rigs/local-web-rig/profiles/app/includes/eslint/mixins/todoc.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/todoc']
+};

--- a/rigs/local-web-rig/profiles/app/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-web-rig/profiles/default/includes/eslint/patch/custom-config-package-names');

--- a/rigs/local-web-rig/profiles/app/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-web-rig/profiles/default/includes/eslint/patch/modern-module-resolution');

--- a/rigs/local-web-rig/profiles/app/includes/eslint/profile/web-app.js
+++ b/rigs/local-web-rig/profiles/app/includes/eslint/profile/web-app.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/app/includes/eslint/profile/web-app']
+};

--- a/rigs/local-web-rig/profiles/library/includes/eslint/mixins/friendly-locals.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/friendly-locals']
+};

--- a/rigs/local-web-rig/profiles/library/includes/eslint/mixins/packlets.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/packlets']
+};

--- a/rigs/local-web-rig/profiles/library/includes/eslint/mixins/react.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/react']
+};

--- a/rigs/local-web-rig/profiles/library/includes/eslint/mixins/todoc.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/mixins/todoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/default/includes/eslint/mixins/todoc']
+};

--- a/rigs/local-web-rig/profiles/library/includes/eslint/patch/custom-config-package-names.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/patch/custom-config-package-names.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-web-rig/profiles/default/includes/eslint/patch/custom-config-package-names');

--- a/rigs/local-web-rig/profiles/library/includes/eslint/patch/modern-module-resolution.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/patch/modern-module-resolution.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/heft-web-rig/profiles/default/includes/eslint/patch/modern-module-resolution');

--- a/rigs/local-web-rig/profiles/library/includes/eslint/profile/web-app.js
+++ b/rigs/local-web-rig/profiles/library/includes/eslint/profile/web-app.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+module.exports = {
+  extends: ['@rushstack/heft-web-rig/profiles/library/includes/eslint/profile/web-app']
+};

--- a/rush.json
+++ b/rush.json
@@ -537,6 +537,12 @@
       "shouldPublish": false
     },
     {
+      "packageName": "eslint-8-test",
+      "projectFolder": "build-tests/eslint-8-test",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
+    {
       "packageName": "package-extractor-test-01",
       "projectFolder": "build-tests/package-extractor-test-01",
       "reviewCategory": "tests",


### PR DESCRIPTION
## Summary
Allows resolution of extended shareable configurations even when the package they are sourced from is not prefixed with `eslint-config-`.

## Details
In order to allow use of ESLint configurations provided via Heft rigs, we need to allow consumption of configurations from packages not prefixed with `eslint-config-`, since Heft rigs obviously do not have the same naming restrictions.

The solution first attempts to resolve using the default logic, and falls back to attempting to resolve using the provided extended config name directly, without modification. This is done to allow for backwards-compatibility with intentionally short-named extended configs (cases where the prefix is intentionally omitted), since ESLint prefixes the `eslint-config-` to the package name during normalization if it was not found. For example, if `@rushstack` was specified as an extends configuration, then it would normally resolve to @rushstack/eslint-config.

## How it was tested
Tested using resolution logic in Rushstack by moving the ESLint configuration into the rig. A future change will transition Rushstack to use the @rushstack/eslint-config package via `@rushstack/heft-node-rig`/`@rushstack/heft-web-rig`/`local-node-rig`/`local-web-rig`
