### PR TITLE
[rush] Update "rush init" template to document missing experiment

### DIFF
--- a/common/changes/@microsoft/rush/main_2023-12-23-05-43.json
+++ b/common/changes/@microsoft/rush/main_2023-12-23-05-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update `rush init` template to document the \"buildSkipWithAllowWarningsInSuccessfulBuild\" experiment",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -44,6 +44,12 @@
   /*[LINE "HYPOTHETICAL"]*/ "buildCacheWithAllowWarningsInSuccessfulBuild": true,
 
   /**
+   * If true, build skipping will respect the allowWarningsInSuccessfulBuild flag and skip builds with warnings.
+   * This will not replay warnings from the skipped build.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "buildSkipWithAllowWarningsInSuccessfulBuild": true,
+
+  /**
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -13,13 +13,13 @@ import schemaJson from '../schemas/experiments.schema.json';
 export interface IExperimentsJson {
   /**
    * By default, 'rush install' passes --no-prefer-frozen-lockfile to 'pnpm install'.
-   * Set this option to true to pass '--frozen-lockfile' instead.
+   * Set this option to true to pass '--frozen-lockfile' instead for faster installs.
    */
   usePnpmFrozenLockfileForRushInstall?: boolean;
 
   /**
    * By default, 'rush update' passes --no-prefer-frozen-lockfile to 'pnpm install'.
-   * Set this option to true to pass '--prefer-frozen-lockfile' instead.
+   * Set this option to true to pass '--prefer-frozen-lockfile' instead to minimize shrinkwrap changes.
    */
   usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
 


### PR DESCRIPTION
We forgot to add `buildSkipWithAllowWarningsInSuccessfulBuild` to the **experiments.json** template