### PR TITLE
[heft-typescript] Fix updateShapeSignature break

### DIFF
--- a/common/changes/@rushstack/heft-typescript-plugin/heft-typescript-dts-map-fix_2024-01-02-21-31.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/heft-typescript-dts-map-fix_2024-01-02-21-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Fix break in watch mode during updateShapeSignature call.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}


### PR DESCRIPTION
## Summary
Fixes #4224
Fixes #4470 

## Details
`Program#emit` contains an additional parameter `forceDtsEmit` that is not in the published types, and is passed during shape signature computation. Heft was not forwarding this parameter when overriding the program, resulting in behavior changes.

## How it was tested
Local repro of the issue in #4224. Running `heft-webpack5-everything-test` in watch mode and changing `class ChunkClass` in `ChunkClass.ts` to `class Chunk Class`.

## Impacted documentation
None