### PR TITLE
[rush] Add opt-in ability to use IPC in watch mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,10 +16,17 @@
 				"--nolazy",
 				"--inspect-brk"
 			],
+      "skipFiles": ["<node_internals>/**"],
+      // Don't scan the file system on startup
+      "outFiles": [],
+      // Evaluate source maps for all workspace-local files
+      "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"env": {
 				"NODE_ENV": "development"
 			},
-			"sourceMaps": true
+			"sourceMaps": true,
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		},
 		{
 			"type": "node",

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -7,7 +7,9 @@
     "build": "heft build --clean",
     "start": "heft build-watch",
     "_phase:build": "heft run --only build -- --clean",
-    "_phase:test": "heft run --only test -- --clean"
+    "_phase:build:ipc": "heft run-watch --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean",
+    "_phase:test:ipc": "heft run-watch --only test -- --clean"
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",

--- a/common/changes/@microsoft/rush/heft-server_2023-09-07-21-59.json
+++ b/common/changes/@microsoft/rush/heft-server_2023-09-07-21-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"withTerminalAsync\" resource lifetime helper to `IOperationRunnerContext` to manage the creation and cleanup of logging for operation execution.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/heft-server_2023-09-07-21-59.json
+++ b/common/changes/@microsoft/rush/heft-server_2023-09-07-21-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add a \"withTerminalAsync\" resource lifetime helper to `IOperationRunnerContext` to manage the creation and cleanup of logging for operation execution.",
+      "comment": "Add a \"runWithTerminalAsync\" resource lifetime helper to `IOperationRunnerContext` to manage the creation and cleanup of logging for operation execution.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/rush-ipc_2024-01-18-21-16.json
+++ b/common/changes/@microsoft/rush/rush-ipc_2024-01-18-21-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds a new option `useIPCInWatchMode` to the `operationSettings` items of `rush-project.json`. Setting this value to `true` tells Rush to open an IPC channel to the created child process and attempt to keep it alive across incremental runs. If the process exits it will be restarted on the next execution.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/rush-ipc_2024-01-18-21-16.json
+++ b/common/changes/@microsoft/rush/rush-ipc_2024-01-18-21-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Adds a new option `useIPCInWatchMode` to the `operationSettings` items of `rush-project.json`. Setting this value to `true` tells Rush to open an IPC channel to the created child process and attempt to keep it alive across incremental runs. If the process exits it will be restarted on the next execution.",
+      "comment": "Adds a new experiment `useIPCScriptsInWatchMode`. When this flag is enabled and Rush is running in watch mode, it will check for npm scripts named `_phase:<phase-name>:ipc`, and if found, use them instead of the normal invocation of `_phase:<phase-name>`. When doing so, it will provide an IPC channel to the child process and expect the child to outlive the current build pass.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/operation-graph/rush-ipc_2024-01-20-00-49.json
+++ b/common/changes/@rushstack/operation-graph/rush-ipc_2024-01-20-00-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Fix memory leaks on abort controllers.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -69,5 +69,12 @@
   /**
    * If true, Rush will not allow node_modules in the repo folder or in parent folders.
    */
-  // "forbidPhantomResolvableNodeModulesFolders": true
+  // "forbidPhantomResolvableNodeModulesFolders": true,
+
+  /**
+   * If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead
+   * of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist
+   * across invocations.
+   */
+  // "useIPCScriptsInWatchMode": true
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3278,6 +3278,9 @@ importers:
       '@rushstack/heft-webpack5-plugin':
         specifier: workspace:*
         version: link:../../heft-plugins/heft-webpack5-plugin
+      '@rushstack/operation-graph':
+        specifier: workspace:*
+        version: link:../operation-graph
       '@rushstack/webpack-deep-imports-plugin':
         specifier: workspace:*
         version: link:../../webpack/webpack-deep-imports-plugin

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.114.3",
-    "nextBump": "patch",
+    "nextBump": "minor",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -387,6 +387,7 @@ export interface ICreateOperationsContext {
     readonly buildCacheConfiguration: BuildCacheConfiguration | undefined;
     readonly cobuildConfiguration: CobuildConfiguration | undefined;
     readonly customParameters: ReadonlyMap<string, CommandLineParameter>;
+    readonly invalidateOperation?: ((operation: Operation, reason: string) => void) | undefined;
     readonly isIncrementalBuildAllowed: boolean;
     readonly isInitial: boolean;
     readonly isWatch: boolean;
@@ -458,6 +459,7 @@ export interface IExperimentsJson {
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     phasedCommands?: boolean;
     printEventHooksOutputToConsole?: boolean;
+    useIPCScriptsInWatchMode?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;
     usePnpmLockfileOnlyThenFrozenLockfileForRushUpdate?: boolean;
     usePnpmPreferFrozenLockfileForRushUpdate?: boolean;
@@ -979,6 +981,7 @@ export class PhasedCommandHooks {
     readonly beforeLog: SyncHook<ITelemetryData, void>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
     readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]>;
+    readonly shutdown: SyncHook<void>;
     readonly waitingForChanges: SyncHook<void>;
 }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -598,12 +598,12 @@ export interface IOperationRunnerContext {
     // @internal
     _operationMetadataManager?: _OperationMetadataManager;
     quietMode: boolean;
-    status: OperationStatus;
-    stopwatch: IStopwatchResult;
-    withTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, options: {
+    runWithTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, options: {
         createLogFile: boolean;
         logFileSuffix?: string;
     }): Promise<T>;
+    status: OperationStatus;
+    stopwatch: IStopwatchResult;
 }
 
 // @alpha (undocumented)

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -590,7 +590,6 @@ export interface IOperationRunner {
 
 // @beta
 export interface IOperationRunnerContext {
-    readonly changedProjectsOnly: boolean;
     collatedWriter: CollatedWriter;
     debugMode: boolean;
     error?: Error;
@@ -598,7 +597,6 @@ export interface IOperationRunnerContext {
     _operationMetadataManager?: _OperationMetadataManager;
     quietMode: boolean;
     status: OperationStatus;
-    stdioSummarizer: StdioSummarizer;
     stopwatch: IStopwatchResult;
     withTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, createLogFile: boolean, logFileSuffix?: string): Promise<T>;
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -600,7 +600,10 @@ export interface IOperationRunnerContext {
     quietMode: boolean;
     status: OperationStatus;
     stopwatch: IStopwatchResult;
-    withTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, createLogFile: boolean, logFileSuffix?: string): Promise<T>;
+    withTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, options: {
+        createLogFile: boolean;
+        logFileSuffix?: string;
+    }): Promise<T>;
 }
 
 // @alpha (undocumented)
@@ -981,7 +984,7 @@ export class PhasedCommandHooks {
     readonly beforeLog: SyncHook<ITelemetryData, void>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
     readonly onOperationStatusChanged: SyncHook<[IOperationExecutionResult]>;
-    readonly shutdown: SyncHook<void>;
+    readonly shutdownAsync: AsyncParallelHook<void>;
     readonly waitingForChanges: SyncHook<void>;
 }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -600,6 +600,7 @@ export interface IOperationRunnerContext {
     status: OperationStatus;
     stdioSummarizer: StdioSummarizer;
     stopwatch: IStopwatchResult;
+    withTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, createLogFile: boolean, logFileSuffix?: string): Promise<T>;
 }
 
 // @alpha (undocumented)

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -87,5 +87,11 @@
   /**
    * If set to true, Rush will generate a `project-impact-graph.yaml` file in the repository root during `rush update`.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "generateProjectImpactGraphDuringRushUpdate": true
+  /*[LINE "HYPOTHETICAL"]*/ "generateProjectImpactGraphDuringRushUpdate": true,
+  /**
+   * If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead
+   * of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist
+   * across invocations.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "useIPCScriptsInWatchMode": true
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -64,6 +64,7 @@
     "local-node-rig": "workspace:*",
     "@rushstack/heft-webpack5-plugin": "workspace:*",
     "@rushstack/heft": "workspace:*",
+    "@rushstack/operation-graph": "workspace:*",
     "@rushstack/webpack-deep-imports-plugin": "workspace:*",
     "@rushstack/webpack-preserve-dynamic-require-plugin": "workspace:*",
     "@types/cli-table": "0.3.0",

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -94,6 +94,13 @@ export interface IExperimentsJson {
    * If set to true, Rush will generate a `project-impact-graph.yaml` file in the repository root during `rush update`.
    */
   generateProjectImpactGraphDuringRushUpdate?: boolean;
+
+  /**
+   * If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead
+   * of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist
+   * across invocations.
+   */
+  useIPCScriptsInWatchMode?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -503,12 +503,26 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   }
 
   private _registerWatchModeInterface(projectWatcher: ProjectWatcher): void {
-    const toggleWatcherKey: string = 'w';
-    const buildOnceKey: string = 'b';
-    const invalidateKey: string = 'i';
-    const shutdownKey: string = 'x';
+    const toggleWatcherKey: 'w' = 'w';
+    const buildOnceKey: 'b' = 'b';
+    const invalidateKey: 'i' = 'i';
+    const shutdownKey: 'x' = 'x';
 
     const terminal: ITerminal = this._terminal;
+
+    projectWatcher.setPromptGenerator((isPaused: boolean) => {
+      const promptLines: string[] = [
+        `  Press <${toggleWatcherKey}> to ${isPaused ? 'resume' : 'pause'}.`,
+        `  Press <${invalidateKey}> to invalidate all projects.`
+      ];
+      if (isPaused) {
+        promptLines.push(`  Press <${buildOnceKey}> to build once.`);
+      }
+      if (this._noIPCParameter?.value === false) {
+        promptLines.push(`  Press <${shutdownKey}> to reset child processes.`);
+      }
+      return promptLines;
+    });
 
     process.stdin.setRawMode(true);
     process.stdin.resume();

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -55,7 +55,7 @@ export interface IOperationRunnerContext {
    *
    * Will write to a log file corresponding to the phase and project, and clean it up upon completion.
    */
-  withTerminalAsync<T>(
+  runWithTerminalAsync<T>(
     callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
     options: {
       createLogFile: boolean;

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -57,8 +57,10 @@ export interface IOperationRunnerContext {
    */
   withTerminalAsync<T>(
     callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
-    createLogFile: boolean,
-    logFileSuffix?: string
+    options: {
+      createLogFile: boolean;
+      logFileSuffix?: string;
+    }
   ): Promise<T>;
 }
 

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { StdioSummarizer } from '@rushstack/terminal';
+import type {  ITerminal, ITerminalProvider, StdioSummarizer } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
@@ -61,6 +61,17 @@ export interface IOperationRunnerContext {
    * ignore dependent projects.
    */
   readonly changedProjectsOnly: boolean;
+
+  /**
+   * Invokes the specified callback with a terminal that is associated with this operation.
+   *
+   * Will write to a log file corresponding to the phase and project, and clean it up upon completion.
+   */
+  withTerminalAsync<T>(
+    callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
+    createLogFile: boolean,
+    logFileSuffix?: string
+  ): Promise<T>;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type {  ITerminal, ITerminalProvider, StdioSummarizer } from '@rushstack/terminal';
+import type { ITerminal, ITerminalProvider } from '@rushstack/terminal';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 
 import type { OperationStatus } from './OperationStatus';
@@ -27,10 +27,6 @@ export interface IOperationRunnerContext {
    */
   quietMode: boolean;
   /**
-   * Object used to report a summary at the end of the Rush invocation.
-   */
-  stdioSummarizer: StdioSummarizer;
-  /**
    * Object used to manage metadata of the operation.
    *
    * @internal
@@ -53,14 +49,6 @@ export interface IOperationRunnerContext {
    * it later (for example to re-print errors at end of execution).
    */
   error?: Error;
-
-  /**
-   * Normally the incremental build logic will rebuild changed projects as well as
-   * any projects that directly or indirectly depend on a changed project.
-   * If true, then the incremental build logic will only rebuild changed projects and
-   * ignore dependent projects.
-   */
-  readonly changedProjectsOnly: boolean;
 
   /**
    * Invokes the specified callback with a terminal that is associated with this operation.

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+
+import {
+  TerminalProviderSeverity,
+  type ITerminal,
+  type ITerminalProvider
+} from '@rushstack/node-core-library';
+import type {
+  IAfterExecuteEventMessage,
+  IRequestRunEventMessage,
+  ISyncEventMessage,
+  IRunCommandMessage,
+  IExitCommandMessage
+} from '@rushstack/operation-graph';
+
+import type { IPhase } from '../../api/CommandLineConfiguration';
+import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import { Utilities } from '../../utilities/Utilities';
+import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import { OperationError } from './OperationError';
+import { OperationStatus } from './OperationStatus';
+
+export interface IIPCOperationRunnerOptions {
+  phase: IPhase;
+  project: RushConfigurationProject;
+  name: string;
+  shellCommand: string;
+  persist: boolean;
+  requestRun: (requestor?: string) => void;
+}
+
+function isAfterExecuteEventMessage(message: unknown): message is IAfterExecuteEventMessage {
+  return typeof message === 'object' && (message as IAfterExecuteEventMessage).event === 'after-execute';
+}
+
+function isRequestRunEventMessage(message: unknown): message is IRequestRunEventMessage {
+  return typeof message === 'object' && (message as IRequestRunEventMessage).event === 'requestRun';
+}
+
+function isSyncEventMessage(message: unknown): message is ISyncEventMessage {
+  return typeof message === 'object' && (message as ISyncEventMessage).event === 'sync';
+}
+
+/**
+ * Runner that hosts a long-lived process to which it communicates via IPC.
+ */
+export class IPCOperationRunner implements IOperationRunner {
+  public readonly name: string;
+  public readonly cacheable: boolean = false;
+  public readonly reportTiming: boolean = true;
+  public readonly silent: boolean = false;
+  public readonly warningsAreAllowed: boolean;
+
+  private readonly _rushConfiguration: RushConfiguration;
+  private readonly _shellCommand: string;
+  private readonly _workingDirectory: string;
+  private readonly _persist: boolean;
+  private readonly _requestRun: (requestor?: string) => void;
+
+  private _ipcProcess: ChildProcess | undefined;
+  private _processReadyPromise: Promise<void> | undefined;
+
+  public constructor(options: IIPCOperationRunnerOptions) {
+    this.name = options.name;
+    this.warningsAreAllowed =
+      EnvironmentConfiguration.allowWarningsInSuccessfulBuild ||
+      options.phase.allowWarningsOnSuccess ||
+      false;
+    this._rushConfiguration = options.project.rushConfiguration;
+    this._shellCommand = options.shellCommand;
+    this._workingDirectory = options.project.projectFolder;
+    this._persist = options.persist;
+    this._requestRun = options.requestRun;
+  }
+
+  public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
+    return await context.withTerminalAsync(
+      async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
+        let isConnected: boolean = false;
+        if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {
+          // Run the operation
+          terminal.writeLine('Invoking: ' + this._shellCommand);
+
+          this._ipcProcess = Utilities.executeLifecycleCommandAsync(this._shellCommand, {
+            rushConfiguration: this._rushConfiguration,
+            workingDirectory: this._workingDirectory,
+            initCwd: this._rushConfiguration.commonTempFolder,
+            handleOutput: true,
+            environmentPathOptions: {
+              includeProjectBin: true
+            },
+            ipc: true,
+            connectSubprocessTerminator: true
+          });
+
+          let resolveReadyPromise!: () => void;
+
+          this._processReadyPromise = new Promise<void>((resolve) => {
+            resolveReadyPromise = resolve;
+          });
+
+          this._ipcProcess.on('message', (message: unknown) => {
+            if (isRequestRunEventMessage(message)) {
+              this._requestRun(message.requestor);
+            } else if (isSyncEventMessage(message)) {
+              resolveReadyPromise();
+            }
+          });
+        } else {
+          terminal.writeLine(`Connecting to existing IPC process...`);
+        }
+        const subProcess: ChildProcess = this._ipcProcess;
+        let hasWarningOrError: boolean = false;
+
+        function onStdout(data: Buffer): void {
+          const text: string = data.toString();
+          terminalProvider.write(text, TerminalProviderSeverity.log);
+        }
+        function onStderr(data: Buffer): void {
+          const text: string = data.toString();
+          terminalProvider.write(text, TerminalProviderSeverity.error);
+          hasWarningOrError = true;
+        }
+
+        // Hook into events, in order to get live streaming of the log
+        subProcess.stdout?.on('data', onStdout);
+        subProcess.stderr?.on('data', onStderr);
+
+        const status: OperationStatus = await new Promise((resolve, reject) => {
+          function finishHandler(message: unknown): void {
+            if (isAfterExecuteEventMessage(message)) {
+              terminal.writeLine('Received finish notification');
+              subProcess.stdout?.off('data', onStdout);
+              subProcess.stderr?.off('data', onStderr);
+              subProcess.off('message', finishHandler);
+              subProcess.off('error', reject);
+              subProcess.off('exit', onExit);
+              terminal.writeLine('Disconnected from IPC process');
+              // These types are currently distinct but have the same underlying values
+              resolve(message.status as unknown as OperationStatus);
+            }
+          }
+
+          function onExit(code: number): void {
+            try {
+              if (code !== 0) {
+                // Do NOT reject here immediately, give a chance for other logic to suppress the error
+                context.error = new OperationError('error', `Returned error code: ${code}`);
+                resolve(OperationStatus.Failure);
+              } else if (hasWarningOrError) {
+                resolve(OperationStatus.SuccessWithWarning);
+              } else {
+                resolve(OperationStatus.Success);
+              }
+            } catch (error) {
+              reject(error as OperationError);
+            }
+          }
+
+          subProcess.on('message', finishHandler);
+          subProcess.on('error', reject);
+          subProcess.on('exit', onExit);
+
+          this._processReadyPromise!.then(() => {
+            isConnected = true;
+            terminal.writeLine('Child supports IPC protocol. Sending "run" command...');
+            const runCommand: IRunCommandMessage = {
+              command: 'run'
+            };
+            subProcess.send(runCommand);
+          }, reject);
+        });
+
+        if (isConnected && !this._persist) {
+          this.shutdown();
+          await once(subProcess, 'exit');
+        }
+
+        return status === OperationStatus.Success && hasWarningOrError
+          ? OperationStatus.SuccessWithWarning
+          : status;
+      },
+      true
+    );
+  }
+
+  public getConfigHash(): string {
+    return this._shellCommand;
+  }
+
+  public shutdown(): void {
+    const { _ipcProcess: subProcess } = this;
+    if (!subProcess) {
+      return;
+    }
+
+    if (subProcess.connected) {
+      const exitCommand: IExitCommandMessage = {
+        command: 'exit'
+      };
+      subProcess.send(exitCommand);
+    }
+  }
+}

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -76,7 +76,7 @@ export class IPCOperationRunner implements IOperationRunner {
   }
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
-    return await context.withTerminalAsync(
+    return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
         let isConnected: boolean = false;
         if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -4,11 +4,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 
-import {
-  TerminalProviderSeverity,
-  type ITerminal,
-  type ITerminalProvider
-} from '@rushstack/node-core-library';
 import type {
   IAfterExecuteEventMessage,
   IRequestRunEventMessage,
@@ -16,6 +11,7 @@ import type {
   IRunCommandMessage,
   IExitCommandMessage
 } from '@rushstack/operation-graph';
+import { TerminalProviderSeverity, type ITerminal, type ITerminalProvider } from '@rushstack/terminal';
 
 import type { IPhase } from '../../api/CommandLineConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IPhase } from '../../api/CommandLineConfiguration';
+import type {
+  ICreateOperationsContext,
+  IPhasedCommandPlugin,
+  PhasedCommandHooks
+} from '../../pluginFramework/PhasedCommandHooks';
+import type { IOperationExecutionResult } from './IOperationExecutionResult';
+import { IPCOperationRunner } from './IPCOperationRunner';
+import type { Operation } from './Operation';
+import { OperationStatus } from './OperationStatus';
+import {
+  PLUGIN_NAME as ShellOperationPluginName,
+  formatCommand,
+  getCustomParameterValuesByPhase,
+  getDisplayName
+} from './ShellOperationRunnerPlugin';
+
+const PLUGIN_NAME: 'IPCOperationRunnerPlugin' = 'IPCOperationRunnerPlugin';
+
+/**
+ * Plugin that implements compatible phases via IPC to a long-lived watch process.
+ */
+export class IPCOperationRunnerPlugin implements IPhasedCommandPlugin {
+  public apply(hooks: PhasedCommandHooks): void {
+    // Workaround until the operation graph persists for the lifetime of the watch process
+    const runnerCache: Map<string, IPCOperationRunner> = new Map();
+
+    const operationStatesByRunner: WeakMap<IPCOperationRunner, IOperationExecutionResult> = new WeakMap();
+
+    let currentContext: ICreateOperationsContext | undefined;
+
+    hooks.createOperations.tapPromise(
+      {
+        name: PLUGIN_NAME,
+        before: ShellOperationPluginName
+      },
+      async (operations: Set<Operation>, context: ICreateOperationsContext) => {
+        const { isWatch } = context;
+        currentContext = context;
+
+        const getCustomParameterValuesForPhase: (phase: IPhase) => ReadonlyArray<string> =
+          getCustomParameterValuesByPhase();
+
+        for (const operation of operations) {
+          const { associatedPhase: phase, associatedProject: project, runner } = operation;
+
+          if (runner || !phase || !project) {
+            continue;
+          }
+
+          const rawScript: string | undefined = project.packageJson.scripts?.[`${phase.name}:ipc`];
+          if (!rawScript) {
+            continue;
+          }
+
+          const commandToRun: string = formatCommand(rawScript, getCustomParameterValuesForPhase(phase));
+
+          const operationName: string = getDisplayName(phase, project);
+          let maybeIpcOperationRunner: IPCOperationRunner | undefined = runnerCache.get(operationName);
+          if (!maybeIpcOperationRunner) {
+            const ipcOperationRunner: IPCOperationRunner = (maybeIpcOperationRunner = new IPCOperationRunner({
+              phase,
+              project,
+              name: operationName,
+              shellCommand: commandToRun,
+              persist: isWatch,
+              requestRun: (requestor?: string) => {
+                const operationState: IOperationExecutionResult | undefined =
+                  operationStatesByRunner.get(ipcOperationRunner);
+                if (!operationState) {
+                  return;
+                }
+
+                const status: OperationStatus = operationState.status;
+                if (
+                  status === OperationStatus.Waiting ||
+                  status === OperationStatus.Ready ||
+                  status === OperationStatus.Queued
+                ) {
+                  // Already pending. No-op.
+                  return;
+                }
+
+                currentContext?.invalidateOperation?.(operation, requestor || 'IPC');
+              }
+            }));
+            runnerCache.set(operationName, ipcOperationRunner);
+          }
+
+          operation.runner = maybeIpcOperationRunner;
+        }
+
+        return operations;
+      }
+    );
+
+    hooks.beforeExecuteOperations.tap(
+      PLUGIN_NAME,
+      (records: Map<Operation, IOperationExecutionResult>, context: ICreateOperationsContext) => {
+        currentContext = context;
+        for (const [{ runner }, result] of records) {
+          if (runner instanceof IPCOperationRunner) {
+            operationStatesByRunner.set(runner, result);
+          }
+        }
+      }
+    );
+
+    hooks.shutdown.tap(PLUGIN_NAME, () => {
+      for (const runner of runnerCache.values()) {
+        runner.shutdown();
+      }
+    });
+  }
+}

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
@@ -109,10 +109,8 @@ export class IPCOperationRunnerPlugin implements IPhasedCommandPlugin {
       }
     );
 
-    hooks.shutdown.tap(PLUGIN_NAME, () => {
-      for (const runner of runnerCache.values()) {
-        runner.shutdown();
-      }
+    hooks.shutdownAsync.tapPromise(PLUGIN_NAME, async () => {
+      await Promise.all(Array.from(runnerCache.values(), (runner) => runner.shutdownAsync()));
     });
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -125,8 +125,7 @@ export class OperationExecutionManager {
       streamCollator: this._streamCollator,
       onOperationStatusChanged,
       debugMode,
-      quietMode,
-      changedProjectsOnly
+      quietMode
     };
 
     let totalOperations: number = 0;

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -12,10 +12,7 @@ import {
   Terminal,
   type TerminalWritable
 } from '@rushstack/terminal';
-import {
-  InternalError,
-  NewlineKind
-} from '@rushstack/node-core-library';
+import { InternalError, NewlineKind } from '@rushstack/node-core-library';
 import { CollatedTerminal, type CollatedWriter, type StreamCollator } from '@rushstack/stream-collator';
 
 import { OperationStatus } from './OperationStatus';
@@ -181,9 +178,9 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
   }
 
   /**
-   * {@inheritdoc IOperationRunnerContext.withTerminalAsync}
+   * {@inheritdoc IOperationRunnerContext.runWithTerminalAsync}
    */
-  public async withTerminalAsync<T>(
+  public async runWithTerminalAsync<T>(
     callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
     options: {
       createLogFile: boolean;

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -1,9 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { StdioSummarizer } from '@rushstack/terminal';
-import { InternalError } from '@rushstack/node-core-library';
-import type { CollatedWriter, StreamCollator } from '@rushstack/stream-collator';
+import {
+  type ITerminal,
+  type ITerminalProvider,
+  DiscardStdoutTransform,
+  SplitterTransform,
+  StderrLineTransform,
+  StdioSummarizer,
+  TextRewriterTransform,
+  Terminal,
+  type TerminalWritable
+} from '@rushstack/terminal';
+import {
+  InternalError,
+  NewlineKind
+} from '@rushstack/node-core-library';
+import { CollatedTerminal, type CollatedWriter, type StreamCollator } from '@rushstack/stream-collator';
 
 import { OperationStatus } from './OperationStatus';
 import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
@@ -12,6 +25,8 @@ import { Stopwatch } from '../../utilities/Stopwatch';
 import { OperationMetadataManager } from './OperationMetadataManager';
 import type { IPhase } from '../../api/CommandLineConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import { CollatedTerminalProvider } from '../../utilities/CollatedTerminalProvider';
+import { ProjectLogWritable } from './ProjectLogWritable';
 
 export interface IOperationExecutionRecordContext {
   streamCollator: StreamCollator;
@@ -168,6 +183,89 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
     }
     this._status = newStatus;
     this._context.onOperationStatusChanged?.(this);
+  }
+
+  /**
+   * {@inheritdoc IOperationRunnerContext.withTerminalAsync}
+   */
+  public async withTerminalAsync<T>(
+    callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
+    createLogFile: boolean,
+    logFileSuffix: string = ''
+  ): Promise<T> {
+    const { associatedPhase, associatedProject, stdioSummarizer } = this;
+    const projectLogWritable: ProjectLogWritable | undefined =
+      createLogFile && associatedProject && associatedPhase
+        ? new ProjectLogWritable(
+            associatedProject,
+            this.collatedWriter.terminal,
+            `${associatedPhase.logFilenameIdentifier}${logFileSuffix}`
+          )
+        : undefined;
+
+    try {
+      //#region OPERATION LOGGING
+      // TERMINAL PIPELINE:
+      //
+      //                             +--> quietModeTransform? --> collatedWriter
+      //                             |
+      // normalizeNewlineTransform --1--> stderrLineTransform --2--> removeColorsTransform --> projectLogWritable
+      //                                                        |
+      //                                                        +--> stdioSummarizer
+      const destination: TerminalWritable = projectLogWritable
+        ? new SplitterTransform({
+            destinations: [
+              new TextRewriterTransform({
+                destination: projectLogWritable,
+                removeColors: true,
+                normalizeNewlines: NewlineKind.OsDefault
+              }),
+              stdioSummarizer
+            ]
+          })
+        : stdioSummarizer;
+
+      const stderrLineTransform: StderrLineTransform = new StderrLineTransform({
+        destination,
+        newlineKind: NewlineKind.Lf // for StdioSummarizer
+      });
+
+      const splitterTransform1: SplitterTransform = new SplitterTransform({
+        destinations: [
+          this.quietMode
+            ? new DiscardStdoutTransform({ destination: this.collatedWriter })
+            : this.collatedWriter,
+          stderrLineTransform
+        ]
+      });
+
+      const normalizeNewlineTransform: TextRewriterTransform = new TextRewriterTransform({
+        destination: splitterTransform1,
+        normalizeNewlines: NewlineKind.Lf,
+        ensureNewlineAtEnd: true
+      });
+
+      const collatedTerminal: CollatedTerminal = new CollatedTerminal(normalizeNewlineTransform);
+      const terminalProvider: CollatedTerminalProvider = new CollatedTerminalProvider(collatedTerminal, {
+        debugEnabled: this.debugMode
+      });
+      const terminal: Terminal = new Terminal(terminalProvider);
+      //#endregion
+
+      const result: T = await callback(terminal, terminalProvider);
+
+      normalizeNewlineTransform.close();
+
+      // If the pipeline is wired up correctly, then closing normalizeNewlineTransform should
+      // have closed projectLogWritable.
+      if (projectLogWritable?.isOpen) {
+        throw new InternalError('The output file handle was not closed');
+      }
+
+      return result;
+    } finally {
+      projectLogWritable?.close();
+    }
   }
 
   public async executeAsync({

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -185,10 +185,13 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
    */
   public async withTerminalAsync<T>(
     callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>,
-    createLogFile: boolean,
-    logFileSuffix: string = ''
+    options: {
+      createLogFile: boolean;
+      logFileSuffix: string;
+    }
   ): Promise<T> {
     const { associatedPhase, associatedProject, stdioSummarizer } = this;
+    const { createLogFile, logFileSuffix = '' } = options;
     const projectLogWritable: ProjectLogWritable | undefined =
       createLogFile && associatedProject && associatedPhase
         ? new ProjectLogWritable(

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -34,7 +34,6 @@ export interface IOperationExecutionRecordContext {
 
   debugMode: boolean;
   quietMode: boolean;
-  changedProjectsOnly: boolean;
 }
 
 /**
@@ -144,10 +143,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public get quietMode(): boolean {
     return this._context.quietMode;
-  }
-
-  public get changedProjectsOnly(): boolean {
-    return this._context.changedProjectsOnly;
   }
 
   public get collatedWriter(): CollatedWriter {

--- a/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
+++ b/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
@@ -10,7 +10,6 @@ import { PackageNameParsers } from '../../api/PackageNameParsers';
 import { RushConstants } from '../RushConstants';
 
 export class ProjectLogWritable extends TerminalWritable {
-  private readonly _project: RushConfigurationProject;
   private readonly _terminal: CollatedTerminal;
 
   public readonly logPath: string;
@@ -27,7 +26,6 @@ export class ProjectLogWritable extends TerminalWritable {
     logFilenameIdentifier: string
   ) {
     super();
-    this._project = project;
     this._terminal = terminal;
 
     // Delete the legacy logs

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -119,7 +119,9 @@ export class ShellOperationRunner implements IOperationRunner {
 
         return status;
       },
-      true
+      {
+        createLogFile: true
+      }
     );
   }
 }

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -65,7 +65,7 @@ export class ShellOperationRunner implements IOperationRunner {
   }
 
   private async _executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
-    return await context.withTerminalAsync(
+    return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider) => {
         let hasWarningOrError: boolean = false;
         const projectFolder: string = this._rushProject.projectFolder;

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -6,15 +6,14 @@ import type * as child_process from 'node:child_process';
 import { Text } from '@rushstack/node-core-library';
 import { type ITerminal, type ITerminalProvider, TerminalProviderSeverity } from '@rushstack/terminal';
 
-import { Utilities } from '../../utilities/Utilities';
-import { OperationStatus } from './OperationStatus';
-import { OperationError } from './OperationError';
-import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import type { IPhase } from '../../api/CommandLineConfiguration';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
-
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import type { IPhase } from '../../api/CommandLineConfiguration';
+import { Utilities } from '../../utilities/Utilities';
+import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
+import { OperationError } from './OperationError';
+import { OperationStatus } from './OperationStatus';
 
 export interface IOperationRunnerOptions {
   rushProject: RushConfigurationProject;
@@ -46,11 +45,11 @@ export class ShellOperationRunner implements IOperationRunner {
     const { phase } = options;
 
     this.name = options.displayName;
+    this.warningsAreAllowed =
+      EnvironmentConfiguration.allowWarningsInSuccessfulBuild || phase.allowWarningsOnSuccess || false;
     this._rushProject = options.rushProject;
     this._rushConfiguration = options.rushConfiguration;
     this._commandToRun = options.commandToRun;
-    this.warningsAreAllowed =
-      EnvironmentConfiguration.allowWarningsInSuccessfulBuild || phase.allowWarningsOnSuccess || false;
   }
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -1,42 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type * as child_process from 'child_process';
-import { Text, NewlineKind, InternalError } from '@rushstack/node-core-library';
-import {
-  Terminal,
-  TerminalChunkKind,
-  TextRewriterTransform,
-  StderrLineTransform,
-  SplitterTransform,
-  DiscardStdoutTransform
-} from '@rushstack/terminal';
-import { CollatedTerminal } from '@rushstack/stream-collator';
+import type * as child_process from 'node:child_process';
+
+import { Text } from '@rushstack/node-core-library';
+import { type ITerminal, type ITerminalProvider, TerminalProviderSeverity } from '@rushstack/terminal';
 
 import { Utilities } from '../../utilities/Utilities';
 import { OperationStatus } from './OperationStatus';
 import { OperationError } from './OperationError';
 import type { IOperationRunner, IOperationRunnerContext } from './IOperationRunner';
-import { ProjectLogWritable } from './ProjectLogWritable';
-import { CollatedTerminalProvider } from '../../utilities/CollatedTerminalProvider';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import type { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';
 import type { IPhase } from '../../api/CommandLineConfiguration';
 
 export interface IOperationRunnerOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   commandToRun: string;
-  projectChangeAnalyzer: ProjectChangeAnalyzer;
   displayName: string;
   phase: IPhase;
-  /**
-   * The set of phases being executed in the current command, for validation of rush-project.json
-   */
-  selectedPhases: Iterable<IPhase>;
 }
 
 /**
@@ -54,7 +39,6 @@ export class ShellOperationRunner implements IOperationRunner {
 
   private readonly _commandToRun: string;
 
-  private readonly _logFilenameIdentifier: string;
   private readonly _rushProject: RushConfigurationProject;
   private readonly _rushConfiguration: RushConfiguration;
 
@@ -67,7 +51,6 @@ export class ShellOperationRunner implements IOperationRunner {
     this._commandToRun = options.commandToRun;
     this.warningsAreAllowed =
       EnvironmentConfiguration.allowWarningsInSuccessfulBuild || phase.allowWarningsOnSuccess || false;
-    this._logFilenameIdentifier = phase.logFilenameIdentifier;
   }
 
   public async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
@@ -83,128 +66,62 @@ export class ShellOperationRunner implements IOperationRunner {
   }
 
   private async _executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
-    const projectLogWritable: ProjectLogWritable = new ProjectLogWritable(
-      this._rushProject,
-      context.collatedWriter.terminal,
-      this._logFilenameIdentifier
-    );
+    return await context.withTerminalAsync(
+      async (terminal: ITerminal, terminalProvider: ITerminalProvider) => {
+        let hasWarningOrError: boolean = false;
+        const projectFolder: string = this._rushProject.projectFolder;
 
-    try {
-      //#region OPERATION LOGGING
-      // TERMINAL PIPELINE:
-      //
-      //                             +--> quietModeTransform? --> collatedWriter
-      //                             |
-      // normalizeNewlineTransform --1--> stderrLineTransform --2--> removeColorsTransform --> projectLogWritable
-      //                                                        |
-      //                                                        +--> stdioSummarizer
-      const removeColorsTransform: TextRewriterTransform = new TextRewriterTransform({
-        destination: projectLogWritable,
-        removeColors: true,
-        normalizeNewlines: NewlineKind.OsDefault
-      });
+        // Run the operation
+        terminal.writeLine('Invoking: ' + this._commandToRun);
 
-      const splitterTransform2: SplitterTransform = new SplitterTransform({
-        destinations: [removeColorsTransform, context.stdioSummarizer]
-      });
-
-      const stderrLineTransform: StderrLineTransform = new StderrLineTransform({
-        destination: splitterTransform2,
-        newlineKind: NewlineKind.Lf // for StdioSummarizer
-      });
-
-      const discardTransform: DiscardStdoutTransform = new DiscardStdoutTransform({
-        destination: context.collatedWriter
-      });
-
-      const splitterTransform1: SplitterTransform = new SplitterTransform({
-        destinations: [context.quietMode ? discardTransform : context.collatedWriter, stderrLineTransform]
-      });
-
-      const normalizeNewlineTransform: TextRewriterTransform = new TextRewriterTransform({
-        destination: splitterTransform1,
-        normalizeNewlines: NewlineKind.Lf,
-        ensureNewlineAtEnd: true
-      });
-
-      const collatedTerminal: CollatedTerminal = new CollatedTerminal(normalizeNewlineTransform);
-      const terminalProvider: CollatedTerminalProvider = new CollatedTerminalProvider(collatedTerminal, {
-        debugEnabled: context.debugMode
-      });
-      const terminal: Terminal = new Terminal(terminalProvider);
-      //#endregion
-
-      let hasWarningOrError: boolean = false;
-      const projectFolder: string = this._rushProject.projectFolder;
-
-      // Run the operation
-      terminal.writeLine('Invoking: ' + this._commandToRun);
-
-      const subProcess: child_process.ChildProcess = Utilities.executeLifecycleCommandAsync(
-        this._commandToRun,
-        {
-          rushConfiguration: this._rushConfiguration,
-          workingDirectory: projectFolder,
-          initCwd: this._rushConfiguration.commonTempFolder,
-          handleOutput: true,
-          environmentPathOptions: {
-            includeProjectBin: true
+        const subProcess: child_process.ChildProcess = Utilities.executeLifecycleCommandAsync(
+          this._commandToRun,
+          {
+            rushConfiguration: this._rushConfiguration,
+            workingDirectory: projectFolder,
+            initCwd: this._rushConfiguration.commonTempFolder,
+            handleOutput: true,
+            environmentPathOptions: {
+              includeProjectBin: true
+            }
           }
-        }
-      );
+        );
 
-      // Hook into events, in order to get live streaming of the log
-      if (subProcess.stdout !== null) {
-        subProcess.stdout.on('data', (data: Buffer) => {
+        // Hook into events, in order to get live streaming of the log
+        subProcess.stdout?.on('data', (data: Buffer) => {
           const text: string = data.toString();
-          collatedTerminal.writeChunk({ text, kind: TerminalChunkKind.Stdout });
+          terminalProvider.write(text, TerminalProviderSeverity.log);
         });
-      }
-      if (subProcess.stderr !== null) {
-        subProcess.stderr.on('data', (data: Buffer) => {
+        subProcess.stderr?.on('data', (data: Buffer) => {
           const text: string = data.toString();
-          collatedTerminal.writeChunk({ text, kind: TerminalChunkKind.Stderr });
+          terminalProvider.write(text, TerminalProviderSeverity.error);
           hasWarningOrError = true;
         });
-      }
 
-      let status: OperationStatus = await new Promise(
-        (resolve: (status: OperationStatus) => void, reject: (error: OperationError) => void) => {
-          subProcess.on('close', (code: number) => {
-            try {
-              if (code !== 0) {
-                // Do NOT reject here immediately, give a chance for other logic to suppress the error
-                context.error = new OperationError('error', `Returned error code: ${code}`);
-                resolve(OperationStatus.Failure);
-              } else if (hasWarningOrError) {
-                resolve(OperationStatus.SuccessWithWarning);
-              } else {
-                resolve(OperationStatus.Success);
+        const status: OperationStatus = await new Promise(
+          (resolve: (status: OperationStatus) => void, reject: (error: OperationError) => void) => {
+            subProcess.on('close', (code: number) => {
+              try {
+                if (code !== 0) {
+                  // Do NOT reject here immediately, give a chance for other logic to suppress the error
+                  context.error = new OperationError('error', `Returned error code: ${code}`);
+                  resolve(OperationStatus.Failure);
+                } else if (hasWarningOrError) {
+                  resolve(OperationStatus.SuccessWithWarning);
+                } else {
+                  resolve(OperationStatus.Success);
+                }
+              } catch (error) {
+                reject(error as OperationError);
               }
-            } catch (error) {
-              reject(error as OperationError);
-            }
-          });
-        }
-      );
+            });
+          }
+        );
 
-      // projectLogWritable should be closed before copy the logs to build cache
-      normalizeNewlineTransform.close();
-
-      // If the pipeline is wired up correctly, then closing normalizeNewlineTransform should
-      // have closed projectLogWritable.
-      if (projectLogWritable.isOpen) {
-        throw new InternalError('The output file handle was not closed');
-      }
-
-      if (terminalProvider.hasErrors) {
-        status = OperationStatus.Failure;
-      }
-
-      return status;
-    } finally {
-      projectLogWritable.close();
-    }
+        return status;
+      },
+      true
+    );
   }
 }
 

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -29,7 +29,7 @@ function createShellOperations(
   operations: Set<Operation>,
   context: ICreateOperationsContext
 ): Set<Operation> {
-  const { phaseSelection: selectedPhases, projectChangeAnalyzer, rushConfiguration } = context;
+  const { rushConfiguration } = context;
 
   const customParametersByPhase: Map<IPhase, string[]> = new Map();
 
@@ -75,10 +75,8 @@ function createShellOperations(
           commandToRun: commandToRun || '',
           displayName,
           phase,
-          projectChangeAnalyzer,
           rushConfiguration,
-          rushProject: project,
-          selectedPhases
+          rushProject: project
         });
         operation.runner = shellOperationRunner;
       } else {

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../pluginFramework/PhasedCommandHooks';
 import type { Operation } from './Operation';
 
-const PLUGIN_NAME: 'ShellOperationRunnerPlugin' = 'ShellOperationRunnerPlugin';
+export const PLUGIN_NAME: 'ShellOperationRunnerPlugin' = 'ShellOperationRunnerPlugin';
 
 /**
  * Core phased command plugin that provides the functionality for executing an operation via shell command.
@@ -31,21 +31,8 @@ function createShellOperations(
 ): Set<Operation> {
   const { rushConfiguration } = context;
 
-  const customParametersByPhase: Map<IPhase, string[]> = new Map();
-
-  function getCustomParameterValuesForPhase(phase: IPhase): ReadonlyArray<string> {
-    let customParameterValues: string[] | undefined = customParametersByPhase.get(phase);
-    if (!customParameterValues) {
-      customParameterValues = [];
-      for (const tsCommandLineParameter of phase.associatedParameters) {
-        tsCommandLineParameter.appendToArgList(customParameterValues);
-      }
-
-      customParametersByPhase.set(phase, customParameterValues);
-    }
-
-    return customParameterValues;
-  }
+  const getCustomParameterValuesForPhase: (phase: IPhase) => ReadonlyArray<string> =
+    getCustomParameterValuesByPhase();
 
   for (const operation of operations) {
     const { associatedPhase: phase, associatedProject: project } = operation;
@@ -107,6 +94,34 @@ function getScriptToRun(
     return undefined;
   }
 
+  return formatCommand(rawCommand, customParameterValues);
+}
+
+/**
+ * Memoizer for custom parameter values by phase
+ * @returns A function that returns the custom parameter values for a given phase
+ */
+export function getCustomParameterValuesByPhase(): (phase: IPhase) => ReadonlyArray<string> {
+  const customParametersByPhase: Map<IPhase, string[]> = new Map();
+
+  function getCustomParameterValuesForPhase(phase: IPhase): ReadonlyArray<string> {
+    let customParameterValues: string[] | undefined = customParametersByPhase.get(phase);
+    if (!customParameterValues) {
+      customParameterValues = [];
+      for (const tsCommandLineParameter of phase.associatedParameters) {
+        tsCommandLineParameter.appendToArgList(customParameterValues);
+      }
+
+      customParametersByPhase.set(phase, customParameterValues);
+    }
+
+    return customParameterValues;
+  }
+
+  return getCustomParameterValuesForPhase;
+}
+
+export function formatCommand(rawCommand: string, customParameterValues: ReadonlyArray<string>): string {
   if (!rawCommand) {
     return '';
   } else {
@@ -115,7 +130,7 @@ function getScriptToRun(
   }
 }
 
-function getDisplayName(phase: IPhase, project: RushConfigurationProject): string {
+export function getDisplayName(phase: IPhase, project: RushConfigurationProject): string {
   if (phase.isSynthetic) {
     // Because this is a synthetic phase, just use the project name because there aren't any other phases
     return project.packageName;

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { AsyncSeriesBailHook, AsyncSeriesHook, AsyncSeriesWaterfallHook, SyncHook } from 'tapable';
+import {
+  AsyncParallelHook,
+  AsyncSeriesBailHook,
+  AsyncSeriesHook,
+  AsyncSeriesWaterfallHook,
+  SyncHook
+} from 'tapable';
 
 import type { CommandLineParameter } from '@rushstack/ts-command-line';
 import type { BuildCacheConfiguration } from '../api/BuildCacheConfiguration';
@@ -152,7 +158,7 @@ export class PhasedCommandHooks {
   /**
    * Hook invoked to shutdown long-lived work in plugins.
    */
-  public readonly shutdown: SyncHook<void> = new SyncHook(undefined, 'shutdown');
+  public readonly shutdownAsync: AsyncParallelHook<void> = new AsyncParallelHook(undefined, 'shutdown');
 
   /**
    * Hook invoked after a run has finished and the command is watching for changes.

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -92,6 +92,12 @@ export interface ICreateOperationsContext {
    * The Rush configuration
    */
   readonly rushConfiguration: RushConfiguration;
+  /**
+   * Marks an operation's result as invalid, potentially triggering a new build. Only applicable in watch mode.
+   * @param operation - The operation to invalidate
+   * @param reason - The reason for invalidating the operation
+   */
+  readonly invalidateOperation?: ((operation: Operation, reason: string) => void) | undefined;
 }
 
 /**
@@ -142,6 +148,11 @@ export class PhasedCommandHooks {
   public readonly afterExecuteOperation: AsyncSeriesHook<
     [IOperationRunnerContext & IOperationExecutionResult]
   > = new AsyncSeriesHook(['runnerContext'], 'afterExecuteOperation');
+
+  /**
+   * Hook invoked to shutdown long-lived work in plugins.
+   */
+  public readonly shutdown: SyncHook<void> = new SyncHook(undefined, 'shutdown');
 
   /**
    * Hook invoked after a run has finished and the command is watching for changes.

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -61,6 +61,10 @@
     "generateProjectImpactGraphDuringRushUpdate": {
       "description": "If set to true, Rush will generate a `project-impact-graph.yaml` file in the repository root during `rush update`.",
       "type": "boolean"
+    },
+    "useIPCScriptsInWatchMode": {
+      "description": "If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist across invocations.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -11,7 +11,8 @@ import {
   type IPackageJson,
   FileSystem,
   FileConstants,
-  type FileSystemStats
+  type FileSystemStats,
+  SubprocessTerminator
 } from '@rushstack/node-core-library';
 
 import type { RushConfiguration } from '../api/RushConfiguration';
@@ -90,6 +91,11 @@ export interface ILifecycleCommandOptions {
    * If true, attempt to establish a NodeJS IPC channel to the child process.
    */
   ipc?: boolean;
+
+  /**
+   * If true, wire up SubprocessTerminator to the child process.
+   */
+  connectSubprocessTerminator?: boolean;
 }
 
 export interface IEnvironmentPathOptions {
@@ -473,7 +479,15 @@ export class Utilities {
     command: string,
     options: ILifecycleCommandOptions
   ): child_process.ChildProcess {
-    return Utilities._executeLifecycleCommandInternal(command, child_process.spawn, options);
+    const child: child_process.ChildProcess = Utilities._executeLifecycleCommandInternal(
+      command,
+      child_process.spawn,
+      options
+    );
+    if (options.connectSubprocessTerminator) {
+      SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
+    }
+    return child;
   }
 
   /**
@@ -603,12 +617,18 @@ export class Utilities {
       stdio.push('ipc');
     }
 
-    return spawnFunction(shellCommand, [commandFlags, command], {
+    const spawnOptions: child_process.SpawnOptions = {
       cwd: options.workingDirectory,
       shell: useShell,
       env: environment,
       stdio
-    });
+    };
+
+    if (options.connectSubprocessTerminator) {
+      Object.assign(spawnOptions, SubprocessTerminator.RECOMMENDED_OPTIONS);
+    }
+
+    return spawnFunction(shellCommand, [commandFlags, command], spawnOptions);
   }
 
   /**


### PR DESCRIPTION
## Summary
Adds the ability for Rush to communicate with long-lived child build processes via the IPC protocol from `@rushstack/operation-graph`.

## Details
Adds a new experiment `useIPCScriptsInWatchMode`. When this flag is enabled and Rush is running in watch mode, it will check for npm scripts named `_phase:<phase-name>:ipc`, and if found, use them instead of the normal invocation of `_phase:<phase-name>`. When doing so, it will provide an IPC channel to the child process and expect the child to outlive the current build pass.

For watch-enabled commands, when opted into the experiment, adds a flag `--no-ipc` that disables the behavior for the current execution.

Updates the watcher prompt with new functionality:
- Press `i` to invalidate all projects and force a rebuild.
- Press `x` to shut down all IPC children (they will be recreated on the next pass).

![image](https://github.com/microsoft/rushstack/assets/26827560/b7bdf323-d1b9-44ec-8996-5ecbd92b7378)

![image](https://github.com/microsoft/rushstack/assets/26827560/4b28e571-e63f-4589-b529-5e050cc70ef1)

Factors out the logic used to construct the project logger to disk to share the code between the existing `ShellOperationRunner` and the new `IPCOperationRunner`.

In theory the capabilities of the `IPCOperationRunner` are a superset of those of the `ShellOperationRunner`, but as currently designed the `IPCOperationRunner` explicitly disables the build cache.

## Not included in this PR
Automated shutdown of child processes in response to memory pressure, or ability to selectively shut down processes via CLI.

## How it was tested
- [x] Local runs on the codespace
- [x] Prerelease build

## Impacted documentation
Documentation on `experiments.json`. Documentation for watch mode commands.