### PR TITLE
[eslint-patch] Fix patch compatibility with ESLint >=7.0.0 and <7.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ These GitHub repositories provide supplementary resources for Rush Stack:
 | [/build-tests/api-extractor-test-02](./build-tests/api-extractor-test-02/) | Building this project is a regression test for api-extractor |
 | [/build-tests/api-extractor-test-03](./build-tests/api-extractor-test-03/) | Building this project is a regression test for api-extractor |
 | [/build-tests/api-extractor-test-04](./build-tests/api-extractor-test-04/) | Building this project is a regression test for api-extractor |
+| [/build-tests/eslint-7-11-test](./build-tests/eslint-7-11-test/) | This project contains a build test to validate ESLint 7.11.0 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
+| [/build-tests/eslint-7-7-test](./build-tests/eslint-7-7-test/) | This project contains a build test to validate ESLint 7.7.0 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
 | [/build-tests/eslint-7-test](./build-tests/eslint-7-test/) | This project contains a build test to validate ESLint 7 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
 | [/build-tests/eslint-8-test](./build-tests/eslint-8-test/) | This project contains a build test to validate ESLint 8 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin) |
 | [/build-tests/hashed-folder-copy-plugin-webpack4-test](./build-tests/hashed-folder-copy-plugin-webpack4-test/) | Building this project exercises @rushstack/hashed-folder-copy-plugin with Webpack 4. |

--- a/build-tests/eslint-7-11-test/.eslintrc.js
+++ b/build-tests/eslint-7-11-test/.eslintrc.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
 // This is a workaround for https://github.com/microsoft/rushstack/issues/3021

--- a/build-tests/eslint-7-11-test/.eslintrc.js
+++ b/build-tests/eslint-7-11-test/.eslintrc.js
@@ -1,0 +1,27 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
+// This is a workaround for https://github.com/microsoft/rushstack/issues/3021
+require('local-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names');
+
+module.exports = {
+  extends: [
+    'local-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool',
+    'local-node-rig/profiles/default/includes/eslint/mixins/friendly-locals'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname },
+
+  overrides: [
+    /**
+     * Override the parser from local-eslint-config. Since the config is coming
+     * from the workspace instead of the external NPM package, the versions of ESLint
+     * and TypeScript that the config consumes will be resolved from the devDependencies
+     * of the config instead of from the eslint-7-test package. Overriding the parser
+     * ensures that the these dependencies come from the eslint-7-test package. See:
+     * https://github.com/microsoft/rushstack/issues/3021
+     */
+    {
+      files: ['*.ts', '*.tsx'],
+      parser: '@typescript-eslint/parser'
+    }
+  ]
+};

--- a/build-tests/eslint-7-11-test/README.md
+++ b/build-tests/eslint-7-11-test/README.md
@@ -1,0 +1,6 @@
+# eslint-7-11-test
+
+This project folder is one of the **build-tests** for the Rushstack [ESLint configuration](https://www.npmjs.com/package/@rushstack/eslint-config) (and by extension, the [ESLint plugin](https://www.npmjs.com/package/@rushstack/eslint-plugin))
+package. This project builds using ESLint v7.11.0 and contains a simple index file to ensure that the build runs ESLint successfully against source code.
+
+Please see the [ESLint Heft task documentation](https://rushstack.io/pages/heft_tasks/eslint/) for documentation and tutorials.

--- a/build-tests/eslint-7-11-test/config/rig.json
+++ b/build-tests/eslint-7-11-test/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "local-node-rig"
+}

--- a/build-tests/eslint-7-11-test/package.json
+++ b/build-tests/eslint-7-11-test/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "eslint-7-11-test",
+  "description": "This project contains a build test to validate ESLint 7.11.0 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin)",
+  "version": "1.0.0",
+  "private": true,
+  "main": "lib/index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean"
+  },
+  "devDependencies": {
+    "@rushstack/heft": "workspace:*",
+    "local-node-rig": "workspace:*",
+    "@types/node": "18.17.15",
+    "@typescript-eslint/parser": "~5.59.2",
+    "eslint": "7.11.0",
+    "typescript": "~5.0.4"
+  }
+}

