### PR TITLE
[heft] Fix an issue where 'heft clean' crashes.

### DIFF
--- a/apps/heft/src/cli/actions/CleanAction.ts
+++ b/apps/heft/src/cli/actions/CleanAction.ts
@@ -18,7 +18,7 @@ import type { HeftTaskSession } from '../../pluginFramework/HeftTaskSession';
 import { Constants } from '../../utilities/Constants';
 import { definePhaseScopingParameters, expandPhases } from './RunAction';
 import { deleteFilesAsync, type IDeleteOperation } from '../../plugins/DeleteFilesPlugin';
-import { initializeHeft, runWithLoggingAsync } from '../HeftActionRunner';
+import { ensureCliAbortSignal, initializeHeft, runWithLoggingAsync } from '../HeftActionRunner';
 
 export class CleanAction extends CommandLineAction implements IHeftAction {
   public readonly watch: boolean = false;
@@ -78,7 +78,7 @@ export class CleanAction extends CommandLineAction implements IHeftAction {
 
   protected async onExecute(): Promise<void> {
     const { heftConfiguration } = this._internalHeftSession;
-    const abortSignal: AbortSignal = new AbortSignal();
+    const abortSignal: AbortSignal = ensureCliAbortSignal(this._terminal);
 
     initializeHeft(heftConfiguration, this._terminal, this._verboseFlag.value);
     await runWithLoggingAsync(

--- a/common/changes/@rushstack/heft/fix-heft-clean_2023-09-26-20-16.json
+++ b/common/changes/@rushstack/heft/fix-heft-clean_2023-09-26-20-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix an issue where `heft clean` would crash with `ERR_ILLEGAL_CONSTRUCTOR`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/4351

## Details

`heft clean` was directly constructing an `AbortSignal` object via `new AbortSignal()`, which isn't allowed. This change refactors the code used in `HeftActionRunner` to construct the `AbortSignal` to also be used by `heft clean`.

## How it was tested

Tested in this repo and in the repro provided in https://github.com/microsoft/rushstack/issues/4351.