### PR TITLE
[terminal] Fix a phantom dependency on "colors"

### DIFF
--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -41,7 +41,6 @@
     "@rushstack/terminal": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",
     "@types/tapable": "1.0.6",
-    "chokidar": "~3.4.0",
     "fast-glob": "~3.3.1",
     "git-repo-info": "~2.1.0",
     "ignore": "~5.1.6",

--- a/apps/lockfile-explorer-web/package.json
+++ b/apps/lockfile-explorer-web/package.json
@@ -12,7 +12,6 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {
-    "@fluentui/react": "^8.96.1",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",
     "@lifaon/path": "~2.1.0",

--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   rush-lib-test:
     dependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.113.4.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.113.4.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.114.0.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.114.0.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
@@ -30,15 +30,15 @@ importers:
   rush-sdk-test:
     dependencies:
       '@rushstack/rush-sdk':
-        specifier: file:rushstack-rush-sdk-5.113.4.tgz
-        version: file:../temp/tarballs/rushstack-rush-sdk-5.113.4.tgz(@types/node@18.17.15)
+        specifier: file:rushstack-rush-sdk-5.114.0.tgz
+        version: file:../temp/tarballs/rushstack-rush-sdk-5.114.0.tgz(@types/node@18.17.15)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
       '@microsoft/rush-lib':
-        specifier: file:microsoft-rush-lib-5.113.4.tgz
-        version: file:../temp/tarballs/microsoft-rush-lib-5.113.4.tgz(@types/node@18.17.15)
+        specifier: file:microsoft-rush-lib-5.114.0.tgz
+        version: file:../temp/tarballs/microsoft-rush-lib-5.114.0.tgz(@types/node@18.17.15)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -55,14 +55,14 @@ importers:
         specifier: file:rushstack-eslint-config-3.6.4.tgz
         version: file:../temp/tarballs/rushstack-eslint-config-3.6.4.tgz(eslint@8.7.0)(typescript@5.3.3)
       '@rushstack/heft':
-        specifier: file:rushstack-heft-0.64.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-0.64.7.tgz
+        specifier: file:rushstack-heft-0.65.0.tgz
+        version: file:../temp/tarballs/rushstack-heft-0.65.0.tgz
       '@rushstack/heft-lint-plugin':
-        specifier: file:rushstack-heft-lint-plugin-0.3.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.7.tgz(@rushstack/heft@0.64.7)
+        specifier: file:rushstack-heft-lint-plugin-0.3.9.tgz
+        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.9.tgz(@rushstack/heft@0.65.0)
       '@rushstack/heft-typescript-plugin':
-        specifier: file:rushstack-heft-typescript-plugin-0.3.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.7.tgz(@rushstack/heft@0.64.7)
+        specifier: file:rushstack-heft-typescript-plugin-0.3.9.tgz
+        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.9.tgz(@rushstack/heft@0.65.0)
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -79,14 +79,14 @@ importers:
         specifier: file:rushstack-eslint-config-3.6.4.tgz
         version: file:../temp/tarballs/rushstack-eslint-config-3.6.4.tgz(eslint@8.7.0)(typescript@4.7.4)
       '@rushstack/heft':
-        specifier: file:rushstack-heft-0.64.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-0.64.7.tgz
+        specifier: file:rushstack-heft-0.65.0.tgz
+        version: file:../temp/tarballs/rushstack-heft-0.65.0.tgz
       '@rushstack/heft-lint-plugin':
-        specifier: file:rushstack-heft-lint-plugin-0.3.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.7.tgz(@rushstack/heft@0.64.7)
+        specifier: file:rushstack-heft-lint-plugin-0.3.9.tgz
+        version: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.9.tgz(@rushstack/heft@0.65.0)
       '@rushstack/heft-typescript-plugin':
-        specifier: file:rushstack-heft-typescript-plugin-0.3.7.tgz
-        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.7.tgz(@rushstack/heft@0.64.7)
+        specifier: file:rushstack-heft-typescript-plugin-0.3.9.tgz
+        version: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.9.tgz(@rushstack/heft@0.65.0)
       eslint:
         specifier: ~8.7.0
         version: 8.7.0
@@ -4241,22 +4241,22 @@ packages:
     optionalDependencies:
       commander: 2.20.3
 
-  file:../temp/tarballs/microsoft-rush-lib-5.113.4.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.113.4.tgz}
-    id: file:../temp/tarballs/microsoft-rush-lib-5.113.4.tgz
+  file:../temp/tarballs/microsoft-rush-lib-5.114.0.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/microsoft-rush-lib-5.114.0.tgz}
+    id: file:../temp/tarballs/microsoft-rush-lib-5.114.0.tgz
     name: '@microsoft/rush-lib'