--- a/build-tests/eslint-7-11-test/src/index.ts
+++ b/build-tests/eslint-7-11-test/src/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export class Foo {
+  private _bar: string = 'bar';
+  public baz: string = this._bar;
+}

--- a/build-tests/eslint-7-11-test/tsconfig.json
+++ b/build-tests/eslint-7-11-test/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es5",
+    "lib": ["es5"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/build-tests/eslint-7-7-test/.eslintrc.js
+++ b/build-tests/eslint-7-7-test/.eslintrc.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
 // This is a workaround for https://github.com/microsoft/rushstack/issues/3021

--- a/build-tests/eslint-7-7-test/.eslintrc.js
+++ b/build-tests/eslint-7-7-test/.eslintrc.js
@@ -1,0 +1,27 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
+// This is a workaround for https://github.com/microsoft/rushstack/issues/3021
+require('local-node-rig/profiles/default/includes/eslint/patch/custom-config-package-names');
+
+module.exports = {
+  extends: [
+    'local-node-rig/profiles/default/includes/eslint/profile/node-trusted-tool',
+    'local-node-rig/profiles/default/includes/eslint/mixins/friendly-locals'
+  ],
+  parserOptions: { tsconfigRootDir: __dirname },
+
+  overrides: [
+    /**
+     * Override the parser from local-eslint-config. Since the config is coming
+     * from the workspace instead of the external NPM package, the versions of ESLint
+     * and TypeScript that the config consumes will be resolved from the devDependencies
+     * of the config instead of from the eslint-7-test package. Overriding the parser
+     * ensures that the these dependencies come from the eslint-7-test package. See:
+     * https://github.com/microsoft/rushstack/issues/3021
+     */
+    {
+      files: ['*.ts', '*.tsx'],
+      parser: '@typescript-eslint/parser'
+    }
+  ]
+};

--- a/build-tests/eslint-7-7-test/README.md
+++ b/build-tests/eslint-7-7-test/README.md
@@ -1,0 +1,6 @@
+# eslint-7-7-test
+
+This project folder is one of the **build-tests** for the Rushstack [ESLint configuration](https://www.npmjs.com/package/@rushstack/eslint-config) (and by extension, the [ESLint plugin](https://www.npmjs.com/package/@rushstack/eslint-plugin))
+package. This project builds using ESLint v7.7.0 and contains a simple index file to ensure that the build runs ESLint successfully against source code.
+
+Please see the [ESLint Heft task documentation](https://rushstack.io/pages/heft_tasks/eslint/) for documentation and tutorials.

--- a/build-tests/eslint-7-7-test/config/rig.json
+++ b/build-tests/eslint-7-7-test/config/rig.json
@@ -1,0 +1,7 @@
+{
+  // The "rig.json" file directs tools to look for their config files in an external package.
+  // Documentation for this system: https://www.npmjs.com/package/@rushstack/rig-package
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+
+  "rigPackageName": "local-node-rig"
+}

--- a/build-tests/eslint-7-7-test/package.json
+++ b/build-tests/eslint-7-7-test/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "eslint-7-7-test",
+  "description": "This project contains a build test to validate ESLint 7.7.0 compatibility with the latest version of @rushstack/eslint-config (and by extension, the ESLint plugin)",
+  "version": "1.0.0",
+  "private": true,
+  "main": "lib/index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "heft build --clean",
+    "_phase:build": "heft run --only build -- --clean"
+  },
+  "devDependencies": {
+    "@rushstack/heft": "workspace:*",
+    "local-node-rig": "workspace:*",
+    "@types/node": "18.17.15",
+    "@typescript-eslint/parser": "~5.59.2",
+    "eslint": "7.7.0",
+    "typescript": "~5.0.4"
+  }
+}

--- a/build-tests/eslint-7-7-test/src/index.ts
+++ b/build-tests/eslint-7-7-test/src/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export class Foo {
+  private _bar: string = 'bar';
+  public baz: string = this._bar;
+}

--- a/build-tests/eslint-7-7-test/tsconfig.json
+++ b/build-tests/eslint-7-7-test/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es5",
+    "lib": ["es5"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/build-tests/eslint-7-test/.eslintrc.js
+++ b/build-tests/eslint-7-test/.eslintrc.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
 // This is a workaround for https://github.com/microsoft/rushstack/issues/3021

--- a/build-tests/eslint-8-test/.eslintrc.js
+++ b/build-tests/eslint-8-test/.eslintrc.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('local-node-rig/profiles/default/includes/eslint/patch/modern-module-resolution');
 // This is a workaround for https://github.com/microsoft/rushstack/issues/3021

--- a/common/changes/@rushstack/eslint-patch/user-danade-FixEslint7_2023-09-30-04-21.json
+++ b/common/changes/@rushstack/eslint-patch/user-danade-FixEslint7_2023-09-30-04-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix patch compatibility with ESLint 7 for versions matching <7.12.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/tree-pattern/user-danade-FixEslint7_2023-09-30-04-21.json
+++ b/common/changes/@rushstack/tree-pattern/user-danade-FixEslint7_2023-09-30-04-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/tree-pattern",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -61,9 +61,9 @@
    */
   "allowedAlternativeVersions": {
     /**
-     * Used by build-tests/eslint-7-test
+     * Used by build-tests/eslint-7-7-test, build-tests/eslint-7-11-test, and build-tests/eslint-7-test
      */
-    "eslint": ["~7.30.0"],
+    "eslint": ["7.7.0", "7.11.0", "~7.30.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1030,6 +1030,48 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
 
+  ../../build-tests/eslint-7-11-test:
+    devDependencies:
+      '@rushstack/heft':
+        specifier: workspace:*
+        version: link:../../apps/heft
+      '@types/node':
+        specifier: 18.17.15
+        version: 18.17.15
+      '@typescript-eslint/parser':
+        specifier: ~5.59.2
+        version: 5.59.11(eslint@7.11.0)(typescript@5.0.4)
+      eslint:
+        specifier: 7.11.0
+        version: 7.11.0
+      local-node-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-node-rig
+      typescript:
+        specifier: ~5.0.4
+        version: 5.0.4
+
+  ../../build-tests/eslint-7-7-test:
+    devDependencies:
+      '@rushstack/heft':
+        specifier: workspace:*
+        version: link:../../apps/heft
+      '@types/node':
+        specifier: 18.17.15
+        version: 18.17.15
+      '@typescript-eslint/parser':
+        specifier: ~5.59.2
+        version: 5.59.11(eslint@7.7.0)(typescript@5.0.4)
+      eslint:
+        specifier: 7.7.0
+        version: 7.7.0
+      local-node-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-node-rig
+      typescript:
+        specifier: ~5.0.4
+        version: 5.0.4
+
   ../../build-tests/eslint-7-test:
     devDependencies:
       '@rushstack/heft':
@@ -1710,7 +1752,7 @@ importers:
         version: 29.5.5
       '@types/node':
         specifier: ts4.9
-        version: 20.7.0
+        version: 20.7.2
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -3322,7 +3364,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.4.0
-        version: 3.4.0(eslint@7.30.0)(typescript@5.0.4)
+        version: 3.4.0(eslint@8.7.0)(typescript@5.0.4)
       '@rushstack/heft':
         specifier: 0.62.0
         version: 0.62.0(@types/node@18.17.15)
@@ -3336,8 +3378,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       eslint:
-        specifier: ~7.30.0
-        version: 7.30.0
+        specifier: ~8.7.0
+        version: 8.7.0
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
@@ -6468,16 +6510,6 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@7.30.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 7.30.0
-      eslint-visitor-keys: 3.4.2
-    dev: true
-
   /@eslint-community/eslint-utils@4.4.0(eslint@8.46.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6500,6 +6532,24 @@ packages:
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  /@eslint/eslintrc@0.1.3:
+    resolution: {integrity: sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 7.3.1
+      globals: 12.4.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      js-yaml: 3.13.1
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@eslint/eslintrc@0.4.3:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -9225,29 +9275,6 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@rushstack/eslint-config@3.4.0(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-KZNwM1S3LkhzJ6mBjXaJBo7maUN44Chu2CjsHnIui3i6W/FlazLyjme3929ACsVA8nyC4VlPOQYDRy2d3siPGw==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '>=4.7.0'
-    dependencies:
-      '@rushstack/eslint-patch': 1.5.0
-      '@rushstack/eslint-plugin': 0.13.1(eslint@7.30.0)(typescript@5.0.4)
-      '@rushstack/eslint-plugin-packlets': 0.8.1(eslint@7.30.0)(typescript@5.0.4)
-      '@rushstack/eslint-plugin-security': 0.7.1(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/eslint-plugin': 5.59.11(@typescript-eslint/parser@5.59.11)(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/experimental-utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
-      eslint: 7.30.0
-      eslint-plugin-promise: 6.0.1(eslint@7.30.0)
-      eslint-plugin-react: 7.27.1(eslint@7.30.0)
-      eslint-plugin-tsdoc: 0.2.17
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@rushstack/eslint-config@3.4.0(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-KZNwM1S3LkhzJ6mBjXaJBo7maUN44Chu2CjsHnIui3i6W/FlazLyjme3929ACsVA8nyC4VlPOQYDRy2d3siPGw==}
     peerDependencies:
@@ -9275,19 +9302,6 @@ packages:
     resolution: {integrity: sha512-EF3948ckf3f5uPgYbQ6GhyA56Dmv8yg0+ir+BroRjwdxyZJsekhZzawOecC2rOTPCz173t7ZcR1HHZu0dZgOCw==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.8.1(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-p3u2AfJsam6g29ah1P3yA9O65EACmcHmQtbsn+NdQEfZ1J72tm+x3d2PucFC381AeIcMVjULm9H/SGS+mHgDZA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.1
-      '@typescript-eslint/experimental-utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@rushstack/eslint-plugin-packlets@0.8.1(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-p3u2AfJsam6g29ah1P3yA9O65EACmcHmQtbsn+NdQEfZ1J72tm+x3d2PucFC381AeIcMVjULm9H/SGS+mHgDZA==}
     peerDependencies:
@@ -9301,19 +9315,6 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security@0.7.1(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-84N42tlONhcbXdlk5Rkb+/pVxPnH+ojX8XwtFoecCRV88/4Ii7eGEyJPb73lOpHaE3NJxLzLVIeixKYQmdjImA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.1
-      '@typescript-eslint/experimental-utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@rushstack/eslint-plugin-security@0.7.1(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-84N42tlONhcbXdlk5Rkb+/pVxPnH+ojX8XwtFoecCRV88/4Ii7eGEyJPb73lOpHaE3NJxLzLVIeixKYQmdjImA==}
     peerDependencies:
@@ -9322,19 +9323,6 @@ packages:
       '@rushstack/tree-pattern': 0.3.1
       '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.7.0)(typescript@5.0.4)
       eslint: 8.7.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin@0.13.1(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-qQ6iPCm8SFuY+bpcSv5hlYtdwDHcFlE6wlpUHa0ywG9tGVBYM5But8S4qVRFq1iejAuFX+ubNUOyFJHvxpox+A==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.1
-      '@typescript-eslint/experimental-utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11445,8 +11433,8 @@ packages:
     resolution: {integrity: sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==}
     dev: false
 
-  /@types/node@20.7.0:
-    resolution: {integrity: sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==}
+  /@types/node@20.7.2:
+    resolution: {integrity: sha512-RcdC3hOBOauLP+r/kRt27NrByYtDjsXyAuSbR87O6xpsvi763WI+5fbSIvYJrXnt9w4RuxhV6eAXfIs7aaf/FQ==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -11693,34 +11681,6 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/scope-manager': 5.59.11(typescript@5.0.4)
-      '@typescript-eslint/type-utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      debug: 4.3.4
-      eslint: 7.30.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11748,19 +11708,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils@5.59.11(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils@5.59.11(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11772,6 +11719,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@typescript-eslint/parser@5.59.11(eslint@7.11.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.59.11(typescript@5.0.4)
+      '@typescript-eslint/types': 5.59.11(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
+      debug: 4.3.4
+      eslint: 7.11.0
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/parser@5.59.11(eslint@7.30.0)(typescript@5.0.4):
     resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
@@ -11788,6 +11755,26 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
       debug: 4.3.4
       eslint: 7.30.0
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@5.59.11(eslint@7.7.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.59.11(typescript@5.0.4)
+      '@typescript-eslint/types': 5.59.11(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
+      debug: 4.3.4
+      eslint: 7.7.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -11830,26 +11817,6 @@ packages:
     transitivePeerDependencies:
       - typescript
     dev: false
-
-  /@typescript-eslint/type-utils@5.59.11(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.11(eslint@7.30.0)(typescript@5.0.4)
-      debug: 4.3.4
-      eslint: 7.30.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/type-utils@5.59.11(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
@@ -11927,26 +11894,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@typescript-eslint/utils@5.59.11(eslint@7.30.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@7.30.0)
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.59.11(typescript@5.0.4)
-      '@typescript-eslint/types': 5.59.11(typescript@5.0.4)
-      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.0.4)
-      eslint: 7.30.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@typescript-eslint/utils@5.59.11(eslint@8.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
@@ -12791,6 +12738,11 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.3.1
+    dev: true
+
+  /astral-regex@1.0.0:
+    resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
+    engines: {node: '>=4'}
     dev: true
 
   /astral-regex@2.0.0:
@@ -15918,15 +15870,6 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-promise@6.0.1(eslint@7.30.0):
-    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      eslint: 7.30.0
-    dev: true
-
   /eslint-plugin-promise@6.0.1(eslint@8.7.0):
     resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -15943,29 +15886,6 @@ packages:
     dependencies:
       eslint: 8.7.0
     dev: false
-
-  /eslint-plugin-react@7.27.1(eslint@7.30.0):
-    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flatmap: 1.3.1
-      doctrine: 2.1.0
-      eslint: 7.30.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.0.8
-      object.entries: 1.1.6
-      object.fromentries: 2.0.6
-      object.hasown: 1.1.2
-      object.values: 1.1.6
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.4
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.8
-    dev: true
 
   /eslint-plugin-react@7.27.1(eslint@8.7.0):
     resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
@@ -16045,6 +15965,52 @@ packages:
     resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  /eslint@7.11.0:
+    resolution: {integrity: sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    hasBin: true
+    dependencies:
+      '@babel/code-frame': 7.22.10
+      '@eslint/eslintrc': 0.1.3
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      enquirer: 2.4.1
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+      eslint-visitor-keys: 2.1.0
+      espree: 7.3.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      file-entry-cache: 5.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.1.2
+      globals: 12.4.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 3.13.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.5.4
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      table: 5.4.6
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint@7.30.0:
     resolution: {integrity: sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -16088,6 +16054,51 @@ packages:
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint@7.7.0:
+    resolution: {integrity: sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    hasBin: true
+    dependencies:
+      '@babel/code-frame': 7.22.10
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      enquirer: 2.4.1
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+      eslint-visitor-keys: 1.3.0
+      espree: 7.3.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      file-entry-cache: 5.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.1.2
+      globals: 12.4.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 3.13.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.5.4
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      table: 5.4.6
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
@@ -16566,6 +16577,13 @@ packages:
       escape-string-regexp: 1.0.5
     dev: false
 
+  /file-entry-cache@5.0.1:
+    resolution: {integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==}
+    engines: {node: '>=4'}
+    dependencies:
+      flat-cache: 2.0.1
+    dev: true
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -16705,6 +16723,15 @@ packages:
       micromatch: 3.1.10
       resolve-dir: 1.0.1
 
+  /flat-cache@2.0.1:
+    resolution: {integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==}
+    engines: {node: '>=4'}
+    dependencies:
+      flatted: 2.0.2
+      rimraf: 2.6.3
+      write: 1.0.3
+    dev: true
+
   /flat-cache@3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -16720,6 +16747,10 @@ packages:
   /flatstr@1.0.12:
     resolution: {integrity: sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==}
     dev: false
+
+  /flatted@2.0.2:
+    resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
+    dev: true
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
@@ -17220,6 +17251,13 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+
+  /globals@12.4.0:
+    resolution: {integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.8.1
+    dev: true
 
   /globals@13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -23433,6 +23471,15 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  /slice-ansi@2.1.0:
+    resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      ansi-styles: 3.2.1
+      astral-regex: 1.0.0
+      is-fullwidth-code-point: 2.0.0
+    dev: true
+
   /slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
@@ -24055,6 +24102,16 @@ packages:
 
   /synchronous-promise@2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
+    dev: true
+
+  /table@5.4.6:
+    resolution: {integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      ajv: 6.12.6
+      lodash: 4.17.21
+      slice-ansi: 2.1.0
+      string-width: 3.1.0
     dev: true
 
   /table@6.8.1:
@@ -25979,6 +26036,13 @@ packages:
       js-yaml: 4.1.0
       write-file-atomic: 3.0.3
     dev: false
+
+  /write@1.0.3:
+    resolution: {integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==}
+    engines: {node: '>=4'}
+    dependencies:
+      mkdirp: 0.5.6
+    dev: true
 
   /ws@6.2.2:
     resolution: {integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d2f44ef5ae58d7f9cd054dc38f03cce18f09a893",
+  "pnpmShrinkwrapHash": "8e080c6ec927d3b02d4f9e475bf43f884aa48671",
   "preferredVersionsHash": "1926a5b12ac8f4ab41e76503a0d1d0dccc9c0e06"
 }

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -21,7 +21,7 @@
     "@rushstack/heft-node-rig": "2.3.2",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
-    "eslint": "~7.30.0",
+    "eslint": "~8.7.0",
     "typescript": "~5.0.4"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -531,6 +531,18 @@
       "shouldPublish": false
     },
     {
+      "packageName": "eslint-7-7-test",
+      "projectFolder": "build-tests/eslint-7-7-test",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
+    {
+      "packageName": "eslint-7-11-test",
+      "projectFolder": "build-tests/eslint-7-11-test",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
+    {
       "packageName": "eslint-7-test",
       "projectFolder": "build-tests/eslint-7-test",
       "reviewCategory": "tests",


### PR DESCRIPTION
## Summary

Changes made in #4353 introduced compatibility issues with a specific range of ESLint 7 versions. This was caused by two different issues:
- a change in the logic which was an attempt to improve the speed of resolution of the required modules, and
- the `naming` module being moved from the standard `eslint` package to the `@eslint/eslintrc` package in 7.8.0, before the larger change to move the `config-array-factory` module there as well in 7.12.0.

This change fixes both issues, and adds new test projects for `eslint@7.7.0` and `eslint@7.11.0` to ensure that this issue does not arise again.

Fixes #4368

## How it was tested

Added new test projects and confirmed that the patch is correctly consumed.