### PR TITLE
[api-extractor] Classify arrow functions as function kind in the doc model exports.

### DIFF
--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -252,7 +252,7 @@ export class ApiModelGenerator {
       case ts.SyntaxKind.VariableDeclaration:
         // check for arrow functions in variable declaration
         const functionDeclaration: ts.FunctionDeclaration | undefined =
-          this._hasFunctionDeclaration(astDeclaration);
+          this._tryFindFunctionDeclaration(astDeclaration);
         if (functionDeclaration) {
           this._processApiFunction(astDeclaration, context, functionDeclaration);
         } else {
@@ -265,7 +265,7 @@ export class ApiModelGenerator {
     }
   }
 
-  private _hasFunctionDeclaration(astDeclaration: AstDeclaration): ts.FunctionDeclaration | undefined {
+  private _tryFindFunctionDeclaration(astDeclaration: AstDeclaration): ts.FunctionDeclaration | undefined {
     const children: ts.Node[] = astDeclaration.declaration.getChildren(
       astDeclaration.declaration.getSourceFile()
     );

--- a/build-tests/api-extractor-scenarios/etc/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -173,27 +173,28 @@
       "preserveMemberOrder": false,
       "members": [
         {
-          "kind": "Variable",
-          "canonicalReference": "api-extractor-scenarios!defaultFunctionStatement:var",
+          "kind": "Function",
+          "canonicalReference": "api-extractor-scenarios!defaultFunctionStatement:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "defaultFunctionStatement: "
+              "text": "defaultFunctionStatement: () => "
             },
             {
               "kind": "Content",
-              "text": "() => void"
+              "text": "void"
             }
           ],
           "fileUrlPath": "src/defaultExportOfEntryPoint2/index.ts",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "defaultFunctionStatement",
-          "variableTypeTokenRange": {
+          "returnTypeTokenRange": {
             "startIndex": 1,
             "endIndex": 2
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "defaultFunctionStatement"
         }
       ]
     }

--- a/build-tests/api-extractor-scenarios/etc/spanSorting/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/spanSorting/api-extractor-scenarios.api.json
@@ -375,27 +375,45 @@
           "implementsTokenRanges": []
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "api-extractor-scenarios!exampleD:var",
+          "kind": "Function",
+          "canonicalReference": "api-extractor-scenarios!exampleD:function(1)",
           "docComment": "/**\n * Outer description\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "exampleD: "
+              "text": "exampleD: (o: "
             },
             {
               "kind": "Content",
-              "text": "(o: {\n    a: number;\n    b(): string;\n}) => void"
+              "text": "{\n    a: number;\n    b(): string;\n}"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "void"
             }
           ],
           "fileUrlPath": "src/spanSorting/index.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 4
+          },
           "releaseTag": "Public",
-          "name": "exampleD",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "o",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "exampleD"
         }
       ]
     }

--- a/common/changes/@microsoft/api-extractor/bartvandenende-wm-api-extractor-arrow-func_2024-02-06-14-12.json
+++ b/common/changes/@microsoft/api-extractor/bartvandenende-wm-api-extractor-arrow-func_2024-02-06-14-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "\"Classify arrow functions as 'function' kind in the doc model export\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/bartvandenende-wm-api-extractor-arrow-func_2024-02-06-14-12.json
+++ b/common/changes/@microsoft/api-extractor/bartvandenende-wm-api-extractor-arrow-func_2024-02-06-14-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "\"Classify arrow functions as 'function' kind in the doc model export\"",
+      "comment": "Classify arrow functions as `function` kind in the doc model export.",
       "type": "minor"
     }
   ],


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Classify arrow functions as function kind in the doc model exports.

Related issue ticket https://github.com/microsoft/rushstack/issues/1629

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

<img width="730" alt="Screenshot 2024-02-06 at 16 54 40" src="https://github.com/microsoft/rushstack/assets/65355342/9726f3cd-6f85-48dc-83a0-8c4d6f704d47">

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

The current behaviour of api-extractor is to classify arrow functions as `variable` kind. Even though syntactically correct, semantically (for documentation & usage purposes) this doesn't make any sense - and worse - it invalidates any documentation effort in the docstrings related to parameter descriptions, return types etc. 

This PR modifies the doc-model generation to identify arrow functions in the variable declarations and processes them as function kinds instead.

Example code
```typescript
/**
 * Demo log function
 * @param message - log message
 * @public
 */
export const log = (message: string): void => {console.log(message)}
```

**doc model exports**
_Previous behaviour_
```json
{
  "kind": "Variable",
  "canonicalReference": "sample-lib!log:var",
  "docComment": "/**\n * Demo log function\n *\n * @param message - log message\n */\n",
  "excerptTokens": [
    {
      "kind": "Content",
      "text": "log: "
    },
    {
      "kind": "Content",
      "text": "(message: string) => void"
    }
  ],
  "fileUrlPath": "src/index.ts",
  "isReadonly": true,
  "releaseTag": "Public",
  "name": "log",
  "variableTypeTokenRange": {
    "startIndex": 1,
    "endIndex": 2
  }
}
```

_New behaviour_
```json
  {
    "kind": "Function",
    "canonicalReference": "sample-lib!log:function(1)",
    "docComment": "/**\n * Demo log function\n *\n * @param message - log message\n */\n",
    "excerptTokens": [
      {
        "kind": "Content",
        "text": "log: (message: "
      },
      {
        "kind": "Content",
        "text": "string"
      },
      {
        "kind": "Content",
        "text": ") => "
      },
      {
        "kind": "Content",
        "text": "void"
      }
    ],
    "fileUrlPath": "src/index.ts",
    "returnTypeTokenRange": {
      "startIndex": 3,
      "endIndex": 4
    },
    "releaseTag": "Public",
    "overloadIndex": 1,
    "parameters": [
      {
        "parameterName": "message",
        "parameterTypeTokenRange": {
          "startIndex": 1,
          "endIndex": 2
        },
        "isOptional": false
      }
    ],
    "name": "log"
  }
``` 

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

manual testing

## Impacted documentation

N/A

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
