### PR TITLE
[rush] Allow skip if cache configured but disabled

### DIFF
--- a/common/changes/@microsoft/rush/allow-skip-if-cache-disabled_2023-10-18-21-58.json
+++ b/common/changes/@microsoft/rush/allow-skip-if-cache-disabled_2023-10-18-21-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow legacy skip behavior if build cache is configured but disabled. When running in verbose mode, log the type of incremental logic in use.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/allow-skip-if-cache-disabled_2023-10-18-21-58.json
+++ b/common/changes/@microsoft/rush/allow-skip-if-cache-disabled_2023-10-18-21-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Allow legacy skip behavior if build cache is configured but disabled. When running in verbose mode, log the type of incremental logic in use.",
+      "comment": "Allow the output preservation incremental strategy if the build cache is configured but disabled. When running in verbose mode, log the incremental strategy that is being used.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -351,7 +351,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         customParametersByName.set(configParameter.longName, parserParameter);
       }
 
-      if (buildCacheConfiguration) {
+      if (buildCacheConfiguration?.buildCacheEnabled) {
+        terminal.writeVerboseLine(`Incremental mode: build cache`);
         new CacheableOperationPlugin({
           allowWarningsInSuccessfulBuild:
             !!this.rushConfiguration.experimentsConfiguration.configuration
@@ -361,12 +362,15 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           terminal
         }).apply(this.hooks);
       } else if (!this._disableBuildCache) {
+        terminal.writeVerboseLine(`Incremental mode: legacy skip detection`);
         // Explicitly disabling the build cache also disables legacy skip detection.
         new LegacySkipPlugin({
           terminal,
           changedProjectsOnly,
           isIncrementalBuildAllowed: this._isIncrementalBuildAllowed
         }).apply(this.hooks);
+      } else {
+        terminal.writeVerboseLine(`Incremental mode: disabled`);
       }
 
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -352,7 +352,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       }
 
       if (buildCacheConfiguration?.buildCacheEnabled) {
-        terminal.writeVerboseLine(`Incremental mode: build cache`);
+        terminal.writeVerboseLine(`Incremental strategy: cache restoration`);
         new CacheableOperationPlugin({
           allowWarningsInSuccessfulBuild:
             !!this.rushConfiguration.experimentsConfiguration.configuration
@@ -362,7 +362,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           terminal
         }).apply(this.hooks);
       } else if (!this._disableBuildCache) {
-        terminal.writeVerboseLine(`Incremental mode: legacy skip detection`);
+        terminal.writeVerboseLine(`Incremental strategy: output preservation`);
         // Explicitly disabling the build cache also disables legacy skip detection.
         new LegacySkipPlugin({
           terminal,
@@ -370,7 +370,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           isIncrementalBuildAllowed: this._isIncrementalBuildAllowed
         }).apply(this.hooks);
       } else {
-        terminal.writeVerboseLine(`Incremental mode: disabled`);
+        terminal.writeVerboseLine(`Incremental strategy: none (full rebuild)`);
       }
 
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this


### PR DESCRIPTION
## Summary
Ensure that if the build cache is configured, but the `buildCacheEnabled` flag is set to `false`, that the legacy skip detection logic is allowed to occur.

Fixes #4394 

## Details
The build cache (and thereby cobuilds) plugin will now only be applied if the build cache is both configured and enabled.

## How it was tested
Temporarily changed `buildCacheEnabled` to `false` in `common/config/rush/build-cache.json` and verified that skip detection occurred when running `rush build`.

## Impacted documentation
Any docs on build cache vs. skip.