### PR TITLE
[rush](package-deps-hash) Avoid defect to be produced when spawned "git hash-object" process stdin fails while computing repo-state

### DIFF
--- a/common/changes/@rushstack/package-deps-hash/avoid-getrepostate-to-crash_2024-01-11-09-03.json
+++ b/common/changes/@rushstack/package-deps-hash/avoid-getrepostate-to-crash_2024-01-11-09-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Avoid defect to be produced bit spawnGitAsync when the underlying child process stdin stream fails while computing repo-state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/libraries/package-deps-hash/package.json
+++ b/libraries/package-deps-hash/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "@rushstack/node-core-library": "workspace:*",
     "local-node-rig": "workspace:*"
   },
   "dependencies": {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes #4475 

As explained in #3517, symlinked directories can't be hashed by `git hash-object`. Whatever the underlying reason is for that, as I already stated in the issue, executed commands should not crash due to this problem and just emit a warning.

Note that we might consider this to be a workaround while we fix the root cause which is discarding symlinked directories from the analysis. However I feel like having error handlers there will be worth it anyway as other errors could occur in the future and we definitely don't want to crash the process at this step which is not mandatory for Rush to properly work (file diffing).

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->


I solved the problem by simply attaching an "error" handler on the underlying child process' stdin stream to avoid EPIPE errors (fatal) to occur. This error happens because the git child process closes because of the mentioned errors, but the `stdin` Readable keeps pushing file paths while the Writable is closed.


## How it was tested

Mainly through manual testing using https://github.com/antoine-coulon/rushelp and the Docker container created from it. The issue can easily be re-created, just run the container, move to `/build` and run `rush my-bulk-command`, EPIPE will occur. This is because `git status` includes `/bin` and `/lib` symlinked directories so as I said git child process will emit errors.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

None 
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
