### PR TITLE
[rush] Validate "projectFolder" and "publishFolder"

### DIFF
--- a/common/changes/@microsoft/rush/rush-schema-changes_2024-02-22-21-30.json
+++ b/common/changes/@microsoft/rush/rush-schema-changes_2024-02-22-21-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Validate that the \"projectFolder\" and \"publishFolder\" fields in the \"projects\" list in \"rush.json\" are normalized POSIX relative paths that do not end in trailing \"/\" or contain \"\\\\\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -214,7 +214,7 @@ export class RushConfigurationProject {
     this.packageName = packageName;
     this.projectRelativeFolder = projectRelativeFolder;
 
-    validateRelativePathField(projectRelativeFolder, 'projectFolder');
+    validateRelativePathField(projectRelativeFolder, 'projectFolder', rushConfiguration.rushJsonFile);
 
     // For example, the depth of "a/b/c" would be 3.  The depth of "a" is 1.
     const projectFolderDepth: number = projectRelativeFolder.split('/').length;
@@ -331,7 +331,7 @@ export class RushConfigurationProject {
     this.publishFolder = absoluteProjectFolder;
     const { publishFolder } = projectJson;
     if (publishFolder) {
-      validateRelativePathField(publishFolder, 'publishFolder');
+      validateRelativePathField(publishFolder, 'publishFolder', rushConfiguration.rushJsonFile);
       this.publishFolder = path.join(this.publishFolder, publishFolder);
     }
 
@@ -509,30 +509,32 @@ export class RushConfigurationProject {
   }
 }
 
