### PR TITLE
[heft] "heft --debug test" and "heft test --verbose" should enable Jest's verbose mode

### DIFF
--- a/build-tests/heft-jest-reporters-test/config/jest.config.json
+++ b/build-tests/heft-jest-reporters-test/config/jest.config.json
@@ -2,7 +2,7 @@
   "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
   "coverageDirectory": "<rootDir>/coverage",
   "reporters": ["default", "../lib/test/customJestReporter.cjs"],
-  "testMatch": ["<rootDir>/lib/**.test.cjs"],
+  "testMatch": ["<rootDir>/lib/**/*.test.cjs"],
   "collectCoverageFrom": [
     "lib/**/*.cjs",
     "!lib/**/*.d.ts",

--- a/common/changes/@rushstack/heft-jest-plugin/octogonz-jest-console-log_2023-10-20-19-18.json
+++ b/common/changes/@rushstack/heft-jest-plugin/octogonz-jest-console-log_2023-10-20-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Use Jest verbose logging when `heft --debug test` or `heft test --verbose` is specified",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/octogonz-jest-console-log_2023-10-20-23-29.json
+++ b/common/changes/@rushstack/heft-jest-plugin/octogonz-jest-console-log_2023-10-20-23-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Fix an issue where `silent: true` was ignored when specified in `jest.config.json`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -591,6 +591,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       rootDir: buildFolderPath,
 
       silent: options.silent || false,
+      verbose: (taskSession.parameters.verbose || taskSession.parameters.debug) && !options.silent,
       testNamePattern: options.testNamePattern,
       testPathIgnorePatterns: options.testPathIgnorePatterns ? [options.testPathIgnorePatterns] : undefined,
       testPathPattern: options.testPathPattern ? [options.testPathPattern] : undefined,

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -585,7 +585,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       silent = false;
     } else {
       // If "silent" is specified via IJestPluginOptions, that takes precedence over jest.config.json
-      options.silent ?? jestConfig.silent ?? false;
+      silent = options.silent ?? jestConfig.silent ?? false;
     }
 
     const jestArgv: Config.Argv = {

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -591,7 +591,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
       rootDir: buildFolderPath,
 
       silent: options.silent || false,
-      verbose: (taskSession.parameters.verbose || taskSession.parameters.debug) && !options.silent,
+      verbose: taskSession.parameters.verbose || taskSession.parameters.debug,
       testNamePattern: options.testNamePattern,
       testPathIgnorePatterns: options.testPathIgnorePatterns ? [options.testPathIgnorePatterns] : undefined,
       testPathPattern: options.testPathPattern ? [options.testPathPattern] : undefined,


### PR DESCRIPTION
## Summary

**The problem:** When debugging code, it's common practice to add `console.log()` in various files to monitor variable states, while also interactively stepping through breakpoints in the VS Code debugger.  This experience is broken for unit tests, because Jest reroutes `console.log()` to a special handler that only prints the output after the test has completed.

## Details

Why would Jest do that?  The ideal model seems something like:

- When debugging tests, `console.log()` should print to the interactive console
- For a normal build, `console.log()` should fail the build, because nobody wants thousands of lines of noisy unit test output in their CI logs

However, perhaps this restriction was too difficult to enforce. Probably many projects will call `console.log()` as part of their normal execution, and if it can't be mocked easily, then when Jest runs that code, it will always print to the console as a side effect.  So instead Jest reroutes `console.log()` to its internal `BufferedConsole` which collects the strings, which are then passed to the Jest reporter for reporting at the end of the test.  This probably also ensures that parallel test runs don't interfere with each other's output.  

This also allows the `console.log()` output to be reformatted so that it cannot be confused with build logs from the toolchain.  Our `HeftJestReporter` adds blue prefixes as seen below, for example:

![image](https://github.com/microsoft/rushstack/assets/4673363/12dc08cb-cadd-4973-91cf-241adcc9b973)

Okay, but what about interactive debugging? It is extremely frustrating to call `console.log()` while stepping through code in the debugger, and it doesn't get printed, and there's no way to see the results without using watch windows to access Jest internals.

How can we ensure that `console.log()` gets printed immediately in that scenario, rather than buffering it?  The obvious answer is to hook into Jest's `BufferedConsole` provider and also print to the real `console.log()` API. This would have the benefit of being compatible with VS Code's `"console": "internalConsole"` in **launch.json**, whereas Jest's output gets printed to STDERR and is therefore invisible without `"console": "integratedTerminal"`.

But unfortunately, this turns out to be impossible without monkey-patching Jest, because the buffering is hard-wired:

[jest-runner/src/runTest.ts](https://github.com/jestjs/jest/blob/a30a52fbdd35db6ca7cfc2f03efc03153da18e99/packages/jest-runner/src/runTest.ts#L135)
```ts
  if (globalConfig.silent) {
    testConsole = new NullConsole(consoleOut, consoleOut, consoleFormatter);
  } else if (globalConfig.verbose) {
    testConsole = new CustomConsole(consoleOut, consoleOut, consoleFormatter);
  } else {
    testConsole = new BufferedConsole();
  }
```

However although we can't intercept the logging events, if we set `globalConfig.verbose` then we get `CustomConsole`  which does prints interactively, but just with rather ugly-looking output:

![image](https://github.com/microsoft/rushstack/assets/4673363/20796d1c-0b22-477a-9889-313a081bb785)

Despite being ugly, I think it is an improvement for the interactive debugging experience, and perhaps more consistent with expectations of `--verbose`.  So that is what I've done in this PR.

How do we distinguish debugging from a normal build?  In this PR the definition is `heft --debug test` or `heft test --verbose`.

## Possible alternative implementation

If someone really hates the `CustomConsole` formatting, we could consider monkey-patching Jest instead.

What is particularly annoying with Jest's design is that `console.error()` gets formatted like a build failure:

![image](https://github.com/microsoft/rushstack/assets/4673363/a88ce499-872e-436c-bf65-e0dd524e5f5b)

But then the Jest run "succeeds" with process exit code `0`.  🤦 

## How it was tested

- Tested as shown in the screenshots above
- I also confirmed that `verbose:true` does not affect the routing of logging to STDERR vs STDOUT (which would impact Rush's interpretation of "success with warnings")
- I also confirmed that the process exit code is unaffected by this change

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
@D4N14L @elliot-nelson @dmichon-msft 