### PR TITLE
[hashed-folder-copy-webpack-plugin] Fix hashed-folder-copy-plugin on Windows.

### DIFF
--- a/common/changes/@rushstack/hashed-folder-copy-plugin/fix-hashed-folder-copy-plugin-windows_2024-01-25-19-47.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/fix-hashed-folder-copy-plugin-windows_2024-01-25-19-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "Fix an issue where builds running on Windows and not on the C drive would not discover assets.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/webpack/hashed-folder-copy-plugin/src/HashedFolderDependency.ts
+++ b/webpack/hashed-folder-copy-plugin/src/HashedFolderDependency.ts
@@ -159,7 +159,7 @@ function _getHashedFolderDependencyForWebpackInstance(webpack: typeof import('we
             compilation.errors.push(new webpack.WebpackError(errorMessage));
             return renderError(errorMessage);
           } else {
-            resolvedGlobsBase = path.posix.resolve(context, globsBase);
+            resolvedGlobsBase = path.resolve(context, globsBase);
           }
         } else if (path.isAbsolute(globsBase)) {
           // This is an absolute path
@@ -213,7 +213,7 @@ function _getHashedFolderDependencyForWebpackInstance(webpack: typeof import('we
           }
 
           if (packagePath) {
-            resolvedGlobsBase = path.posix.join(packagePath, pathInsidePackage);
+            resolvedGlobsBase = path.join(packagePath, pathInsidePackage);
           } else {
             const errorMessage: string = `Unable to resolve package "${packageName}"`;
             compilation.errors.push(new webpack.WebpackError(errorMessage));

--- a/webpack/hashed-folder-copy-plugin/src/test/HashedFolderCopyPlugin.test.ts
+++ b/webpack/hashed-folder-copy-plugin/src/test/HashedFolderCopyPlugin.test.ts
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+jest.mock('node:path', () => {
+  const path: typeof import('path') = jest.requireActual('path');
+  return path.posix;
+});
+
 jest.mock(
   'fast-glob/out/providers/provider',
   () => {
-    const path: typeof import('path') = require('path');
+    const path: typeof import('path') = jest.requireActual('path');
     const { default: provider } = jest.requireActual('fast-glob/out/providers/provider');
     provider.prototype._getRootDirectory = function (task: { base: string }) {
       // fast-glob calls `path.resolve` which doesn't work correctly with the MemFS volume while running on Windows


### PR DESCRIPTION
## Summary

There is an issue where the glob pattern doesn't match anything when a build is running on Windows on the non-default drive. This is because the glob path base is constructed with `path.posix.resolve`, which drops the drive letter.

## How it was tested

Tested on Windows on the non-default drive.

## Impacted documentation

None.