### PR TITLE
[rush-lib] Fix concurrency of rush-lib build script

### DIFF
--- a/common/changes/@microsoft/rush/user-danade-FixConcurrency_2023-10-27-21-34.json
+++ b/common/changes/@microsoft/rush/user-danade-FixConcurrency_2023-10-27-21-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/scripts/copyEmptyModules.js
+++ b/libraries/rush-lib/scripts/copyEmptyModules.js
@@ -46,6 +46,7 @@ module.exports = {
     const jsInFolderPath = `${buildFolderPath}/lib-esnext`;
     const dtsInFolderPath = `${buildFolderPath}/lib-commonjs`;
     const outFolderPath = `${buildFolderPath}/lib`;
+    const emptyModuleBuffer = Buffer.from('module.exports = {};', 'utf8');
     const folderPathQueue = new AsyncQueue([undefined]);
 
     await Async.forEachAsync(
@@ -66,7 +67,7 @@ module.exports = {
             if (strippedJsFileText === 'export {};') {
               const outJsPath = `${outFolderPath}/${relativeItemPath}`;
               terminal.writeVerboseLine(`Writing stub to ${outJsPath}`);
-              await FileSystem.writeFileAsync(outJsPath, 'module.exports = {};', {
+              await FileSystem.writeFileAsync(outJsPath, emptyModuleBuffer, {
                 ensureFolderExists: true
               });
 

--- a/libraries/rush-lib/scripts/copyEmptyModules.js
+++ b/libraries/rush-lib/scripts/copyEmptyModules.js
@@ -46,18 +46,19 @@ module.exports = {
     const jsInFolderPath = `${buildFolderPath}/lib-esnext`;
     const dtsInFolderPath = `${buildFolderPath}/lib-commonjs`;
     const outFolderPath = `${buildFolderPath}/lib`;
-    const folderPathQueue = new AsyncQueue([jsInFolderPath]);
+    const folderPathQueue = new AsyncQueue([undefined]);
 
     await Async.forEachAsync(
       folderPathQueue,
-      async ([folderPath, callback]) => {
+      async ([relativeFolderPath, callback]) => {
+        const folderPath = relativeFolderPath ? `${jsInFolderPath}/${relativeFolderPath}` : jsInFolderPath;
         const folderItems = await FileSystem.readFolderItemsAsync(folderPath);
         for (const folderItem of folderItems) {
           const itemName = folderItem.name;
-          const relativeItemPath = `${folderPath}/${itemName}`;
+          const relativeItemPath = relativeFolderPath ? `${relativeFolderPath}/${itemName}` : itemName;
 
           if (folderItem.isDirectory()) {
-            folderPathQueue.add(relativeItemPath);
+            folderPathQueue.push(relativeItemPath);
           } else if (folderItem.isFile() && itemName.endsWith(JS_FILE_EXTENSION)) {
             const jsInPath = `${jsInFolderPath}/${relativeItemPath}`;
             const jsFileText = await FileSystem.readFileAsync(jsInPath);

--- a/libraries/rush-lib/scripts/copyEmptyModules.js
+++ b/libraries/rush-lib/scripts/copyEmptyModules.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { FileSystem, Async } = require('@rushstack/node-core-library');
+const { FileSystem, Async, AsyncQueue } = require('@rushstack/node-core-library');
 
 const JS_FILE_EXTENSION = '.js';
 const DTS_FILE_EXTENSION = '.d.ts';
@@ -46,39 +46,43 @@ module.exports = {
     const jsInFolderPath = `${buildFolderPath}/lib-esnext`;
     const dtsInFolderPath = `${buildFolderPath}/lib-commonjs`;
     const outFolderPath = `${buildFolderPath}/lib`;
-    async function searchAsync(relativeFolderPath) {
-      const folderItems = await FileSystem.readFolderItemsAsync(
-        relativeFolderPath ? `${jsInFolderPath}/${relativeFolderPath}` : jsInFolderPath
-      );
-      await Async.forEachAsync(folderItems, async (folderItem) => {
-        const itemName = folderItem.name;
-        const relativeItemPath = relativeFolderPath ? `${relativeFolderPath}/${itemName}` : itemName;
+    const folderPathQueue = new AsyncQueue([jsInFolderPath]);
 
-        if (folderItem.isDirectory()) {
-          await searchAsync(relativeItemPath);
-        } else if (folderItem.isFile() && itemName.endsWith(JS_FILE_EXTENSION)) {
-          const jsInPath = `${jsInFolderPath}/${relativeItemPath}`;
-          const jsFileText = await FileSystem.readFileAsync(jsInPath);
-          const strippedJsFileText = stripCommentsFromJsFile(jsFileText);
-          if (strippedJsFileText === 'export {};') {
-            const outJsPath = `${outFolderPath}/${relativeItemPath}`;
-            terminal.writeVerboseLine(`Writing stub to ${outJsPath}`);
-            await FileSystem.writeFileAsync(outJsPath, 'module.exports = {};', {
-              ensureFolderExists: true
-            });
+    await Async.forEachAsync(
+      folderPathQueue,
+      async ([folderPath, callback]) => {
+        const folderItems = await FileSystem.readFolderItemsAsync(folderPath);
+        for (const folderItem of folderItems) {
+          const itemName = folderItem.name;
+          const relativeItemPath = `${folderPath}/${itemName}`;
 
-            const relativeDtsPath = relativeItemPath.slice(0, -JS_FILE_EXTENSION.length) + DTS_FILE_EXTENSION;
-            const inDtsPath = `${dtsInFolderPath}/${relativeDtsPath}`;
-            const outDtsPath = `${outFolderPath}/${relativeDtsPath}`;
-            terminal.writeVerboseLine(`Copying ${inDtsPath} to ${outDtsPath}`);
-            // We know this is a file, don't need the redundant checks in FileSystem.copyFileAsync
-            const buffer = await FileSystem.readFileToBufferAsync(inDtsPath);
-            await FileSystem.writeFileAsync(outDtsPath, buffer, { ensureFolderExists: true });
+          if (folderItem.isDirectory()) {
+            folderPathQueue.add(relativeItemPath);
+          } else if (folderItem.isFile() && itemName.endsWith(JS_FILE_EXTENSION)) {
+            const jsInPath = `${jsInFolderPath}/${relativeItemPath}`;
+            const jsFileText = await FileSystem.readFileAsync(jsInPath);
+            const strippedJsFileText = stripCommentsFromJsFile(jsFileText);
+            if (strippedJsFileText === 'export {};') {
+              const outJsPath = `${outFolderPath}/${relativeItemPath}`;
+              terminal.writeVerboseLine(`Writing stub to ${outJsPath}`);
+              await FileSystem.writeFileAsync(outJsPath, 'module.exports = {};', {
+                ensureFolderExists: true
+              });
+
+              const relativeDtsPath =
+                relativeItemPath.slice(0, -JS_FILE_EXTENSION.length) + DTS_FILE_EXTENSION;
+              const inDtsPath = `${dtsInFolderPath}/${relativeDtsPath}`;
+              const outDtsPath = `${outFolderPath}/${relativeDtsPath}`;
+              terminal.writeVerboseLine(`Copying ${inDtsPath} to ${outDtsPath}`);
+              // We know this is a file, don't need the redundant checks in FileSystem.copyFileAsync
+              const buffer = await FileSystem.readFileToBufferAsync(inDtsPath);
+              await FileSystem.writeFileAsync(outDtsPath, buffer, { ensureFolderExists: true });
+            }
           }
         }
-      });
-    }
-
-    await searchAsync(undefined);
+        callback();
+      },
+      { concurrency: 10 }
+    );
   }
 };


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Recent change #4401 added concurrent path traversal to the buildscript used by rush-lib. This however would allow for ballooning of the concurrency since it doesn't use the `AsyncQueue` class. This PR addresses this issue.

## How it was tested

Tested locally by building rush-lib and confirming output.
