### PR TITLE
[package-extractor] Ignore links to paths outside the source directory if explicitly excluded

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-FixExcludedLinks_2023-11-16-00-36.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-FixExcludedLinks_2023-11-16-00-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Links that target a path outside of the source directory can now be ignored using \"patternsToInclude\" and \"patternsToExclude\" options",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -538,7 +538,7 @@ export class PackageExtractor {
               baseFolderPath: packageJsonRealFolderPath,
               getRealPathAsync: async (filePath: string) => {
                 try {
-                  return (await state.symlinkAnalyzer.analyzePathAsync(filePath)).nodePath;
+                  return (await state.symlinkAnalyzer.analyzePathAsync({ inputPath: filePath })).nodePath;
                 } catch (error: unknown) {
                   if (FileSystem.isFileDoesNotExistError(error as Error)) {
                     return filePath;
@@ -577,7 +577,7 @@ export class PackageExtractor {
               baseFolderPath: pnpmDotFolderPath,
               getRealPathAsync: async (filePath: string) => {
                 try {
-                  return (await state.symlinkAnalyzer.analyzePathAsync(filePath)).nodePath;
+                  return (await state.symlinkAnalyzer.analyzePathAsync({ inputPath: filePath })).nodePath;
                 } catch (error: unknown) {
                   if (FileSystem.isFileDoesNotExistError(error as Error)) {
                     return filePath;
@@ -791,7 +791,9 @@ export class PackageExtractor {
 
           const copyDestinationPath: string = path.join(targetFolderPath, npmPackFile);
 
-          const copySourcePathNode: PathNode = await state.symlinkAnalyzer.analyzePathAsync(copySourcePath);
+          const copySourcePathNode: PathNode = await state.symlinkAnalyzer.analyzePathAsync({
+            inputPath: copySourcePath
+          });
           if (copySourcePathNode.kind !== 'link') {
             if (!options.createArchiveOnly) {
               await FileSystem.ensureFolderAsync(path.dirname(copyDestinationPath));
@@ -838,8 +840,24 @@ export class PackageExtractor {
             return;
           }
 
-          const sourcePathNode: PathNode = await state.symlinkAnalyzer.analyzePathAsync(sourcePath);
-          if (sourcePathNode.kind === 'file') {
+          const sourcePathNode: PathNode | undefined = await state.symlinkAnalyzer.analyzePathAsync({
+            inputPath: sourcePath,
+            // Treat all links to external paths as if they are files for this scenario. In the future, we may
+            // want to explore the target of the external link to see if all files within the target are
+            // excluded, and throw if they are not.
+            shouldIgnoreExternalLink: (linkSourcePath: string) => {
+              // Ignore the provided linkSourcePath since it may not be the first link in the chain. Instead,
+              // we will consider only the relativeSourcePath, since that would be our entrypoint into the
+              // link chain.
+              return isFileExcluded(relativeSourcePath);
+            }
+          });
+
+          if (sourcePathNode === undefined) {
+            // The target was a symlink that is excluded. We don't need to do anything.
+            callback();
+            return;
+          } else if (sourcePathNode.kind === 'file') {
             // Only ignore files and not folders to ensure that we traverse the contents of all folders. This is
             // done so that we can match against subfolder patterns, ex. "src/subfolder/**/*"
             if (relativeSourcePath !== '' && isFileExcluded(relativeSourcePath)) {

--- a/libraries/package-extractor/src/SymlinkAnalyzer.ts
+++ b/libraries/package-extractor/src/SymlinkAnalyzer.ts
@@ -65,6 +65,12 @@ export interface ISymlinkAnalyzerOptions {
   requiredSourceParentPath?: string;
 }
 
+export interface IAnalyzePathOptions {
+  inputPath: string;
+  preserveLinks?: boolean;
+  shouldIgnoreExternalLink?: (path: string) => boolean;
+}
+
 export class SymlinkAnalyzer {
   private readonly _requiredSourceParentPath: string | undefined;
 
@@ -78,7 +84,15 @@ export class SymlinkAnalyzer {
     this._requiredSourceParentPath = options.requiredSourceParentPath;
   }
 
-  public async analyzePathAsync(inputPath: string, preserveLinks: boolean = false): Promise<PathNode> {
+  public async analyzePathAsync(
+    options: IAnalyzePathOptions & { shouldIgnoreExternalLink: (path: string) => boolean }
+  ): Promise<PathNode | undefined>;
+  public async analyzePathAsync(
+    options: IAnalyzePathOptions & { shouldIgnoreExternalLink?: never }
+  ): Promise<PathNode>;
+  public async analyzePathAsync(options: IAnalyzePathOptions): Promise<PathNode | undefined> {
+    const { inputPath, preserveLinks = false, shouldIgnoreExternalLink } = options;
+
     // First, try to short-circuit the analysis if we've already analyzed this path
     const resolvedPath: string = path.resolve(inputPath);
     const existingNode: PathNode | undefined = this._nodesByPath.get(resolvedPath);
@@ -114,6 +128,11 @@ export class SymlinkAnalyzer {
               resolvedLinkTargetPath
             );
             if (relativeLinkTargetPath.startsWith('..')) {
+              // Symlinks that link outside of the source folder may be ignored. Check to see if we
+              // can ignore this one and if so, return undefined.
+              if (shouldIgnoreExternalLink?.(currentPath)) {
+                return undefined;
+              }
               throw new Error(
                 `Symlink targets not under folder "${this._requiredSourceParentPath}": ` +
                   `${currentPath} -> ${resolvedLinkTargetPath}`
@@ -147,7 +166,10 @@ export class SymlinkAnalyzer {
 
       if (!preserveLinks) {
         while (currentNode?.kind === 'link') {
-          const targetNode: PathNode = await this.analyzePathAsync(currentNode.linkTarget, true);
+          const targetNode: PathNode = await this.analyzePathAsync({
+            inputPath: currentNode.linkTarget,
+            preserveLinks: true
+          });
 
           // Have we created an ILinkInfo for this link yet?
           if (!this._linkInfosByPath.has(currentNode.nodePath)) {


### PR DESCRIPTION
## Summary

This change ensures that links to paths outside of the source directory are excluded if the path to the link is excluded explicitly using either of `patternsToInclude` or `patternsToExclude` options. Fixes #4421

## How it was tested

Tested using repro provided in source issue.