-export function validateRelativePathField(relativePath: string, name: string): void {
+export function validateRelativePathField(relativePath: string, field: string, file: string): void {
   // path.isAbsolute delegates depending on platform; however, path.posix.isAbsolute('C:/a') returns false,
   // while path.win32.isAbsolute('C:/a') returns true. We want consistent validation across platforms.
   if (path.posix.isAbsolute(relativePath) || path.win32.isAbsolute(relativePath)) {
-    throw new Error(`The value "${relativePath}" in the "${name}" field must be a relative path.`);
+    throw new Error(
+      `The value "${relativePath}" in the "${field}" field in "${file}" must be a relative path.`
+    );
   }
 
   if (relativePath.includes('\\')) {
     throw new Error(
-      `The value "${relativePath}" in the "${name}" field may not contain backslashes ('\\'), since they are interpreted differently` +
+      `The value "${relativePath}" in the "${field}" field in "${file}" may not contain backslashes ('\\'), since they are interpreted differently` +
         ` on POSIX and Windows. Paths must use '/' as the path separator.`
     );
   }
 
   if (relativePath.endsWith('/')) {
     throw new Error(
-      `The value "${relativePath}" in the "${name}" field may not end with a trailing '/' character.`
+      `The value "${relativePath}" in the "${field}" field in "${file}" may not end with a trailing '/' character.`
     );
   }
 
   const normalized: string = path.posix.normalize(relativePath);
   if (relativePath !== normalized) {
     throw new Error(
-      `The value "${relativePath}" in the "${name}" field should be replaced with its normalized form "${normalized}".`
+      `The value "${relativePath}" in the "${field}" field in "${file}" should be replaced with its normalized form "${normalized}".`
     );
   }
 }

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -510,6 +510,8 @@ export class RushConfigurationProject {
 }
 
 export function validateRelativePathField(relativePath: string, name: string): void {
+  // path.isAbsolute delegates depending on platform; however, path.posix.isAbsolute('C:/a') returns false,
+  // while path.win32.isAbsolute('C:/a') returns true. We want consistent validation across platforms.
   if (path.posix.isAbsolute(relativePath) || path.win32.isAbsolute(relativePath)) {
     throw new Error(`The value "${relativePath}" in the "${name}" field must be a relative path.`);
   }

--- a/libraries/rush-lib/src/api/test/RushConfigurationProject.test.ts
+++ b/libraries/rush-lib/src/api/test/RushConfigurationProject.test.ts
@@ -5,35 +5,49 @@ import { validateRelativePathField } from '../RushConfigurationProject';
 
 describe(validateRelativePathField.name, () => {
   it('accepts valid paths', () => {
-    validateRelativePathField('path/to/project', 'projectFolder');
-    validateRelativePathField('project', 'projectFolder');
-    validateRelativePathField('.', 'projectFolder');
-    validateRelativePathField('..', 'projectFolder');
-    validateRelativePathField('../path/to/project', 'projectFolder');
+    validateRelativePathField('path/to/project', 'projectFolder', '/rush.json');
+    validateRelativePathField('project', 'projectFolder', '/rush.json');
+    validateRelativePathField('.', 'projectFolder', '/rush.json');
+    validateRelativePathField('..', 'projectFolder', '/rush.json');
+    validateRelativePathField('../path/to/project', 'projectFolder', '/rush.json');
   });
 
   it('should throw an error if the path is not relative', () => {
     expect(() =>
-      validateRelativePathField('C:/path/to/project', 'projectFolder')
+      validateRelativePathField('C:/path/to/project', 'projectFolder', '/rush.json')
     ).toThrowErrorMatchingSnapshot();
     expect(() =>
-      validateRelativePathField('/path/to/project', 'publishFolder')
+      validateRelativePathField('/path/to/project', 'publishFolder', '/rush.json')
     ).toThrowErrorMatchingSnapshot();
   });
 
   it('should throw an error if the path ends in a trailing slash', () => {
-    expect(() => validateRelativePathField('path/to/project/', 'someField')).toThrowErrorMatchingSnapshot();
-    expect(() => validateRelativePathField('p/', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('path/to/project/', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('p/', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it('should throw an error if the path contains backslashes', () => {
-    expect(() => validateRelativePathField('path\\to\\project', 'someField')).toThrowErrorMatchingSnapshot();
-    expect(() => validateRelativePathField('path\\', 'someOtherField')).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('path\\to\\project', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('path\\', 'someOtherField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it('should throw an error if the path is not normalized', () => {
-    expect(() => validateRelativePathField('path/../to/project', 'someField')).toThrowErrorMatchingSnapshot();
-    expect(() => validateRelativePathField('path/./to/project', 'someField')).toThrowErrorMatchingSnapshot();
-    expect(() => validateRelativePathField('./path/to/project', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('path/../to/project', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('path/./to/project', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('./path/to/project', 'someField', '/repo/rush.json')
+    ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/libraries/rush-lib/src/api/test/RushConfigurationProject.test.ts
+++ b/libraries/rush-lib/src/api/test/RushConfigurationProject.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { validateRelativePathField } from '../RushConfigurationProject';
+
+describe(validateRelativePathField.name, () => {
+  it('accepts valid paths', () => {
+    validateRelativePathField('path/to/project', 'projectFolder');
+    validateRelativePathField('project', 'projectFolder');
+    validateRelativePathField('.', 'projectFolder');
+    validateRelativePathField('..', 'projectFolder');
+    validateRelativePathField('../path/to/project', 'projectFolder');
+  });
+
+  it('should throw an error if the path is not relative', () => {
+    expect(() =>
+      validateRelativePathField('C:/path/to/project', 'projectFolder')
+    ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      validateRelativePathField('/path/to/project', 'publishFolder')
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw an error if the path ends in a trailing slash', () => {
+    expect(() => validateRelativePathField('path/to/project/', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() => validateRelativePathField('p/', 'someField')).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw an error if the path contains backslashes', () => {
+    expect(() => validateRelativePathField('path\\to\\project', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() => validateRelativePathField('path\\', 'someOtherField')).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw an error if the path is not normalized', () => {
+    expect(() => validateRelativePathField('path/../to/project', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() => validateRelativePathField('path/./to/project', 'someField')).toThrowErrorMatchingSnapshot();
+    expect(() => validateRelativePathField('./path/to/project', 'someField')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/libraries/rush-lib/src/api/test/__snapshots__/RushConfigurationProject.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/RushConfigurationProject.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateRelativePathField should throw an error if the path contains backslashes 1`] = `"The value \\"path\\\\to\\\\project\\" in the \\"someField\\" field may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
+exports[`validateRelativePathField should throw an error if the path contains backslashes 1`] = `"The value \\"path\\\\to\\\\project\\" in the \\"someField\\" field in \\"/repo/rush.json\\" may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
 
-exports[`validateRelativePathField should throw an error if the path contains backslashes 2`] = `"The value \\"path\\\\\\" in the \\"someOtherField\\" field may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
+exports[`validateRelativePathField should throw an error if the path contains backslashes 2`] = `"The value \\"path\\\\\\" in the \\"someOtherField\\" field in \\"/repo/rush.json\\" may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
 
-exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 1`] = `"The value \\"path/to/project/\\" in the \\"someField\\" field may not end with a trailing '/' character."`;
+exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 1`] = `"The value \\"path/to/project/\\" in the \\"someField\\" field in \\"/repo/rush.json\\" may not end with a trailing '/' character."`;
 
-exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 2`] = `"The value \\"p/\\" in the \\"someField\\" field may not end with a trailing '/' character."`;
+exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 2`] = `"The value \\"p/\\" in the \\"someField\\" field in \\"/repo/rush.json\\" may not end with a trailing '/' character."`;
 
-exports[`validateRelativePathField should throw an error if the path is not normalized 1`] = `"The value \\"path/../to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"to/project\\"."`;
+exports[`validateRelativePathField should throw an error if the path is not normalized 1`] = `"The value \\"path/../to/project\\" in the \\"someField\\" field in \\"/repo/rush.json\\" should be replaced with its normalized form \\"to/project\\"."`;
 
-exports[`validateRelativePathField should throw an error if the path is not normalized 2`] = `"The value \\"path/./to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"path/to/project\\"."`;
+exports[`validateRelativePathField should throw an error if the path is not normalized 2`] = `"The value \\"path/./to/project\\" in the \\"someField\\" field in \\"/repo/rush.json\\" should be replaced with its normalized form \\"path/to/project\\"."`;
 
-exports[`validateRelativePathField should throw an error if the path is not normalized 3`] = `"The value \\"./path/to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"path/to/project\\"."`;
+exports[`validateRelativePathField should throw an error if the path is not normalized 3`] = `"The value \\"./path/to/project\\" in the \\"someField\\" field in \\"/repo/rush.json\\" should be replaced with its normalized form \\"path/to/project\\"."`;
 
-exports[`validateRelativePathField should throw an error if the path is not relative 1`] = `"The value \\"C:/path/to/project\\" in the \\"projectFolder\\" field must be a relative path."`;
+exports[`validateRelativePathField should throw an error if the path is not relative 1`] = `"The value \\"C:/path/to/project\\" in the \\"projectFolder\\" field in \\"/rush.json\\" must be a relative path."`;
 
-exports[`validateRelativePathField should throw an error if the path is not relative 2`] = `"The value \\"/path/to/project\\" in the \\"publishFolder\\" field must be a relative path."`;
+exports[`validateRelativePathField should throw an error if the path is not relative 2`] = `"The value \\"/path/to/project\\" in the \\"publishFolder\\" field in \\"/rush.json\\" must be a relative path."`;

--- a/libraries/rush-lib/src/api/test/__snapshots__/RushConfigurationProject.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/RushConfigurationProject.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validateRelativePathField should throw an error if the path contains backslashes 1`] = `"The value \\"path\\\\to\\\\project\\" in the \\"someField\\" field may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
+
+exports[`validateRelativePathField should throw an error if the path contains backslashes 2`] = `"The value \\"path\\\\\\" in the \\"someOtherField\\" field may not contain backslashes ('\\\\'), since they are interpreted differently on POSIX and Windows. Paths must use '/' as the path separator."`;
+
+exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 1`] = `"The value \\"path/to/project/\\" in the \\"someField\\" field may not end with a trailing '/' character."`;
+
+exports[`validateRelativePathField should throw an error if the path ends in a trailing slash 2`] = `"The value \\"p/\\" in the \\"someField\\" field may not end with a trailing '/' character."`;
+
+exports[`validateRelativePathField should throw an error if the path is not normalized 1`] = `"The value \\"path/../to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"to/project\\"."`;
+
+exports[`validateRelativePathField should throw an error if the path is not normalized 2`] = `"The value \\"path/./to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"path/to/project\\"."`;
+
+exports[`validateRelativePathField should throw an error if the path is not normalized 3`] = `"The value \\"./path/to/project\\" in the \\"someField\\" field should be replaced with its normalized form \\"path/to/project\\"."`;
+
+exports[`validateRelativePathField should throw an error if the path is not relative 1`] = `"The value \\"C:/path/to/project\\" in the \\"projectFolder\\" field must be a relative path."`;
+
+exports[`validateRelativePathField should throw an error if the path is not relative 2`] = `"The value \\"/path/to/project\\" in the \\"publishFolder\\" field must be a relative path."`;


### PR DESCRIPTION
## Summary
Fixes #4506

## Details
Ensures that the values in `projectFolder` and `publishFolder` for each project entry in `rush.json` do not contain backslashes, are normalized POSIX relative paths, and do not end in a trailing slash.

## How it was tested
Added unit tests for the validator.
Manually tested by temporarily making rush.json invalid.

## Impacted documentation
Docs on the values of `projectFolder` and `publishFolder`.