### PR TITLE
[eslint-plugin]: Allow using `as const` in `typedef-var`

### DIFF
--- a/common/changes/@rushstack/eslint-plugin/feat-typedef-var-as-const_2024-02-05-18-53.json
+++ b/common/changes/@rushstack/eslint-plugin/feat-typedef-var-as-const_2024-02-05-18-53.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@rushstack/eslint-plugin",
       "comment": "Allow using `as const` in `typedef-var`",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/eslint-plugin"

--- a/common/changes/@rushstack/eslint-plugin/feat-typedef-var-as-const_2024-02-05-18-53.json
+++ b/common/changes/@rushstack/eslint-plugin/feat-typedef-var-as-const_2024-02-05-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Allow using `as const` in `typedef-var`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/eslint/eslint-plugin/src/test/typedef-var.test.ts
+++ b/eslint/eslint-plugin/src/test/typedef-var.test.ts
@@ -47,6 +47,9 @@ ruleTester.run('typedef-var', typedefVar, {
       code: 'for (const x of []) { }'
     },
     {
+      code: 'const x = 1 as const;'
+    },
+    {
       // prettier-ignore
       code: [
         'let { a , b } = {',

--- a/eslint/eslint-plugin/src/test/typedef-var.test.ts
+++ b/eslint/eslint-plugin/src/test/typedef-var.test.ts
@@ -50,6 +50,9 @@ ruleTester.run('typedef-var', typedefVar, {
       code: 'const x = 1 as const;'
     },
     {
+      code: 'const x: 1 = 1;'
+    },
+    {
       code: 'const x: number = 1;'
     },
     {

--- a/eslint/eslint-plugin/src/test/typedef-var.test.ts
+++ b/eslint/eslint-plugin/src/test/typedef-var.test.ts
@@ -50,6 +50,9 @@ ruleTester.run('typedef-var', typedefVar, {
       code: 'const x = 1 as const;'
     },
     {
+      code: 'const x: number = 1;'
+    },
+    {
       // prettier-ignore
       code: [
         'let { a , b } = {',

--- a/eslint/eslint-plugin/src/typedef-var.ts
+++ b/eslint/eslint-plugin/src/typedef-var.ts
@@ -50,6 +50,16 @@ const typedefVar: TSESLint.RuleModule<MessageIds, Options> = {
           return;
         }
 
+        if (
+          node.init?.type === AST_NODE_TYPES.TSAsExpression &&
+          node.init.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
+          node.init.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier &&
+          node.init.typeAnnotation.typeName.name === 'const'
+        ) {
+          // An `as const` type declaration was provided
+          return;
+        }
+
         // These are @typescript-eslint/typedef exemptions
         if (
           node.id.type === AST_NODE_TYPES.ArrayPattern /* ArrayDestructuring */ ||


### PR DESCRIPTION
## Summary

Closes #4446 


## Details

Added support for `const x = 1 as const` instead of forcing the developer to add a type annotation.
In addition, added a missing test for the "happy flow" of writing `const x: number = 1;`

