### PR TITLE
[Terminal] Replace 'colors' with 'supports-color'.

### DIFF
--- a/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
+++ b/build-tests/install-test-workspace/workspace/common/pnpm-lock.yaml
@@ -3168,8 +3168,8 @@ packages:
     dependencies:
       semver-compare: 1.0.0
 
-  /pnpm-sync-lib@0.1.3:
-    resolution: {integrity: sha512-bNGuQmEnlIUSxrdtHTZHFt9JKEBqN39nU1QgTdMWjBeXIxCV7M99ylOoE4uH7KutHHacKlW7PD4+2ktApPUzog==}
+  /pnpm-sync-lib@0.1.4:
+    resolution: {integrity: sha512-3xwsXcsu+lj2l1nTF0TcgjHuMrnPpQJqHioPj5DTL9gFU+RSsoND2nEMelOo9qAz+BlPelxXZOc5z1Tgs7gwiQ==}
 
   /postcss@8.4.24:
     resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
@@ -3739,6 +3739,12 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
+  /supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      has-flag: 4.0.0
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4266,7 +4272,7 @@ packages:
       node-fetch: 2.6.7
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
-      pnpm-sync-lib: 0.1.3
+      pnpm-sync-lib: 0.1.4
       read-package-tree: 5.1.6
       rxjs: 6.6.7
       semver: 7.5.4
@@ -4613,6 +4619,7 @@ packages:
       '@rushstack/node-core-library': file:../temp/tarballs/rushstack-node-core-library-4.0.2.tgz(@types/node@18.17.15)
       '@types/node': 18.17.15
       colors: 1.2.5
+      supports-color: 8.1.1
 
   file:../temp/tarballs/rushstack-tree-pattern-0.3.3.tgz:
     resolution: {tarball: file:../temp/tarballs/rushstack-tree-pattern-0.3.3.tgz}

--- a/common/changes/@rushstack/terminal/use-supports-color_2024-02-23-18-24.json
+++ b/common/changes/@rushstack/terminal/use-supports-color_2024-02-23-18-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Replace the `colors` dependency with `supports-color` for detecting if STDOUT and STDERR support color.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/changes/@rushstack/terminal/use-supports-color_2024-02-24-17-12.json
+++ b/common/changes/@rushstack/terminal/use-supports-color_2024-02-24-17-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Add a `Colorize.rainbow` API.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -419,10 +419,6 @@
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "colors",
-      "allowedCategories": [ "libraries", "tests" ]
-    },
-    {
       "name": "compression",
       "allowedCategories": [ "libraries" ]
     },
@@ -796,6 +792,10 @@
     },
     {
       "name": "sudo",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "supports-color",
       "allowedCategories": [ "libraries" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -164,7 +164,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -379,7 +379,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -409,7 +409,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -478,7 +478,7 @@ importers:
         version: 10.0.130
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -500,7 +500,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ~7.20.0
-        version: 7.20.12
+        version: 7.20.12(supports-color@9.4.0)
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
@@ -545,7 +545,7 @@ importers:
         version: 5.2.7(webpack@4.47.0)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       heft-storybook-react-tutorial-storykit:
         specifier: workspace:*
         version: link:../heft-storybook-react-tutorial-storykit
@@ -588,7 +588,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ~7.20.0
-        version: 7.20.12
+        version: 7.20.12(supports-color@9.4.0)
       '@storybook/addon-actions':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -771,7 +771,7 @@ importers:
         version: 6.6.0(webpack@5.82.1)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -810,7 +810,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -1140,10 +1140,10 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -1158,10 +1158,10 @@ importers:
         version: link:../../apps/heft
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -1231,7 +1231,7 @@ importers:
         version: 1.0.6
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1255,7 +1255,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1289,7 +1289,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1319,7 +1319,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1331,7 +1331,7 @@ importers:
     devDependencies:
       '@jest/reporters':
         specifier: ~29.5.0
-        version: 29.5.0
+        version: 29.5.0(supports-color@9.4.0)
       '@jest/types':
         specifier: 29.5.0
         version: 29.5.0
@@ -1352,7 +1352,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1427,7 +1427,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1475,7 +1475,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1515,7 +1515,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1597,7 +1597,7 @@ importers:
         version: 5.2.7(webpack@4.47.0)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~4.5.2
         version: 4.5.2(webpack@4.47.0)
@@ -1657,7 +1657,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1777,7 +1777,7 @@ importers:
         version: 20.11.20
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@4.9.5)
@@ -1825,7 +1825,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       file-loader:
         specifier: ~6.0.0
         version: 6.0.0(webpack@4.47.0)
@@ -1879,7 +1879,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -2088,7 +2088,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
@@ -2162,7 +2162,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
@@ -2201,7 +2201,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -2255,16 +2255,16 @@ importers:
         version: link:../eslint-plugin-security
       '@typescript-eslint/eslint-plugin':
         specifier: ~6.19.0
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(typescript@5.3.3)
+        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       eslint-plugin-promise:
         specifier: ~6.1.1
         version: 6.1.1(eslint@8.7.0)
@@ -2277,7 +2277,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2289,7 +2289,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -2307,7 +2307,7 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2317,7 +2317,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2332,16 +2332,16 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/rule-tester':
         specifier: ~6.19.0
         version: 6.19.1(@eslint/eslintrc@3.0.1)(eslint@8.7.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(typescript@5.3.3)
+        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2353,14 +2353,14 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
     devDependencies:
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2375,13 +2375,13 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(typescript@5.3.3)
+        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2393,7 +2393,7 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2403,7 +2403,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2418,16 +2418,16 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/rule-tester':
         specifier: ~6.19.0
         version: 6.19.1(@eslint/eslintrc@3.0.1)(eslint@8.7.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(typescript@5.3.3)
+        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2442,7 +2442,7 @@ importers:
         version: link:../eslint-patch
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       eslint-plugin-deprecation:
         specifier: 2.0.0
         version: 2.0.0(eslint@8.7.0)(typescript@5.3.3)
@@ -2461,7 +2461,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2520,7 +2520,7 @@ importers:
         version: link:../../apps/heft
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -2532,13 +2532,13 @@ importers:
     dependencies:
       '@jest/core':
         specifier: ~29.5.0
-        version: 29.5.0
+        version: 29.5.0(supports-color@9.4.0)
       '@jest/reporters':
         specifier: ~29.5.0
-        version: 29.5.0
+        version: 29.5.0(supports-color@9.4.0)
       '@jest/transform':
         specifier: ~29.5.0
-        version: 29.5.0
+        version: 29.5.0(supports-color@9.4.0)
       '@rushstack/heft-config-file':
         specifier: workspace:*
         version: link:../../libraries/heft-config-file
@@ -2547,13 +2547,13 @@ importers:
         version: link:../../libraries/node-core-library
       jest-config:
         specifier: ~29.5.0
-        version: 29.5.0(@types/node@18.17.15)
+        version: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
       jest-resolve:
         specifier: ~29.5.0
         version: 29.5.0
       jest-snapshot:
         specifier: ~29.5.0
-        version: 29.5.0
+        version: 29.5.0(supports-color@9.4.0)
       lodash:
         specifier: ~4.17.15
         version: 4.17.21
@@ -2581,7 +2581,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       jest-environment-jsdom:
         specifier: ~29.5.0
         version: 29.5.0
@@ -2633,7 +2633,7 @@ importers:
         version: 7.5.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -2673,7 +2673,7 @@ importers:
         version: link:../../apps/heft
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -2853,7 +2853,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -2909,7 +2909,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3008,7 +3008,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 7.0.0
         version: 7.0.0
@@ -3045,7 +3045,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3119,7 +3119,7 @@ importers:
         version: 7.5.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -3141,7 +3141,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3435,16 +3435,16 @@ importers:
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../node-core-library
-      colors:
-        specifier: ~1.2.1
-        version: 1.2.5
+      supports-color:
+        specifier: ~9.4.0
+        version: 9.4.0
     devDependencies:
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3459,13 +3459,13 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.6.4
-        version: 3.6.4(eslint@8.7.0)(typescript@5.3.3)
+        version: 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3474,7 +3474,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -3499,7 +3499,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3634,7 +3634,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       jest-environment-node:
         specifier: ~29.5.0
         version: 29.5.0
@@ -3686,7 +3686,7 @@ importers:
         version: 3.4.1(webpack@5.82.1)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -3756,7 +3756,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       jest-junit:
         specifier: 12.3.0
         version: 12.3.0
@@ -3786,7 +3786,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       jest-junit:
         specifier: 12.3.0
         version: 12.3.0
@@ -4042,7 +4042,7 @@ importers:
         version: 1.86.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0
+        version: 8.7.0(supports-color@9.4.0)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -4747,13 +4747,13 @@ packages:
       '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.12.9)
-      '@babel/helpers': 7.23.9
+      '@babel/helpers': 7.23.9(supports-color@9.4.0)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -4764,7 +4764,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core@7.20.12:
+  /@babel/core@7.20.12(supports-color@9.4.0):
     resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -4773,13 +4773,13 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
-      '@babel/helpers': 7.23.9
+      '@babel/helpers': 7.23.9(supports-color@9.4.0)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4795,13 +4795,13 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
-      '@babel/helpers': 7.23.9
+      '@babel/helpers': 7.23.9(supports-color@9.4.0)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4848,7 +4848,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -4866,7 +4866,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -4877,12 +4877,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/traverse': 7.23.9
-      debug: 4.3.4
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -4895,10 +4895,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -4955,7 +4955,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -4997,7 +4997,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
@@ -5009,7 +5009,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -5055,12 +5055,12 @@ packages:
       '@babel/types': 7.23.9
     dev: true
 
-  /@babel/helpers@7.23.9:
+  /@babel/helpers@7.23.9(supports-color@9.4.0):
     resolution: {integrity: sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
     transitivePeerDependencies:
       - supports-color
@@ -5084,7 +5084,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5094,7 +5094,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.20.12)
@@ -5106,7 +5106,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5118,7 +5118,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5129,7 +5129,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.20.12)
@@ -5141,7 +5141,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.20.12)
     dev: true
@@ -5153,7 +5153,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5178,7 +5178,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
@@ -5192,7 +5192,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.20.12)
@@ -5205,7 +5205,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5216,7 +5216,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.20.12):
@@ -5224,7 +5224,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.20.12):
@@ -5232,7 +5232,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.20.12):
@@ -5240,7 +5240,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.20.12):
@@ -5249,7 +5249,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5259,7 +5259,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5268,7 +5268,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5278,7 +5278,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5287,7 +5287,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5297,7 +5297,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5307,7 +5307,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5317,7 +5317,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5326,7 +5326,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.20.12):
@@ -5334,7 +5334,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
@@ -5352,7 +5352,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.20.12):
@@ -5360,7 +5360,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.20.12):
@@ -5368,7 +5368,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.20.12):
@@ -5376,7 +5376,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
@@ -5393,7 +5393,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.20.12):
@@ -5401,7 +5401,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.20.12):
@@ -5409,7 +5409,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.20.12):
@@ -5418,7 +5418,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5428,7 +5428,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.20.12):
@@ -5437,7 +5437,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.20.12):
@@ -5446,7 +5446,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5457,7 +5457,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5467,7 +5467,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.20.12)
@@ -5480,7 +5480,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.20.12)
@@ -5492,7 +5492,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5502,7 +5502,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5512,7 +5512,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5523,7 +5523,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.20.12)
@@ -5535,7 +5535,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
@@ -5552,7 +5552,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.23.9
     dev: true
