### PR TITLE
[webpack5-localization-plugin] Add support for output.hashSalt.

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/hash-salt_2024-02-10-00-58.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/hash-salt_2024-02-10-00-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Add support for the `output.hashSalt` option when the `realContentHashes` feature is enabled.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/webpack/webpack5-localization-plugin/src/test/MixedAsync.test.ts
+++ b/webpack/webpack5-localization-plugin/src/test/MixedAsync.test.ts
@@ -65,7 +65,8 @@ async function testMixedAsyncInner(minimize: boolean): Promise<void> {
     output: {
       path: '/release',
       filename: '[name]-[locale]-[contenthash].js',
-      chunkFilename: 'chunks/[name]-[locale]-[contenthash].js'
+      chunkFilename: 'chunks/[name]-[locale]-[contenthash].js',
+      hashSalt: '1'
     },
     module: {
       rules: [

--- a/webpack/webpack5-localization-plugin/src/test/__snapshots__/MixedAsync.test.ts.snap
+++ b/webpack/webpack5-localization-plugin/src/test/__snapshots__/MixedAsync.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`LocalizationPlugin Handles async localized and non-localized chunks (minified): Content 1`] = `
 Object {
-  "/release/chunks/async1-none-601040199af8b30e4f45.js": "(self.webpackChunk=self.webpackChunk||[]).push([[515],{\\"./a/async1.js\\":()=>{console.log(\\"blah1\\")}}]);",
-  "/release/chunks/async2-none-e2b5ccff78b9ee8b0269.js": "(self.webpackChunk=self.webpackChunk||[]).push([[989],{\\"./a/async2.js\\":()=>{console.log(\\"blah2\\")}}]);",
-  "/release/chunks/asyncLoc1-LOCALE1-168f848b770aa62ad17d.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[14],{\\"./a/asyncLoc1.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test,t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"blah\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"something else\\"}}}]);",
-  "/release/chunks/asyncLoc1-LOCALE2-14e0a3b5691b9628be91.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[14],{\\"./a/asyncLoc1.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test,t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"baz\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"some random translation\\"}}}]);",
-  "/release/chunks/asyncLoc2-LOCALE1-e442ade75ccc8ccb7d2f.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[5],{\\"./a/asyncLoc2.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test+t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"blah\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"something else\\"}}}]);",
-  "/release/chunks/asyncLoc2-LOCALE2-fd29172ccf479e97aa94.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[5],{\\"./a/asyncLoc2.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test+t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"baz\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"some random translation\\"}}}]);",
-  "/release/main-LOCALE1-3cbc930b5f99a71a9557.js": "(()=>{var e,r,t,n={},o={};function a(e){var r=o[e];if(void 0!==r)return r.exports;var t=o[e]={exports:{}};return n[e](t,t.exports,a),t.exports}a.m=n,r=Object.getPrototypeOf?e=>Object.getPrototypeOf(e):e=>e.__proto__,a.t=function(t,n){if(1&n&&(t=this(t)),8&n)return t;if(\\"object\\"==typeof t&&t){if(4&n&&t.__esModule)return t;if(16&n&&\\"function\\"==typeof t.then)return t}var o=Object.create(null);a.r(o);var i={};e=e||[null,r({}),r([]),r(r)];for(var c=2&n&&t;\\"object\\"==typeof c&&!~e.indexOf(c);c=r(c))Object.getOwnPropertyNames(c).forEach((e=>i[e]=()=>t[e]));return i.default=()=>t,a.d(o,i),o},a.d=(e,r)=>{for(var t in r)a.o(r,t)&&!a.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},a.f={},a.e=e=>Promise.all(Object.keys(a.f).reduce(((r,t)=>(a.f[t](e,r),r)),[])),a.u=e=>\\"chunks/\\"+{5:\\"asyncLoc2\\",14:\\"asyncLoc1\\",515:\\"async1\\",989:\\"async2\\"}[e]+\\"-\\"+({5:1,14:1}[e]?\\"LOCALE1\\":\\"none\\")+\\"-\\"+{5:\\"e442ade75ccc8ccb7d2f\\",14:\\"168f848b770aa62ad17d\\",515:\\"601040199af8b30e4f45\\",989:\\"e2b5ccff78b9ee8b0269\\"}[e]+\\".js\\",a.g=function(){if(\\"object\\"==typeof globalThis)return globalThis;try{return this||new Function(\\"return this\\")()}catch(e){if(\\"object\\"==typeof window)return window}}(),a.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),t={},a.l=(e,r,n,o)=>{if(t[e])t[e].push(r);else{var i,c;if(void 0!==n)for(var s=document.getElementsByTagName(\\"script\\"),u=0;u<s.length;u++){var f=s[u];if(f.getAttribute(\\"src\\")==e){i=f;break}}i||(c=!0,(i=document.createElement(\\"script\\")).charset=\\"utf-8\\",i.timeout=120,a.nc&&i.setAttribute(\\"nonce\\",a.nc),i.src=e),t[e]=[r];var l=(r,n)=>{i.onerror=i.onload=null,clearTimeout(d);var o=t[e];if(delete t[e],i.parentNode&&i.parentNode.removeChild(i),o&&o.forEach((e=>e(n))),r)return r(n)},d=setTimeout(l.bind(null,void 0,{type:\\"timeout\\",target:i}),12e4);i.onerror=l.bind(null,i.onerror),i.onload=l.bind(null,i.onload),c&&document.head.appendChild(i)}},a.r=e=>{\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},(()=>{var e;a.g.importScripts&&(e=a.g.location+\\"\\");var r=a.g.document;if(!e&&r&&(r.currentScript&&(e=r.currentScript.src),!e)){var t=r.getElementsByTagName(\\"script\\");if(t.length)for(var n=t.length-1;n>-1&&!e;)e=t[n--].src}if(!e)throw new Error(\\"Automatic publicPath is not supported in this browser\\");e=e.replace(/#.*$/,\\"\\").replace(/\\\\?.*$/,\\"\\").replace(/\\\\/[^\\\\/]+$/,\\"/\\"),a.p=e})(),(()=>{var e={179:0};a.f.j=(r,t)=>{var n=a.o(e,r)?e[r]:void 0;if(0!==n)if(n)t.push(n[2]);else{var o=new Promise(((t,o)=>n=e[r]=[t,o]));t.push(n[2]=o);var i=a.p+a.u(r),c=new Error;a.l(i,(t=>{if(a.o(e,r)&&(0!==(n=e[r])&&(e[r]=void 0),n)){var o=t&&(\\"load\\"===t.type?\\"missing\\":t.type),i=t&&t.target&&t.target.src;c.message=\\"Loading chunk \\"+r+\\" failed.\\\\n(\\"+o+\\": \\"+i+\\")\\",c.name=\\"ChunkLoadError\\",c.type=o,c.request=i,n[1](c)}}),\\"chunk-\\"+r,r)}};var r=(r,t)=>{var n,o,[i,c,s]=t,u=0;if(i.some((r=>0!==e[r]))){for(n in c)a.o(c,n)&&(a.m[n]=c[n]);s&&s(a)}for(r&&r(t);u<i.length;u++)o=i[u],a.o(e,o)&&e[o]&&e[o][0](),e[o]=0},t=self.webpackChunk=self.webpackChunk||[];t.forEach(r.bind(null,0)),t.push=r.bind(null,t.push.bind(t))})(),a.e(14).then(a.bind(a,\\"./a/asyncLoc1.js\\")),a.e(5).then(a.bind(a,\\"./a/asyncLoc2.js\\")),a.e(515).then(a.t.bind(a,\\"./a/async1.js\\",23)),a.e(989).then(a.t.bind(a,\\"./a/async2.js\\",23))})();",
-  "/release/main-LOCALE2-ba8327e9cbb975e3da43.js": "(()=>{var e,r,t,n={},o={};function a(e){var r=o[e];if(void 0!==r)return r.exports;var t=o[e]={exports:{}};return n[e](t,t.exports,a),t.exports}a.m=n,r=Object.getPrototypeOf?e=>Object.getPrototypeOf(e):e=>e.__proto__,a.t=function(t,n){if(1&n&&(t=this(t)),8&n)return t;if(\\"object\\"==typeof t&&t){if(4&n&&t.__esModule)return t;if(16&n&&\\"function\\"==typeof t.then)return t}var o=Object.create(null);a.r(o);var i={};e=e||[null,r({}),r([]),r(r)];for(var c=2&n&&t;\\"object\\"==typeof c&&!~e.indexOf(c);c=r(c))Object.getOwnPropertyNames(c).forEach((e=>i[e]=()=>t[e]));return i.default=()=>t,a.d(o,i),o},a.d=(e,r)=>{for(var t in r)a.o(r,t)&&!a.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},a.f={},a.e=e=>Promise.all(Object.keys(a.f).reduce(((r,t)=>(a.f[t](e,r),r)),[])),a.u=e=>\\"chunks/\\"+{5:\\"asyncLoc2\\",14:\\"asyncLoc1\\",515:\\"async1\\",989:\\"async2\\"}[e]+\\"-\\"+({5:1,14:1}[e]?\\"LOCALE2\\":\\"none\\")+\\"-\\"+{5:\\"fd29172ccf479e97aa94\\",14:\\"14e0a3b5691b9628be91\\",515:\\"601040199af8b30e4f45\\",989:\\"e2b5ccff78b9ee8b0269\\"}[e]+\\".js\\",a.g=function(){if(\\"object\\"==typeof globalThis)return globalThis;try{return this||new Function(\\"return this\\")()}catch(e){if(\\"object\\"==typeof window)return window}}(),a.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),t={},a.l=(e,r,n,o)=>{if(t[e])t[e].push(r);else{var i,c;if(void 0!==n)for(var s=document.getElementsByTagName(\\"script\\"),u=0;u<s.length;u++){var f=s[u];if(f.getAttribute(\\"src\\")==e){i=f;break}}i||(c=!0,(i=document.createElement(\\"script\\")).charset=\\"utf-8\\",i.timeout=120,a.nc&&i.setAttribute(\\"nonce\\",a.nc),i.src=e),t[e]=[r];var l=(r,n)=>{i.onerror=i.onload=null,clearTimeout(d);var o=t[e];if(delete t[e],i.parentNode&&i.parentNode.removeChild(i),o&&o.forEach((e=>e(n))),r)return r(n)},d=setTimeout(l.bind(null,void 0,{type:\\"timeout\\",target:i}),12e4);i.onerror=l.bind(null,i.onerror),i.onload=l.bind(null,i.onload),c&&document.head.appendChild(i)}},a.r=e=>{\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},(()=>{var e;a.g.importScripts&&(e=a.g.location+\\"\\");var r=a.g.document;if(!e&&r&&(r.currentScript&&(e=r.currentScript.src),!e)){var t=r.getElementsByTagName(\\"script\\");if(t.length)for(var n=t.length-1;n>-1&&!e;)e=t[n--].src}if(!e)throw new Error(\\"Automatic publicPath is not supported in this browser\\");e=e.replace(/#.*$/,\\"\\").replace(/\\\\?.*$/,\\"\\").replace(/\\\\/[^\\\\/]+$/,\\"/\\"),a.p=e})(),(()=>{var e={179:0};a.f.j=(r,t)=>{var n=a.o(e,r)?e[r]:void 0;if(0!==n)if(n)t.push(n[2]);else{var o=new Promise(((t,o)=>n=e[r]=[t,o]));t.push(n[2]=o);var i=a.p+a.u(r),c=new Error;a.l(i,(t=>{if(a.o(e,r)&&(0!==(n=e[r])&&(e[r]=void 0),n)){var o=t&&(\\"load\\"===t.type?\\"missing\\":t.type),i=t&&t.target&&t.target.src;c.message=\\"Loading chunk \\"+r+\\" failed.\\\\n(\\"+o+\\": \\"+i+\\")\\",c.name=\\"ChunkLoadError\\",c.type=o,c.request=i,n[1](c)}}),\\"chunk-\\"+r,r)}};var r=(r,t)=>{var n,o,[i,c,s]=t,u=0;if(i.some((r=>0!==e[r]))){for(n in c)a.o(c,n)&&(a.m[n]=c[n]);s&&s(a)}for(r&&r(t);u<i.length;u++)o=i[u],a.o(e,o)&&e[o]&&e[o][0](),e[o]=0},t=self.webpackChunk=self.webpackChunk||[];t.forEach(r.bind(null,0)),t.push=r.bind(null,t.push.bind(t))})(),a.e(14).then(a.bind(a,\\"./a/asyncLoc1.js\\")),a.e(5).then(a.bind(a,\\"./a/asyncLoc2.js\\")),a.e(515).then(a.t.bind(a,\\"./a/async1.js\\",23)),a.e(989).then(a.t.bind(a,\\"./a/async2.js\\",23))})();",
+  "/release/chunks/async1-none-cae03d2626cc2ffa3508.js": "(self.webpackChunk=self.webpackChunk||[]).push([[515],{\\"./a/async1.js\\":()=>{console.log(\\"blah1\\")}}]);",
+  "/release/chunks/async2-none-a3af93683846f20fd06d.js": "(self.webpackChunk=self.webpackChunk||[]).push([[989],{\\"./a/async2.js\\":()=>{console.log(\\"blah2\\")}}]);",
+  "/release/chunks/asyncLoc1-LOCALE1-42ac7deedbceee724ebe.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[14],{\\"./a/asyncLoc1.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test,t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"blah\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"something else\\"}}}]);",
+  "/release/chunks/asyncLoc1-LOCALE2-9569ed1013c7d99991f0.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[14],{\\"./a/asyncLoc1.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test,t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"baz\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"some random translation\\"}}}]);",
+  "/release/chunks/asyncLoc2-LOCALE1-fbbf37c75a89cefa3a8b.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[5],{\\"./a/asyncLoc2.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test+t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"blah\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"something else\\"}}}]);",
+  "/release/chunks/asyncLoc2-LOCALE2-6f7d6cb21f686f18a3de.js": "\\"use strict\\";(self.webpackChunk=self.webpackChunk||[]).push([[5],{\\"./a/asyncLoc2.js\\":(s,_,n)=>{n.r(_);var o=n(\\"./a/strings1.loc.json\\"),t=n(\\"./a/strings2.loc.json\\");console.log(o.Z.test+t.Z.another)},\\"./a/strings1.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={test:\\"baz\\"}},\\"./a/strings2.loc.json\\":(s,_,n)=>{n.d(_,{Z:()=>o});const o={another:\\"some random translation\\"}}}]);",
+  "/release/main-LOCALE1-db5fee2775538b16fa56.js": "(()=>{var e,r,t,n={},o={};function a(e){var r=o[e];if(void 0!==r)return r.exports;var t=o[e]={exports:{}};return n[e](t,t.exports,a),t.exports}a.m=n,r=Object.getPrototypeOf?e=>Object.getPrototypeOf(e):e=>e.__proto__,a.t=function(t,n){if(1&n&&(t=this(t)),8&n)return t;if(\\"object\\"==typeof t&&t){if(4&n&&t.__esModule)return t;if(16&n&&\\"function\\"==typeof t.then)return t}var o=Object.create(null);a.r(o);var i={};e=e||[null,r({}),r([]),r(r)];for(var c=2&n&&t;\\"object\\"==typeof c&&!~e.indexOf(c);c=r(c))Object.getOwnPropertyNames(c).forEach((e=>i[e]=()=>t[e]));return i.default=()=>t,a.d(o,i),o},a.d=(e,r)=>{for(var t in r)a.o(r,t)&&!a.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},a.f={},a.e=e=>Promise.all(Object.keys(a.f).reduce(((r,t)=>(a.f[t](e,r),r)),[])),a.u=e=>\\"chunks/\\"+{5:\\"asyncLoc2\\",14:\\"asyncLoc1\\",515:\\"async1\\",989:\\"async2\\"}[e]+\\"-\\"+({5:1,14:1}[e]?\\"LOCALE1\\":\\"none\\")+\\"-\\"+{5:\\"fbbf37c75a89cefa3a8b\\",14:\\"42ac7deedbceee724ebe\\",515:\\"cae03d2626cc2ffa3508\\",989:\\"a3af93683846f20fd06d\\"}[e]+\\".js\\",a.g=function(){if(\\"object\\"==typeof globalThis)return globalThis;try{return this||new Function(\\"return this\\")()}catch(e){if(\\"object\\"==typeof window)return window}}(),a.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),t={},a.l=(e,r,n,o)=>{if(t[e])t[e].push(r);else{var i,c;if(void 0!==n)for(var s=document.getElementsByTagName(\\"script\\"),f=0;f<s.length;f++){var u=s[f];if(u.getAttribute(\\"src\\")==e){i=u;break}}i||(c=!0,(i=document.createElement(\\"script\\")).charset=\\"utf-8\\",i.timeout=120,a.nc&&i.setAttribute(\\"nonce\\",a.nc),i.src=e),t[e]=[r];var l=(r,n)=>{i.onerror=i.onload=null,clearTimeout(d);var o=t[e];if(delete t[e],i.parentNode&&i.parentNode.removeChild(i),o&&o.forEach((e=>e(n))),r)return r(n)},d=setTimeout(l.bind(null,void 0,{type:\\"timeout\\",target:i}),12e4);i.onerror=l.bind(null,i.onerror),i.onload=l.bind(null,i.onload),c&&document.head.appendChild(i)}},a.r=e=>{\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},(()=>{var e;a.g.importScripts&&(e=a.g.location+\\"\\");var r=a.g.document;if(!e&&r&&(r.currentScript&&(e=r.currentScript.src),!e)){var t=r.getElementsByTagName(\\"script\\");if(t.length)for(var n=t.length-1;n>-1&&!e;)e=t[n--].src}if(!e)throw new Error(\\"Automatic publicPath is not supported in this browser\\");e=e.replace(/#.*$/,\\"\\").replace(/\\\\?.*$/,\\"\\").replace(/\\\\/[^\\\\/]+$/,\\"/\\"),a.p=e})(),(()=>{var e={179:0};a.f.j=(r,t)=>{var n=a.o(e,r)?e[r]:void 0;if(0!==n)if(n)t.push(n[2]);else{var o=new Promise(((t,o)=>n=e[r]=[t,o]));t.push(n[2]=o);var i=a.p+a.u(r),c=new Error;a.l(i,(t=>{if(a.o(e,r)&&(0!==(n=e[r])&&(e[r]=void 0),n)){var o=t&&(\\"load\\"===t.type?\\"missing\\":t.type),i=t&&t.target&&t.target.src;c.message=\\"Loading chunk \\"+r+\\" failed.\\\\n(\\"+o+\\": \\"+i+\\")\\",c.name=\\"ChunkLoadError\\",c.type=o,c.request=i,n[1](c)}}),\\"chunk-\\"+r,r)}};var r=(r,t)=>{var n,o,[i,c,s]=t,f=0;if(i.some((r=>0!==e[r]))){for(n in c)a.o(c,n)&&(a.m[n]=c[n]);s&&s(a)}for(r&&r(t);f<i.length;f++)o=i[f],a.o(e,o)&&e[o]&&e[o][0](),e[o]=0},t=self.webpackChunk=self.webpackChunk||[];t.forEach(r.bind(null,0)),t.push=r.bind(null,t.push.bind(t))})(),a.e(14).then(a.bind(a,\\"./a/asyncLoc1.js\\")),a.e(5).then(a.bind(a,\\"./a/asyncLoc2.js\\")),a.e(515).then(a.t.bind(a,\\"./a/async1.js\\",23)),a.e(989).then(a.t.bind(a,\\"./a/async2.js\\",23))})();",
+  "/release/main-LOCALE2-e08dd16ea7f4a44191c3.js": "(()=>{var e,r,t,n={},o={};function a(e){var r=o[e];if(void 0!==r)return r.exports;var t=o[e]={exports:{}};return n[e](t,t.exports,a),t.exports}a.m=n,r=Object.getPrototypeOf?e=>Object.getPrototypeOf(e):e=>e.__proto__,a.t=function(t,n){if(1&n&&(t=this(t)),8&n)return t;if(\\"object\\"==typeof t&&t){if(4&n&&t.__esModule)return t;if(16&n&&\\"function\\"==typeof t.then)return t}var o=Object.create(null);a.r(o);var i={};e=e||[null,r({}),r([]),r(r)];for(var c=2&n&&t;\\"object\\"==typeof c&&!~e.indexOf(c);c=r(c))Object.getOwnPropertyNames(c).forEach((e=>i[e]=()=>t[e]));return i.default=()=>t,a.d(o,i),o},a.d=(e,r)=>{for(var t in r)a.o(r,t)&&!a.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},a.f={},a.e=e=>Promise.all(Object.keys(a.f).reduce(((r,t)=>(a.f[t](e,r),r)),[])),a.u=e=>\\"chunks/\\"+{5:\\"asyncLoc2\\",14:\\"asyncLoc1\\",515:\\"async1\\",989:\\"async2\\"}[e]+\\"-\\"+({5:1,14:1}[e]?\\"LOCALE2\\":\\"none\\")+\\"-\\"+{5:\\"6f7d6cb21f686f18a3de\\",14:\\"9569ed1013c7d99991f0\\",515:\\"cae03d2626cc2ffa3508\\",989:\\"a3af93683846f20fd06d\\"}[e]+\\".js\\",a.g=function(){if(\\"object\\"==typeof globalThis)return globalThis;try{return this||new Function(\\"return this\\")()}catch(e){if(\\"object\\"==typeof window)return window}}(),a.o=(e,r)=>Object.prototype.hasOwnProperty.call(e,r),t={},a.l=(e,r,n,o)=>{if(t[e])t[e].push(r);else{var i,c;if(void 0!==n)for(var s=document.getElementsByTagName(\\"script\\"),f=0;f<s.length;f++){var u=s[f];if(u.getAttribute(\\"src\\")==e){i=u;break}}i||(c=!0,(i=document.createElement(\\"script\\")).charset=\\"utf-8\\",i.timeout=120,a.nc&&i.setAttribute(\\"nonce\\",a.nc),i.src=e),t[e]=[r];var l=(r,n)=>{i.onerror=i.onload=null,clearTimeout(d);var o=t[e];if(delete t[e],i.parentNode&&i.parentNode.removeChild(i),o&&o.forEach((e=>e(n))),r)return r(n)},d=setTimeout(l.bind(null,void 0,{type:\\"timeout\\",target:i}),12e4);i.onerror=l.bind(null,i.onerror),i.onload=l.bind(null,i.onload),c&&document.head.appendChild(i)}},a.r=e=>{\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},(()=>{var e;a.g.importScripts&&(e=a.g.location+\\"\\");var r=a.g.document;if(!e&&r&&(r.currentScript&&(e=r.currentScript.src),!e)){var t=r.getElementsByTagName(\\"script\\");if(t.length)for(var n=t.length-1;n>-1&&!e;)e=t[n--].src}if(!e)throw new Error(\\"Automatic publicPath is not supported in this browser\\");e=e.replace(/#.*$/,\\"\\").replace(/\\\\?.*$/,\\"\\").replace(/\\\\/[^\\\\/]+$/,\\"/\\"),a.p=e})(),(()=>{var e={179:0};a.f.j=(r,t)=>{var n=a.o(e,r)?e[r]:void 0;if(0!==n)if(n)t.push(n[2]);else{var o=new Promise(((t,o)=>n=e[r]=[t,o]));t.push(n[2]=o);var i=a.p+a.u(r),c=new Error;a.l(i,(t=>{if(a.o(e,r)&&(0!==(n=e[r])&&(e[r]=void 0),n)){var o=t&&(\\"load\\"===t.type?\\"missing\\":t.type),i=t&&t.target&&t.target.src;c.message=\\"Loading chunk \\"+r+\\" failed.\\\\n(\\"+o+\\": \\"+i+\\")\\",c.name=\\"ChunkLoadError\\",c.type=o,c.request=i,n[1](c)}}),\\"chunk-\\"+r,r)}};var r=(r,t)=>{var n,o,[i,c,s]=t,f=0;if(i.some((r=>0!==e[r]))){for(n in c)a.o(c,n)&&(a.m[n]=c[n]);s&&s(a)}for(r&&r(t);f<i.length;f++)o=i[f],a.o(e,o)&&e[o]&&e[o][0](),e[o]=0},t=self.webpackChunk=self.webpackChunk||[];t.forEach(r.bind(null,0)),t.push=r.bind(null,t.push.bind(t))})(),a.e(14).then(a.bind(a,\\"./a/asyncLoc1.js\\")),a.e(5).then(a.bind(a,\\"./a/asyncLoc2.js\\")),a.e(515).then(a.t.bind(a,\\"./a/async1.js\\",23)),a.e(989).then(a.t.bind(a,\\"./a/async2.js\\",23))})();",
 }
 `;
 
@@ -20,22 +20,22 @@ Object {
   "entrypoints": Object {
     "main": Object {
       "localizedAssets": Object {
-        "LOCALE1": "main-LOCALE1-3cbc930b5f99a71a9557.js",
-        "LOCALE2": "main-LOCALE2-ba8327e9cbb975e3da43.js",
+        "LOCALE1": "main-LOCALE1-db5fee2775538b16fa56.js",
+        "LOCALE2": "main-LOCALE2-e08dd16ea7f4a44191c3.js",
       },
     },
   },
   "namedChunkGroups": Object {
     "asyncLoc1": Object {
       "localizedAssets": Object {
-        "LOCALE1": "chunks/asyncLoc1-LOCALE1-168f848b770aa62ad17d.js",
-        "LOCALE2": "chunks/asyncLoc1-LOCALE2-14e0a3b5691b9628be91.js",
+        "LOCALE1": "chunks/asyncLoc1-LOCALE1-42ac7deedbceee724ebe.js",
+        "LOCALE2": "chunks/asyncLoc1-LOCALE2-9569ed1013c7d99991f0.js",
       },
     },
     "asyncLoc2": Object {
       "localizedAssets": Object {
-        "LOCALE1": "chunks/asyncLoc2-LOCALE1-e442ade75ccc8ccb7d2f.js",
-        "LOCALE2": "chunks/asyncLoc2-LOCALE2-fd29172ccf479e97aa94.js",
+        "LOCALE1": "chunks/asyncLoc2-LOCALE1-fbbf37c75a89cefa3a8b.js",
+        "LOCALE2": "chunks/asyncLoc2-LOCALE2-6f7d6cb21f686f18a3de.js",
       },
     },
   },
@@ -46,7 +46,7 @@ exports[`LocalizationPlugin Handles async localized and non-localized chunks (mi
 
 exports[`LocalizationPlugin Handles async localized and non-localized chunks (unminified): Content 1`] = `
 Object {
-  "/release/chunks/async1-none-e1cb569a2a326e82328e.js": "(self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[515],{
+  "/release/chunks/async1-none-38a5bffea2da0af62512.js": "(self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[515],{
 
 /***/ \\"./a/async1.js\\":
 /***/ (() => {
@@ -56,7 +56,7 @@ console.log(\\"blah1\\");
 /***/ })
 
 }]);",
-  "/release/chunks/async2-none-41294aefa7aff57927d4.js": "(self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[989],{
+  "/release/chunks/async2-none-c9e2b0fb2741b17cb7ae.js": "(self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[989],{
 
 /***/ \\"./a/async2.js\\":
 /***/ (() => {
@@ -66,7 +66,7 @@ console.log(\\"blah2\\");
 /***/ })
 
 }]);",
