### PR TITLE
Fix `workspace:~` and `workspace:^` in version bump

### DIFF
--- a/common/changes/@microsoft/rush/fix-workspace-publish_2024-02-22-01-55.json
+++ b/common/changes/@microsoft/rush/fix-workspace-publish_2024-02-22-01-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Handle `workspace:~` and `workspace:^` wildcard specifiers when publishing. They remain as-is in package.json but get converted to `~${current}` and `^${current}` in changelogs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/test/PublishUtilities.test.ts
+++ b/libraries/rush-lib/src/logic/test/PublishUtilities.test.ts
@@ -888,7 +888,9 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
       a: 'workspace:~1.0.0',
       b: 'workspace:^1.0.0',
       c: 'workspace:>=1.0.0 <2.0.0',
-      d: 'workspace:*'
+      d: 'workspace:*',
+      e: 'workspace:~',
+      f: 'workspace:^'
     };
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'a', '1.1.0')).toEqual('workspace:~1.1.0');
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'b', '1.2.0')).toEqual('workspace:^1.2.0');
@@ -896,6 +898,8 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
       'workspace:>=1.3.0 <2.0.0'
     );
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'd', '1.4.0')).toEqual('workspace:*');
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'e', '1.5.0')).toEqual('workspace:~');
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'f', '1.6.0')).toEqual('workspace:^');
   });
 
   it('can update dependency versions with prereleases', () => {
@@ -903,7 +907,9 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
       a: 'workspace:~1.0.0-pr.1',
       b: 'workspace:^1.0.0-pr.1',
       c: 'workspace:>=1.0.0-pr.1 <2.0.0',
-      d: 'workspace:*'
+      d: 'workspace:*',
+      e: 'workspace:~',
+      f: 'workspace:^'
     };
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'a', '1.1.0-pr.1')).toEqual(
       'workspace:~1.1.0-pr.1'
@@ -915,6 +921,8 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
       'workspace:>=1.3.0-pr.3 <2.0.0'
     );
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'd', '1.3.0-pr.3')).toEqual('workspace:*');
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'e', '1.5.0-pr.3')).toEqual('workspace:~');
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'f', '1.6.0-pr.3')).toEqual('workspace:^');
   });
 
   it('can update to prerelease', () => {
@@ -922,7 +930,9 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
       a: 'workspace:~1.0.0',
       b: 'workspace:^1.0.0',
       c: 'workspace:>=1.0.0 <2.0.0',
-      d: 'workspace:*'
+      d: 'workspace:*',
+      e: 'workspace:~',
+      f: 'workspace:^'
     };
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'a', '1.0.0-hotfix.0')).toEqual(
       'workspace:~1.0.0-hotfix.0'
@@ -935,6 +945,12 @@ describe(PublishUtilities.getNewDependencyVersion.name, () => {
     );
     expect(PublishUtilities.getNewDependencyVersion(dependencies, 'd', '1.0.0-hotfix.0')).toEqual(
       'workspace:*'
+    );
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'e', '1.0.0-hotfix.0')).toEqual(
+      'workspace:~'
+    );
+    expect(PublishUtilities.getNewDependencyVersion(dependencies, 'f', '1.0.0-hotfix.0')).toEqual(
+      'workspace:^'
     );
   });
 });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Fixes an issue where `rush version --bump` replaced `workspace:~` or `workspace:^` in `package.json` dependencies with `workspace:~${current}` or `workspace:^${current}`.

Rush will now retain the wildcard specifier as-is in `package.json` but reflect the publish-time value in the changelog.

## Details
These publish as `~${current}` and `^${current}` respectively.

## How it was tested
Added unit tests for preserving the values.