@@ -5563,7 +5563,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5573,7 +5573,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5584,7 +5584,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5594,7 +5594,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5605,7 +5605,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5616,7 +5616,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5627,7 +5627,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.20.12)
     dev: true
@@ -5638,7 +5638,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
@@ -5649,7 +5649,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
@@ -5661,7 +5661,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5672,7 +5672,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5682,7 +5682,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
     dev: true
@@ -5693,7 +5693,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5703,7 +5703,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5714,7 +5714,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
@@ -5726,7 +5726,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -5739,7 +5739,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5750,7 +5750,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5761,7 +5761,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5771,7 +5771,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5782,7 +5782,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.20.12)
     dev: true
@@ -5794,7 +5794,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
@@ -5807,7 +5807,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.20.12)
     dev: true
@@ -5818,7 +5818,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5829,7 +5829,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.20.12)
@@ -5851,7 +5851,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5861,7 +5861,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5872,7 +5872,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -5885,7 +5885,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5895,7 +5895,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5905,7 +5905,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
     dev: true
 
@@ -5915,7 +5915,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
@@ -5929,7 +5929,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5940,7 +5940,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: true
@@ -5951,7 +5951,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5961,7 +5961,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5971,7 +5971,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
@@ -5982,7 +5982,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5992,7 +5992,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6002,7 +6002,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6012,7 +6012,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -6025,7 +6025,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6035,7 +6035,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6046,7 +6046,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6057,7 +6057,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6069,7 +6069,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
@@ -6159,7 +6159,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.20.12)
@@ -6170,7 +6170,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.9
       esutils: 2.0.3
@@ -6182,7 +6182,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.20.12)
@@ -6197,7 +6197,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
@@ -6211,7 +6211,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -6237,7 +6237,7 @@ packages:
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
 
-  /@babel/traverse@7.23.9:
+  /@babel/traverse@7.23.9(supports-color@9.4.0):
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -6249,7 +6249,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6677,7 +6677,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       eslint-visitor-keys: 3.4.3
 
   /@eslint-community/regexpp@4.10.0:
@@ -6689,7 +6689,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       espree: 7.3.1
       globals: 12.4.0
       ignore: 4.0.6
@@ -6707,7 +6707,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -6719,12 +6719,12 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/eslintrc@1.4.1:
+  /@eslint/eslintrc@1.4.1(supports-color@9.4.0):
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -6740,7 +6740,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -6757,7 +6757,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       espree: 10.0.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -8295,7 +8295,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
@@ -8306,18 +8306,18 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array@0.9.5:
+  /@humanwhocodes/config-array@0.9.5(supports-color@9.4.0):
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
@@ -8359,7 +8359,7 @@ packages:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  /@jest/core@29.5.0:
+  /@jest/core@29.5.0(supports-color@9.4.0):
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8369,9 +8369,9 @@ packages:
         optional: true
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.5.0
+      '@jest/reporters': 29.5.0(supports-color@9.4.0)
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.5.0(supports-color@9.4.0)
       '@jest/types': 29.5.0
       '@types/node': 18.17.15
       ansi-escapes: 4.3.2
@@ -8380,15 +8380,15 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.5.0(@types/node@18.17.15)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.5.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.5.0
+      jest-resolve-dependencies: 29.7.0(supports-color@9.4.0)
+      jest-runner: 29.7.0(supports-color@9.4.0)
+      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.5.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -8413,7 +8413,7 @@ packages:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       ansi-escapes: 4.3.2
@@ -8427,10 +8427,10 @@ packages:
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-resolve-dependencies: 29.7.0(supports-color@9.4.0)
+      jest-runner: 29.7.0(supports-color@9.4.0)
+      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -8459,12 +8459,12 @@ packages:
     dependencies:
       jest-get-type: 29.6.3
 
-  /@jest/expect@29.7.0:
+  /@jest/expect@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8479,18 +8479,18 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  /@jest/globals@29.7.0:
+  /@jest/globals@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0
+      '@jest/expect': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  /@jest/reporters@29.5.0:
+  /@jest/reporters@29.5.0(supports-color@9.4.0):
     resolution: {integrity: sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8502,7 +8502,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.5.0(supports-color@9.4.0)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.22
       '@types/istanbul-lib-coverage': 2.0.4
@@ -8513,9 +8513,9 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@9.4.0)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@9.4.0)
       istanbul-reports: 3.1.7
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8539,7 +8539,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.22
       '@types/istanbul-lib-coverage': 2.0.4
@@ -8552,7 +8552,7 @@ packages:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@9.4.0)
       istanbul-reports: 3.1.7
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8607,9 +8607,9 @@ packages:
     resolution: {integrity: sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@jest/types': 26.6.2
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
       chalk: 4.1.2
       convert-source-map: 1.9.0
       fast-json-stable-stringify: 2.1.0
@@ -8626,14 +8626,14 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/transform@29.5.0:
+  /@jest/transform@29.5.0(supports-color@9.4.0):
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.22
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8648,14 +8648,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@jest/transform@29.7.0:
+  /@jest/transform@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.22
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -9478,6 +9478,29 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
+  /@rushstack/eslint-config@3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-jeIA1qvGfiIWrHr2lXzIhcdFTZarTawH/Fz0MBh2b4F7n3dP20e+XMmUhT02SuVmb9bCt61PtD3vWHt/WkGjQA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '>=4.7.0'
+    dependencies:
+      '@rushstack/eslint-patch': 1.7.2
+      '@rushstack/eslint-plugin': 0.15.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@rushstack/eslint-plugin-security': 0.8.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.7.0)
+      eslint-plugin-react: 7.33.2(eslint@8.7.0)
+      eslint-plugin-tsdoc: 0.2.17
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@rushstack/eslint-config@3.6.4(eslint@8.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-jeIA1qvGfiIWrHr2lXzIhcdFTZarTawH/Fz0MBh2b4F7n3dP20e+XMmUhT02SuVmb9bCt61PtD3vWHt/WkGjQA==}
     peerDependencies:
@@ -9492,7 +9515,7 @@ packages:
       '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       eslint-plugin-promise: 6.1.1(eslint@8.7.0)
       eslint-plugin-react: 7.33.2(eslint@8.7.0)
       eslint-plugin-tsdoc: 0.2.17
@@ -9501,31 +9524,21 @@ packages:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@3.6.4(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-jeIA1qvGfiIWrHr2lXzIhcdFTZarTawH/Fz0MBh2b4F7n3dP20e+XMmUhT02SuVmb9bCt61PtD3vWHt/WkGjQA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '>=4.7.0'
-    dependencies:
-      '@rushstack/eslint-patch': 1.7.2
-      '@rushstack/eslint-plugin': 0.15.1(eslint@8.7.0)(typescript@5.3.3)
-      '@rushstack/eslint-plugin-packlets': 0.9.1(eslint@8.7.0)(typescript@5.3.3)
-      '@rushstack/eslint-plugin-security': 0.8.1(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      eslint: 8.7.0
-      eslint-plugin-promise: 6.1.1(eslint@8.7.0)
-      eslint-plugin-react: 7.33.2(eslint@8.7.0)
-      eslint-plugin-tsdoc: 0.2.17
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@rushstack/eslint-patch@1.7.2:
     resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
+    dev: true
+
+  /@rushstack/eslint-plugin-packlets@0.9.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-CN7RKrrpBj+UXzOYUxArzV7lUKX8UlZBJWPzdAI8HFYg0g1EVASjGRlcq3Q+e1KRZ1MeliVigRsoodfmJCHv+A==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.3
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /@rushstack/eslint-plugin-packlets@0.9.1(eslint@8.7.0)(typescript@4.9.5):
@@ -9535,20 +9548,20 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-CN7RKrrpBj+UXzOYUxArzV7lUKX8UlZBJWPzdAI8HFYg0g1EVASjGRlcq3Q+e1KRZ1MeliVigRsoodfmJCHv+A==}
+  /@rushstack/eslint-plugin-security@0.8.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-XEMt9dvifXO6mmIfVggUNd4PP8pZlewn1D7OGXdMtLasRUiOkZGOYu24Kj5fgLnPDH1xqAdG9okhPZwT4yar7w==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      eslint: 8.7.0
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9561,20 +9574,20 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security@0.8.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-XEMt9dvifXO6mmIfVggUNd4PP8pZlewn1D7OGXdMtLasRUiOkZGOYu24Kj5fgLnPDH1xqAdG9okhPZwT4yar7w==}
+  /@rushstack/eslint-plugin@0.15.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-xgu6jwMscLCX0SWCDAUEpIFou3ApyTkJC76zgrWs6oOH1oeF8PLfzkdwhaSF8QptXG6oxXV7aqGMkDwH5ToBwQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      eslint: 8.7.0
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9587,20 +9600,7 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin@0.15.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-xgu6jwMscLCX0SWCDAUEpIFou3ApyTkJC76zgrWs6oOH1oeF8PLfzkdwhaSF8QptXG6oxXV7aqGMkDwH5ToBwQ==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9656,18 +9656,18 @@ packages:
       jest-environment-node:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0
-      '@jest/reporters': 29.5.0
-      '@jest/transform': 29.5.0
+      '@jest/core': 29.5.0(supports-color@9.4.0)
+      '@jest/reporters': 29.5.0(supports-color@9.4.0)
+      '@jest/transform': 29.5.0(supports-color@9.4.0)
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-config-file': 0.14.13(@types/node@18.17.15)
       '@rushstack/node-core-library': 4.0.2(@types/node@18.17.15)
       '@rushstack/terminal': 0.9.0(@types/node@18.17.15)
-      jest-config: 29.5.0(@types/node@18.17.15)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
       jest-environment-jsdom: 29.5.0
       jest-environment-node: 29.5.0
       jest-resolve: 29.5.0
-      jest-snapshot: 29.5.0
+      jest-snapshot: 29.5.0(supports-color@9.4.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@types/node'
@@ -9677,7 +9677,7 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0):
+  /@rushstack/heft-jest-plugin@0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@9.4.0):
     resolution: {integrity: sha512-Ct5quYL9myoed4mIROkeGMB4Pu3kHHPA3rCfLEusBqcOkS/afFu6AhIIXAIR8XozAGWLs3mD/7irvF8FB5/4MQ==}
     peerDependencies:
       '@rushstack/heft': '*'