-    version: 5.113.4
+    version: 5.114.0
     engines: {node: '>=5.6.0'}
     dependencies:
       '@pnpm/dependency-path': 2.1.2
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz(@types/node@18.17.15)
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
-      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.1.25.tgz(@types/node@18.17.15)
-      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.6.27.tgz(@types/node@18.17.15)
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
+      '@rushstack/package-deps-hash': file:../temp/tarballs/rushstack-package-deps-hash-4.1.27.tgz(@types/node@18.17.15)
+      '@rushstack/package-extractor': file:../temp/tarballs/rushstack-package-extractor-0.6.29.tgz(@types/node@18.17.15)
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.5.2.tgz
-      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.1.25.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/stream-collator': file:../temp/tarballs/rushstack-stream-collator-4.1.27.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.17.2.tgz
       '@types/node-fetch': 2.6.2
       '@yarnpkg/lockfile': 1.0.2
@@ -4444,21 +4444,20 @@ packages:
       - typescript
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-0.64.7.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.64.7.tgz}
+  file:../temp/tarballs/rushstack-heft-0.65.0.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-0.65.0.tgz}
     name: '@rushstack/heft'
-    version: 0.64.7
+    version: 0.65.0
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz(@types/node@18.17.15)
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
-      '@rushstack/operation-graph': file:../temp/tarballs/rushstack-operation-graph-0.2.9.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
+      '@rushstack/operation-graph': file:../temp/tarballs/rushstack-operation-graph-0.2.10.tgz
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.5.2.tgz
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
       '@rushstack/ts-command-line': file:../temp/tarballs/rushstack-ts-command-line-4.17.2.tgz
       '@types/tapable': 1.0.6
-      chokidar: 3.4.3
       fast-glob: 3.3.1
       git-repo-info: 2.1.1
       ignore: 5.1.9
@@ -4469,46 +4468,46 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz}
-    id: file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz
+  file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz}
+    id: file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz
     name: '@rushstack/heft-config-file'
-    version: 0.14.10
+    version: 0.14.11
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
       '@rushstack/rig-package': file:../temp/tarballs/rushstack-rig-package-0.5.2.tgz
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.7.tgz(@rushstack/heft@0.64.7):
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.7.tgz}
-    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.7.tgz
+  file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.9.tgz(@rushstack/heft@0.65.0):
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.9.tgz}
+    id: file:../temp/tarballs/rushstack-heft-lint-plugin-0.3.9.tgz
     name: '@rushstack/heft-lint-plugin'
-    version: 0.3.7
+    version: 0.3.9
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.64.7.tgz
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.65.0.tgz
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.7.tgz(@rushstack/heft@0.64.7):
-    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.7.tgz}
-    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.7.tgz
+  file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.9.tgz(@rushstack/heft@0.65.0):
+    resolution: {tarball: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.9.tgz}
+    id: file:../temp/tarballs/rushstack-heft-typescript-plugin-0.3.9.tgz
     name: '@rushstack/heft-typescript-plugin'
-    version: 0.3.7
+    version: 0.3.9
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.64.7.tgz
-      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.10.tgz(@types/node@18.17.15)
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/heft': file:../temp/tarballs/rushstack-heft-0.65.0.tgz
+      '@rushstack/heft-config-file': file:../temp/tarballs/rushstack-heft-config-file-0.14.11.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       semver: 7.5.4
       tapable: 1.1.3
@@ -4516,11 +4515,11 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz}
-    id: file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz
+  file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz}
+    id: file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz
     name: '@rushstack/node-core-library'
-    version: 3.66.1
+    version: 4.0.0
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -4528,7 +4527,6 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.17.15
-      colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -4536,39 +4534,39 @@ packages:
       semver: 7.5.4
       z-schema: 5.0.3
 
-  file:../temp/tarballs/rushstack-operation-graph-0.2.9.tgz:
-    resolution: {tarball: file:../temp/tarballs/rushstack-operation-graph-0.2.9.tgz}
+  file:../temp/tarballs/rushstack-operation-graph-0.2.10.tgz:
+    resolution: {tarball: file:../temp/tarballs/rushstack-operation-graph-0.2.10.tgz}
     name: '@rushstack/operation-graph'
-    version: 0.2.9
+    version: 0.2.10
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
     dev: true
 
-  file:../temp/tarballs/rushstack-package-deps-hash-4.1.25.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.1.25.tgz}
-    id: file:../temp/tarballs/rushstack-package-deps-hash-4.1.25.tgz
+  file:../temp/tarballs/rushstack-package-deps-hash-4.1.27.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-deps-hash-4.1.27.tgz}
+    id: file:../temp/tarballs/rushstack-package-deps-hash-4.1.27.tgz
     name: '@rushstack/package-deps-hash'
