### PR TITLE
[rush] Bring back the erroneously removed 'preminor' bump type for lockstepped packages.

### DIFF
--- a/common/changes/@microsoft/rush/bring-back-preminor_2023-12-11-22-59.json
+++ b/common/changes/@microsoft/rush/bring-back-preminor_2023-12-11-22-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Bring back the erroneously removed `preminor` bump type for lockstepped packages.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -40,7 +40,7 @@
   //    * When creating a release branch in Git, this field should be updated according to the
   //    * type of release.
   //    *
-  //    * Valid values are: "prerelease", "minor", "patch", "major"
+  //    * Valid values are: "prerelease", "preminor", "minor", "patch", "major"
   //    */
   //   "nextBump": "prerelease",
   //

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -81,6 +81,8 @@ export enum BumpType {
     // (undocumented)
     'patch' = 2,
     // (undocumented)
+    'preminor' = 3,
+    // (undocumented)
     'prerelease' = 1
 }
 

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
@@ -41,7 +41,7 @@
      * When creating a release branch in Git, this field should be updated according to the
      * type of release.
      *
-     * Valid values are: "prerelease", "minor", "patch", "major"
+     * Valid values are: "prerelease", "preminor", "minor", "patch", "major"
      */
     "nextBump": "prerelease",
 

--- a/libraries/rush-lib/src/api/VersionPolicy.ts
+++ b/libraries/rush-lib/src/api/VersionPolicy.ts
@@ -20,6 +20,13 @@ import { cloneDeep } from '../utilities/objectUtilities';
 /**
  * Type of version bumps
  * @public
+ *
+ * @internalRemarks
+ * This is a copy of the semver ReleaseType enum, but with the `none` value added and
+ * the `premajor` and `prepatch` omitted.
+ * See {@link LockStepVersionPolicy._getReleaseType}.
+ *
+ * TODO: Consider supporting `premajor` and `prepatch` in the future.
  */
 export enum BumpType {
   // No version bump
@@ -28,6 +35,8 @@ export enum BumpType {
   'prerelease' = 1,
   // Patch version bump
   'patch' = 2,
+  // Preminor version bump
+  'preminor' = 3,
   // Minor version bump
   'minor' = 4,
   // Major version bump

--- a/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
@@ -90,6 +90,14 @@ describe(VersionPolicy.name, () => {
       expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
     });
 
+    it('bumps version for preminor release', () => {
+      expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;
+      lockStepVersionPolicy.bump(BumpType.preminor, 'pr');
+      expect(lockStepVersionPolicy.version).toEqual('1.2.0-pr.0');
+      expect(lockStepVersionPolicy.nextBump).toEqual(BumpType.patch);
+    });
+
     it('bumps version for minor release', () => {
       expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -75,7 +75,7 @@ export class VersionAction extends BaseRushAction {
       argumentName: 'BUMPTYPE',
       description:
         'Overrides the bump type in the version-policy.json for the specified version policy. ' +
-        'Valid BUMPTYPE values include: prerelease, patch, minor, major. ' +
+        'Valid BUMPTYPE values include: prerelease, patch, preminor, minor, major. ' +
         'This setting only works for lock-step version policy in bump action.'
     });
     this._prereleaseIdentifier = this.defineStringParameter({
@@ -198,7 +198,7 @@ export class VersionAction extends BaseRushAction {
     if (this._overwriteBump.value && !Enum.tryGetValueByKey(BumpType, this._overwriteBump.value)) {
       throw new Error(
         'The value of override-bump is not valid.  ' +
-          'Valid values include prerelease, patch, minor, and major'
+          'Valid values include prerelease, patch, preminor, minor, and major'
       );
     }
   }

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1318,9 +1318,9 @@ Optional arguments:
   --override-bump BUMPTYPE
                         Overrides the bump type in the version-policy.json 
                         for the specified version policy. Valid BUMPTYPE 
-                        values include: prerelease, patch, minor, major. This 
-                        setting only works for lock-step version policy in 
-                        bump action.
+                        values include: prerelease, patch, preminor, minor, 
+                        major. This setting only works for lock-step version 
+                        policy in bump action.
   --override-prerelease-id ID
                         Overrides the prerelease identifier in the version 
                         value of version-policy.json for the specified 

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -332,23 +332,6 @@ export class PublishUtilities {
     }
   }
 
-  private static _getChangeTypeForSemverReleaseType(releaseType: semver.ReleaseType): ChangeType {
-    switch (releaseType) {
-      case 'major':
-        return ChangeType.major;
-      case 'minor':
-        return ChangeType.minor;
-      case 'patch':
-        return ChangeType.patch;
-      case 'premajor':
-      case 'prepatch':
-      case 'prerelease':
-        return ChangeType.hotfix;
-      default:
-        throw new Error(`Unsupported release type "${releaseType}"`);
-    }
-  }
-
   private static _getNewRangeDependency(newVersion: string): string {
     let upperLimit: string = newVersion;
     if (semver.prerelease(newVersion)) {

--- a/libraries/rush-lib/src/schemas/version-policies.schema.json
+++ b/libraries/rush-lib/src/schemas/version-policies.schema.json
@@ -68,7 +68,7 @@
         },
         "nextBump": {
           "description": "Type of next version bump",
-          "enum": ["none", "prerelease", "minor", "patch", "major"]
+          "enum": ["none", "prerelease", "preminor", "minor", "patch", "major"]
         },
         "mainProject": {
           "description": "The main project for this version policy",


### PR DESCRIPTION


## Summary

Partially reverts https://github.com/microsoft/rushstack/pull/4157. Fixes https://github.com/microsoft/rushstack/issues/4445

## How it was tested

The unit test is brought back.

## Impacted documentation

This page needs to be updated: https://rushjs.io/pages/configs/version-policies_json/#:~:text=nextBump%22%3A%20%22prerelease