@@ -9689,17 +9689,17 @@ packages:
       jest-environment-node:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0
-      '@jest/reporters': 29.5.0
-      '@jest/transform': 29.5.0
+      '@jest/core': 29.5.0(supports-color@9.4.0)
+      '@jest/reporters': 29.5.0(supports-color@9.4.0)
+      '@jest/transform': 29.5.0(supports-color@9.4.0)
       '@rushstack/heft': 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-config-file': 0.14.13(@types/node@18.17.15)
       '@rushstack/node-core-library': 4.0.2(@types/node@18.17.15)
       '@rushstack/terminal': 0.9.0(@types/node@18.17.15)
-      jest-config: 29.5.0(@types/node@18.17.15)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
       jest-environment-node: 29.5.0
       jest-resolve: 29.5.0
-      jest-snapshot: 29.5.0
+      jest-snapshot: 29.5.0(supports-color@9.4.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@types/node'
@@ -9739,14 +9739,14 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.40.6(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(typescript@5.3.3)
+      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-api-extractor-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
       '@rushstack/heft-lint-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       jest-environment-node: 29.5.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -9758,20 +9758,20 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-node-rig@2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15):
+  /@rushstack/heft-node-rig@2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0):
     resolution: {integrity: sha512-nF6+P2aJUYMqFCl2JPQYKh3hjArXQAbiFnDJkNBr4tBQUcgvwgN2VtgMZJEZeg1cPK6DVOnGqFsInHOMCuKLTw==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.40.6(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(typescript@5.3.3)
+      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       '@rushstack/heft': 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-api-extractor-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)
+      '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@9.4.0)
       '@rushstack/heft-lint-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       jest-environment-node: 29.5.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -10212,7 +10212,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/generator': 7.23.6
       '@babel/parser': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
@@ -10302,7 +10302,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@storybook/addon-actions': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-backgrounds': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-controls': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
@@ -10538,7 +10538,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.20.12)
       '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.20.12)
@@ -10655,7 +10655,7 @@ packages:
     peerDependencies:
       jest: '*'
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/preset-env': 7.23.9(@babel/core@7.20.12)
       '@storybook/codemod': 6.4.22(@babel/preset-env@7.23.9)
       '@storybook/core-common': 6.4.22(eslint@8.7.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
@@ -10840,7 +10840,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.20.12)
       '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.20.12)
@@ -11015,12 +11015,12 @@ packages:
   /@storybook/csf-tools@6.4.22:
     resolution: {integrity: sha512-LMu8MZAiQspJAtMBLU2zitsIkqQv7jOwX7ih5JrXlyaDticH7l2j6Q+1mCZNWUOiMTizj0ivulmUsSaYbpToSw==}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/generator': 7.23.6
       '@babel/parser': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
       '@babel/preset-env': 7.23.9(@babel/core@7.20.12)
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       '@mdx-js/mdx': 1.6.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
@@ -11052,7 +11052,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.20.12)
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@storybook/addons': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -11151,7 +11151,7 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4 || ^4 || ^5'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -11181,7 +11181,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/preset-flow': 7.23.3(@babel/core@7.20.12)
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.11.0)(webpack@4.47.0)
@@ -12019,6 +12019,34 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -12036,8 +12064,8 @@ packages:
       '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4
