### PR TITLE
[rush] Support IPC in Utilities helper

### DIFF
--- a/common/changes/@microsoft/rush/ipc_2024-01-04-01-26.json
+++ b/common/changes/@microsoft/rush/ipc_2024-01-04-01-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add ability to enable IPC channels in `Utilities#executeLifeCycleCommand`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -85,6 +85,11 @@ export interface ILifecycleCommandOptions {
    * Options for what should be added to the PATH variable
    */
   environmentPathOptions: IEnvironmentPathOptions;
+
+  /**
+   * If true, attempt to establish a NodeJS IPC channel to the child process.
+   */
+  ipc?: boolean;
 }
 
 export interface IEnvironmentPathOptions {
@@ -593,11 +598,16 @@ export class Utilities {
       }
     });
 
+    const stdio: child_process.StdioOptions = options.handleOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2];
+    if (options.ipc) {
+      stdio.push('ipc');
+    }
+
     return spawnFunction(shellCommand, [commandFlags, command], {
       cwd: options.workingDirectory,
       shell: useShell,
       env: environment,
-      stdio: options.handleOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2]
+      stdio
     });
   }
 


### PR DESCRIPTION
## Summary
Updates the Utilities helper methods for creating child processes with an option to also establish a Node IPC channel.

## Details
This PR is setup work to allow Rush to communicate with tools that support the IPC protocol defined in [`@rushstack/operation-graph/src/protocol.types.ts`](https://github.com/microsoft/rushstack/blob/4c355757c50031ae4935e9f774cc02a95b571783/libraries/operation-graph/src/protocol.types.ts)

## How it was tested
Regular build usage to ensure it did not regress.

## Impacted documentation
None, since this is an internal API.