### PR TITLE
Workaround for issue where "install-test-workspace" sometimes freezes during "rush build"

### DIFF
--- a/build-tests/install-test-workspace/build.js
+++ b/build-tests/install-test-workspace/build.js
@@ -139,7 +139,11 @@ const pnpmInstallArgs = [
   '--recursive',
   '--link-workspace-packages=false',
   // PNPM gets confused by the rewriting performed by our .pnpmfile.cjs afterAllResolved hook
-  '--frozen-lockfile=false'
+  '--frozen-lockfile=false',
+
+  // Workaround for this issue:
+  // https://github.com/pnpm/pnpm/issues/6778#issuecomment-1762418094
+  '--config.confirmModulesPurge=false'
 ];
 
 console.log('\nInstalling:');
@@ -148,7 +152,7 @@ console.log('  pnpm ' + pnpmInstallArgs.join(' '));
 checkSpawnResult(
   Executable.spawnSync(rushConfiguration.packageManagerToolFilename, pnpmInstallArgs, {
     currentWorkingDirectory: path.join(__dirname, 'workspace'),
-    stdio: 'inherit'
+    stdio: ['ignore', 'inherit', 'inherit']
   }),
   'pnpm install'
 );
@@ -187,7 +191,7 @@ console.log('\nBuilding projects...\n');
 checkSpawnResult(
   Executable.spawnSync(rushConfiguration.packageManagerToolFilename, ['run', '--recursive', 'build'], {
     currentWorkingDirectory: path.join(__dirname, 'workspace'),
-    stdio: 'inherit'
+    stdio: ['ignore', 'inherit', 'inherit']
   }),
   'pnpm run'
 );

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   rush-lib-test:
     dependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.107.4.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.107.4.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.109.1.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.109.1.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
@@ -30,15 +30,15 @@ importers:
   rush-sdk-test:
     dependencies:
       '@rushstack/rush-sdk':
-        specifier: file:rushstack-rush-sdk-5.107.4.tgz
-        version: file:../temp/tarballs/rushstack-rush-sdk-5.107.4.tgz(@types/node@18.17.15)
+        specifier: file:rushstack-rush-sdk-5.109.1.tgz
+        version: file:../temp/tarballs/rushstack-rush-sdk-5.109.1.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.107.4.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.107.4.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.109.1.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.109.1.tgz(@types/node@18.17.15)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -2301,7 +2301,7 @@ packages:
     hasBin: true
 
   /json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -3923,11 +3923,11 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.107.4.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.107.4.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.107.4.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.109.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.109.1.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.109.1.tgz
     name: '@microsoft/rush-lib'
-    version: 5.107.4
+    version: 5.109.1
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/dependency-path': 2.1.2
@@ -4264,11 +4264,11 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.107.4.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.107.4.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.107.4.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.109.1.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.109.1.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.109.1.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.107.4
+    version: 5.109.1
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.61.0.tgz(@types/node@18.17.15)
       '@types/node-fetch': 2.6.2


### PR DESCRIPTION
This is a temporary workaround for the PNPM problem discussed here:

https://github.com/pnpm/pnpm/issues/6778#issuecomment-1762418094