-      eslint: 8.7.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
@@ -12047,34 +12075,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
-      eslint: 8.7.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      semver: 7.5.4
-      ts-api-utils: 1.2.1(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@typescript-eslint/parser@6.19.1(eslint@7.11.0)(typescript@5.3.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
@@ -12088,9 +12088,9 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.11.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -12109,9 +12109,9 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.30.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -12130,14 +12130,34 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.7.0
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@typescript-eslint/parser@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   /@typescript-eslint/parser@6.19.1(eslint@8.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
@@ -12153,32 +12173,12 @@ packages:
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4
-      eslint: 8.7.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@typescript-eslint/parser@6.19.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
-      eslint: 8.7.0
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@typescript-eslint/rule-tester@6.19.1(@eslint/eslintrc@3.0.1)(eslint@8.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-1qvOSO9kjtjP66UimQ06tnZC/XVhb2s5hVi2Cn33efnzM3m+j8rwcGJJ9xwKacUWe7U50iHrY9xrakmF7SPWbg==}
@@ -12189,10 +12189,10 @@ packages:
     dependencies:
       '@eslint/eslintrc': 3.0.1
       '@types/semver': 7.5.0
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
       ajv: 6.12.6
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       lodash.merge: 4.6.2
       semver: 7.5.4
     transitivePeerDependencies:
@@ -12219,6 +12219,25 @@ packages:
     transitivePeerDependencies:
       - typescript
 
+  /@typescript-eslint/type-utils@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/type-utils@6.19.1(eslint@8.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -12231,32 +12250,13 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      debug: 4.3.4
-      eslint: 8.7.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@9.4.0)
       ts-api-utils: 1.2.1(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@typescript-eslint/type-utils@6.19.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      debug: 4.3.4
-      eslint: 8.7.0
-      ts-api-utils: 1.2.1(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@typescript-eslint/types@5.59.11(typescript@5.3.3):
     resolution: {integrity: sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==}
@@ -12284,6 +12284,27 @@ packages:
     dependencies:
       typescript: 5.3.3
 
+  /@typescript-eslint/typescript-estree@6.19.1(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
+      debug: 4.3.4(supports-color@9.4.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/typescript-estree@6.19.1(typescript@4.9.5):
     resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -12295,7 +12316,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -12306,26 +12327,23 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.3.3):
-    resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
+  /@typescript-eslint/utils@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^7.0.0 || ^8.0.0
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.7.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
       semver: 7.5.4
-      ts-api-utils: 1.2.1(typescript@5.3.3)
-      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+      - typescript
 
   /@typescript-eslint/utils@6.19.1(eslint@8.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
@@ -12339,30 +12357,12 @@ packages:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
-
-  /@typescript-eslint/utils@6.19.1(eslint@8.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.7.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      eslint: 8.7.0
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   /@typescript-eslint/visitor-keys@6.19.1(typescript@4.9.5):
     resolution: {integrity: sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==}
@@ -12750,7 +12750,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13282,7 +13282,7 @@ packages:
     resolution: {integrity: sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==}
     dependencies:
       archy: 1.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       fastq: 1.17.1
       queue-microtask: 1.2.3
     transitivePeerDependencies:
@@ -13380,19 +13380,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
     dev: true
 
-  /babel-jest@29.7.0(@babel/core@7.20.12):
+  /babel-jest@29.7.0(@babel/core@7.20.12)(supports-color@9.4.0):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.20.12
-      '@jest/transform': 29.7.0
+      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
       babel-preset-jest: 29.6.3(@babel/core@7.20.12)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -13407,7 +13407,7 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2 || ^4 || ^5'
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -13450,14 +13450,14 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
 
-  /babel-plugin-istanbul@6.1.1:
+  /babel-plugin-istanbul@6.1.1(supports-color@9.4.0):
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
       '@babel/helper-plugin-utils': 7.22.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@9.4.0)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13493,7 +13493,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.1.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
     dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.20.12):
@@ -13502,7 +13502,7 @@ packages:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -13514,7 +13514,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-define-polyfill-provider': 0.1.5(@babel/core@7.20.12)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
@@ -13526,7 +13526,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
@@ -13538,7 +13538,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
@@ -13563,7 +13563,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.20.12)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.20.12)
@@ -13583,7 +13583,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
 
@@ -15162,7 +15162,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.4:
+  /debug@4.3.4(supports-color@9.4.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -15172,6 +15172,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+      supports-color: 9.4.0
 
   /debuglog@1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -15330,12 +15331,12 @@ packages:
     hasBin: true
     dependencies:
       '@babel/parser': 7.23.9
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@vue/compiler-sfc': 3.4.19
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.1
@@ -15435,7 +15436,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16299,7 +16300,7 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     dev: false
 
   /eslint-plugin-deprecation@2.0.0(eslint@8.7.0)(typescript@5.3.3):
@@ -16308,8 +16309,8 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@5.3.3)
-      eslint: 8.7.0
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@9.4.0)
       tslib: 2.3.1
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
@@ -16322,7 +16323,7 @@ packages:
     peerDependencies:
       eslint: '>=7.7.0'
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     dev: false
 
   /eslint-plugin-import@2.25.4(eslint@8.7.0):
@@ -16335,7 +16336,7 @@ packages:
       array.prototype.flat: 1.3.2
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0(eslint@8.7.0)
       has: 1.0.4
@@ -16355,9 +16356,9 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.17.0
       comment-parser: 1.3.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       escape-string-regexp: 4.0.0
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       esquery: 1.5.0
       regextras: 0.8.0
       semver: 7.5.4
@@ -16372,7 +16373,7 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
 
   /eslint-plugin-react-hooks@4.3.0(eslint@8.7.0):
     resolution: {integrity: sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==}
@@ -16380,7 +16381,7 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
     dev: false
 
   /eslint-plugin-react@7.33.2(eslint@8.7.0):
@@ -16394,7 +16395,7 @@ packages:
       array.prototype.tosorted: 1.1.3
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.17
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -16447,7 +16448,7 @@ packages:
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       eslint-visitor-keys: 2.1.0
 
   /eslint-visitor-keys@1.3.0:
@@ -16478,7 +16479,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       eslint-scope: 5.1.1
@@ -16525,7 +16526,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -16572,7 +16573,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       eslint-scope: 5.1.1
@@ -16624,7 +16625,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16655,17 +16656,17 @@ packages:
       - supports-color
     dev: true
 
-  /eslint@8.7.0:
+  /eslint@8.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.9.5
+      '@eslint/eslintrc': 1.4.1(supports-color@9.4.0)
+      '@humanwhocodes/config-array': 0.9.5(supports-color@9.4.0)
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16753,7 +16754,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       c8: 7.14.0
     transitivePeerDependencies:
@@ -17345,7 +17346,7 @@ packages:
       chokidar: 3.4.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.7.0
+      eslint: 8.7.0(supports-color@9.4.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.4.3
@@ -17625,7 +17626,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -18251,7 +18252,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18262,7 +18263,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18320,7 +18321,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18330,7 +18331,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18971,11 +18972,11 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  /istanbul-lib-instrument@5.2.1:
+  /istanbul-lib-instrument@5.2.1(supports-color@9.4.0):
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -19004,11 +19005,11 @@ packages:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  /istanbul-lib-source-maps@4.0.1:
+  /istanbul-lib-source-maps@4.0.1(supports-color@9.4.0):
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -19049,12 +19050,12 @@ packages:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  /jest-circus@29.7.0:
+  /jest-circus@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0
+      '@jest/expect': 29.7.0(supports-color@9.4.0)
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
@@ -19065,8 +19066,8 @@ packages:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -19105,7 +19106,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@18.17.15):
+  /jest-config@29.5.0(@types/node@18.17.15)(supports-color@9.4.0):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -19117,22 +19118,22 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@jest/test-sequencer': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.5.0
       '@types/node': 18.17.15
-      babel-jest: 29.7.0(@babel/core@7.20.12)
+      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@9.4.0)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@9.4.0)
       jest-environment-node: 29.5.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.5.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.5
@@ -19156,22 +19157,22 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@jest/test-sequencer': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
-      babel-jest: 29.7.0(@babel/core@7.20.12)
+      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@9.4.0)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@9.4.0)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.5
@@ -19400,12 +19401,12 @@ packages:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  /jest-resolve-dependencies@29.7.0:
+  /jest-resolve-dependencies@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19437,14 +19438,14 @@ packages:
       resolve.exports: 2.0.2
       slash: 3.0.0
 
-  /jest-runner@29.7.0:
+  /jest-runner@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       chalk: 4.1.2
@@ -19456,7 +19457,7 @@ packages:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0
+      jest-runtime: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -19465,16 +19466,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jest-runtime@29.7.0:
+  /jest-runtime@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0
+      '@jest/globals': 29.7.0(supports-color@9.4.0)
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       chalk: 4.1.2
@@ -19487,7 +19488,7 @@ packages:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
@@ -19502,18 +19503,18 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jest-snapshot@29.5.0:
+  /jest-snapshot@29.5.0(supports-color@9.4.0):
     resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.20.12)
-      '@babel/traverse': 7.23.9
+      '@babel/traverse': 7.23.9(supports-color@9.4.0)
       '@babel/types': 7.23.9
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.5.0(supports-color@9.4.0)
       '@jest/types': 29.5.0
       '@types/babel__traverse': 7.20.5
       '@types/prettier': 2.7.3
@@ -19532,17 +19533,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jest-snapshot@29.7.0:
+  /jest-snapshot@29.7.0(supports-color@9.4.0):
     resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.20.12)
       '@babel/types': 7.23.9
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@9.4.0)
       '@jest/types': 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
       chalk: 4.1.2
@@ -19650,7 +19651,7 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0
+      '@jest/core': 29.5.0(supports-color@9.4.0)
       '@jest/types': 29.5.0
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@18.17.15)
@@ -19712,7 +19713,7 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/parser': 7.23.9
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.20.12)
@@ -20214,7 +20215,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       flatted: 3.3.1
       rfdc: 1.3.1
       streamroller: 3.1.5
@@ -21501,7 +21502,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -22422,7 +22423,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -22500,7 +22501,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -22625,7 +22626,7 @@ packages:
   /rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       js-yaml: 4.1.0
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -22665,7 +22666,7 @@ packages:
     engines: {node: '>=8.10.0'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12(supports-color@9.4.0)
       '@babel/generator': 7.23.6
       '@babel/runtime': 7.23.9
       ast-types: 0.14.2
@@ -24099,7 +24100,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -24223,7 +24224,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -24237,7 +24238,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -24354,7 +24355,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@9.4.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -24626,6 +24627,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+
+  /supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -164,7 +164,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -379,7 +379,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -409,7 +409,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -478,7 +478,7 @@ importers:
         version: 10.0.130
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -500,7 +500,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ~7.20.0
-        version: 7.20.12(supports-color@9.4.0)
+        version: 7.20.12(supports-color@8.1.1)
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
@@ -545,7 +545,7 @@ importers:
         version: 5.2.7(webpack@4.47.0)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       heft-storybook-react-tutorial-storykit:
         specifier: workspace:*
         version: link:../heft-storybook-react-tutorial-storykit
@@ -588,7 +588,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ~7.20.0
-        version: 7.20.12(supports-color@9.4.0)
+        version: 7.20.12(supports-color@8.1.1)
       '@storybook/addon-actions':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -771,7 +771,7 @@ importers:
         version: 6.6.0(webpack@5.82.1)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -810,7 +810,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -1140,10 +1140,10 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -1158,10 +1158,10 @@ importers:
         version: link:../../apps/heft
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -1231,7 +1231,7 @@ importers:
         version: 1.0.6
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1255,7 +1255,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1289,7 +1289,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1319,7 +1319,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1331,7 +1331,7 @@ importers:
     devDependencies:
       '@jest/reporters':
         specifier: ~29.5.0
-        version: 29.5.0(supports-color@9.4.0)
+        version: 29.5.0(supports-color@8.1.1)
       '@jest/types':
         specifier: 29.5.0
         version: 29.5.0
@@ -1352,7 +1352,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1427,7 +1427,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1475,7 +1475,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01
@@ -1515,7 +1515,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1597,7 +1597,7 @@ importers:
         version: 5.2.7(webpack@4.47.0)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~4.5.2
         version: 4.5.2(webpack@4.47.0)
@@ -1657,7 +1657,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -1777,7 +1777,7 @@ importers:
         version: 20.11.20
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@4.9.5)
@@ -1825,7 +1825,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       file-loader:
         specifier: ~6.0.0
         version: 6.0.0(webpack@4.47.0)
@@ -1879,7 +1879,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -2088,7 +2088,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
@@ -2162,7 +2162,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
@@ -2201,7 +2201,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -2255,16 +2255,16 @@ importers:
         version: link:../eslint-plugin-security
       '@typescript-eslint/eslint-plugin':
         specifier: ~6.19.0
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       eslint-plugin-promise:
         specifier: ~6.1.1
         version: 6.1.1(eslint@8.7.0)