-    version: 4.1.25
+    version: 4.1.27
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-package-extractor-0.6.27.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.6.27.tgz}
-    id: file:../temp/tarballs/rushstack-package-extractor-0.6.27.tgz
+  file:../temp/tarballs/rushstack-package-extractor-0.6.29.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-package-extractor-0.6.29.tgz}
+    id: file:../temp/tarballs/rushstack-package-extractor-0.6.29.tgz
     name: '@rushstack/package-extractor'
-    version: 0.6.27
+    version: 0.6.29
     dependencies:
       '@pnpm/link-bins': 5.3.25
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
       ignore: 5.1.9
       jszip: 3.8.0
       minimatch: 3.0.8
@@ -4585,43 +4583,44 @@ packages:
       resolve: 1.22.1
       strip-json-comments: 3.1.1
 
-  file:../temp/tarballs/rushstack-rush-sdk-5.113.4.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.113.4.tgz}
-    id: file:../temp/tarballs/rushstack-rush-sdk-5.113.4.tgz
+  file:../temp/tarballs/rushstack-rush-sdk-5.114.0.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-rush-sdk-5.114.0.tgz}
+    id: file:../temp/tarballs/rushstack-rush-sdk-5.114.0.tgz
     name: '@rushstack/rush-sdk'
-    version: 5.113.4
+    version: 5.114.0
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
       '@types/node-fetch': 2.6.2
       tapable: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  file:../temp/tarballs/rushstack-stream-collator-4.1.25.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.1.25.tgz}
-    id: file:../temp/tarballs/rushstack-stream-collator-4.1.25.tgz
+  file:../temp/tarballs/rushstack-stream-collator-4.1.27.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-stream-collator-4.1.27.tgz}
+    id: file:../temp/tarballs/rushstack-stream-collator-4.1.27.tgz
     name: '@rushstack/stream-collator'
-    version: 4.1.25
+    version: 4.1.27
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
-      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
+      '@rushstack/terminal': file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15)
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../temp/tarballs/rushstack-terminal-0.7.24.tgz(@types/node@18.17.15):
-    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.7.24.tgz}
-    id: file:../temp/tarballs/rushstack-terminal-0.7.24.tgz
+  file:../temp/tarballs/rushstack-terminal-0.8.0.tgz(@types/node@18.17.15):
+    resolution: {tarball: file:../temp/tarballs/rushstack-terminal-0.8.0.tgz}
+    id: file:../temp/tarballs/rushstack-terminal-0.8.0.tgz
     name: '@rushstack/terminal'
-    version: 0.7.24
+    version: 0.8.0
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-3.66.1.tgz(@types/node@18.17.15)
+      '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.0.tgz(@types/node@18.17.15)
       '@types/node': 18.17.15
+      colors: 1.2.5
 
   file:../temp/tarballs/rushstack-tree-pattern-0.3.3.tgz:
     resolution: {tarball: file:../temp/tarballs/rushstack-tree-pattern-0.3.3.tgz}

