### PR TITLE
[package-extractor] Ensure that the `folderToCopy` option is included in generated archives

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-FixAdditionalFolderToCopy_2023-09-29-19-40.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-FixAdditionalFolderToCopy_2023-09-29-19-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Ensure the \"folderToCopy\" field is included in generated archives",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -410,7 +410,9 @@ export class PackageExtractor {
     );
 
     if (addditionalFolderToCopy) {
-      // Copy the additional folder directly into the root of the target folder by overriding the
+      // Copy the additional folder directly into the root of the target folder by postfixing the
+      // folder name to the target folder and setting the sourceRootFolder to the root of the
+      // folderToCopy
       const additionalFolderPath: string = path.resolve(sourceRootFolder, addditionalFolderToCopy);
       const targetFolderPath: string = path.join(
         options.targetRootFolder,

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -409,6 +409,21 @@ export class PackageExtractor {
       }
     );
 
+    if (addditionalFolderToCopy) {
+      // Copy the additional folder directly into the root of the target folder by overriding the
+      const additionalFolderPath: string = path.resolve(sourceRootFolder, addditionalFolderToCopy);
+      const targetFolderPath: string = path.join(
+        options.targetRootFolder,
+        path.basename(additionalFolderPath)
+      );
+      const additionalFolderExtractorOptions: IExtractorOptions = {
+        ...options,
+        sourceRootFolder: additionalFolderPath,
+        targetRootFolder: targetFolderPath
+      };
+      await this._extractFolderAsync(additionalFolderPath, additionalFolderExtractorOptions, state);
+    }
+
     switch (linkCreation) {
       case 'script': {
         const sourceFilePath: string = path.join(scriptsFolderPath, createLinksScriptFilename);
@@ -442,15 +457,6 @@ export class PackageExtractor {
 
     terminal.writeLine('Creating extractor-metadata.json');
     await this._writeExtractorMetadataAsync(options, state);
-
-    if (addditionalFolderToCopy) {
-      const sourceFolderPath: string = path.resolve(sourceRootFolder, addditionalFolderToCopy);
-      await FileSystem.copyFilesAsync({
-        sourcePath: sourceFolderPath,
-        destinationPath: targetRootFolder,
-        alreadyExistsBehavior: AlreadyExistsBehavior.Error
-      });
-    }
   }
 
   /**

--- a/libraries/package-extractor/src/test/PackageExtractor.test.ts
+++ b/libraries/package-extractor/src/test/PackageExtractor.test.ts
@@ -392,4 +392,38 @@ describe(PackageExtractor.name, () => {
       )
     ).toBe(true);
   });
+
+  it('should include folderToCopy', async () => {
+    const targetFolder: string = path.join(extractorTargetFolder, 'extractor-output-09');
+
+    await expect(
+      packageExtractor.extractAsync({
+        mainProjectName: project1PackageName,
+        sourceRootFolder: repoRoot,
+        targetRootFolder: targetFolder,
+        overwriteExisting: true,
+        projectConfigurations: [
+          {
+            projectName: project1PackageName,
+            projectFolder: project1Path
+          }
+        ],
+        folderToCopy: project2Path,
+        terminal,
+        createArchiveOnly: false,
+        includeNpmIgnoreFiles: true,
+        linkCreation: 'default',
+        includeDevDependencies: true
+      })
+    ).resolves.not.toThrow();
+
+    // Validate project 1 files
+    expect(FileSystem.exists(path.join(targetFolder, project1RelativePath, 'package.json'))).toBe(true);
+    expect(FileSystem.exists(path.join(targetFolder, project1RelativePath, 'src', 'index.js'))).toBe(true);
+
+    // Validate project 2 files
+    const project2FolderName: string = path.basename(project2Path);
+    expect(FileSystem.exists(path.join(targetFolder, project2FolderName, 'package.json'))).toBe(true);
+    expect(FileSystem.exists(path.join(targetFolder, project2FolderName, 'src', 'index.js'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

During the refactor to the `@rushstack/package-extractor` a change in behavior was accidentally introduced where the `folderToCopy` field was not included in the generated archive. Fixes #4371 

## Details

The `folderToCopy` field is now treated as if it were just another folder being traversed during extraction. The folder is explicitly mapped to the root of the target output folder/archive, just as previously spec'd.

## How it was tested

Added a test to ensure that the copy operation behaves as it had previously.