@@ -2277,7 +2277,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2289,7 +2289,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
@@ -2307,7 +2307,7 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2317,7 +2317,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2332,16 +2332,16 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/rule-tester':
         specifier: ~6.19.0
         version: 6.19.1(@eslint/eslintrc@3.0.1)(eslint@8.7.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2353,14 +2353,14 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
     devDependencies:
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2375,13 +2375,13 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2393,7 +2393,7 @@ importers:
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2403,7 +2403,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2418,16 +2418,16 @@ importers:
         version: 18.17.15
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/rule-tester':
         specifier: ~6.19.0
         version: 6.19.1(@eslint/eslintrc@3.0.1)(eslint@8.7.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree':
         specifier: ~6.19.0
-        version: 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2442,7 +2442,7 @@ importers:
         version: link:../eslint-patch
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       eslint-plugin-deprecation:
         specifier: 2.0.0
         version: 2.0.0(eslint@8.7.0)(typescript@5.3.3)
@@ -2461,7 +2461,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -2520,7 +2520,7 @@ importers:
         version: link:../../apps/heft
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -2532,13 +2532,13 @@ importers:
     dependencies:
       '@jest/core':
         specifier: ~29.5.0
-        version: 29.5.0(supports-color@9.4.0)
+        version: 29.5.0(supports-color@8.1.1)
       '@jest/reporters':
         specifier: ~29.5.0
-        version: 29.5.0(supports-color@9.4.0)
+        version: 29.5.0(supports-color@8.1.1)
       '@jest/transform':
         specifier: ~29.5.0
-        version: 29.5.0(supports-color@9.4.0)
+        version: 29.5.0(supports-color@8.1.1)
       '@rushstack/heft-config-file':
         specifier: workspace:*
         version: link:../../libraries/heft-config-file
@@ -2547,13 +2547,13 @@ importers:
         version: link:../../libraries/node-core-library
       jest-config:
         specifier: ~29.5.0
-        version: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-resolve:
         specifier: ~29.5.0
         version: 29.5.0
       jest-snapshot:
         specifier: ~29.5.0
-        version: 29.5.0(supports-color@9.4.0)
+        version: 29.5.0(supports-color@8.1.1)
       lodash:
         specifier: ~4.17.15
         version: 4.17.21
@@ -2581,7 +2581,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       jest-environment-jsdom:
         specifier: ~29.5.0
         version: 29.5.0
@@ -2633,7 +2633,7 @@ importers:
         version: 7.5.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -2673,7 +2673,7 @@ importers:
         version: link:../../apps/heft
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -2853,7 +2853,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -2909,7 +2909,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3008,7 +3008,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/fs-extra':
         specifier: 7.0.0
         version: 7.0.0
@@ -3045,7 +3045,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3119,7 +3119,7 @@ importers:
         version: 7.5.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -3141,7 +3141,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3436,21 +3436,24 @@ importers:
         specifier: workspace:*
         version: link:../node-core-library
       supports-color:
-        specifier: ~9.4.0
-        version: 9.4.0
+        specifier: ~8.1.1
+        version: 8.1.1
     devDependencies:
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
       '@types/node':
         specifier: 18.17.15
         version: 18.17.15
+      '@types/supports-color':
+        specifier: 8.1.3
+        version: 8.1.3
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
@@ -3459,13 +3462,13 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.6.4
-        version: 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+        version: 3.6.4(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@rushstack/heft':
         specifier: 0.65.4
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3474,7 +3477,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -3499,7 +3502,7 @@ importers:
         version: 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
         specifier: 2.4.16
-        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0)
+        version: 2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3634,7 +3637,7 @@ importers:
         version: 1.0.1
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       jest-environment-node:
         specifier: ~29.5.0
         version: 29.5.0
@@ -3686,7 +3689,7 @@ importers:
         version: 3.4.1(webpack@5.82.1)
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -3756,7 +3759,7 @@ importers:
         version: 18.17.15
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       jest-junit:
         specifier: 12.3.0
         version: 12.3.0
@@ -3786,7 +3789,7 @@ importers:
         version: 1.18.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       jest-junit:
         specifier: 12.3.0
         version: 12.3.0
@@ -4042,7 +4045,7 @@ importers:
         version: 1.86.0
       eslint:
         specifier: ~8.7.0
-        version: 8.7.0(supports-color@9.4.0)
+        version: 8.7.0(supports-color@8.1.1)
       html-webpack-plugin:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.82.1)
@@ -4747,13 +4750,13 @@ packages:
       '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.12.9)
-      '@babel/helpers': 7.23.9(supports-color@9.4.0)
+      '@babel/helpers': 7.23.9(supports-color@8.1.1)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -4764,7 +4767,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core@7.20.12(supports-color@9.4.0):
+  /@babel/core@7.20.12(supports-color@8.1.1):
     resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -4773,13 +4776,13 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
-      '@babel/helpers': 7.23.9(supports-color@9.4.0)
+      '@babel/helpers': 7.23.9(supports-color@8.1.1)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4795,13 +4798,13 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
-      '@babel/helpers': 7.23.9(supports-color@9.4.0)
+      '@babel/helpers': 7.23.9(supports-color@8.1.1)
       '@babel/parser': 7.23.9
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4848,7 +4851,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -4866,7 +4869,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -4877,12 +4880,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
-      debug: 4.3.4(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -4895,10 +4898,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -4955,7 +4958,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -4997,7 +5000,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
@@ -5009,7 +5012,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -5055,12 +5058,12 @@ packages:
       '@babel/types': 7.23.9
     dev: true
 
-  /@babel/helpers@7.23.9(supports-color@9.4.0):
+  /@babel/helpers@7.23.9(supports-color@8.1.1):
     resolution: {integrity: sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
     transitivePeerDependencies:
       - supports-color
@@ -5084,7 +5087,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5094,7 +5097,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.20.12)
@@ -5106,7 +5109,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5118,7 +5121,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5129,7 +5132,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.20.12)
@@ -5141,7 +5144,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.20.12)
     dev: true
@@ -5153,7 +5156,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5178,7 +5181,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
@@ -5192,7 +5195,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.20.12)
@@ -5205,7 +5208,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5216,7 +5219,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.20.12):
@@ -5224,7 +5227,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.20.12):
@@ -5232,7 +5235,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.20.12):
@@ -5240,7 +5243,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.20.12):
@@ -5249,7 +5252,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5259,7 +5262,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5268,7 +5271,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5278,7 +5281,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5287,7 +5290,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5297,7 +5300,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5307,7 +5310,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5317,7 +5320,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5326,7 +5329,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.20.12):
@@ -5334,7 +5337,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
@@ -5352,7 +5355,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.20.12):
@@ -5360,7 +5363,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.20.12):
@@ -5368,7 +5371,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.20.12):
@@ -5376,7 +5379,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
@@ -5393,7 +5396,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.20.12):
@@ -5401,7 +5404,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.20.12):
@@ -5409,7 +5412,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.20.12):
@@ -5418,7 +5421,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5428,7 +5431,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.20.12):
@@ -5437,7 +5440,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.20.12):
@@ -5446,7 +5449,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5457,7 +5460,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5467,7 +5470,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.20.12)
@@ -5480,7 +5483,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.20.12)
@@ -5492,7 +5495,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5502,7 +5505,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5512,7 +5515,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5523,7 +5526,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.20.12)
@@ -5535,7 +5538,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
@@ -5552,7 +5555,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.23.9
     dev: true
@@ -5563,7 +5566,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5573,7 +5576,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5584,7 +5587,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5594,7 +5597,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5605,7 +5608,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5616,7 +5619,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5627,7 +5630,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.20.12)
     dev: true
@@ -5638,7 +5641,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
@@ -5649,7 +5652,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
@@ -5661,7 +5664,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5672,7 +5675,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5682,7 +5685,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
     dev: true
@@ -5693,7 +5696,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5703,7 +5706,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5714,7 +5717,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
@@ -5726,7 +5729,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -5739,7 +5742,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5750,7 +5753,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5761,7 +5764,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5771,7 +5774,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5782,7 +5785,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.20.12)
     dev: true
@@ -5794,7 +5797,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
@@ -5807,7 +5810,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.20.12)
     dev: true
@@ -5818,7 +5821,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.20.12)
     dev: true
@@ -5829,7 +5832,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.20.12)
@@ -5851,7 +5854,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5861,7 +5864,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5872,7 +5875,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -5885,7 +5888,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5895,7 +5898,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5905,7 +5908,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
     dev: true
 
@@ -5915,7 +5918,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
@@ -5929,7 +5932,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -5940,7 +5943,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: true
@@ -5951,7 +5954,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5961,7 +5964,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5971,7 +5974,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
@@ -5982,7 +5985,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5992,7 +5995,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6002,7 +6005,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6012,7 +6015,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
@@ -6025,7 +6028,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6035,7 +6038,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6046,7 +6049,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6057,7 +6060,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
@@ -6069,7 +6072,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
@@ -6159,7 +6162,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.20.12)
@@ -6170,7 +6173,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.9
       esutils: 2.0.3
@@ -6182,7 +6185,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.20.12)
@@ -6197,7 +6200,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
@@ -6211,7 +6214,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -6237,7 +6240,7 @@ packages:
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
 
-  /@babel/traverse@7.23.9(supports-color@9.4.0):
+  /@babel/traverse@7.23.9(supports-color@8.1.1):
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -6249,7 +6252,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6677,7 +6680,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   /@eslint-community/regexpp@4.10.0:
@@ -6689,7 +6692,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 7.3.1
       globals: 12.4.0
       ignore: 4.0.6
