### PR TITLE
[rush-lib] Use configured shrinkwrapFilename for logging shrinkwrapFilePhrase

### DIFF
--- a/common/changes/@microsoft/rush/dmyers-shrinkwrap-filename_2023-10-18-19-31.json
+++ b/common/changes/@microsoft/rush/dmyers-shrinkwrap-filename_2023-10-18-19-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Use configured shrinkwrapFilename when printing out the Shrinkwrap phrase",
+      "comment": "Include the filename of the shrinkwrap file in logging messages for all package managers, not just Yarn.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/dmyers-shrinkwrap-filename_2023-10-18-19-31.json
+++ b/common/changes/@microsoft/rush/dmyers-shrinkwrap-filename_2023-10-18-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use configured shrinkwrapFilename when printing out the Shrinkwrap phrase",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1153,13 +1153,7 @@ export class RushConfiguration {
    * package manager.
    */
   public get shrinkwrapFilePhrase(): string {
-    if (this.packageManager === 'yarn') {
-      // Eventually we'd like to be consistent with Yarn's terminology of calling this a "lock file",
-      // but a lot of Rush documentation uses "shrinkwrap" file and would all need to be updated.
-      return 'shrinkwrap file (yarn.lock)';
-    } else {
-      return 'shrinkwrap file';
-    }
+    return `shrinkwrap file (${this.shrinkwrapFilename})`;
   }
 
   /**


### PR DESCRIPTION

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->
When using a rush-managed project with pnpm, occasionally, there are problems with the shrinkwrap file. The log message goes like `The shrinkwrap file is out of date. You need to run "rush update".` When working with yarn, there is a hard-coded hint as to _what_ the shrinkwrap file is: `The shrinkwrap file (yarn.lock) is out of date. You need to run "rush update".`

Since we have access to the name of the shrinkwrap file, I'm suggesting that we change to implementation to use that so that all package managers include a hint as to what shrinkwrap file it's talking about.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
(covered above)

## How it was tested
I tested this by running tests and manually reviewing in a pnpm and a yarn codebase. 

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
