### PR TITLE
Remove "--color=always" option when invoking pnpm install

### DIFF
--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -292,6 +292,9 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       this.rushConfiguration,
       this.options
     );
+    if (colors.enabled) {
+      packageManagerEnv['FORCE_COLOR'] = '1';
+    }
 
     const commonNodeModulesFolder: string = path.join(
       this.rushConfiguration.commonTempFolder,
@@ -318,7 +321,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       // Run "npm install" in the common folder
       // To ensure that the output is always colored, set the option "--color=always", even when it's piped.
       // Without this argument, certain text that should be colored (such as red) will appear white.
-      const installArgs: string[] = ['install', '--color=always'];
+      const installArgs: string[] = ['install'];
       this.pushConfigurationArgs(installArgs, options);
 
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Why we needed the `color=always` option? The following screenshot shows that the error would be white instead of red without the option. 

<img width="1243" alt="image" src="https://github.com/microsoft/rushstack/assets/16242633/faf0ad83-b643-4009-bcc3-c9f41b03d6fa">

But this `color=always` would cause another problem: in a CI environment that doesn't support colors, it would be like, "This next word should be 35m]purple34m];".

Hence, in this fix, we pass along Rush's own state (`color.enabled`) to pnpm – assuming Rush could determine this state correctly. Besides, we don't use the `--color=always` cli option but use the `FORCE_COLOR` environment variable because we want PNPM's child process also to print colors. 
