### PR TITLE
Fix an issue where globbing assets from a NPM package would fail on Windows.

### DIFF
--- a/build-tests/hashed-folder-copy-plugin-webpack5-test/src/index.ts
+++ b/build-tests/hashed-folder-copy-plugin-webpack5-test/src/index.ts
@@ -10,6 +10,16 @@ const ASSETS_BASE_URL: string = requireFolder({
   ]
 });
 
+const HEFT_SRC_FILES_BASE_URL: string = requireFolder({
+  outputFolder: 'heft_src_files_[hash]',
+  sources: [
+    {
+      globsBase: '@rushstack/heft/src',
+      globPatterns: ['**/*']
+    }
+  ]
+});
+
 function appendImageToBody(url: string): void {
   const image: HTMLImageElement = document.createElement('img');
   image.src = url;
@@ -25,3 +35,5 @@ appendImageToBody(`${ASSETS_BASE_URL2}/red.png`);
 appendImageToBody(`${ASSETS_BASE_URL2}/green.png`);
 appendImageToBody(`${ASSETS_BASE_URL2}/blue.png`);
 appendImageToBody(`${ASSETS_BASE_URL2}/subfolder/yellow.png`);
+
+console.log(HEFT_SRC_FILES_BASE_URL);

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/fix-windows-issue_2023-10-30-22-29.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/fix-windows-issue_2023-10-30-22-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "Fix an issue where globbing assets from a NPM package would fail on Windows.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/webpack/hashed-folder-copy-plugin/src/HashedFolderDependency.ts
+++ b/webpack/hashed-folder-copy-plugin/src/HashedFolderDependency.ts
@@ -238,7 +238,7 @@ function _getHashedFolderDependencyForWebpackInstance(webpack: typeof import('we
             return renderError(errorMessage);
           }
 
-          const globResultFullPath: string = path.posix.resolve(resolvedGlobsBase, globResult);
+          const globResultFullPath: string = path.resolve(resolvedGlobsBase, globResult);
 
           let assetContents: string | Buffer | undefined;
           try {


### PR DESCRIPTION
## Summary

Fix an issue where globbing assets from a NPM package would fail on Windows.

## Details

We used `path.posix.resolve`, which doesn't give a valid result if the second argument is a fully-qualified Windows path.

## How it was tested

Added a test in the `hashed-folder-copy-plugin-webpack5-test` project.

## Impacted documentation

None.