-  "/release/chunks/asyncLoc1-LOCALE1-40f629a47fce31f71795.js": "\\"use strict\\";
+  "/release/chunks/asyncLoc1-LOCALE1-0e3f6d729d9a8d850e0d.js": "\\"use strict\\";
 (self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[14],{
 
 /***/ \\"./a/asyncLoc1.js\\":
@@ -102,7 +102,7 @@ const strings = {\\"another\\":\\"something else\\"};
 /***/ })
 
 }]);",
-  "/release/chunks/asyncLoc1-LOCALE2-47968ebc87e0937a22bc.js": "\\"use strict\\";
+  "/release/chunks/asyncLoc1-LOCALE2-2eebf33f2db768152544.js": "\\"use strict\\";
 (self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[14],{
 
 /***/ \\"./a/asyncLoc1.js\\":
@@ -138,7 +138,7 @@ const strings = {\\"another\\":\\"some random translation\\"};
 /***/ })
 
 }]);",
-  "/release/chunks/asyncLoc2-LOCALE1-e928396bee55883d3b7a.js": "\\"use strict\\";
+  "/release/chunks/asyncLoc2-LOCALE1-862fa13951f910022c37.js": "\\"use strict\\";
 (self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[5],{
 
 /***/ \\"./a/asyncLoc2.js\\":
@@ -174,7 +174,7 @@ const strings = {\\"another\\":\\"something else\\"};
 /***/ })
 
 }]);",
