### PR TITLE
fix(heft-storybook-plugin): not cancelling webpack build during storybook static build

### DIFF
--- a/common/changes/@rushstack/heft-storybook-plugin/fix-storybook-plugin-static-builds_2024-02-11-20-39.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/fix-storybook-plugin-static-builds_2024-02-11-20-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "fix double webpack builds during static storybook builds, expose --webpack-stats-json storybook CLI flag",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/fix-storybook-plugin-static-builds_2024-02-11-20-40.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/fix-storybook-plugin-static-builds_2024-02-11-20-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-storybook-plugin",
-      "comment": "Fix an issue where Webpack would run twice during static storybook builds.",
+      "comment": "Introduce a `captureWebpackStats` configuration option that, when enabled, will pass the `--webpack-stats-json` parameter to Storybook.",
       "type": "minor"
     }
   ],

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -152,6 +152,10 @@ export interface IStorybookPluginOptions {
    * `"cwdPackageName": "my-storybook-ui-library"`
    */
   cwdPackageName?: string;
+  /**
+   * Specifies whether to capture the webpack stats for the storybook build by adding the `--webpack-stats-json` CLI flag.
+   */
+  captureWebpackStats?: boolean;
 }
 
 interface IRunStorybookOptions {
@@ -220,11 +224,11 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
         '@rushstack/heft-webpack4-plugin',
         WEBPACK4_PLUGIN_NAME,
         (accessor: IWebpack4PluginAccessor) => {
-          // Discard Webpack's configuration to prevent Webpack from running only when starting a storybook server
           if (accessor.parameters.isServeMode) {
             this._isServeMode = true;
-            accessor.hooks.onLoadConfiguration.tapPromise(PLUGIN_NAME, configureWebpackTap);
           }
+          // Discard Webpack's configuration to prevent Webpack from running only when performing Storybook build
+          accessor.hooks.onLoadConfiguration.tapPromise(PLUGIN_NAME, configureWebpackTap);
         }
       );
 
@@ -232,11 +236,11 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
         '@rushstack/heft-webpack5-plugin',
         WEBPACK5_PLUGIN_NAME,
         (accessor: IWebpack5PluginAccessor) => {
-          // Discard Webpack's configuration to prevent Webpack from running only when starting a storybook server
           if (accessor.parameters.isServeMode) {
             this._isServeMode = true;
-            accessor.hooks.onLoadConfiguration.tapPromise(PLUGIN_NAME, configureWebpackTap);
           }
+          // Discard Webpack's configuration to prevent Webpack from running only when performing Storybook build
+          accessor.hooks.onLoadConfiguration.tapPromise(PLUGIN_NAME, configureWebpackTap);
         }
       );
 
@@ -399,6 +403,9 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
 
     if (outputFolder) {
       storybookArgs.push('--output-dir', outputFolder);
+    }
+    if (options.captureWebpackStats) {
+      storybookArgs.push('--webpack-stats-json');
     }
     if (!verbose) {
       storybookArgs.push('--quiet');

--- a/heft-plugins/heft-storybook-plugin/src/schemas/storybook.schema.json
+++ b/heft-plugins/heft-storybook-plugin/src/schemas/storybook.schema.json
@@ -32,6 +32,11 @@
       "title": "Specifies an NPM dependency name that is used as the CWD target for the storybook commands",
       "description": "By default the plugin executes the storybook commands in the local package context, but for distribution purposes it can be useful to split the TS library and storybook exports into two packages. For example, If you create a storybook 'app' project \"my-ui-storybook-library-app\" for the storybook preview distribution, and your main UI component `library` is my-ui-storybook-library. Your 'app' project is able to compile the 'library' storybook app using the CWD target: `\"cwdPackageName\": \"my-ui-storybook-library\"`",
       "type": "string"
+    },
+    "captureWebpackStats": {
+      "title": "Specifies whether to capture the webpack stats for storybook build.",
+      "description": "If this is true, then it will capture the webpack stats for storybook build. Defaults to false.",
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Due to the guard around the isServeMode check in the webpack configuration taps the webpack build is only disabled when running in serve mode

This means that when doing a static storybook build it does both the webpack and storybook webpack builds when the `--storybook` cli flag is used

This changes the discarding of the webpack configuration to happen always when `--storybook` is present so static storybook builds don't double up the webpack builds, Fixes #4289 

While I'm here I added a configuration option for passing the `--webpack-stats-json` flag to Storybook to emit the webpack stats file which is required for usage with Chromatic's Turbosnap feature

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Applied the changes as a patch to our monorepo and ran a full chromatic run, doing static builds for all storybooks (with captureWebpackstats set to true). Launched storybook in serve mode to validate that, and did a static build to verify that the webpack build is skipped
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
