### PR TITLE
[rush] Fix typo in rush.json template

### DIFF
--- a/apps/rush/CHANGELOG.json
+++ b/apps/rush/CHANGELOG.json
@@ -11,6 +11,9 @@
             "comment": "(IMPORTANT) Add a new setting `autoInstallPeers` in pnpm-config.json; be aware that Rush changes PNPM's default if you are using PNPM 8 or newer"
           },
           {
+            "comment": "(IMPORTANT) After upgrading, if `rush install` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, please run `rush update --recheck`"
+          },
+          {
             "comment": "Improve visual formatting of custom tips"
           },
           {

--- a/apps/rush/CHANGELOG.md
+++ b/apps/rush/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @microsoft/rush
 
-This log was last generated on Sat, 07 Oct 2023 00:25:27 GMT and should not be manually modified.
+This log was last generated on Sat, 07 Oct 2023 00:58:12 GMT and should not be manually modified.
 
 ## 5.109.0
 Sat, 07 Oct 2023 00:25:27 GMT
@@ -8,6 +8,7 @@ Sat, 07 Oct 2023 00:25:27 GMT
 ### Updates
 
 - (IMPORTANT) Add a new setting `autoInstallPeers` in pnpm-config.json; be aware that Rush changes PNPM's default if you are using PNPM 8 or newer
+- (IMPORTANT) After upgrading, if `rush install` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, please run `rush update --recheck`
 - Improve visual formatting of custom tips
 - Add start `preRushx` and `postRushx` event hooks for monitoring the `rushx` command
 - Update the oldest usable Node.js version to 14.18.0, since 14.17.0 fails to load

--- a/common/changes/@microsoft/rush/octogonz-fix-rush-init_2023-10-07-00-46.json
+++ b/common/changes/@microsoft/rush/octogonz-fix-rush-init_2023-10-07-00-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix incorrect capitalization in the \"rush init\" template",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.109.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -271,12 +271,12 @@
     /**
      * A list of shell commands to run before the "rushx" command starts
      */
-    "preRushX": [],
+    "preRushx": [],
 
     /**
      * A list of shell commands to run after the "rushx" command finishes
      */
-    "postRushX": []
+    "postRushx": []
   },
 
   /**


### PR DESCRIPTION
 

## Summary

After running `rush init`, the resulting repository failed to build because of incorrect capitalization of `preRushX` and `preRushX`.