-  "/release/chunks/asyncLoc2-LOCALE2-92ed268b2fc76b31ee2a.js": "\\"use strict\\";
+  "/release/chunks/asyncLoc2-LOCALE2-c21e197905c17fe34ef7.js": "\\"use strict\\";
 (self[\\"webpackChunk\\"] = self[\\"webpackChunk\\"] || []).push([[5],{
 
 /***/ \\"./a/asyncLoc2.js\\":
@@ -210,7 +210,7 @@ const strings = {\\"another\\":\\"some random translation\\"};
 /***/ })
 
 }]);",
-  "/release/main-LOCALE1-53cd5b4b8031fdd624b7.js": "/******/ (() => { // webpackBootstrap
+  "/release/main-LOCALE1-8345e579c701b1d78cf4.js": "/******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({});
 /************************************************************************/
 /******/ 	// The module cache
@@ -301,7 +301,7 @@ const strings = {\\"another\\":\\"some random translation\\"};
 /******/ 		// This function allow to reference async chunks
 /******/ 		__webpack_require__.u = (chunkId) => {
 /******/ 			// return url for filenames based on template
-/******/ 			return \\"chunks/\\" + {\\"5\\":\\"asyncLoc2\\",\\"14\\":\\"asyncLoc1\\",\\"515\\":\\"async1\\",\\"989\\":\\"async2\\"}[chunkId] + \\"-\\" + ({\\"5\\":1,\\"14\\":1}[chunkId]?\\"LOCALE1\\":\\"none\\") + \\"-\\" + {\\"5\\":\\"e928396bee55883d3b7a\\",\\"14\\":\\"40f629a47fce31f71795\\",\\"515\\":\\"e1cb569a2a326e82328e\\",\\"989\\":\\"41294aefa7aff57927d4\\"}[chunkId] + \\".js\\";
+/******/ 			return \\"chunks/\\" + {\\"5\\":\\"asyncLoc2\\",\\"14\\":\\"asyncLoc1\\",\\"515\\":\\"async1\\",\\"989\\":\\"async2\\"}[chunkId] + \\"-\\" + ({\\"5\\":1,\\"14\\":1}[chunkId]?\\"LOCALE1\\":\\"none\\") + \\"-\\" + {\\"5\\":\\"862fa13951f910022c37\\",\\"14\\":\\"0e3f6d729d9a8d850e0d\\",\\"515\\":\\"38a5bffea2da0af62512\\",\\"989\\":\\"c9e2b0fb2741b17cb7ae\\"}[chunkId] + \\".js\\";
 /******/ 		};
 /******/ 	})();
 /******/ 	
