### PR TITLE
[webpack5-localization-plugin] Export a plugin that does realContentHashes without validating the localization plugin's options.

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/export-truehashplugin_2024-02-10-01-08.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/export-truehashplugin_2024-02-10-01-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Export a `TrueHashPlugin` that performs what the `realContentHash` option does, but without validating the localization plugin's options.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/reviews/api/webpack5-localization-plugin.api.md
+++ b/common/reviews/api/webpack5-localization-plugin.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import type { Chunk } from 'webpack';
 import type { Compiler } from 'webpack';
 import { ILocalizationFile } from '@rushstack/localization-utilities';
@@ -126,6 +128,12 @@ export interface _IStringPlaceholder {
     valuesByLocale: Map<string, string>;
 }
 
+// @public (undocumented)
+export interface ITrueHashPluginOptions {
+    hashFunction?: (contents: string | Buffer) => string;
+    stageOverride?: number;
+}
+
 // @public
 export class LocalizationPlugin implements WebpackPluginInstance {
     constructor(options: ILocalizationPluginOptions);
@@ -140,6 +148,13 @@ export class LocalizationPlugin implements WebpackPluginInstance {
     readonly _options: ILocalizationPluginOptions;
     // (undocumented)
     readonly stringKeys: Map<string, _IStringPlaceholder>;
+}
+
+// @public (undocumented)
+export class TrueHashPlugin implements WebpackPluginInstance {
+    constructor(options?: ITrueHashPluginOptions);
+    // (undocumented)
+    apply(compiler: Compiler): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/webpack/webpack5-localization-plugin/src/TrueHashPlugin.ts
+++ b/webpack/webpack5-localization-plugin/src/TrueHashPlugin.ts
@@ -3,18 +3,29 @@
 
 import type { Compilation, Compiler, WebpackPluginInstance } from 'webpack';
 
-import { LocalizationPlugin } from '../LocalizationPlugin';
-import { type HashFn, getHashFunction, updateAssetHashes } from '../trueHashes';
+import { type HashFn, getHashFunction, updateAssetHashes } from './trueHashes';
+import { LocalizationPlugin } from './LocalizationPlugin';
 
 const PLUGIN_NAME: 'true-hash' = 'true-hash';
 
+/**
+ * @public
+ */
 export interface ITrueHashPluginOptions {
   /**
    * A function that takes the contents of a file and returns a hash.
    */
   hashFunction?: (contents: string | Buffer) => string;
+
+  /**
+   * Optionally override the process assets stage for this plugin.
+   */
+  stageOverride?: number;
 }
 
+/**
+ * @public
+ */
 export class TrueHashPlugin implements WebpackPluginInstance {
   private readonly _options: ITrueHashPluginOptions;
 
@@ -45,7 +56,8 @@ export class TrueHashPlugin implements WebpackPluginInstance {
           )
         );
       } else {
-        const { hashFunction } = this._options;
+        const { hashFunction, stageOverride = thisWebpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE } =
+          this._options;
         const hashFn: HashFn =
           hashFunction ??
           getHashFunction({
@@ -56,7 +68,7 @@ export class TrueHashPlugin implements WebpackPluginInstance {
         compilation.hooks.processAssets.tap(
           {
             name: PLUGIN_NAME,
-            stage: thisWebpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+            stage: stageOverride
           },
           () => updateAssetHashes({ thisWebpack, compilation, hashFn })
         );

--- a/webpack/webpack5-localization-plugin/src/index.ts
+++ b/webpack/webpack5-localization-plugin/src/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 export { LocalizationPlugin, type IStringPlaceholder as _IStringPlaceholder } from './LocalizationPlugin';
+export { TrueHashPlugin, type ITrueHashPluginOptions } from './TrueHashPlugin';
 
 export {
   IDefaultLocaleOptions,
@@ -20,5 +21,4 @@ export {
   IPseudolocalesOptions,
   IResolvedMissingTranslations
 } from './interfaces';
-
 export { ILocalizedWebpackChunk } from './webpackInterfaces';

--- a/webpack/webpack5-localization-plugin/src/test/LocalizedRuntimeTestBase.ts
+++ b/webpack/webpack5-localization-plugin/src/test/LocalizedRuntimeTestBase.ts
@@ -10,7 +10,7 @@ import { Volume } from 'memfs/lib/volume';
 import { MemFSPlugin } from './MemFSPlugin';
 import type { ILocalizationPluginOptions } from '../interfaces';
 import { LocalizationPlugin } from '../LocalizationPlugin';
-import { type ITrueHashPluginOptions, TrueHashPlugin } from './TrueHashPlugin';
+import { type ITrueHashPluginOptions, TrueHashPlugin } from '../TrueHashPlugin';
 
 export function runTests(trueHashPluginOptions: ITrueHashPluginOptions = {}): void {
   async function testLocalizedRuntimeInner(minimize: boolean): Promise<void> {

--- a/webpack/webpack5-localization-plugin/src/test/NonHashedNonLocalizedAssets.test.ts
+++ b/webpack/webpack5-localization-plugin/src/test/NonHashedNonLocalizedAssets.test.ts
@@ -7,7 +7,7 @@ import { promisify } from 'util';
 import webpack, { type Stats } from 'webpack';
 import { Volume } from 'memfs/lib/volume';
 
-import { TrueHashPlugin } from './TrueHashPlugin';
+import { TrueHashPlugin } from '../TrueHashPlugin';
 import { MemFSPlugin } from './MemFSPlugin';
 
 async function testNonLocalizedInner(minimize: boolean): Promise<void> {


### PR DESCRIPTION
## Summary

Export a plugin that does realContentHashes without validating the localization plugin's options.

## How it was tested

Tests already existed.
