### PR TITLE
Clean up install-test-workspace and put the store in ./temp

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   rush-lib-test:
     dependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.113.0.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.113.0.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.113.2.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.113.2.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
@@ -30,15 +30,15 @@ importers:
   rush-sdk-test:
     dependencies:
       '@rushstack/rush-sdk':
-        specifier: file:rushstack-rush-sdk-5.113.0.tgz
-        version: file:../temp/tarballs/rushstack-rush-sdk-5.113.0.tgz(@types/node@18.17.15)
+        specifier: file:rushstack-rush-sdk-5.113.2.tgz
+        version: file:../temp/tarballs/rushstack-rush-sdk-5.113.2.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.113.0.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.113.0.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.113.2.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.113.2.tgz(@types/node@18.17.15)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -234,7 +234,7 @@ packages:
       debug: 4.3.4
       espree: 9.3.2
       globals: 13.15.0
-      ignore: 5.2.0
+      ignore: 5.3.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -1649,7 +1649,7 @@ packages:
     dependencies:
       acorn: 8.7.1
       acorn-jsx: 5.3.2(acorn@8.7.1)
-      eslint-visitor-keys: 3.3.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /esprima@4.0.1:
@@ -1821,9 +1821,6 @@ packages:
     deprecated: '"Please update to latest v2.3 or v2.2"'
     requiresBuild: true
     optional: true
-
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2062,7 +2059,8 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
+    dev: true
 
   /hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
@@ -2251,11 +2249,6 @@ packages:
     hasBin: true
     dependencies:
       ci-info: 2.0.0
-
-  /is-core-module@2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
-    dependencies:
-      has: 1.0.3
 
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
@@ -3423,7 +3416,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -4245,11 +4238,11 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.113.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.113.0.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.113.0.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.113.2.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.113.2.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.113.2.tgz
     name: '@microsoft/rush-lib'
-    version: 5.113.0
+    version: 5.113.2
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/dependency-path': 2.1.2
@@ -4585,11 +4578,11 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.113.0.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.113.0.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.113.0.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.113.2.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.113.2.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.113.2.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.113.0
+    version: 5.113.2
     dependencies:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.64.2.tgz(@types/node@18.17.15)
       '@types/node-fetch': 2.6.2


### PR DESCRIPTION
Currently `install-test-workspace` can end up with a poisoned cache in the pnpm store. This puts the pnpm store in the project's temp folder.