### PR TITLE
[node-core-library] Gracefully handle irregular LockFile.tryAcquire fail on macOS/Linux

### DIFF
--- a/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-14-13.json
+++ b/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Gracefully handle irregular LockFile.tryAcquire fail on macOS/Linux when multiple processes try to acquire the same lock",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-14-13.json
+++ b/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-14-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Gracefully handle irregular LockFile.tryAcquire fail on macOS/Linux when multiple processes try to acquire the same lock",
+      "comment": "LockFile: prevent accidentaly deleting freshly created lockfile when multiple processes try to acquire the same lock on macOS/Linux",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-21-11.json
+++ b/common/changes/@rushstack/node-core-library/feature-lockfile-handle-failure-gracefully_2024-01-29-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add getStatistics() method to FileWriter instances",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -304,9 +304,13 @@ export type FileSystemStats = fs.Stats;
 export class FileWriter {
     close(): void;
     readonly filePath: string;
+    getStatistics(): FileWriterStats;
     static open(filePath: string, flags?: IFileWriterFlags): FileWriter;
     write(text: string): void;
 }
+
+// @public
+export type FileWriterStats = fs.Stats;
 
 // @public
 export enum FolderConstants {

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -304,13 +304,10 @@ export type FileSystemStats = fs.Stats;
 export class FileWriter {
     close(): void;
     readonly filePath: string;
-    getStatistics(): FileWriterStats;
+    getStatistics(): FileSystemStats;
     static open(filePath: string, flags?: IFileWriterFlags): FileWriter;
     write(text: string): void;
 }
-
-// @public
-export type FileWriterStats = fs.Stats;
 
 // @public
 export enum FolderConstants {

--- a/libraries/node-core-library/src/FileWriter.ts
+++ b/libraries/node-core-library/src/FileWriter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type * as fs from 'fs';
+import type { FileSystemStats } from './FileSystem';
 import { Import } from './Import';
 
 const fsx: typeof import('fs-extra') = Import.lazy('fs-extra', require);
@@ -33,15 +33,6 @@ export interface IFileWriterFlags {
    */
   exclusive?: boolean;
 }
-
-/**
- * An alias for the Node.js `fs.Stats` object.
- *
- * @remarks
- * This avoids the need to import the `fs` package when using the {@link FileWriter} API.
- * @public
- */
-export type FileWriterStats = fs.Stats;
 
 /**
  * API for interacting with file handles.
@@ -117,7 +108,7 @@ export class FileWriter {
    * Gets the statistics for the given file handle. Throws if the file handle has been closed.
    * Behind the scenes it uses `fs.statSync()`.
    */
-  public getStatistics(): FileWriterStats {
+  public getStatistics(): FileSystemStats {
     if (!this._fileDescriptor) {
       throw new Error(`Cannot get file statistics, file descriptor has already been released.`);
     }

--- a/libraries/node-core-library/src/FileWriter.ts
+++ b/libraries/node-core-library/src/FileWriter.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type * as fs from 'fs';
 import { Import } from './Import';
 
 const fsx: typeof import('fs-extra') = Import.lazy('fs-extra', require);
@@ -32,6 +33,15 @@ export interface IFileWriterFlags {
    */
   exclusive?: boolean;
 }
+
+/**
+ * An alias for the Node.js `fs.Stats` object.
+ *
+ * @remarks
+ * This avoids the need to import the `fs` package when using the {@link FileWriter} API.
+ * @public
+ */
+export type FileWriterStats = fs.Stats;
 
 /**
  * API for interacting with file handles.
@@ -101,5 +111,17 @@ export class FileWriter {
       this._fileDescriptor = undefined;
       fsx.closeSync(fd);
     }
+  }
+
+  /**
+   * Gets the statistics for the given file handle. Throws if the file handle has been closed.
+   * Behind the scenes it uses `fs.statSync()`.
+   */
+  public getStatistics(): FileWriterStats {
+    if (!this._fileDescriptor) {
+      throw new Error(`Cannot get file statistics, file descriptor has already been released.`);
+    }
+
+    return fsx.fstatSync(this._fileDescriptor);
   }
 }

--- a/libraries/node-core-library/src/LockFile.ts
+++ b/libraries/node-core-library/src/LockFile.ts
@@ -266,7 +266,7 @@ export class LockFile {
         // We should ideally maintain a dictionary of normalized acquired filenames
         lockFileHandle = FileWriter.open(pidLockFilePath);
         lockFileHandle.write(startTime);
-        currentBirthTimeMs = FileSystem.getStatistics(pidLockFilePath).birthtime.getTime();
+        currentBirthTimeMs = lockFileHandle.getStatistics().birthtime.getTime();
       } catch (error) {
         // sometimes FileSystem.getStatistics leads to failure when multiple processes try to acquire
         // lock for the same resource, so if we get an error, gracefully exit.

--- a/libraries/node-core-library/src/LockFile.ts
+++ b/libraries/node-core-library/src/LockFile.ts
@@ -257,15 +257,13 @@ export class LockFile {
 
     let lockFile: LockFile;
 
-    let currentBirthTimeMs: number;
-
     try {
       // open in write mode since if this file exists, it cannot be from the current process
       // TODO: This will malfunction if the same process tries to acquire two locks on the same file.
       // We should ideally maintain a dictionary of normalized acquired filenames
       lockFileHandle = FileWriter.open(pidLockFilePath);
       lockFileHandle.write(startTime);
-      currentBirthTimeMs = lockFileHandle.getStatistics().birthtime.getTime();
+      const currentBirthTimeMs: number = lockFileHandle.getStatistics().birthtime.getTime();
 
       let smallestBirthTimeMs: number = currentBirthTimeMs;
       let smallestBirthTimePid: string = pid.toString();

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -98,7 +98,7 @@ export {
   IFileSystemUpdateTimeParameters,
   IFileSystemWriteFileOptions
 } from './FileSystem';
-export { FileWriter, FileWriterStats, IFileWriterFlags } from './FileWriter';
+export { FileWriter, IFileWriterFlags } from './FileWriter';
 export { LegacyAdapters, LegacyCallback } from './LegacyAdapters';
 export { StringBuilder, IStringBuilder } from './StringBuilder';
 export { ISubprocessOptions, SubprocessTerminator } from './SubprocessTerminator';

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -98,7 +98,7 @@ export {
   IFileSystemUpdateTimeParameters,
   IFileSystemWriteFileOptions
 } from './FileSystem';
-export { FileWriter, IFileWriterFlags } from './FileWriter';
+export { FileWriter, FileWriterStats, IFileWriterFlags } from './FileWriter';
 export { LegacyAdapters, LegacyCallback } from './LegacyAdapters';
 export { StringBuilder, IStringBuilder } from './StringBuilder';
 export { ISubprocessOptions, SubprocessTerminator } from './SubprocessTerminator';

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -201,6 +201,20 @@ describe(LockFile.name, () => {
         // this lock should be undefined since there is an existing lock
         expect(lock).toBeUndefined();
       });
+
+      test('gracefully handles failure to read lock file statistics', () => {
+        const testFolder: string = path.join(libTestFolder, '4');
+        const resourceName: string = 'test';
+
+        // simulate failure; see https://github.com/microsoft/rushstack/issues/4491
+        jest.spyOn(FileSystem, 'getStatistics').mockImplementation(() => {
+          throw new Error();
+        });
+
+        const lock: LockFile | undefined = LockFile.tryAcquire(testFolder, resourceName);
+
+        expect(lock).toBeUndefined();
+      });
     });
   }
 

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -208,7 +208,7 @@ describe(LockFile.name, () => {
         const resourceName: string = 'test';
 
         // simulate failure; see https://github.com/microsoft/rushstack/issues/4491
-        jest.spyOn(FileSystem, 'getStatistics').mockImplementation(() => {
+        jest.spyOn(FileWriter.prototype, 'getStatistics').mockImplementation(() => {
           throw new Error();
         });
 

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -16,6 +16,7 @@ const libTestFolder: string = path.resolve(__dirname, '../../lib/test');
 
 describe(LockFile.name, () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     setLockFileGetProcessStartTime(getProcessStartTime);
   });
 

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -262,14 +262,14 @@ describe(LockFile.name, () => {
         });
 
         const originalReadFile = FileSystem.readFile;
-        jest.spyOn(FileSystem, 'readFile').mockImplementation((path: string) => {
-          if (path === otherPidLockFileName) {
+        jest.spyOn(FileSystem, 'readFile').mockImplementation((filePath: string) => {
+          if (filePath === otherPidLockFileName) {
             // simulate other process lock release right before the current process reads
             // other process lockfile to decide on next steps for acquiring the lock
-            FileSystem.deleteFile(path);
+            FileSystem.deleteFile(filePath);
           }
 
-          return originalReadFile(path);
+          return originalReadFile(filePath);
         });
 
         const deleteFileSpy = jest.spyOn(FileSystem, 'deleteFile');


### PR DESCRIPTION
Fixes #4491

## Summary and details

See https://github.com/microsoft/rushstack/pull/4497#issuecomment-1918189321

There are two fixes in this PR:

1. Fixed the root cause of the unexpected ENOENT error
2. Added `getStatistics` method to `FileWriter` [as requested](https://github.com/microsoft/rushstack/pull/4497#discussion_r1470058232)

## How it was tested

I’ve added a corresponding test case to LockFile tests suite