### PR TITLE
[webpack5-localization-plugin] Filter out non-JS chunks.

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/stricter-js-detection_2024-02-10-07-30.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/stricter-js-detection_2024-02-10-07-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Filter out non-JS chunks.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
+++ b/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
@@ -30,6 +30,7 @@ import type { IAssetPathOptions } from './webpackInterfaces';
 import { markEntity, getMark } from './utilities/EntityMarker';
 import { processLocalizedAsset, processNonLocalizedAsset } from './AssetProcessor';
 import { getHashFunction, type HashFn, updateAssetHashes } from './trueHashes';
+import { chunkIsJs } from './utilities/chunkUtilities';
 
 /**
  * @public
@@ -309,6 +310,10 @@ export class LocalizationPlugin implements WebpackPluginInstance {
           const localizedChunkNames: string[] = [];
 
           for (const chunk of chunks) {
+            if (!chunkIsJs(chunk, chunkGraph)) {
+              continue;
+            }
+
             const isLocalized: boolean = _chunkHasLocalizedModules(
               chunkGraph,
               chunk,

--- a/webpack/webpack5-localization-plugin/src/utilities/chunkUtilities.ts
+++ b/webpack/webpack5-localization-plugin/src/utilities/chunkUtilities.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { Chunk, ChunkGraph } from 'webpack';
+
+export function chunkIsJs(chunk: Chunk, chunkGraph: ChunkGraph): boolean {
+  return !!chunkGraph.getChunkModulesIterableBySourceType(chunk, 'javascript');
+}


### PR DESCRIPTION
## Summary

This PR adds logic to filter out non-JS chunks from processing.

## How it was tested

Tested in a repo that generates some non-JS chunks.