@@ -6707,7 +6710,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -6719,12 +6722,12 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/eslintrc@1.4.1(supports-color@9.4.0):
+  /@eslint/eslintrc@1.4.1(supports-color@8.1.1):
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -6740,7 +6743,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -6757,7 +6760,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 10.0.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -8295,7 +8298,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
@@ -8306,18 +8309,18 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array@0.9.5(supports-color@9.4.0):
+  /@humanwhocodes/config-array@0.9.5(supports-color@8.1.1):
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.0.8
     transitivePeerDependencies:
       - supports-color
@@ -8359,7 +8362,7 @@ packages:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  /@jest/core@29.5.0(supports-color@9.4.0):
+  /@jest/core@29.5.0(supports-color@8.1.1):
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8369,9 +8372,9 @@ packages:
         optional: true
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.5.0(supports-color@9.4.0)
+      '@jest/reporters': 29.5.0(supports-color@8.1.1)
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.5.0(supports-color@9.4.0)
+      '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@jest/types': 29.5.0
       '@types/node': 18.17.15
       ansi-escapes: 4.3.2
@@ -8380,15 +8383,15 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.5.0
-      jest-resolve-dependencies: 29.7.0(supports-color@9.4.0)
-      jest-runner: 29.7.0(supports-color@9.4.0)
-      jest-runtime: 29.7.0(supports-color@9.4.0)
-      jest-snapshot: 29.5.0(supports-color@9.4.0)
+      jest-resolve-dependencies: 29.7.0(supports-color@8.1.1)
+      jest-runner: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.5.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -8413,7 +8416,7 @@ packages:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       ansi-escapes: 4.3.2
@@ -8427,10 +8430,10 @@ packages:
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0(supports-color@9.4.0)
-      jest-runner: 29.7.0(supports-color@9.4.0)
-      jest-runtime: 29.7.0(supports-color@9.4.0)
-      jest-snapshot: 29.7.0(supports-color@9.4.0)
+      jest-resolve-dependencies: 29.7.0(supports-color@8.1.1)
+      jest-runner: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -8459,12 +8462,12 @@ packages:
     dependencies:
       jest-get-type: 29.6.3
 
-  /@jest/expect@29.7.0(supports-color@9.4.0):
+  /@jest/expect@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8479,18 +8482,18 @@ packages:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  /@jest/globals@29.7.0(supports-color@9.4.0):
+  /@jest/globals@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@9.4.0)
+      '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  /@jest/reporters@29.5.0(supports-color@9.4.0):
+  /@jest/reporters@29.5.0(supports-color@8.1.1):
     resolution: {integrity: sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8502,7 +8505,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.5.0(supports-color@9.4.0)
+      '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.22
       '@types/istanbul-lib-coverage': 2.0.4
@@ -8513,9 +8516,9 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 5.2.1(supports-color@9.4.0)
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@9.4.0)
+      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
       istanbul-reports: 3.1.7
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8539,7 +8542,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.22
       '@types/istanbul-lib-coverage': 2.0.4
@@ -8552,7 +8555,7 @@ packages:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@9.4.0)
+      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
       istanbul-reports: 3.1.7
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8607,9 +8610,9 @@ packages:
     resolution: {integrity: sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@jest/types': 26.6.2
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 1.9.0
       fast-json-stable-stringify: 2.1.0
@@ -8626,14 +8629,14 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/transform@29.5.0(supports-color@9.4.0):
+  /@jest/transform@29.5.0(supports-color@8.1.1):
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.22
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8648,14 +8651,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@jest/transform@29.7.0(supports-color@9.4.0):
+  /@jest/transform@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.22
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -9478,21 +9481,21 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@rushstack/eslint-config@3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@rushstack/eslint-config@3.6.4(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-jeIA1qvGfiIWrHr2lXzIhcdFTZarTawH/Fz0MBh2b4F7n3dP20e+XMmUhT02SuVmb9bCt61PtD3vWHt/WkGjQA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.7.2
-      '@rushstack/eslint-plugin': 0.15.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@rushstack/eslint-plugin-packlets': 0.9.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@rushstack/eslint-plugin-security': 0.8.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@rushstack/eslint-plugin': 0.15.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@rushstack/eslint-plugin-security': 0.8.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.7.0)
       eslint-plugin-react: 7.33.2(eslint@8.7.0)
       eslint-plugin-tsdoc: 0.2.17
@@ -9515,7 +9518,7 @@ packages:
       '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.7.0)
       eslint-plugin-react: 7.33.2(eslint@8.7.0)
       eslint-plugin-tsdoc: 0.2.17
@@ -9528,14 +9531,14 @@ packages:
     resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@rushstack/eslint-plugin-packlets@0.9.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-CN7RKrrpBj+UXzOYUxArzV7lUKX8UlZBJWPzdAI8HFYg0g1EVASjGRlcq3Q+e1KRZ1MeliVigRsoodfmJCHv+A==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9548,20 +9551,20 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security@0.8.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@rushstack/eslint-plugin-security@0.8.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-XEMt9dvifXO6mmIfVggUNd4PP8pZlewn1D7OGXdMtLasRUiOkZGOYu24Kj5fgLnPDH1xqAdG9okhPZwT4yar7w==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9574,20 +9577,20 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin@0.15.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@rushstack/eslint-plugin@0.15.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-xgu6jwMscLCX0SWCDAUEpIFou3ApyTkJC76zgrWs6oOH1oeF8PLfzkdwhaSF8QptXG6oxXV7aqGMkDwH5ToBwQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9600,7 +9603,7 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.3
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9656,18 +9659,18 @@ packages:
       jest-environment-node:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(supports-color@9.4.0)
-      '@jest/reporters': 29.5.0(supports-color@9.4.0)
-      '@jest/transform': 29.5.0(supports-color@9.4.0)
+      '@jest/core': 29.5.0(supports-color@8.1.1)
+      '@jest/reporters': 29.5.0(supports-color@8.1.1)
+      '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-config-file': 0.14.13(@types/node@18.17.15)
       '@rushstack/node-core-library': 4.0.2(@types/node@18.17.15)
       '@rushstack/terminal': 0.9.0(@types/node@18.17.15)
-      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-environment-jsdom: 29.5.0
       jest-environment-node: 29.5.0
       jest-resolve: 29.5.0
-      jest-snapshot: 29.5.0(supports-color@9.4.0)
+      jest-snapshot: 29.5.0(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@types/node'
@@ -9677,7 +9680,7 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@9.4.0):
+  /@rushstack/heft-jest-plugin@0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1):
     resolution: {integrity: sha512-Ct5quYL9myoed4mIROkeGMB4Pu3kHHPA3rCfLEusBqcOkS/afFu6AhIIXAIR8XozAGWLs3mD/7irvF8FB5/4MQ==}
     peerDependencies:
       '@rushstack/heft': '*'
@@ -9689,17 +9692,17 @@ packages:
       jest-environment-node:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(supports-color@9.4.0)
-      '@jest/reporters': 29.5.0(supports-color@9.4.0)
-      '@jest/transform': 29.5.0(supports-color@9.4.0)
+      '@jest/core': 29.5.0(supports-color@8.1.1)
+      '@jest/reporters': 29.5.0(supports-color@8.1.1)
+      '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@rushstack/heft': 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-config-file': 0.14.13(@types/node@18.17.15)
       '@rushstack/node-core-library': 4.0.2(@types/node@18.17.15)
       '@rushstack/terminal': 0.9.0(@types/node@18.17.15)
-      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@9.4.0)
+      jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-environment-node: 29.5.0
       jest-resolve: 29.5.0
-      jest-snapshot: 29.5.0(supports-color@9.4.0)
+      jest-snapshot: 29.5.0(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@types/node'
@@ -9739,14 +9742,14 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.40.6(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@rushstack/heft': link:../../apps/heft
       '@rushstack/heft-api-extractor-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
       '@rushstack/heft-lint-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin': 0.3.13(@rushstack/heft@..+apps+heft)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -9758,20 +9761,20 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-node-rig@2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@9.4.0):
+  /@rushstack/heft-node-rig@2.4.16(@rushstack/heft@0.65.4)(@types/node@18.17.15)(supports-color@8.1.1):
     resolution: {integrity: sha512-nF6+P2aJUYMqFCl2JPQYKh3hjArXQAbiFnDJkNBr4tBQUcgvwgN2VtgMZJEZeg1cPK6DVOnGqFsInHOMCuKLTw==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.40.6(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@rushstack/eslint-config': 3.6.4(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@rushstack/heft': 0.65.4(@types/node@18.17.15)
       '@rushstack/heft-api-extractor-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@9.4.0)
+      '@rushstack/heft-jest-plugin': 0.11.14(@rushstack/heft@0.65.4)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1)
       '@rushstack/heft-lint-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin': 0.3.13(@rushstack/heft@0.65.4)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -10212,7 +10215,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/generator': 7.23.6
       '@babel/parser': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
@@ -10302,7 +10305,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@storybook/addon-actions': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-backgrounds': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-controls': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
@@ -10538,7 +10541,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.20.12)
       '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.20.12)
@@ -10655,7 +10658,7 @@ packages:
     peerDependencies:
       jest: '*'
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/preset-env': 7.23.9(@babel/core@7.20.12)
       '@storybook/codemod': 6.4.22(@babel/preset-env@7.23.9)
       '@storybook/core-common': 6.4.22(eslint@8.7.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
@@ -10840,7 +10843,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.20.12)
       '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.20.12)
@@ -11015,12 +11018,12 @@ packages:
   /@storybook/csf-tools@6.4.22:
     resolution: {integrity: sha512-LMu8MZAiQspJAtMBLU2zitsIkqQv7jOwX7ih5JrXlyaDticH7l2j6Q+1mCZNWUOiMTizj0ivulmUsSaYbpToSw==}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/generator': 7.23.6
       '@babel/parser': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.20.12)
       '@babel/preset-env': 7.23.9(@babel/core@7.20.12)
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       '@mdx-js/mdx': 1.6.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
@@ -11052,7 +11055,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.20.12)
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@storybook/addons': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -11151,7 +11154,7 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4 || ^4 || ^5'
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -11181,7 +11184,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/preset-flow': 7.23.3(@babel/core@7.20.12)
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.11.0)(webpack@4.47.0)
@@ -11916,6 +11919,10 @@ packages:
     resolution: {integrity: sha512-R6vDd7CHxcWMzv5wfVhR3qyCRVQoZKwVd6kit0rkozTThRZSXZKEW2Kz3AxfVqq9+UyJAz1g8Q+bJ3CL6NzztQ==}
     dev: true
 
