### PR TITLE
[rush] Fix an issue with the CWD of the http build cache provider's token handler script.

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-10-16-22-02.json
+++ b/common/changes/@microsoft/rush/main_2023-10-16-22-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where running `rush update-cloud-credentials --interactive` in a repo configured to use the `http` build cache with a tokenHandler script provided would run the script in the console's CWD instead of in the repo root. If the tokenHandler script refered to a script in the repo (for example `node common/scripts/cache-auth.js`) and the user's CWD was inside a project folder, the script would not be found.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-http-build-cache-plugin/src/HttpBuildCacheProvider.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/HttpBuildCacheProvider.ts
@@ -39,7 +39,7 @@ export interface IHttpBuildCacheProviderOptions {
   cacheKeyPrefix?: string;
   isCacheWriteAllowed: boolean;
   pluginName: string;
-  rushProjectRoot: string;
+  rushRepoRoot: string;
 }
 
 const MAX_HTTP_CACHE_ATTEMPTS: number = 3;
@@ -47,7 +47,6 @@ const DEFAULT_MIN_HTTP_RETRY_DELAY_MS = 2500;
 
 export class HttpBuildCacheProvider implements ICloudBuildCacheProvider {
   private readonly _pluginName: string;
-  private readonly _rushSession: RushSession;
   private readonly _rushProjectRoot: string;
   private readonly _environmentCredential: string | undefined;
   private readonly _isCacheWriteAllowedByConfiguration: boolean;
@@ -65,8 +64,7 @@ export class HttpBuildCacheProvider implements ICloudBuildCacheProvider {
 
   public constructor(options: IHttpBuildCacheProviderOptions, rushSession: RushSession) {
     this._pluginName = options.pluginName;
-    this._rushSession = rushSession;
-    this._rushProjectRoot = options.rushProjectRoot;
+    this._rushProjectRoot = options.rushRepoRoot;
 
     this._environmentCredential = EnvironmentConfiguration.buildCacheCredential;
     this._isCacheWriteAllowedByConfiguration = options.isCacheWriteAllowed;
@@ -156,7 +154,9 @@ export class HttpBuildCacheProvider implements ICloudBuildCacheProvider {
 
     const cmd: string = `${this._tokenHandler.exec} ${(this._tokenHandler.args || []).join(' ')}`;
     terminal.writeVerboseLine(`Running '${cmd}' to get credentials`);
-    const result = Executable.spawnSync(this._tokenHandler.exec, this._tokenHandler.args || []);
+    const result = Executable.spawnSync(this._tokenHandler.exec, this._tokenHandler.args || [], {
+      currentWorkingDirectory: this._rushProjectRoot
+    });
 
     terminal.writeErrorLine(result.stderr);
 

--- a/rush-plugins/rush-http-build-cache-plugin/src/HttpBuildCacheProvider.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/HttpBuildCacheProvider.ts
@@ -39,7 +39,7 @@ export interface IHttpBuildCacheProviderOptions {
   cacheKeyPrefix?: string;
   isCacheWriteAllowed: boolean;
   pluginName: string;
-  rushRepoRoot: string;
+  rushJsonFolder: string;
 }
 
 const MAX_HTTP_CACHE_ATTEMPTS: number = 3;
@@ -64,7 +64,7 @@ export class HttpBuildCacheProvider implements ICloudBuildCacheProvider {
 
   public constructor(options: IHttpBuildCacheProviderOptions, rushSession: RushSession) {
     this._pluginName = options.pluginName;
-    this._rushProjectRoot = options.rushRepoRoot;
+    this._rushProjectRoot = options.rushJsonFolder;
 
     this._environmentCredential = EnvironmentConfiguration.buildCacheCredential;
     this._isCacheWriteAllowedByConfiguration = options.isCacheWriteAllowed;

--- a/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
@@ -64,7 +64,7 @@ export class RushHttpBuildCachePlugin implements IRushPlugin {
 
         const options: IHttpBuildCacheProviderOptions = {
           pluginName: this.pluginName,
-          rushProjectRoot: rushConfig.rushJsonFolder,
+          rushRepoRoot: rushConfig.rushJsonFolder,
           url: url,
           uploadMethod: uploadMethod,
           headers: headers,

--- a/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
@@ -64,7 +64,7 @@ export class RushHttpBuildCachePlugin implements IRushPlugin {
 
         const options: IHttpBuildCacheProviderOptions = {
           pluginName: this.pluginName,
-          rushRepoRoot: rushConfig.rushJsonFolder,
+          rushJsonFolder: rushConfig.rushJsonFolder,
           url: url,
           uploadMethod: uploadMethod,
           headers: headers,

--- a/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
@@ -9,9 +9,9 @@ import fetch, { Response } from 'node-fetch';
 import { RushSession, EnvironmentConfiguration } from '@rushstack/rush-sdk';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/node-core-library';
 
-import { HttpBuildCacheProvider } from '../HttpBuildCacheProvider';
+import { HttpBuildCacheProvider, type IHttpBuildCacheProviderOptions } from '../HttpBuildCacheProvider';
 
-const EXAMPLE_OPTIONS = {
+const EXAMPLE_OPTIONS: IHttpBuildCacheProviderOptions = {
   url: 'https://buildcache.example.acme.com',
   tokenHandler: {
     exec: 'node',
@@ -20,7 +20,7 @@ const EXAMPLE_OPTIONS = {
   uploadMethod: 'POST',
   isCacheWriteAllowed: false,
   pluginName: 'example-plugin',
-  rushProjectRoot: '/repo',
+  rushRepoRoot: '/repo',
   minHttpRetryDelayMs: 1
 };
 

--- a/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/test/HttpBuildCacheProvider.test.ts
@@ -20,7 +20,7 @@ const EXAMPLE_OPTIONS: IHttpBuildCacheProviderOptions = {
   uploadMethod: 'POST',
   isCacheWriteAllowed: false,
   pluginName: 'example-plugin',
-  rushRepoRoot: '/repo',
+  rushJsonFolder: '/repo',
   minHttpRetryDelayMs: 1
 };
 


### PR DESCRIPTION
## Details

The CWD may be set incorrectly when running `rush update-cloud-credentials --interactive` command with the `http` build cache provider configured.

## How it was tested

Tested in a repo with this issue.