### PR TITLE
[rush] Allow the device code credential options to be extended in subclasses Azure authentication subclasses.

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-11-29-08-31.json
+++ b/common/changes/@microsoft/rush/main_2023-11-29-08-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow the device code credential options to be extended in subclasses Azure authentication subclasses, used in advanced authentication scenarios.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/main_2023-11-29-08-31.json
+++ b/common/changes/@microsoft/rush/main_2023-11-29-08-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Allow the device code credential options to be extended in subclasses Azure authentication subclasses, used in advanced authentication scenarios.",
+      "comment": "Allow the device code credential options to be extended Azure authentication subclasses, used in advanced authentication scenarios.",
       "type": "none"
     }
   ],

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.112.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -6,6 +6,7 @@
 
 import { AzureAuthorityHosts } from '@azure/identity';
 import { DeviceCodeCredential } from '@azure/identity';
+import { DeviceCodeCredentialOptions } from '@azure/identity';
 import type { ICredentialCacheEntry } from '@rushstack/rush-sdk';
 import type { IRushPlugin } from '@rushstack/rush-sdk';
 import type { ITerminal } from '@rushstack/node-core-library';
@@ -15,6 +16,8 @@ import type { RushSession } from '@rushstack/rush-sdk';
 // @public (undocumented)
 export abstract class AzureAuthenticationBase {
     constructor(options: IAzureAuthenticationBaseOptions);
+    // (undocumented)
+    protected readonly _additionalDeviceCodeCredentialOptions: DeviceCodeCredentialOptions | undefined;
     // (undocumented)
     protected readonly _azureEnvironment: AzureEnvironmentName;
     // (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { DeviceCodeCredential, type DeviceCodeInfo, AzureAuthorityHosts } from '@azure/identity';
+import {
+  DeviceCodeCredential,
+  type DeviceCodeInfo,
+  AzureAuthorityHosts,
+  type DeviceCodeCredentialOptions
+} from '@azure/identity';
 import type { ITerminal } from '@rushstack/node-core-library';
 import { CredentialCache } from '@rushstack/rush-sdk';
 // Use a separate import line so the .d.ts file ends up with an `import type { ... }`
@@ -90,6 +95,7 @@ export abstract class AzureAuthenticationBase {
   protected abstract readonly _credentialNameForCache: string;
   protected abstract readonly _credentialKindForLogging: string;
   protected readonly _credentialUpdateCommandForLogging: string | undefined;
+  protected readonly _additionalDeviceCodeCredentialOptions: DeviceCodeCredentialOptions | undefined;
 
   protected readonly _azureEnvironment: AzureEnvironmentName;
 
@@ -239,6 +245,7 @@ export abstract class AzureAuthenticationBase {
     }
 
     const deviceCodeCredential: DeviceCodeCredential = new DeviceCodeCredential({
+      ...this._additionalDeviceCodeCredentialOptions,
       authorityHost: authorityHost,
       userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
         PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);


### PR DESCRIPTION
## Summary

Allow custom options to be passed to the device code credential constructor. This allows the same base class to be used to query against Azure Key Vaults.

## How it was tested

Tested in a repo that does Key Vault authentication.