### PR TITLE
[operation-graph] Enforce concurrency limits

### DIFF
--- a/common/changes/@rushstack/node-core-library/async-priority-queue_2023-09-27-19-06.json
+++ b/common/changes/@rushstack/node-core-library/async-priority-queue_2023-09-27-19-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add Async.getSignal for promise-based signaling. Add MinimumHeap for use as a priority queue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/operation-graph/async-priority-queue_2023-09-27-19-07.json
+++ b/common/changes/@rushstack/operation-graph/async-priority-queue_2023-09-27-19-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Enforce task concurrency limits and respect priority for sequencing.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -34,6 +34,7 @@ export class AnsiEscape {
 // @beta
 export class Async {
     static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
+    static getSignal(): [Promise<void>, () => void, (err: Error) => void];
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
@@ -794,6 +795,16 @@ export class MapExtensions {
     static toObject<TValue>(map: Map<string, TValue>): {
         [key: string]: TValue;
     };
+}
+
+// @beta
+export class MinimumHeap<T> {
+    constructor(comparator: (a: T, b: T) => number);
+    peek(): T | undefined;
+    poll(): T | undefined;
+    push(item: T): void;
+    // (undocumented)
+    get size(): number;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -803,7 +803,6 @@ export class MinimumHeap<T> {
     peek(): T | undefined;
     poll(): T | undefined;
     push(item: T): void;
-    // (undocumented)
     get size(): number;
 }
 

--- a/common/reviews/api/operation-graph.api.md
+++ b/common/reviews/api/operation-graph.api.md
@@ -32,7 +32,7 @@ export interface ICancelCommandMessage {
 export interface IExecuteOperationContext extends Omit<IOperationRunnerContext, 'isFirstRun' | 'requestRun'> {
     afterExecute(operation: Operation, state: IOperationState): void;
     beforeExecute(operation: Operation, state: IOperationState): void;
-    queueWork<T>(workFn: () => Promise<T>, priority: number): Promise<T>;
+    queueWork(workFn: () => Promise<OperationStatus>, priority: number): Promise<OperationStatus>;
     requestRun?: (requestor?: string) => void;
     terminal: ITerminal;
 }

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -189,14 +189,26 @@ export class Async {
       }
     }
   }
+
+  /**
+   * Returns a Signal, a.k.a. a "deferred promise".
+   */
+  public static getSignal(): [Promise<void>, () => void, (err: Error) => void] {
+    return getSignal();
+  }
 }
 
-function getSignal(): [Promise<void>, () => void] {
+/**
+ * Returns an unwrapped promise.
+ */
+function getSignal(): [Promise<void>, () => void, (err: Error) => void] {
   let resolver: () => void;
-  const promise: Promise<void> = new Promise<void>((resolve) => {
+  let rejecter: (err: Error) => void;
+  const promise: Promise<void> = new Promise<void>((resolve, reject) => {
     resolver = resolve;
+    rejecter = reject;
   });
-  return [promise, resolver!];
+  return [promise, resolver!, rejecter!];
 }
 
 /**

--- a/libraries/node-core-library/src/MinimumHeap.ts
+++ b/libraries/node-core-library/src/MinimumHeap.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * Implements a standard heap data structure for items of type T and a custom comparator.
+ * The root will always be the minimum value as determined by the comparator.
+ *
+ * @beta
+ */
+export class MinimumHeap<T> {
+  private readonly _items: T[] = [];
+  private readonly _comparator: (a: T, b: T) => number;
+
+  /**
+   * Constructs a new MinimumHeap instance.
+   * @param comparator - a comparator function that determines the order of the items in the heap.
+   *   If the comparator returns a value less than zero, then `a` will be considered less than `b`.
+   *   If the comparator returns zero, then `a` and `b` are considered equal.
+   *   Otherwise, `a` will be considered greater than `b`.
+   */
+  public constructor(comparator: (a: T, b: T) => number) {
+    this._comparator = comparator;
+  }
+
+  /**
+   * @returns the number of items in the heap.
+   */
+  public get size(): number {
+    return this._items.length;
+  }
+
+  /**
+   * Retrieves the root item from the heap without removing it.
+   * @returns the root item, or `undefined` if the heap is empty
+   */
+  public peek(): T | undefined {
+    return this._items[0];
+  }
+
+  /**
+   * Retrieves and removes the root item from the heap. The next smallest item will become the new root.
+   * @returns the root item, or `undefined` if the heap is empty
+   */
+  public poll(): T | undefined {
+    if (this.size > 0) {
+      const result: T = this._items[0];
+      const item: T = this._items.pop()!;
+
+      const size: number = this.size;
+      if (size === 0) {
+        // Short circuit in the trivial case
+        return result;
+      }
+
+      let index: number = 0;
+
+      let smallerChildIndex: number = index * 2 + 1;
+
+      while (smallerChildIndex < size) {
+        let smallerChild: T = this._items[smallerChildIndex];
+
+        const rightChildIndex: number = smallerChildIndex + 1;
+
+        if (rightChildIndex < size) {
+          const rightChild: T = this._items[rightChildIndex];
+          if (this._comparator(rightChild, smallerChild) < 0) {
+            smallerChildIndex = rightChildIndex;
+            smallerChild = rightChild;
+          }
+        }
+
+        if (this._comparator(smallerChild, item) < 0) {
+          this._items[index] = smallerChild;
+          index = smallerChildIndex;
+          smallerChildIndex = index * 2 + 1;
+        } else {
+          break;
+        }
+      }
+
+      // Place the item in its final location satisfying the heap property
+      this._items[index] = item;
+
+      return result;
+    }
+  }
+
+  /**
+   * Pushes an item into the heap.
+   * @param item - the item to push
+   */
+  public push(item: T): void {
+    let index: number = this.size;
+    while (index > 0) {
+      // Due to zero-based indexing the parent is not exactly a bit shift
+      const parentIndex: number = ((index + 1) >> 1) - 1;
+      const parent: T = this._items[parentIndex];
+      if (this._comparator(item, parent) < 0) {
+        this._items[index] = parent;
+        index = parentIndex;
+      } else {
+        break;
+      }
+    }
+    this._items[index] = item;
+  }
+}

--- a/libraries/node-core-library/src/MinimumHeap.ts
+++ b/libraries/node-core-library/src/MinimumHeap.ts
@@ -23,6 +23,7 @@ export class MinimumHeap<T> {
   }
 
   /**
+   * Returns the number of items in the heap.
    * @returns the number of items in the heap.
    */
   public get size(): number {
@@ -54,7 +55,7 @@ export class MinimumHeap<T> {
 
       let index: number = 0;
 
-      let smallerChildIndex: number = index * 2 + 1;
+      let smallerChildIndex: number = 1;
 
       while (smallerChildIndex < size) {
         let smallerChild: T = this._items[smallerChildIndex];

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -59,6 +59,7 @@ export {
 } from './JsonSchema';
 export { LockFile } from './LockFile';
 export { MapExtensions } from './MapExtensions';
+export { MinimumHeap } from './MinimumHeap';
 export { PosixModeBits } from './PosixModeBits';
 export { ProtectableMap, IProtectableMapParameters } from './ProtectableMap';
 export { IPackageJsonLookupParameters, PackageJsonLookup } from './PackageJsonLookup';

--- a/libraries/node-core-library/src/test/MinimumHeap.test.ts
+++ b/libraries/node-core-library/src/test/MinimumHeap.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { MinimumHeap } from '../MinimumHeap';
+
+describe(MinimumHeap.name, () => {
+  it('iterates in sorted order', () => {
+    const comparator: (a: number, b: number) => number = (a: number, b: number) => a - b;
+
+    const heap: MinimumHeap<number> = new MinimumHeap<number>(comparator);
+    for (const x of [1, 3, -2, 9, 6, 12, 11, 0, -5, 2, 3, 1, -21]) {
+      heap.push(x);
+    }
+
+    const iterationResults: number[] = [];
+    while (heap.size > 0) {
+      iterationResults.push(heap.poll()!);
+    }
+
+    expect(iterationResults).toEqual(iterationResults.slice().sort(comparator));
+  });
+});

--- a/libraries/operation-graph/src/WorkQueue.ts
+++ b/libraries/operation-graph/src/WorkQueue.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Async, MinimumHeap } from '@rushstack/node-core-library';
+
+import { OperationStatus } from './OperationStatus';
+
+interface IQueueItem {
+  task: () => Promise<void>;
+  priority: number;
+}
+
+export class WorkQueue {
+  private readonly _queue: MinimumHeap<IQueueItem>;
+  private readonly _abortSignal: AbortSignal;
+  private readonly _abortPromise: Promise<void>;
+
+  private _pushPromise: Promise<void>;
+  private _resolvePush: () => void;
+  private _resolvePushTimeout: NodeJS.Timeout | undefined;
+
+  public constructor(abortSignal: AbortSignal) {
+    // Sort by priority descending. Thus the comparator returns a negative number if a has higher priority than b.
+    this._queue = new MinimumHeap((a: IQueueItem, b: IQueueItem) => b.priority - a.priority);
+    this._abortSignal = abortSignal;
+    this._abortPromise = abortSignal.aborted
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          abortSignal.addEventListener('abort', () => resolve(), { once: true });
+        });
+    [this._pushPromise, this._resolvePush] = Async.getSignal();
+    this._resolvePushTimeout = undefined;
+  }
+
+  public async *[Symbol.asyncIterator](): AsyncIterableIterator<() => Promise<void>> {
+    while (!this._abortSignal.aborted) {
+      while (this._queue.size > 0) {
+        const item: IQueueItem = this._queue.poll()!;
+        yield item.task;
+      }
+
+      await Promise.race([this._pushPromise, this._abortPromise]);
+    }
+  }
+
+  public pushAsync(task: () => Promise<OperationStatus>, priority: number): Promise<OperationStatus> {
+    return new Promise((resolve, reject) => {
+      this._queue.push({
+        task: () => task().then(resolve, reject),
+        priority
+      });
+
+      this._abortPromise.finally(() => resolve(OperationStatus.Aborted));
+
+      this._resolvePushDebounced();
+    });
+  }
+
+  private _resolvePushDebounced(): void {
+    if (!this._resolvePushTimeout) {
+      this._resolvePushTimeout = setTimeout(() => {
+        this._resolvePushTimeout = undefined;
+        this._resolvePush();
+        [this._pushPromise, this._resolvePush] = Async.getSignal();
+      });
+    }
+  }
+}

--- a/libraries/operation-graph/src/test/WorkQueue.test.ts
+++ b/libraries/operation-graph/src/test/WorkQueue.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Async } from '@rushstack/node-core-library';
+import { OperationStatus } from '../OperationStatus';
+import { WorkQueue } from '../WorkQueue';
+
+describe(WorkQueue.name, () => {
+  it('Executes in dependency order', async () => {
+    const abortController: AbortController = new AbortController();
+
+    const queue: WorkQueue = new WorkQueue(abortController.signal);
+
+    const executed: Set<number> = new Set();
+
+    const outerPromises: Promise<OperationStatus>[] = [];
+
+    for (let i: number = 0; i < 10; i++) {
+      outerPromises.push(
+        queue.pushAsync(async () => {
+          executed.add(i);
+          return OperationStatus.Success;
+        }, i)
+      );
+    }
+
+    let expectedCount: number = 0;
+    const queuePromise: Promise<void> = (async () => {
+      for await (const task of queue) {
+        expect(executed.size).toBe(expectedCount);
+        await task();
+        ++expectedCount;
+        expect(executed.has(outerPromises.length - expectedCount)).toBe(true);
+      }
+    })();
+
+    expect((await Promise.all(outerPromises)).every((status) => status === OperationStatus.Success)).toBe(
+      true
+    );
+    abortController.abort();
+    await queuePromise;
+  });
+
+  it('Aborts any tasks left on the queue when aborted', async () => {
+    const abortController: AbortController = new AbortController();
+
+    const queue: WorkQueue = new WorkQueue(abortController.signal);
+
+    const executed: Set<number> = new Set();
+
+    const outerPromises: Promise<OperationStatus>[] = [];
+
+    for (let i: number = 0; i < 10; i++) {
+      outerPromises.push(
+        queue.pushAsync(async () => {
+          executed.add(i);
+          return OperationStatus.Success;
+        }, i)
+      );
+    }
+
+    let expectedCount: number = 0;
+    for await (const task of queue) {
+      expect(executed.size).toBe(expectedCount);
+      await task();
+      ++expectedCount;
+      expect(executed.has(outerPromises.length - expectedCount)).toBe(true);
+
+      if (expectedCount === 1) {
+        abortController.abort();
+      }
+    }
+
+    const results: OperationStatus[] = await Promise.all(outerPromises);
+    // The last pushed operation had the highest priority, so is the only one executed before the abort call
+    expect(results.pop()).toBe(OperationStatus.Success);
+    for (const result of results) {
+      expect(result).toBe(OperationStatus.Aborted);
+    }
+  });
+
+  it('works with Async.forEachAsync', async () => {
+    const abortController: AbortController = new AbortController();
+
+    const queue: WorkQueue = new WorkQueue(abortController.signal);
+
+    const executed: Set<number> = new Set();
+
+    const outerPromises: Promise<OperationStatus>[] = [];
+
+    for (let i: number = 0; i < 10; i++) {
+      outerPromises.push(
+        queue.pushAsync(async () => {
+          executed.add(i);
+          return OperationStatus.Success;
+        }, i)
+      );
+    }
+
+    let expectedCount: number = 0;
+    const queuePromise: Promise<void> = Async.forEachAsync(
+      queue,
+      async (task) => {
+        expect(executed.size).toBe(expectedCount);
+        await task();
+        ++expectedCount;
+        expect(executed.has(outerPromises.length - expectedCount)).toBe(true);
+      },
+      { concurrency: 1 }
+    );
+
+    expect((await Promise.all(outerPromises)).every((status) => status === OperationStatus.Success)).toBe(
+      true
+    );
+    abortController.abort();
+    await queuePromise;
+  });
+
+  it('works concurrently with Async.forEachAsync', async () => {
+    const abortController: AbortController = new AbortController();
+
+    const queue: WorkQueue = new WorkQueue(abortController.signal);
+
+    let running: number = 0;
+    let maxRunning: number = 0;
+
+    const array: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    const fn: () => Promise<OperationStatus> = jest.fn(async () => {
+      running++;
+      await Async.sleep(1);
+      maxRunning = Math.max(maxRunning, running);
+      running--;
+      return OperationStatus.Success;
+    });
+    const outerPromises: Promise<OperationStatus>[] = array.map((index) => queue.pushAsync(fn, 0));
+
+    const queuePromise: Promise<void> = Async.forEachAsync(queue, (task) => task(), { concurrency: 3 });
+    expect((await Promise.all(outerPromises)).every((status) => status === OperationStatus.Success)).toBe(
+      true
+    );
+
+    abortController.abort();
+    await queuePromise;
+
+    expect(fn).toHaveBeenCalledTimes(8);
+    expect(maxRunning).toEqual(3);
+  });
+});

--- a/libraries/operation-graph/src/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/operation-graph/src/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -12,6 +12,10 @@ exports[`OperationExecutionManager executeAsync single pass handles empty input 
 
 exports[`OperationExecutionManager executeAsync single pass handles trivial input 1`] = `""`;
 
+exports[`OperationExecutionManager executeAsync single pass respects concurrency 1`] = `""`;
+
+exports[`OperationExecutionManager executeAsync single pass respects priority order 1`] = `""`;
+
 exports[`OperationExecutionManager executeAsync watch mode executes in order: first 1`] = `""`;
 
 exports[`OperationExecutionManager executeAsync watch mode executes in order: second 1`] = `""`;


### PR DESCRIPTION
## Summary
Updates the work scheduler in Heft to respect the passed in parallelism constraint for task execution.

## Details
Adds an implementation of a min heap to `@rushstack/node-core-library` with accompanying unit tests.

Uses said min heap and wraps it in a queue structure that iterates items until aborted.

## How it was tested
Added unit tests for the min heap.
Added unit tests for the work queue.
Added unit tests to OperationExecutionManager that validate concurrency and priority.
Ran all build+test in the @rushstack repository, since this code is used by Heft.

## Impacted documentation
API docs for @rushstack/node-core-library and @rushstack/operation-graph.