### PR TITLE
[rush-lib] Add autoInstallPeers in pnpm-config

### DIFF
--- a/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
+++ b/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "[rush-lib] Add autoInstallPeers in pnpm-config",
+      "comment": "Add a new setting `autoInstallPeers` in pnpm-config.json",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
+++ b/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-lib] Add autoInstallPeers in pnpm-config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
+++ b/common/changes/@microsoft/rush/chao-auto-install-peers_2023-10-03-20-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add a new setting `autoInstallPeers` in pnpm-config.json",
+      "comment": "(IMPORTANT) Add a new setting `autoInstallPeers` in pnpm-config.json; be aware that Rush changes PNPM's default if you are using PNPM 8 or newer",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -651,6 +651,7 @@ export interface IPhasedCommand extends IRushCommand {
 
 // @internal
 export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
+    autoInstallPeers?: boolean;
     globalAllowedDeprecatedVersions?: Record<string, string>;
     globalNeverBuiltDependencies?: string[];
     globalOverrides?: Record<string, string>;
@@ -965,6 +966,7 @@ export class PhasedCommandHooks {
 
 // @public
 export class PnpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
+    readonly autoInstallPeers: boolean | undefined;
     readonly globalAllowedDeprecatedVersions: Record<string, string> | undefined;
     readonly globalNeverBuiltDependencies: string[] | undefined;
     readonly globalOverrides: Record<string, string> | undefined;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -44,11 +44,21 @@
   /*[LINE "DEMO"]*/ "resolutionMode": "time-based",
 
   /**
-   * When true, any missing non-optional peer dependencies are automatically installed.
-   *
+   * This setting determines whether PNPM will automatically install (non-optional)
+   * missing peer dependencies instead of reporting an error.  Doing so conveniently
+   * avoids the need to specify peer versions in package.json, but in a large monorepo
+   * this often creates worse problems.  The reason is that peer dependency behavior
+   * is inherently complicated, and it is easier to troubleshoot consequences of an explicit
+   * version than an invisible heuristic.  The original NPM RFC discussion pointed out
+   * some other problems with this feature: https://github.com/npm/rfcs/pull/43
+
+   * IMPORTANT: Without Rush, the setting defaults to true for PNPM 8 and newer; however,
+   * as of Rush version 5.109.0 the default is always false unless `autoInstallPeers`
+   * is specified in pnpm-config.json or .npmrc, regardless of your PNPM version.
+
    * PNPM documentation: https://pnpm.io/npmrc#auto-install-peers
-   *
-   * The default is `false`.
+
+   * The default value is false.
    */
   /*[LINE "DEMO"]*/ "autoInstallPeers": false,
 

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -44,6 +44,15 @@
   /*[LINE "DEMO"]*/ "resolutionMode": "time-based",
 
   /**
+   * When true, any missing non-optional peer dependencies are automatically installed.
+   *
+   * PNPM documentation: https://pnpm.io/npmrc#auto-install-peers
+   *
+   * The default is `false`.
+   */
+  /*[LINE "DEMO"]*/ "autoInstallPeers": false,
+
+  /**
    * If true, then Rush will add the `--strict-peer-dependencies` command-line parameter when
    * invoking PNPM.  This causes `rush update` to fail if there are unsatisfied peer dependencies,
    * which is an invalid state that can cause build failures or incompatible dependency versions.

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -644,6 +644,27 @@ ${gitLfsHookHandling}
       }
 
       /*
+        If user set auto-install-peers in pnpm-config.json only, use the value in pnpm-config.json
+        If user set auto-install-peers in pnpm-config.json and .npmrc, use the value in pnpm-config.json
+        If user set auto-install-peers in .npmrc only, do nothing, let pnpm handle it
+        If user does not set auto-install-peers in pnpm-config.json and .npmrc, do nothing, let pnpm handle it
+      */
+      const isAutoInstallPeersInNpmrc: boolean = isVariableSetInNpmrcFile(
+        this.rushConfiguration.commonRushConfigFolder,
+        'auto-install-peers'
+      );
+      const autoInstallPeers: boolean | undefined = this.rushConfiguration.pnpmOptions.autoInstallPeers;
+      if (autoInstallPeers !== undefined) {
+        if (isAutoInstallPeersInNpmrc) {
+          this._terminal.writeWarningLine(
+            `Warning: PNPM's auto-install-peers is specified in both .npmrc and pnpm-config.json. ` +
+              `The value in pnpm-config.json will take precedence.`
+          );
+        }
+        args.push(`--config.auto-install-peers=${autoInstallPeers}`);
+      }
+
+      /*
         If user set resolution-mode in pnpm-config.json only, use the value in pnpm-config.json
         If user set resolution-mode in pnpm-config.json and .npmrc, use the value in pnpm-config.json
         If user set resolution-mode in .npmrc only, do nothing, let pnpm handle it

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -647,13 +647,14 @@ ${gitLfsHookHandling}
         If user set auto-install-peers in pnpm-config.json only, use the value in pnpm-config.json
         If user set auto-install-peers in pnpm-config.json and .npmrc, use the value in pnpm-config.json
         If user set auto-install-peers in .npmrc only, do nothing, let pnpm handle it
-        If user does not set auto-install-peers in pnpm-config.json and .npmrc, do nothing, let pnpm handle it
+        If user does not set auto-install-peers in both pnpm-config.json and .npmrc, rush will default it to "false"
       */
       const isAutoInstallPeersInNpmrc: boolean = isVariableSetInNpmrcFile(
         this.rushConfiguration.commonRushConfigFolder,
         'auto-install-peers'
       );
-      const autoInstallPeers: boolean | undefined = this.rushConfiguration.pnpmOptions.autoInstallPeers;
+
+      let autoInstallPeers: boolean | undefined = this.rushConfiguration.pnpmOptions.autoInstallPeers;
       if (autoInstallPeers !== undefined) {
         if (isAutoInstallPeersInNpmrc) {
           this._terminal.writeWarningLine(
@@ -661,6 +662,12 @@ ${gitLfsHookHandling}
               `The value in pnpm-config.json will take precedence.`
           );
         }
+      } else if (!isAutoInstallPeersInNpmrc) {
+        // if auto-install-peers isn't specified in either .npmrc or pnpm-config.json,
+        // then rush will default it to "false"
+        autoInstallPeers = false;
+      }
+      if (autoInstallPeers !== undefined) {
         args.push(`--config.auto-install-peers=${autoInstallPeers}`);
       }
 

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -107,6 +107,10 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
    * {@inheritDoc PnpmOptionsConfiguration.resolutionMode}
    */
   resolutionMode?: PnpmResolutionMode;
+  /**
+   * {@inheritDoc PnpmOptionsConfiguration.autoInstallPeers}
+   */
+  autoInstallPeers?: boolean;
 }
 
 /**
@@ -208,6 +212,14 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
    * The default value is true.  (For now.)
    */
   public readonly useWorkspaces: boolean;
+
+  /**
+   * When true, any missing non-optional peer dependencies are automatically installed.
+   *
+   * @remarks
+   * The default value is same as PNPM default value.  (In PNPM 8.x, this value is true)
+   */
+  public readonly autoInstallPeers: boolean | undefined;
 
   /**
    * The "globalOverrides" setting provides a simple mechanism for overriding version selections
@@ -332,6 +344,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     this.unsupportedPackageJsonSettings = json.unsupportedPackageJsonSettings;
     this._globalPatchedDependencies = json.globalPatchedDependencies;
     this.resolutionMode = json.resolutionMode;
+    this.autoInstallPeers = json.autoInstallPeers;
   }
 
   /** @internal */

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -165,6 +165,11 @@
       "description": "This option overrides the resolution-mode in PNPM. Use it if you want to change the default resolution behavior when installing dependencies. Defaults to \"highest\".\n\nPNPM documentation: https://pnpm.io/npmrc#resolution-mode.",
       "type": "string",
       "enum": ["highest", "time-based", "lowest-direct"]
+    },
+
+    "autoInstallPeers": {
+      "description": "This option overrides the auto-install-peers in PNPM. Use it if you want to change the default resolution behavior when installing dependencies. Defaults to \"highest\".\n\nPNPM documentation: https://pnpm.io/npmrc#auto-install-peers.",
+      "type": "boolean"
     }
   }
 }

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -168,7 +168,7 @@
     },
 
     "autoInstallPeers": {
-      "description": "This option overrides the auto-install-peers in PNPM. Use it if you want to change the default resolution behavior when installing dependencies. Defaults to \"highest\".\n\nPNPM documentation: https://pnpm.io/npmrc#auto-install-peers.",
+      "description": "This setting determines whether PNPM will automatically install (non-optional) missing peer dependencies instead of reporting an error. With Rush, the default value is always false.\n\nPNPM documentation: https://pnpm.io/npmrc#auto-install-peers",
       "type": "boolean"
     }
   }


### PR DESCRIPTION
## Summary

PNPM8 changes the default value for `auto-install-peers` setting. It is default to true in
[PNPM8](https://pnpm.io/npmrc#auto-install-peers)

In this PR, we want to provide a option inside `pnpm-config.json` to let user overwrite `auto-install-peers` setting easily.

## Details

If user set auto-install-peers in `pnpm-config.json` only, use the value in `pnpm-config.json`
If user set auto-install-peers in `pnpm-config.json` and `.npmrc`, use the value in `pnpm-config.json`, and output a warning message
If user set auto-install-peers in `.npmrc` only, do nothing, let pnpm handle it
If user does not set auto-install-peers in both `pnpm-config.json` and `.npmrc`, rush will default it to `false`

## How it was tested

Manually tested on rush-example repo. 

## Impacted documentation

N/A
