### PR TITLE
[rush] Fix an issue with pnpm-lock.yaml not getting synced back.

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-01-31-21-44.json
+++ b/common/changes/@microsoft/rush/main_2024-01-31-21-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where `rush update` would sometimes not correctly sync the `pnpm-lock.yaml` file back to `common/config/rush/` after a project's `package.json` has been updated.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -303,10 +303,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
 
       // Now, we compare these two objects to see if they are equal or not
-      shrinkwrapIsUpToDate = objectsAreDeepEqual(
-        packagePathToDependenciesMetaInPackageJson,
-        packagePathToDependenciesMetaInShrinkwrapFile
-      );
+      shrinkwrapIsUpToDate =
+        objectsAreDeepEqual(
+          packagePathToDependenciesMetaInPackageJson,
+          packagePathToDependenciesMetaInShrinkwrapFile
+        ) && shrinkwrapIsUpToDate;
     }
 
     // Write the common package.json


### PR DESCRIPTION
## Summary

This is a regression that was introduced in https://github.com/microsoft/rushstack/pull/4453.

## Details

The `shrinkwrapIsUpToDate` is currently being set to whether the last project in `rush.json`'s project list's `dependenciesMeta` matches what's in the lockfile and ignores other checks. This PR includes the other checks.

## How it was tested

Tested locally.

## Impacted documentation

None.