--- a/common/changes/@microsoft/rush/octogonz-fix-package-deps_2024-02-20-21-19.json
+++ b/common/changes/@microsoft/rush/octogonz-fix-package-deps_2024-02-20-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve `rush scan` to analyze APIs such as `Import.lazy()` and `await import()`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft/octogonz-fix-package-deps_2024-02-20-21-19.json
+++ b/common/changes/@rushstack/heft/octogonz-fix-package-deps_2024-02-20-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix a recent regression causing `Error: Cannot find module 'colors/safe'` (GitHub #4525)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/heft/octogonz-fix-package-deps_2024-02-20-21-20.json
+++ b/common/changes/@rushstack/heft/octogonz-fix-package-deps_2024-02-20-21-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Remove a no longer needed dependency on the `chokidar` package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-fix-package-deps_2024-02-20-21-19.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-fix-package-deps_2024-02-20-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Remove a no longer needed dependency on the `colors` package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/terminal/octogonz-fix-package-deps_2024-02-20-21-19.json
+++ b/common/changes/@rushstack/terminal/octogonz-fix-package-deps_2024-02-20-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Fix a recent regression causing `Error: Cannot find module 'colors/safe'` (GitHub #4525)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       '@types/tapable':
         specifier: 1.0.6
         version: 1.0.6
-      chokidar:
-        specifier: ~3.4.0
-        version: 3.4.3
       fast-glob:
         specifier: ~3.3.1
         version: 3.3.1
@@ -235,9 +232,6 @@ importers:
 
   ../../apps/lockfile-explorer-web:
     dependencies:
-      '@fluentui/react':
-        specifier: ^8.96.1
-        version: 8.110.12(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@lifaon/path':
         specifier: ~2.1.0
         version: 2.1.0
@@ -2996,9 +2990,6 @@ importers:
 
   ../../libraries/node-core-library:
     dependencies:
-      colors:
-        specifier: ~1.2.1
-        version: 1.2.5
       fs-extra:
         specifier: ~7.0.1
         version: 7.0.1
@@ -3450,6 +3441,9 @@ importers:
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../node-core-library
+      colors:
+        specifier: ~1.2.1
+        version: 1.2.5
     devDependencies:
       '@rushstack/heft':
         specifier: 0.64.0
@@ -3463,9 +3457,6 @@ importers:
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
-      colors:
-        specifier: ~1.2.1
-        version: 1.2.5
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -16,7 +16,6 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {
-    "colors": "~1.2.1",
     "fs-extra": "~7.0.1",
     "import-lazy": "~4.0.0",
     "jju": "~1.4.0",

--- a/libraries/rush-lib/src/cli/actions/ScanAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ScanAction.ts
@@ -67,20 +67,24 @@ export class ScanAction extends BaseConfiglessRushAction {
 
     const requireRegExps: RegExp[] = [
       // Example: require('something')
-      /\brequire\s*\(\s*[']([^']+\s*)[']\)/,
-      /\brequire\s*\(\s*["]([^"]+)["]\s*\)/,
+      /\brequire\s*\(\s*[']([^']+\s*)[']\s*\)/,
+      /\brequire\s*\(\s*["]([^"]+\s*)["]\s*\)/,
 
       // Example: require.ensure('something')
-      /\brequire.ensure\s*\(\s*[']([^']+\s*)[']\)/,
-      /\brequire.ensure\s*\(\s*["]([^"]+)["]\s*\)/,
+      /\brequire\.ensure\s*\(\s*[']([^']+\s*)[']\s*\)/,
+      /\brequire\.ensure\s*\(\s*["]([^"]+\s*)["]\s*\)/,
 
       // Example: require.resolve('something')
-      /\brequire.resolve\s*\(\s*[']([^']+\s*)[']\)/,
-      /\brequire.resolve\s*\(\s*["]([^"]+)["]\s*\)/,
+      /\brequire\.resolve\s*\(\s*[']([^']+\s*)[']\s*\)/,
+      /\brequire\.resolve\s*\(\s*["]([^"]+\s*)["]\s*\)/,
 
       // Example: System.import('something')
-      /\bSystem.import\s*\(\s*[']([^']+\s*)[']\)/,
-      /\bSystem.import\s*\(\s*["]([^"]+)["]\s*\)/,
+      /\bSystem\.import\s*\(\s*[']([^']+\s*)[']\s*\)/,
+      /\bSystem\.import\s*\(\s*["]([^"]+\s*)["]\s*\)/,
+
+      // Example: Import.lazy('something', require);
+      /\bImport\.lazy\s*\(\s*[']([^']+\s*)[']/,
+      /\bImport\.lazy\s*\(\s*["]([^"]+\s*)["]/,
 
       // Example:
       //
@@ -93,6 +97,10 @@ export class ScanAction extends BaseConfiglessRushAction {
       // Example:  import 'something';
       /\bimport\s*[']([^']+)[']\s*\;/,
       /\bimport\s*["]([^"]+)["]\s*\;/,
+
+      // Example: await import('fast-glob')
+      /\bimport\s*\(\s*[']([^']+)[']\s*\)/,
+      /\bimport\s*\(\s*["]([^"]+)["]\s*\)/,
 
       // Example:
       // /// <reference types="something" />

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -16,15 +16,15 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {
-    "@rushstack/node-core-library": "workspace:*"
+    "@rushstack/node-core-library": "workspace:*",
+    "colors": "~1.2.1"
   },
   "devDependencies": {
     "@rushstack/heft": "0.64.0",
     "@rushstack/heft-node-rig": "2.4.0",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
-    "local-eslint-config": "workspace:*",
-    "colors": "~1.2.1"
+    "local-eslint-config": "workspace:*"
   },
   "peerDependencies": {
     "@types/node": "*"


### PR DESCRIPTION


## Summary

Fixes https://github.com/microsoft/rushstack/issues/4525

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Fix this error that will occur sometimes when invoking Heft, Rush, or any other library that depends on the updated `@rushstack/terminal` after PR https://github.com/microsoft/rushstack/pull/3176
```
Error: Cannot find module 'colors/safe'
Require stack:
- /workspaces/the-wireguard-effect/node_modules/.pnpm/@rushstack+terminal@0.8.0_@types+node@20.11.19/node_modules/@rushstack/terminal/lib/ConsoleTerminalProvider.js
- /workspaces/the-wireguard-effect/node_modules/.pnpm/@rushstack+terminal@0.8.0_@types+node@20.11.19/node_modules/@rushstack/terminal/lib/index.js
```