### PR TITLE
[set-webpack-public-path-plugin] Only emit an error about unsupported library types if the public path is actually used.

### DIFF
--- a/common/changes/@rushstack/set-webpack-public-path-plugin/guard-error_2024-01-18-04-38.json
+++ b/common/changes/@rushstack/set-webpack-public-path-plugin/guard-error_2024-01-18-04-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/set-webpack-public-path-plugin",
+      "comment": "Only emit an error about unsupported library types if the public path is actually used.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/set-webpack-public-path-plugin"
+}

--- a/webpack/set-webpack-public-path-plugin/src/test/__snapshots__/SetPublicPathCurrentScriptPlugin.test.ts.snap
+++ b/webpack/set-webpack-public-path-plugin/src/test/__snapshots__/SetPublicPathCurrentScriptPlugin.test.ts.snap
@@ -1,6 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -50,11 +93,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -104,31 +190,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r=document.currentScript;define(\\"MyLibrary\\",[],(()=>{return c={},e=r?r.src:\\"\\",c.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(c.p),{};var e,c}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_deed8afe870a5fe703ae.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_0bde4e32a2c948a7e265.js": "(()=>{var r=document.currentScript;define(\\"MyLibrary\\",[],(()=>{return c={},e=r?r.src:\\"\\",c.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(c.p),{};var e,c}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles amd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -177,11 +325,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -230,31 +420,95 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_edcf84f77954338454ea.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_63bd0745dba5dd68c24d.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -305,11 +559,55 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -360,31 +658,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r=document.currentScript;(()=>{var e,a={};e=r?r.src:\\"\\",a.p=e.slice(0,e.lastIndexOf(\\"/\\")+1);var o={};console.log(a.p);var i=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var n in o)i[n]=o[n];o.__esModule&&Object.defineProperty(i,\\"__esModule\\",{value:!0})})()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_c46fa6e9dce17d2b90d4.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_0cf134716f1cb00b4bfb.js": "(()=>{var r=document.currentScript;(()=>{var e,a={};e=r?r.src:\\"\\",a.p=e.slice(0,e.lastIndexOf(\\"/\\")+1);var o={};console.log(a.p);var i=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var n in o)i[n]=o[n];o.__esModule&&Object.defineProperty(i,\\"__esModule\\",{value:!0})})()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles assign-properties library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -433,11 +793,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -486,31 +888,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_a61d0ddd7fbc122d026c.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_af50948fd9b47cdf66b5.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -559,11 +1023,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -612,31 +1118,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,e,c=document.currentScript;e={},r=c?c.src:\\"\\",e.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_1146d6514379b550ffe0.js": "(()=>{var r,e,c=document.currentScript;e={},r=c?c.src:\\"\\",e.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-module library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -685,11 +1253,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -738,31 +1348,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e,r,o=document.currentScript;r={},e=o?o.src:\\"\\",r.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(r.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_fdc7b1aa4223e178b616.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_90247274377f248cf2a0.js": "(()=>{var e,r,o=document.currentScript;r={},e=o?o.src:\\"\\",r.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(r.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs-static library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -811,11 +1483,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -864,31 +1578,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,e,c=document.currentScript;e={},r=c?c.src:\\"\\",e.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_1146d6514379b550ffe0.js": "(()=>{var r,e,c=document.currentScript;e={},r=c?c.src:\\"\\",e.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles commonjs2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -937,11 +1713,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -990,31 +1808,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_2a005bee247e00a0a3f2.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles global library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1063,11 +1943,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1116,31 +2038,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;MyLibrary((c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),{}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_f119a2e1669e0baf47d0.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_a9d1cef220b5e7f93a8e.js": "(()=>{var r,c,e=document.currentScript;MyLibrary((c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),{}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles jsonp library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1189,11 +2173,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1242,31 +2268,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_2a005bee247e00a0a3f2.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles self library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1326,11 +2425,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1390,31 +2542,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e=document.currentScript;System.register(\\"MyLibrary\\",[],(function(r,t){return{execute:function(){var t,c;r((c={},t=e?e.src:\\"\\",c.p=t.slice(0,t.lastIndexOf(\\"/\\")+1),console.log(c.p),{}))}}}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d81fbd36473e27aa0fb.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_1a45796a396297604c1d.js": "(()=>{var e=document.currentScript;System.register(\\"MyLibrary\\",[],(function(r,t){return{execute:function(){var t,c;r((c={},t=e?e.src:\\"\\",c.p=t.slice(0,t.lastIndexOf(\\"/\\")+1),console.log(c.p),{}))}}}))})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles system library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1463,11 +2677,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1516,31 +2772,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r=document.currentScript;(()=>{var c,e={};c=r?r.src:\\"\\",e.p=c.slice(0,c.lastIndexOf(\\"/\\")+1),console.log(e.p),this.MyLibrary={}})()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4d6fb5abdd3eb7fe4115.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_c6197810253dab934cb5.js": "(()=>{var r=document.currentScript;(()=>{var c,e={};c=r?r.src:\\"\\",e.p=c.slice(0,c.lastIndexOf(\\"/\\")+1),console.log(e.p),this.MyLibrary={}})()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles this library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1600,11 +2929,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1664,31 +3046,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e,o,t=document.currentScript;e=self,o=()=>{return o={},e=t?t.src:\\"\\",o.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(o.p),{};var e,o},\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_a6627e23f74d93a203db.js": "(()=>{var e,o,t=document.currentScript;e=self,o=()=>{return o={},e=t?t.src:\\"\\",o.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(o.p),{};var e,o},\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1748,11 +3203,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1812,31 +3320,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e,o,t=document.currentScript;e=self,o=()=>{return o={},e=t?t.src:\\"\\",o.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(o.p),{};var e,o},\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_a6627e23f74d93a203db.js": "(()=>{var e,o,t=document.currentScript;e=self,o=()=>{return o={},e=t?t.src:\\"\\",o.p=e.slice(0,e.lastIndexOf(\\"/\\")+1),console.log(o.p),{};var e,o},\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles umd2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1886,7 +3457,7 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development): Errors 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (uses public path): Errors 1`] = `
 Array [
   Object {
     "message": "The \\"var\\" output.library.type is not supported by the SetPublicPathCurrentScriptPlugin plugin. Including this plugin with produce unexpected or invalid results.",
@@ -1894,9 +3465,52 @@ Array [
 ]
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1946,7 +3560,7 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash): Errors 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (uses public path): Errors 1`] = `
 Array [
   Object {
     "message": "The \\"var\\" output.library.type is not supported by the SetPublicPathCurrentScriptPlugin plugin. Including this plugin with produce unexpected or invalid results.",
@@ -1954,11 +3568,21 @@ Array [
 ]
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production): Content 1`] = `Object {}`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production): Errors 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (uses public path): Content 1`] = `Object {}`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (uses public path): Errors 1`] = `
 Array [
   Object {
     "message": "The \\"var\\" output.library.type is not supported by the SetPublicPathCurrentScriptPlugin plugin. Including this plugin with produce unexpected or invalid results.",
@@ -1966,11 +3590,21 @@ Array [
 ]
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash): Content 1`] = `Object {}`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_cdf966d89dde9e0e6511.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash): Errors 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (uses public path): Content 1`] = `Object {}`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (uses public path): Errors 1`] = `
 Array [
   Object {
     "message": "The \\"var\\" output.library.type is not supported by the SetPublicPathCurrentScriptPlugin plugin. Including this plugin with produce unexpected or invalid results.",
@@ -1978,9 +3612,51 @@ Array [
 ]
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles var library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2029,11 +3705,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{ var __RUSHSTACK_CURRENT_SCRIPT__ = document.currentScript; /*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2082,26 +3800,46 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash): Content 1`] = `
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_5e7a9248e729d9296340.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_b1349b02271e8b1b9101.js": "(()=>{var r,c,e=document.currentScript;c={},r=e?e.src:\\"\\",c.p=r.slice(0,r.lastIndexOf(\\"/\\")+1),console.log(c.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathCurrentScriptPlugin Handles window library output (production+hash) (uses public path): Warnings 1`] = `Array []`;

--- a/webpack/set-webpack-public-path-plugin/src/test/__snapshots__/SetPublicPathPlugin.test.ts.snap
+++ b/webpack/set-webpack-public-path-plugin/src/test/__snapshots__/SetPublicPathPlugin.test.ts.snap
@@ -1,6 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -64,11 +107,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -132,31 +218,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_06c010cf0040396d1f7c.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_06c010cf0040396d1f7c\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
+  "/release/main_deed8afe870a5fe703ae.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_a96c22591ae020f988e2.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_a96c22591ae020f988e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(t)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),{};var e}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles amd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -219,11 +367,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -286,31 +476,95 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_86e272ef302853299160.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_86e272ef302853299160\\\\.js/i;if(r&&r.length)for(var c=0;c<r.length;c++)if(r[c]){var f=r[c].getAttribute(\\"src\\");if(f&&f.match(a)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),MyLibrary={}})();",
+  "/release/main_edcf84f77954338454ea.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0926637b4ac11d8978ba.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_0926637b4ac11d8978ba\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -375,11 +629,55 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -444,31 +742,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_513046254cc472f77583.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_513046254cc472f77583\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var f=a[i].getAttribute(\\"src\\");if(f&&f.match(t)){r=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+  "/release/main_c46fa6e9dce17d2b90d4.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0a683184f3afcbf97c6c.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_0a683184f3afcbf97c6c\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles assign-properties library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -531,11 +891,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -598,31 +1000,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_a61d0ddd7fbc122d026c.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_be77d75ccbe921238d90.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_be77d75ccbe921238d90\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var s=e[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -685,11 +1149,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -752,31 +1258,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -839,11 +1407,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -906,31 +1516,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var s=t[i].getAttribute(\\"src\\");if(s&&s.match(a)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_d4579c73e2e1104978e2.js": "(()=>{var e={};(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_d4579c73e2e1104978e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(t)){a=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+  "/release/main_fdc7b1aa4223e178b616.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_7f615e94560b668d69b0.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_7f615e94560b668d69b0\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(t)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -993,11 +1665,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1060,31 +1774,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1147,11 +1923,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1214,31 +2032,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles global library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1301,11 +2181,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1368,31 +2290,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "MyLibrary((()=>{var r={};return(()=>{var t,e=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_242806bd12c243936aee.js": "MyLibrary((()=>{var e={};return(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_242806bd12c243936aee\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{}})());",
+  "/release/main_f119a2e1669e0baf47d0.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_d62c4a558867b9317512.js": "MyLibrary((()=>{var r={};return(()=>{var t,a=document.getElementsByTagName(\\"script\\"),e=/main_d62c4a558867b9317512\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(e)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles jsonp library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1455,11 +2439,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1522,31 +2548,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles self library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1620,11 +2719,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1698,31 +2850,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),n=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var a=r[i].getAttribute(\\"src\\");if(a&&a.match(n)){e=a.substring(0,a.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d81fbd36473e27aa0fb.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_b258ae75091c8f8b8490.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main_b258ae75091c8f8b8490\\\\.js/i;if(r&&r.length)for(var n=0;n<r.length;n++)if(r[n]){var i=r[n].getAttribute(\\"src\\");if(i&&i.match(a)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles system library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1785,11 +2999,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1852,31 +3108,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_353654d52cbd656ea3c2.js": "(()=>{var t={};(()=>{var e,a=document.getElementsByTagName(\\"script\\"),r=/main_353654d52cbd656ea3c2\\\\.js/i;if(a&&a.length)for(var c=0;c<a.length;c++)if(a[c]){var i=a[c].getAttribute(\\"src\\");if(i&&i.match(r)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
+  "/release/main_4d6fb5abdd3eb7fe4115.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_db75e39898539074e63f.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_db75e39898539074e63f\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles this library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -1950,11 +3279,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2028,31 +3410,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2126,11 +3581,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2204,31 +3712,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles umd2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2292,11 +3863,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2360,31 +3974,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "var MyLibrary;(()=>{var r={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),e=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(e)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=a})(),console.log(r.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_cdf966d89dde9e0e6511.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_6a43fdec20033b6103e3.js": "var MyLibrary;(()=>{var a={};(()=>{var r,e=document.getElementsByTagName(\\"script\\"),t=/main_6a43fdec20033b6103e3\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=r})(),console.log(a.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles var library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2447,11 +4123,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2514,31 +4232,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_ec4abce5016e8fcfb666.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_ec4abce5016e8fcfb666\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),window.MyLibrary={}})();",
+  "/release/main_5e7a9248e729d9296340.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_45661b5c41db58a7c856.js": "(()=>{var e={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),r=/main_45661b5c41db58a7c856\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(r)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),window.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"[name]_[hash].js","isTokenized":true}}}) Handles window library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2602,11 +4383,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2670,31 +4494,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_06c010cf0040396d1f7c.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_06c010cf0040396d1f7c\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
+  "/release/main_deed8afe870a5fe703ae.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_a96c22591ae020f988e2.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_a96c22591ae020f988e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(t)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),{};var e}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles amd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2757,11 +4643,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2824,31 +4752,95 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_86e272ef302853299160.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_86e272ef302853299160\\\\.js/i;if(r&&r.length)for(var c=0;c<r.length;c++)if(r[c]){var f=r[c].getAttribute(\\"src\\");if(f&&f.match(a)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),MyLibrary={}})();",
+  "/release/main_edcf84f77954338454ea.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0926637b4ac11d8978ba.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_0926637b4ac11d8978ba\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2913,11 +4905,55 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -2982,31 +5018,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_513046254cc472f77583.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_513046254cc472f77583\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var f=a[i].getAttribute(\\"src\\");if(f&&f.match(t)){r=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+  "/release/main_c46fa6e9dce17d2b90d4.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0a683184f3afcbf97c6c.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_0a683184f3afcbf97c6c\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles assign-properties library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3069,11 +5167,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3136,31 +5276,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_a61d0ddd7fbc122d026c.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_be77d75ccbe921238d90.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_be77d75ccbe921238d90\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var s=e[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3223,11 +5425,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3290,31 +5534,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-module library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3377,11 +5683,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3444,31 +5792,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var s=t[i].getAttribute(\\"src\\");if(s&&s.match(a)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_d4579c73e2e1104978e2.js": "(()=>{var e={};(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_d4579c73e2e1104978e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(t)){a=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+  "/release/main_fdc7b1aa4223e178b616.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_7f615e94560b668d69b0.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_7f615e94560b668d69b0\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(t)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs-static library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3531,11 +5941,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3598,31 +6050,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles commonjs2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3685,11 +6199,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3752,31 +6308,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles global library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3839,11 +6457,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3906,31 +6566,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "MyLibrary((()=>{var r={};return(()=>{var t,e=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_242806bd12c243936aee.js": "MyLibrary((()=>{var e={};return(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_242806bd12c243936aee\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{}})());",
+  "/release/main_f119a2e1669e0baf47d0.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_d62c4a558867b9317512.js": "MyLibrary((()=>{var r={};return(()=>{var t,a=document.getElementsByTagName(\\"script\\"),e=/main_d62c4a558867b9317512\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(e)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles jsonp library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -3993,11 +6715,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4060,31 +6824,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles self library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4158,11 +6995,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4236,31 +7126,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),n=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var a=r[i].getAttribute(\\"src\\");if(a&&a.match(n)){e=a.substring(0,a.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d81fbd36473e27aa0fb.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_b258ae75091c8f8b8490.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main_b258ae75091c8f8b8490\\\\.js/i;if(r&&r.length)for(var n=0;n<r.length;n++)if(r[n]){var i=r[n].getAttribute(\\"src\\");if(i&&i.match(a)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles system library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4323,11 +7275,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4390,31 +7384,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_353654d52cbd656ea3c2.js": "(()=>{var t={};(()=>{var e,a=document.getElementsByTagName(\\"script\\"),r=/main_353654d52cbd656ea3c2\\\\.js/i;if(a&&a.length)for(var c=0;c<a.length;c++)if(a[c]){var i=a[c].getAttribute(\\"src\\");if(i&&i.match(r)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
+  "/release/main_4d6fb5abdd3eb7fe4115.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_db75e39898539074e63f.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_db75e39898539074e63f\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles this library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4488,11 +7555,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4566,31 +7686,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4664,11 +7857,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4742,31 +7988,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles umd2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4830,11 +8139,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4898,31 +8250,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "var MyLibrary;(()=>{var r={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),e=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(e)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=a})(),console.log(r.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_cdf966d89dde9e0e6511.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_6a43fdec20033b6103e3.js": "var MyLibrary;(()=>{var a={};(()=>{var r,e=document.getElementsByTagName(\\"script\\"),t=/main_6a43fdec20033b6103e3\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=r})(),console.log(a.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles var library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -4985,11 +8399,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5052,31 +8508,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_ec4abce5016e8fcfb666.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_ec4abce5016e8fcfb666\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),window.MyLibrary={}})();",
+  "/release/main_5e7a9248e729d9296340.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_45661b5c41db58a7c856.js": "(()=>{var e={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),r=/main_45661b5c41db58a7c856\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(r)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),window.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"name":"foobar.js"}}}) Handles window library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5140,11 +8659,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5208,31 +8770,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_06c010cf0040396d1f7c.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_06c010cf0040396d1f7c\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
+  "/release/main_deed8afe870a5fe703ae.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_a96c22591ae020f988e2.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_a96c22591ae020f988e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(t)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),{};var e}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles amd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5295,11 +8919,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5362,31 +9028,95 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_86e272ef302853299160.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_86e272ef302853299160\\\\.js/i;if(r&&r.length)for(var c=0;c<r.length;c++)if(r[c]){var f=r[c].getAttribute(\\"src\\");if(f&&f.match(a)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),MyLibrary={}})();",
+  "/release/main_edcf84f77954338454ea.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0926637b4ac11d8978ba.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_0926637b4ac11d8978ba\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5451,11 +9181,55 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5520,31 +9294,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_513046254cc472f77583.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_513046254cc472f77583\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var f=a[i].getAttribute(\\"src\\");if(f&&f.match(t)){r=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+  "/release/main_c46fa6e9dce17d2b90d4.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0a683184f3afcbf97c6c.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_0a683184f3afcbf97c6c\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles assign-properties library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5607,11 +9443,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5674,31 +9552,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_a61d0ddd7fbc122d026c.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_be77d75ccbe921238d90.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_be77d75ccbe921238d90\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var s=e[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5761,11 +9701,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5828,31 +9810,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-module library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5915,11 +9959,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -5982,31 +10068,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var s=t[i].getAttribute(\\"src\\");if(s&&s.match(a)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_d4579c73e2e1104978e2.js": "(()=>{var e={};(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_d4579c73e2e1104978e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(t)){a=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+  "/release/main_fdc7b1aa4223e178b616.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_7f615e94560b668d69b0.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_7f615e94560b668d69b0\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(t)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs-static library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6069,11 +10217,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6136,31 +10326,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles commonjs2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6223,11 +10475,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6290,31 +10584,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles global library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6377,11 +10733,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6444,31 +10842,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "MyLibrary((()=>{var r={};return(()=>{var t,e=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_242806bd12c243936aee.js": "MyLibrary((()=>{var e={};return(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_242806bd12c243936aee\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{}})());",
+  "/release/main_f119a2e1669e0baf47d0.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_d62c4a558867b9317512.js": "MyLibrary((()=>{var r={};return(()=>{var t,a=document.getElementsByTagName(\\"script\\"),e=/main_d62c4a558867b9317512\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(e)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles jsonp library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6531,11 +10991,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6598,31 +11100,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles self library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6696,11 +11271,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6774,31 +11402,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),n=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var a=r[i].getAttribute(\\"src\\");if(a&&a.match(n)){e=a.substring(0,a.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d81fbd36473e27aa0fb.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_b258ae75091c8f8b8490.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main_b258ae75091c8f8b8490\\\\.js/i;if(r&&r.length)for(var n=0;n<r.length;n++)if(r[n]){var i=r[n].getAttribute(\\"src\\");if(i&&i.match(a)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles system library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6861,11 +11551,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -6928,31 +11660,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_353654d52cbd656ea3c2.js": "(()=>{var t={};(()=>{var e,a=document.getElementsByTagName(\\"script\\"),r=/main_353654d52cbd656ea3c2\\\\.js/i;if(a&&a.length)for(var c=0;c<a.length;c++)if(a[c]){var i=a[c].getAttribute(\\"src\\");if(i&&i.match(r)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
+  "/release/main_4d6fb5abdd3eb7fe4115.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_db75e39898539074e63f.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_db75e39898539074e63f\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles this library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7026,11 +11831,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7104,31 +11962,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7202,11 +12133,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7280,31 +12264,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles umd2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7368,11 +12415,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7436,31 +12526,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "var MyLibrary;(()=>{var r={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),e=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(e)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=a})(),console.log(r.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_cdf966d89dde9e0e6511.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_6a43fdec20033b6103e3.js": "var MyLibrary;(()=>{var a={};(()=>{var r,e=document.getElementsByTagName(\\"script\\"),t=/main_6a43fdec20033b6103e3\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=r})(),console.log(a.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles var library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7523,11 +12675,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7590,31 +12784,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_ec4abce5016e8fcfb666.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_ec4abce5016e8fcfb666\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),window.MyLibrary={}})();",
+  "/release/main_5e7a9248e729d9296340.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_45661b5c41db58a7c856.js": "(()=>{var e={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),r=/main_45661b5c41db58a7c856\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(r)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),window.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true},"regexVariable":"REGEXP_VAR"}}) Handles window library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7678,11 +12935,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+define(\\"MyLibrary\\", [], () => { return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7746,31 +13046,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_06c010cf0040396d1f7c.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_06c010cf0040396d1f7c\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{};var e}));",
+  "/release/main_deed8afe870a5fe703ae.js": "define(\\"MyLibrary\\",[],(()=>(console.log(\\"Hello world!\\"),{})));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_a96c22591ae020f988e2.js": "define(\\"MyLibrary\\",[],(()=>{return e={},(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_a96c22591ae020f988e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(t)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),{};var e}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles amd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7833,11 +13195,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7900,31 +13304,95 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_86e272ef302853299160.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_86e272ef302853299160\\\\.js/i;if(r&&r.length)for(var c=0;c<r.length;c++)if(r[c]){var f=r[c].getAttribute(\\"src\\");if(f&&f.match(a)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),MyLibrary={}})();",
+  "/release/main_edcf84f77954338454ea.js": "console.log(\\"Hello world!\\"),MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0926637b4ac11d8978ba.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_0926637b4ac11d8978ba\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -7989,11 +13457,55 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	var __webpack_export_target__ = (MyLibrary = typeof MyLibrary === \\"undefined\\" ? {} : MyLibrary);
+/******/ 	for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+/******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8058,31 +13570,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_513046254cc472f77583.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_513046254cc472f77583\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var f=a[i].getAttribute(\\"src\\");if(f&&f.match(t)){r=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+  "/release/main_c46fa6e9dce17d2b90d4.js": "(()=>{var e={};console.log(\\"Hello world!\\");var r=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var o in e)r[o]=e[o];e.__esModule&&Object.defineProperty(r,\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_0a683184f3afcbf97c6c.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_0a683184f3afcbf97c6c\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})();var r={};console.log(e.p);var a=MyLibrary=\\"undefined\\"==typeof MyLibrary?{}:MyLibrary;for(var t in r)a[t]=r[t];r.__esModule&&Object.defineProperty(a,\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles assign-properties library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8145,11 +13719,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8212,31 +13828,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_a61d0ddd7fbc122d026c.js": "console.log(\\"Hello world!\\"),exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_be77d75ccbe921238d90.js": "(()=>{var a={};(()=>{var t,e=document.getElementsByTagName(\\"script\\"),r=/main_be77d75ccbe921238d90\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var s=e[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}a.p=t})(),console.log(a.p),exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8299,11 +13977,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8366,31 +14086,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-module library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8453,11 +14235,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	Object.defineProperty((exports.MyLibrary = exports.MyLibrary || {}), \\"__esModule\\", { value: true });
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8520,31 +14344,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var s=t[i].getAttribute(\\"src\\");if(s&&s.match(a)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_d4579c73e2e1104978e2.js": "(()=>{var e={};(()=>{var a,r=document.getElementsByTagName(\\"script\\"),t=/main_d4579c73e2e1104978e2\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(t)){a=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+  "/release/main_fdc7b1aa4223e178b616.js": "console.log(\\"Hello world!\\"),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0});",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_7f615e94560b668d69b0.js": "(()=>{var e={};(()=>{var r,a=document.getElementsByTagName(\\"script\\"),t=/main_7f615e94560b668d69b0\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(t)){r=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),Object.defineProperty(exports.MyLibrary=exports.MyLibrary||{},\\"__esModule\\",{value:!0})})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs-static library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8607,11 +14493,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	module.exports.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8674,31 +14602,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_4618d8f04314a0c07b24.js": "console.log(\\"Hello world!\\"),module.exports.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_215ebada3ff1a04863f1.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_215ebada3ff1a04863f1\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),module.exports.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles commonjs2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8761,11 +14751,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8828,31 +14860,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles global library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8915,11 +15009,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+MyLibrary(/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+);",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -8982,31 +15118,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "MyLibrary((()=>{var r={};return(()=>{var t,e=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_242806bd12c243936aee.js": "MyLibrary((()=>{var e={};return(()=>{var r,t=document.getElementsByTagName(\\"script\\"),a=/main_242806bd12c243936aee\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(a)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=r})(),console.log(e.p),{}})());",
+  "/release/main_f119a2e1669e0baf47d0.js": "MyLibrary((console.log(\\"Hello world!\\"),{}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_d62c4a558867b9317512.js": "MyLibrary((()=>{var r={};return(()=>{var t,a=document.getElementsByTagName(\\"script\\"),e=/main_d62c4a558867b9317512\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var n=a[i].getAttribute(\\"src\\");if(n&&n.match(e)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=t})(),console.log(r.p),{}})());",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles jsonp library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9069,11 +15267,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	self.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9136,31 +15376,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_f149476a0a4b7c1ee37d.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_f149476a0a4b7c1ee37d\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+  "/release/main_7d39ca5328225a0694e5.js": "console.log(\\"Hello world!\\"),self.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_8cd12c1b85d952bb65f6.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_8cd12c1b85d952bb65f6\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),self.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles self library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9234,11 +15547,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+System.register(\\"MyLibrary\\", [], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
+
+
+	return {
+
+		execute: function() {
+			__WEBPACK_DYNAMIC_EXPORT__(
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+
+			);
+		}
+	};
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9312,31 +15678,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),n=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var a=r[i].getAttribute(\\"src\\");if(a&&a.match(n)){e=a.substring(0,a.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_7d81fbd36473e27aa0fb.js": "System.register(\\"MyLibrary\\",[],(function(e,o){return{execute:function(){e((console.log(\\"Hello world!\\"),{}))}}}));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_b258ae75091c8f8b8490.js": "System.register(\\"MyLibrary\\",[],(function(e,t){return{execute:function(){var t;e((t={},(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main_b258ae75091c8f8b8490\\\\.js/i;if(r&&r.length)for(var n=0;n<r.length;n++)if(r[n]){var i=r[n].getAttribute(\\"src\\");if(i&&i.match(a)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),{}))}}}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles system library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9399,11 +15827,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	this.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9466,31 +15936,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var s=r[i].getAttribute(\\"src\\");if(s&&s.match(a)){e=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_353654d52cbd656ea3c2.js": "(()=>{var t={};(()=>{var e,a=document.getElementsByTagName(\\"script\\"),r=/main_353654d52cbd656ea3c2\\\\.js/i;if(a&&a.length)for(var c=0;c<a.length;c++)if(a[c]){var i=a[c].getAttribute(\\"src\\");if(i&&i.match(r)){e=i.substring(0,i.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),this.MyLibrary={}})();",
+  "/release/main_4d6fb5abdd3eb7fe4115.js": "(()=>{console.log(\\"Hello world!\\"),this.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_db75e39898539074e63f.js": "(()=>{var e={};(()=>{var t,a=document.getElementsByTagName(\\"script\\"),r=/main_db75e39898539074e63f\\\\.js/i;if(a&&a.length)for(var i=0;i<a.length;i++)if(a[i]){var s=a[i].getAttribute(\\"src\\");if(s&&s.match(r)){t=s.substring(0,s.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),this.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles this library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9564,11 +16107,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9642,31 +16238,104 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9740,11 +16409,64 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports[\\"MyLibrary\\"] = factory();
+	else
+		root[\\"MyLibrary\\"] = factory();
+})(self, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9818,31 +16540,94 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main\\\\.js/i;if(o&&o.length)for(var n=0;n<o.length;n++)if(o[n]){var f=o[n].getAttribute(\\"src\\");if(f&&f.match(r)){t=f.substring(0,f.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_8c43c348dc21118df193.js": "!function(e,o){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=o():\\"function\\"==typeof define&&define.amd?define([],o):\\"object\\"==typeof exports?exports.MyLibrary=o():e.MyLibrary=o()}(self,(()=>(console.log(\\"Hello world!\\"),{})));",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_cf828947bceb5d39f0a1.js": "!function(e,t){\\"object\\"==typeof exports&&\\"object\\"==typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define([],t):\\"object\\"==typeof exports?exports.MyLibrary=t():e.MyLibrary=t()}(self,(()=>{return e={},(()=>{var t,o=document.getElementsByTagName(\\"script\\"),r=/main_cf828947bceb5d39f0a1\\\\.js/i;if(o&&o.length)for(var f=0;f<o.length;f++)if(o[f]){var n=o[f].getAttribute(\\"src\\");if(n&&n.match(r)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),{};var e}));",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles umd2 library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9906,11 +16691,54 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+var MyLibrary;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -9974,31 +16802,93 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "var MyLibrary;(()=>{var r={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),e=/main\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(e)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}r.p=a})(),console.log(r.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main_cdf966d89dde9e0e6511.js": "var MyLibrary;console.log(\\"Hello world!\\"),MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main_6a43fdec20033b6103e3.js": "var MyLibrary;(()=>{var a={};(()=>{var r,e=document.getElementsByTagName(\\"script\\"),t=/main_6a43fdec20033b6103e3\\\\.js/i;if(e&&e.length)for(var i=0;i<e.length;i++)if(e[i]){var n=e[i].getAttribute(\\"src\\");if(n&&n.match(t)){r=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}a.p=r})(),console.log(a.p),MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles var library output (production+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -10061,11 +16951,53 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "/*
+ * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses \\"eval()\\" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with \\"devtool: false\\".
+ * If you are looking for production-ready output files, see mode: \\"production\\" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ \\"../../../../../../entry.js\\":
+/*!**********************************!*\\\\
+  !*** ../../../../../../entry.js ***!
+  \\\\**********************************/
+/***/ (() => {
+
+eval(\\"console.log(\\\\\\"Hello world!\\\\\\");\\\\n\\\\n//# sourceURL=webpack://MyLibrary/../../../../../../entry.js?\\");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__[\\"../../../../../../entry.js\\"]();
+/******/ 	window.MyLibrary = __webpack_exports__;
+/******/ 	
+/******/ })()
+;",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "/*
  * ATTENTION: The \\"eval\\" devtool has been used (maybe by default in mode: \\"development\\").
@@ -10128,26 +17060,46 @@ eval(\\"console.log(__webpack_require__.p);\\\\n\\\\n//# sourceURL=webpack://MyL
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (development+hash) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (doesn't use public path): Content 1`] = `
+Object {
+  "/release/main.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (doesn't use public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (uses public path): Content 1`] = `
 Object {
   "/release/main.js": "(()=>{var t={};(()=>{var e,r=document.getElementsByTagName(\\"script\\"),a=/main\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){e=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}t.p=e})(),console.log(t.p),window.MyLibrary={}})();",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (uses public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production) (uses public path): Warnings 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash): Content 1`] = `
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (doesn't use public path): Content 1`] = `
 Object {
-  "/release/main_ec4abce5016e8fcfb666.js": "(()=>{var e={};(()=>{var t,r=document.getElementsByTagName(\\"script\\"),a=/main_ec4abce5016e8fcfb666\\\\.js/i;if(r&&r.length)for(var i=0;i<r.length;i++)if(r[i]){var n=r[i].getAttribute(\\"src\\");if(n&&n.match(a)){t=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=t})(),console.log(e.p),window.MyLibrary={}})();",
+  "/release/main_5e7a9248e729d9296340.js": "console.log(\\"Hello world!\\"),window.MyLibrary={};",
 }
 `;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash): Errors 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (doesn't use public path): Errors 1`] = `Array []`;
 
-exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash): Warnings 1`] = `Array []`;
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (doesn't use public path): Warnings 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (uses public path): Content 1`] = `
+Object {
+  "/release/main_45661b5c41db58a7c856.js": "(()=>{var e={};(()=>{var a,t=document.getElementsByTagName(\\"script\\"),r=/main_45661b5c41db58a7c856\\\\.js/i;if(t&&t.length)for(var i=0;i<t.length;i++)if(t[i]){var n=t[i].getAttribute(\\"src\\");if(n&&n.match(r)){a=n.substring(0,n.lastIndexOf(\\"/\\")+1);break}}e.p=a})(),console.log(e.p),window.MyLibrary={}})();",
+}
+`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (uses public path): Errors 1`] = `Array []`;
+
+exports[`SetPublicPathPlugin (with {"scriptName":{"useAssetName":true}}}) Handles window library output (production+hash) (uses public path): Warnings 1`] = `Array []`;

--- a/webpack/set-webpack-public-path-plugin/src/test/testBase.ts
+++ b/webpack/set-webpack-public-path-plugin/src/test/testBase.ts
@@ -13,13 +13,16 @@ export function testForPlugin(pluginName: string, getPlugin: () => webpack.Webpa
   async function testForLibraryType(
     libraryType: string,
     mode: 'development' | 'production',
-    withHash: boolean
+    withHash: boolean,
+    includePublicPath: boolean
   ): Promise<void> {
     const memoryFileSystem: Volume = new Volume();
     memoryFileSystem.fromJSON(
       {
         '/package.json': '{}',
-        '/entry.js': 'console.log(__webpack_public_path__);'
+        '/entry.js': includePublicPath
+          ? 'console.log(__webpack_public_path__);'
+          : 'console.log("Hello world!");'
       },
       '/src'
     );
@@ -77,20 +80,36 @@ export function testForPlugin(pluginName: string, getPlugin: () => webpack.Webpa
       'jsonp',
       'system'
     ]) {
-      it(`Handles ${libraryType} library output (production)`, async () => {
-        await testForLibraryType(libraryType, 'production', false);
+      it(`Handles ${libraryType} library output (production) (uses public path)`, async () => {
+        await testForLibraryType(libraryType, 'production', false, true);
       });
 
-      it(`Handles ${libraryType} library output (production+hash)`, async () => {
-        await testForLibraryType(libraryType, 'production', true);
+      it(`Handles ${libraryType} library output (production+hash) (uses public path)`, async () => {
+        await testForLibraryType(libraryType, 'production', true, true);
       });
 
-      it(`Handles ${libraryType} library output (development)`, async () => {
-        await testForLibraryType(libraryType, 'development', false);
+      it(`Handles ${libraryType} library output (development) (uses public path)`, async () => {
+        await testForLibraryType(libraryType, 'development', false, true);
       });
 
-      it(`Handles ${libraryType} library output (development+hash)`, async () => {
-        await testForLibraryType(libraryType, 'development', false);
+      it(`Handles ${libraryType} library output (development+hash) (uses public path)`, async () => {
+        await testForLibraryType(libraryType, 'development', false, true);
+      });
+
+      it(`Handles ${libraryType} library output (production) (doesn't use public path)`, async () => {
+        await testForLibraryType(libraryType, 'production', false, false);
+      });
+
+      it(`Handles ${libraryType} library output (production+hash) (doesn't use public path)`, async () => {
+        await testForLibraryType(libraryType, 'production', true, false);
+      });
+
+      it(`Handles ${libraryType} library output (development) (doesn't use public path)`, async () => {
+        await testForLibraryType(libraryType, 'development', false, false);
+      });
+
+      it(`Handles ${libraryType} library output (development+hash) (doesn't use public path)`, async () => {
+        await testForLibraryType(libraryType, 'development', false, false);
       });
     }
   });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Guards the unsupported library error in a check of if the public path is actually used.

## How it was tested

Added a test case.

## Impacted documentation

None.