+  /@types/supports-color@8.1.3:
+    resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
+    dev: true
+
   /@types/tapable@1.0.6:
     resolution: {integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==}
 
@@ -12019,7 +12026,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12031,13 +12038,13 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
@@ -12064,8 +12071,8 @@ packages:
       '@typescript-eslint/type-utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
@@ -12088,9 +12095,9 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.11.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -12109,9 +12116,9 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.30.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -12130,16 +12137,16 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.7.0
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@typescript-eslint/parser@6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12151,10 +12158,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -12173,8 +12180,8 @@ packages:
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -12189,10 +12196,10 @@ packages:
     dependencies:
       '@eslint/eslintrc': 3.0.1
       '@types/semver': 7.5.0
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
       ajv: 6.12.6
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       lodash.merge: 4.6.2
       semver: 7.5.4
     transitivePeerDependencies:
@@ -12219,7 +12226,7 @@ packages:
     transitivePeerDependencies:
       - typescript
 
-  /@typescript-eslint/type-utils@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@typescript-eslint/type-utils@6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12229,10 +12236,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       ts-api-utils: 1.2.1(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -12250,8 +12257,8 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.7.0(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.7.0(supports-color@8.1.1)
       ts-api-utils: 1.2.1(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -12284,7 +12291,7 @@ packages:
     dependencies:
       typescript: 5.3.3
 
-  /@typescript-eslint/typescript-estree@6.19.1(supports-color@9.4.0)(typescript@5.3.3):
+  /@typescript-eslint/typescript-estree@6.19.1(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12295,7 +12302,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.3.3)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -12316,7 +12323,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.19.1(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -12327,7 +12334,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12338,8 +12345,8 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/types': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -12357,7 +12364,7 @@ packages:
       '@typescript-eslint/scope-manager': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/types': 6.19.1(typescript@4.9.5)
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@4.9.5)
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -12750,7 +12757,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13282,7 +13289,7 @@ packages:
     resolution: {integrity: sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==}
     dependencies:
       archy: 1.0.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fastq: 1.17.1
       queue-microtask: 1.2.3
     transitivePeerDependencies:
@@ -13380,19 +13387,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
     dev: true
 
-  /babel-jest@29.7.0(@babel/core@7.20.12)(supports-color@9.4.0):
+  /babel-jest@29.7.0(@babel/core@7.20.12)(supports-color@8.1.1):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       babel-preset-jest: 29.6.3(@babel/core@7.20.12)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -13407,7 +13414,7 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2 || ^4 || ^5'
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -13450,14 +13457,14 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
 
-  /babel-plugin-istanbul@6.1.1(supports-color@9.4.0):
+  /babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
       '@babel/helper-plugin-utils': 7.22.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1(supports-color@9.4.0)
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13493,7 +13500,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.1.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
     dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.20.12):
@@ -13502,7 +13509,7 @@ packages:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -13514,7 +13521,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.1.5(@babel/core@7.20.12)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
@@ -13526,7 +13533,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
@@ -13538,7 +13545,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
@@ -13563,7 +13570,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.20.12)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.20.12)
@@ -13583,7 +13590,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
 
@@ -15162,7 +15169,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.4(supports-color@9.4.0):
+  /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -15172,7 +15179,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 9.4.0
+      supports-color: 8.1.1
 
   /debuglog@1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -15331,12 +15338,12 @@ packages:
     hasBin: true
     dependencies:
       '@babel/parser': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@vue/compiler-sfc': 3.4.19
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.1
@@ -15436,7 +15443,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16300,7 +16307,7 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     dev: false
 
   /eslint-plugin-deprecation@2.0.0(eslint@8.7.0)(typescript@5.3.3):
@@ -16309,8 +16316,8 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@9.4.0)(typescript@5.3.3)
-      eslint: 8.7.0(supports-color@9.4.0)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.7.0)(supports-color@8.1.1)(typescript@5.3.3)
+      eslint: 8.7.0(supports-color@8.1.1)
       tslib: 2.3.1
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
@@ -16323,7 +16330,7 @@ packages:
     peerDependencies:
       eslint: '>=7.7.0'
     dependencies:
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     dev: false
 
   /eslint-plugin-import@2.25.4(eslint@8.7.0):
@@ -16336,7 +16343,7 @@ packages:
       array.prototype.flat: 1.3.2
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0(eslint@8.7.0)
       has: 1.0.4
@@ -16356,9 +16363,9 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.17.0
       comment-parser: 1.3.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       esquery: 1.5.0
       regextras: 0.8.0
       semver: 7.5.4
@@ -16373,7 +16380,7 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
 
   /eslint-plugin-react-hooks@4.3.0(eslint@8.7.0):
     resolution: {integrity: sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==}
@@ -16381,7 +16388,7 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
     dev: false
 
   /eslint-plugin-react@7.33.2(eslint@8.7.0):
@@ -16395,7 +16402,7 @@ packages:
       array.prototype.tosorted: 1.1.3
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.17
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -16448,7 +16455,7 @@ packages:
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
 
   /eslint-visitor-keys@1.3.0:
@@ -16479,7 +16486,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       eslint-scope: 5.1.1
@@ -16526,7 +16533,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -16573,7 +16580,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       eslint-scope: 5.1.1
@@ -16625,7 +16632,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16656,17 +16663,17 @@ packages:
       - supports-color
     dev: true
 
-  /eslint@8.7.0(supports-color@9.4.0):
+  /eslint@8.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.4.1(supports-color@9.4.0)
-      '@humanwhocodes/config-array': 0.9.5(supports-color@9.4.0)
+      '@eslint/eslintrc': 1.4.1(supports-color@8.1.1)
+      '@humanwhocodes/config-array': 0.9.5(supports-color@8.1.1)
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16754,7 +16761,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       c8: 7.14.0
     transitivePeerDependencies:
@@ -17346,7 +17353,7 @@ packages:
       chokidar: 3.4.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.7.0(supports-color@9.4.0)
+      eslint: 8.7.0(supports-color@8.1.1)
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.4.3
@@ -17626,7 +17633,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -18252,7 +18259,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18263,7 +18270,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18321,7 +18328,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18331,7 +18338,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18972,11 +18979,11 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  /istanbul-lib-instrument@5.2.1(supports-color@9.4.0):
+  /istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -19005,11 +19012,11 @@ packages:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  /istanbul-lib-source-maps@4.0.1(supports-color@9.4.0):
+  /istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -19050,12 +19057,12 @@ packages:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  /jest-circus@29.7.0(supports-color@9.4.0):
+  /jest-circus@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@9.4.0)
+      '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
@@ -19066,8 +19073,8 @@ packages:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0(supports-color@9.4.0)
-      jest-snapshot: 29.7.0(supports-color@9.4.0)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -19106,7 +19113,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@18.17.15)(supports-color@9.4.0):
+  /jest-config@29.5.0(@types/node@18.17.15)(supports-color@8.1.1):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -19118,22 +19125,22 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.5.0
       '@types/node': 18.17.15
-      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@9.4.0)
+      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@9.4.0)
+      jest-circus: 29.7.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.5.0
-      jest-runner: 29.7.0(supports-color@9.4.0)
+      jest-runner: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.5
@@ -19157,22 +19164,22 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0(@types/node@18.17.15)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
-      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@9.4.0)
+      babel-jest: 29.7.0(@babel/core@7.20.12)(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@9.4.0)
+      jest-circus: 29.7.0(supports-color@8.1.1)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@9.4.0)
+      jest-runner: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.5
@@ -19401,12 +19408,12 @@ packages:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  /jest-resolve-dependencies@29.7.0(supports-color@9.4.0):
+  /jest-resolve-dependencies@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19438,14 +19445,14 @@ packages:
       resolve.exports: 2.0.2
       slash: 3.0.0
 
-  /jest-runner@29.7.0(supports-color@9.4.0):
+  /jest-runner@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       chalk: 4.1.2
@@ -19457,7 +19464,7 @@ packages:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -19466,16 +19473,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jest-runtime@29.7.0(supports-color@9.4.0):
+  /jest-runtime@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0(supports-color@9.4.0)
+      '@jest/globals': 29.7.0(supports-color@8.1.1)
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0(@types/node@18.17.15)
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 18.17.15
       chalk: 4.1.2
@@ -19488,7 +19495,7 @@ packages:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
@@ -19503,18 +19510,18 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jest-snapshot@29.5.0(supports-color@9.4.0):
+  /jest-snapshot@29.5.0(supports-color@8.1.1):
     resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.20.12)
