### PR TITLE
[rush] Increase oldest usable Node.js version from 8.9.0 -> 14.18.0

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-rush-ancient-version_2023-10-04-23-03.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-ancient-version_2023-10-04-23-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the oldest usable Node.js version to 14.18.0, since 14.17.0 fails to load",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
+++ b/libraries/rush-lib/src/logic/NodeJsCompatibility.ts
@@ -49,7 +49,7 @@ export class NodeJsCompatibility {
     // IMPORTANT: If this test fails, the Rush CLI front-end process will terminate with an error.
     // Only increment it when our code base is known to use newer features (e.g. "async"/"await") that
     // have no hope of working with older Node.js.
-    if (semver.satisfies(nodeVersion, '< 8.9.0')) {
+    if (semver.satisfies(nodeVersion, '<14.18.0')) {
       // eslint-disable-next-line no-console
       console.error(
         colors.red(


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

When invoked from Node.js 14.17.0 or earlier, recent releases of Rush now crash with the error shown below. Node 14 is no longer supported, but the problem is that ***our users don't know that,*** because the crash happens before Rush's incompatibility warnings get printed. As a result, our on-call was receiving support tickets from users confused by this error.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

![image](https://github.com/microsoft/rushstack/assets/4673363/71280350-7cac-4f57-97b2-34479478134e)

## Details

This is a regression caused by [PR #7](https://github.com/chengcyber/rushstack/pull/7/files#diff-f9234ed7851357be3cadb4d45ecbcf8253e90bfec1f8205fad71cd811cf5a565) which got merged into the Cobuilds PR.  It introduced an import with the `node:` prefix which is apparently a relatively new feature in Node.js:

```ts
import path from 'node:path';
```

I notice that some other plugins are now also using this syntax:

https://github.com/microsoft/rushstack/blob/3ae59aa7e0c12686d71e02092b213db1d4cccbea/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts#L4-L8

@dmichon-msft a couple questions:
- Is there some technical advantage to the `node:` prefix that justifies breaking compatibility?
- If so, shouldn't we apply it it universally across the Rush Stack code base, rather than inconsistently in just a few files?

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

The above screenshot confirms that with Node.js 14.18.0, Rush is able to print the `--help` output. That means `warnAboutCompatibilityIssues()` was invoked successfully.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation
None.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
@iclanton @theJiawen 