@@ -496,7 +496,7 @@ var __webpack_exports__ = {};
 __webpack_require__.e(/* import() | asyncLoc1 */ 14).then(__webpack_require__.bind(__webpack_require__, \\"./a/asyncLoc1.js\\"));__webpack_require__.e(/* import() | asyncLoc2 */ 5).then(__webpack_require__.bind(__webpack_require__, \\"./a/asyncLoc2.js\\"));__webpack_require__.e(/* import() | async1 */ 515).then(__webpack_require__.t.bind(__webpack_require__, \\"./a/async1.js\\", 23));__webpack_require__.e(/* import() | async2 */ 989).then(__webpack_require__.t.bind(__webpack_require__, \\"./a/async2.js\\", 23));
 /******/ })()
 ;",
-  "/release/main-LOCALE2-b233e0d532d0327ed6a8.js": "/******/ (() => { // webpackBootstrap
+  "/release/main-LOCALE2-9f3e7cd89069987e6049.js": "/******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({});
 /************************************************************************/
 /******/ 	// The module cache
@@ -587,7 +587,7 @@ __webpack_require__.e(/* import() | asyncLoc1 */ 14).then(__webpack_require__.bi
 /******/ 		// This function allow to reference async chunks
 /******/ 		__webpack_require__.u = (chunkId) => {
 /******/ 			// return url for filenames based on template
-/******/ 			return \\"chunks/\\" + {\\"5\\":\\"asyncLoc2\\",\\"14\\":\\"asyncLoc1\\",\\"515\\":\\"async1\\",\\"989\\":\\"async2\\"}[chunkId] + \\"-\\" + ({\\"5\\":1,\\"14\\":1}[chunkId]?\\"LOCALE2\\":\\"none\\") + \\"-\\" + {\\"5\\":\\"92ed268b2fc76b31ee2a\\",\\"14\\":\\"47968ebc87e0937a22bc\\",\\"515\\":\\"e1cb569a2a326e82328e\\",\\"989\\":\\"41294aefa7aff57927d4\\"}[chunkId] + \\".js\\";
+/******/ 			return \\"chunks/\\" + {\\"5\\":\\"asyncLoc2\\",\\"14\\":\\"asyncLoc1\\",\\"515\\":\\"async1\\",\\"989\\":\\"async2\\"}[chunkId] + \\"-\\" + ({\\"5\\":1,\\"14\\":1}[chunkId]?\\"LOCALE2\\":\\"none\\") + \\"-\\" + {\\"5\\":\\"c21e197905c17fe34ef7\\",\\"14\\":\\"2eebf33f2db768152544\\",\\"515\\":\\"38a5bffea2da0af62512\\",\\"989\\":\\"c9e2b0fb2741b17cb7ae\\"}[chunkId] + \\".js\\";
 /******/ 		};
 /******/ 	})();
 /******/ 	
