### PR TITLE
[node-core-library] Fix parsing of process name on MacOS

### DIFF
--- a/common/changes/@rushstack/node-core-library/user-danade-FixProcessList_2024-01-23-18-56.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-FixProcessList_2024-01-23-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix Executable.getProcessInfoBy* methods truncating the process name on MacOS",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/test/Executable.test.ts
+++ b/libraries/node-core-library/src/test/Executable.test.ts
@@ -341,18 +341,19 @@ describe('Executable process list', () => {
   ];
 
   const UNIX_PROCESS_LIST_OUTPUT: (string | null)[] = [
-    'COMMAND                PPID   PID\n',
+    'PPID   PID   COMMAND\n',
     // Test that the parser can handle referencing a parent that doesn't exist
-    'init                      0     1\n',
-    'process2           ',
+    '   0     1   init\n',
     // Test that the parser can handle a line that is truncated in the middle of a field
     // Test that the parser can handle an entry referencing a parent that hasn't been seen yet
-    '       2     4\n',
-    'process0                  1     2\n',
+    // Test that the parser can handle whitespace at the end of the process name.
+    '   2     4',
+    '   process2           \n',
+    '   1     2   process0\n',
     // Test that the parser can handle empty strings
     '',
     // Test children handling when multiple entries reference the same parent
-    'process1                  1     3\n'
+    '   1     3   process1\n'
   ];
 
   test('parses win32 output', () => {

--- a/libraries/node-core-library/src/test/Executable.test.ts
+++ b/libraries/node-core-library/src/test/Executable.test.ts
@@ -357,7 +357,10 @@ describe('Executable process list', () => {
   ];
 
   test('parses win32 output', () => {
-    const processListMap: Map<number, IProcessInfo> = parseProcessListOutput(WIN32_PROCESS_LIST_OUTPUT);
+    const processListMap: Map<number, IProcessInfo> = parseProcessListOutput(
+      WIN32_PROCESS_LIST_OUTPUT,
+      'win32'
+    );
     const results: IProcessInfo[] = [...processListMap.values()].sort();
 
     // Expect 7 because we reference a parent that doesn't exist
@@ -380,7 +383,8 @@ describe('Executable process list', () => {
 
   test('parses win32 stream output', async () => {
     const processListMap: Map<number, IProcessInfo> = await parseProcessListOutputAsync(
-      Readable.from(WIN32_PROCESS_LIST_OUTPUT)
+      Readable.from(WIN32_PROCESS_LIST_OUTPUT),
+      'win32'
     );
     const results: IProcessInfo[] = [...processListMap.values()].sort();
 
@@ -403,7 +407,10 @@ describe('Executable process list', () => {
   });
 
   test('parses unix output', () => {
-    const processListMap: Map<number, IProcessInfo> = parseProcessListOutput(UNIX_PROCESS_LIST_OUTPUT);
+    const processListMap: Map<number, IProcessInfo> = parseProcessListOutput(
+      UNIX_PROCESS_LIST_OUTPUT,
+      'linux'
+    );
     const results: IProcessInfo[] = [...processListMap.values()].sort();
 
     // Expect 5 because we reference a parent that doesn't exist
@@ -424,7 +431,8 @@ describe('Executable process list', () => {
 
   test('parses unix stream output', async () => {
     const processListMap: Map<number, IProcessInfo> = await parseProcessListOutputAsync(
-      Readable.from(UNIX_PROCESS_LIST_OUTPUT)
+      Readable.from(UNIX_PROCESS_LIST_OUTPUT),
+      'linux'
     );
     const results: IProcessInfo[] = [...processListMap.values()].sort();
 


### PR DESCRIPTION
## Summary

Fix parsing of the process name when using `Executable.getProcessInfoBy*` methods

## Details

On MacOS, the default `ps` command behavior truncates the process name from the `ps` command output. This PR instructs `ps` to display using the "wide" format, and specifies the command name last. This ensures that the output is not truncated regardless of how long the process name is.

## How it was tested

Tested by running on a Mac and an Ubuntu machine to ensure cross-compatibility of the changes.