-      '@babel/traverse': 7.23.9(supports-color@9.4.0)
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
       '@babel/types': 7.23.9
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.5.0(supports-color@9.4.0)
+      '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@jest/types': 29.5.0
       '@types/babel__traverse': 7.20.5
       '@types/prettier': 2.7.3
@@ -19533,17 +19540,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jest-snapshot@29.7.0(supports-color@9.4.0):
+  /jest-snapshot@29.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.20.12)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.20.12)
       '@babel/types': 7.23.9
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@9.4.0)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
       chalk: 4.1.2
@@ -19651,7 +19658,7 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(supports-color@9.4.0)
+      '@jest/core': 29.5.0(supports-color@8.1.1)
       '@jest/types': 29.5.0
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@18.17.15)
@@ -19713,7 +19720,7 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/parser': 7.23.9
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.20.12)
@@ -20215,7 +20222,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       flatted: 3.3.1
       rfdc: 1.3.1
       streamroller: 3.1.5
@@ -21502,7 +21509,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -22423,7 +22430,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -22501,7 +22508,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -22626,7 +22633,7 @@ packages:
   /rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       js-yaml: 4.1.0
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -22666,7 +22673,7 @@ packages:
     engines: {node: '>=8.10.0'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.20.12(supports-color@9.4.0)
+      '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/generator': 7.23.6
       '@babel/runtime': 7.23.9
       ast-types: 0.14.2
@@ -24100,7 +24107,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -24224,7 +24231,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -24238,7 +24245,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -24355,7 +24362,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -24627,10 +24634,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-
-  /supports-color@9.4.0:
-    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
-    engines: {node: '>=12'}
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0abfecaf3d1cfcd6d0bf5608693b9953a5e6389a",
+  "pnpmShrinkwrapHash": "eea8b6e9184ef13a202936a9b855668654757e62",
   "preferredVersionsHash": "40d4640a94cff77f7808a2f1960cc76231eb6f86"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "58dfbad420ffbe246c9ad8edd95b8eacaca6c6c6",
+  "pnpmShrinkwrapHash": "0abfecaf3d1cfcd6d0bf5608693b9953a5e6389a",
   "preferredVersionsHash": "40d4640a94cff77f7808a2f1960cc76231eb6f86"
 }

--- a/common/reviews/api/terminal.api.md
+++ b/common/reviews/api/terminal.api.md
@@ -63,6 +63,8 @@ export class Colorize {
     // (undocumented)
     static magentaBackground(text: string): string;
     // (undocumented)
+    static rainbow(text: string): string;
+    // (undocumented)
     static red(text: string): string;
     // (undocumented)
     static redBackground(text: string): string;

--- a/common/reviews/api/terminal.api.md
+++ b/common/reviews/api/terminal.api.md
@@ -85,7 +85,7 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
     get eolCharacter(): string;
     // (undocumented)
     static readonly supportsColor: boolean;
-    get supportsColor(): boolean;
+    readonly supportsColor: boolean;
     verboseEnabled: boolean;
     write(data: string, severity: TerminalProviderSeverity): void;
 }

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
-    "colors": "~1.2.1"
+    "supports-color": "~9.4.0"
   },
   "devDependencies": {
     "@rushstack/heft": "0.65.4",

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -17,13 +17,14 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
-    "supports-color": "~9.4.0"
+    "supports-color": "~8.1.1"
   },
   "devDependencies": {
     "@rushstack/heft": "0.65.4",
     "@rushstack/heft-node-rig": "2.4.16",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
+    "@types/supports-color": "8.1.3",
     "local-eslint-config": "workspace:*"
   },
   "peerDependencies": {

--- a/libraries/terminal/src/Colorize.ts
+++ b/libraries/terminal/src/Colorize.ts
@@ -45,6 +45,15 @@ export enum SgrParameterAttribute {
   HiddenOff = 28
 }
 
+const RAINBOW_SEQUENCE: SgrParameterAttribute[] = [
+  SgrParameterAttribute.RedForeground,
+  SgrParameterAttribute.YellowForeground,
+  SgrParameterAttribute.GreenForeground,
+  SgrParameterAttribute.CyanForeground,
+  SgrParameterAttribute.BlueForeground,
+  SgrParameterAttribute.MagentaForeground
+];
+
 /**
  * The static functions on this class are used to produce colored text
  * for use with a terminal that supports ANSI escape codes.
@@ -254,6 +263,20 @@ export class Colorize {
       SgrParameterAttribute.HiddenOff,
       text
     );
+  }
+
+  public static rainbow(text: string): string {
+    return Colorize._applyColorSequence(text, RAINBOW_SEQUENCE);
+  }
+
+  private static _applyColorSequence(text: string, sequence: SgrParameterAttribute[]): string {
+    let result: string = '';
+    const sequenceLength: number = sequence.length;
+    for (let i: number = 0; i < text.length; i++) {
+      result += AnsiEscape.getEscapeSequenceForAnsiCode(sequence[i % sequenceLength]) + text[i];
+    }
+
+    return result + AnsiEscape.getEscapeSequenceForAnsiCode(SgrParameterAttribute.DefaultForeground);
   }
 
   private static _wrapTextInAnsiEscapeCodes(startCode: number, endCode: number, text: string): string {

--- a/libraries/terminal/src/ConsoleTerminalProvider.ts
+++ b/libraries/terminal/src/ConsoleTerminalProvider.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { EOL } from 'os';
-import { enabled as supportsColor } from 'colors/safe';
+import supportsColor from 'supports-color';
 
 import { type ITerminalProvider, TerminalProviderSeverity } from './ITerminalProvider';
 
@@ -32,17 +32,22 @@ export interface IConsoleTerminalProviderOptions {
  * @beta
  */
 export class ConsoleTerminalProvider implements ITerminalProvider {
-  public static readonly supportsColor: boolean = supportsColor;
+  public static readonly supportsColor: boolean = !!supportsColor.stdout && !!supportsColor.stderr;
 
   /**
    * If true, verbose-level messages should be written to the console.
    */
-  public verboseEnabled: boolean = false;
+  public readonly verboseEnabled: boolean;
 
   /**
    * If true, debug-level messages should be written to the console.
    */
-  public debugEnabled: boolean = false;
+  public readonly debugEnabled: boolean;
+
+  /**
+   * {@inheritDoc ITerminalProvider.supportsColor}
+   */
+  public readonly supportsColor: boolean = ConsoleTerminalProvider.supportsColor;
 
   public constructor(options: Partial<IConsoleTerminalProviderOptions> = {}) {
     this.verboseEnabled = !!options.verboseEnabled;
@@ -87,12 +92,5 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
    */
   public get eolCharacter(): string {
     return EOL;
-  }
-
-  /**
-   * {@inheritDoc ITerminalProvider.supportsColor}
-   */
-  public get supportsColor(): boolean {
-    return supportsColor;
   }
 }

--- a/libraries/terminal/src/ConsoleTerminalProvider.ts
+++ b/libraries/terminal/src/ConsoleTerminalProvider.ts
@@ -37,12 +37,12 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
   /**
    * If true, verbose-level messages should be written to the console.
    */
-  public readonly verboseEnabled: boolean;
+  public verboseEnabled: boolean;
 
   /**
    * If true, debug-level messages should be written to the console.
    */
-  public readonly debugEnabled: boolean;
+  public debugEnabled: boolean;
 
   /**
    * {@inheritDoc ITerminalProvider.supportsColor}

--- a/libraries/terminal/src/test/AnsiEscape.test.ts
+++ b/libraries/terminal/src/test/AnsiEscape.test.ts
@@ -1,26 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-// Explicitly use the colors package here instead of Colorize
-import colors from 'colors/safe';
 import { AnsiEscape } from '../AnsiEscape';
+import { Colorize } from '../Colorize';
 
 describe(AnsiEscape.name, () => {
-  let initialColorsEnabled: boolean;
-
-  beforeAll(() => {
-    initialColorsEnabled = colors.enabled;
-    colors.enable();
-  });
-
-  afterAll(() => {
-    if (!initialColorsEnabled) {
-      colors.disable();
-    }
-  });
-
   it('calls removeCodes() successfully', () => {
-    const coloredInput: string = colors.rainbow('Hello, world!');
+    const coloredInput: string = Colorize.green('Hello, world!');
     const decoloredInput: string = AnsiEscape.removeCodes(coloredInput);
     expect(coloredInput).not.toBe(decoloredInput);
     expect(decoloredInput).toBe('Hello, world!');

--- a/libraries/terminal/src/test/AnsiEscape.test.ts
+++ b/libraries/terminal/src/test/AnsiEscape.test.ts
@@ -6,7 +6,7 @@ import { Colorize } from '../Colorize';
 
 describe(AnsiEscape.name, () => {
   it('calls removeCodes() successfully', () => {
-    const coloredInput: string = Colorize.green('Hello, world!');
+    const coloredInput: string = Colorize.rainbow('Hello, world!');
     const decoloredInput: string = AnsiEscape.removeCodes(coloredInput);
     expect(coloredInput).not.toBe(decoloredInput);
     expect(decoloredInput).toBe('Hello, world!');


### PR DESCRIPTION
## Summary

This PR finishes out the colors/Colorize/Terminal work. This resolves https://github.com/microsoft/rushstack/issues/3147.

## How it was tested

Ran on a console that supports color with and without the `FORCE_COLOR=0` env var, and in CI.

## Impacted documentation

None.