@@ -792,22 +792,22 @@ Object {
   "entrypoints": Object {
     "main": Object {
       "localizedAssets": Object {
-        "LOCALE1": "main-LOCALE1-53cd5b4b8031fdd624b7.js",
-        "LOCALE2": "main-LOCALE2-b233e0d532d0327ed6a8.js",
+        "LOCALE1": "main-LOCALE1-8345e579c701b1d78cf4.js",
+        "LOCALE2": "main-LOCALE2-9f3e7cd89069987e6049.js",
       },
     },
   },
   "namedChunkGroups": Object {
     "asyncLoc1": Object {
       "localizedAssets": Object {
-        "LOCALE1": "chunks/asyncLoc1-LOCALE1-40f629a47fce31f71795.js",
-        "LOCALE2": "chunks/asyncLoc1-LOCALE2-47968ebc87e0937a22bc.js",
+        "LOCALE1": "chunks/asyncLoc1-LOCALE1-0e3f6d729d9a8d850e0d.js",
+        "LOCALE2": "chunks/asyncLoc1-LOCALE2-2eebf33f2db768152544.js",
       },
     },
     "asyncLoc2": Object {
       "localizedAssets": Object {
-        "LOCALE1": "chunks/asyncLoc2-LOCALE1-e928396bee55883d3b7a.js",
-        "LOCALE2": "chunks/asyncLoc2-LOCALE2-92ed268b2fc76b31ee2a.js",
+        "LOCALE1": "chunks/asyncLoc2-LOCALE1-862fa13951f910022c37.js",
+        "LOCALE2": "chunks/asyncLoc2-LOCALE2-c21e197905c17fe34ef7.js",
       },
     },
   },


### PR DESCRIPTION
## Summary

Includes a hash salt in hash calculation if one is provided.

## How it was tested

Included a unit test.