### PR TITLE
[api-extractor] Remove "const" keyword before enum to use with typescript isolatedModules

### DIFF
--- a/apps/api-extractor/src/api/ConsoleMessageId.ts
+++ b/apps/api-extractor/src/api/ConsoleMessageId.ts
@@ -11,7 +11,7 @@
  *
  * @public
  */
-export const enum ConsoleMessageId {
+export enum ConsoleMessageId {
   /**
    * "Analysis will use the bundled TypeScript version ___"
    */

--- a/apps/api-extractor/src/api/ExtractorLogLevel.ts
+++ b/apps/api-extractor/src/api/ExtractorLogLevel.ts
@@ -9,7 +9,7 @@
  *
  * @public
  */
-export const enum ExtractorLogLevel {
+export enum ExtractorLogLevel {
   /**
    * The message will be displayed as an error.
    *

--- a/apps/api-extractor/src/api/ExtractorMessage.ts
+++ b/apps/api-extractor/src/api/ExtractorMessage.ts
@@ -28,7 +28,7 @@ export interface IExtractorMessageProperties {
  * Specifies a category of messages for use with {@link ExtractorMessage}.
  * @public
  */
-export const enum ExtractorMessageCategory {
+export enum ExtractorMessageCategory {
   /**
    * Messages originating from the TypeScript compiler.
    *

--- a/apps/api-extractor/src/api/ExtractorMessageId.ts
+++ b/apps/api-extractor/src/api/ExtractorMessageId.ts
@@ -11,7 +11,7 @@
  *
  * @public
  */
-export const enum ExtractorMessageId {
+export enum ExtractorMessageId {
   /**
    * "The doc comment should not contain more than one release tag."
    */

--- a/common/changes/@microsoft/api-extractor/remove-const-enum_2024-02-24-20-35.json
+++ b/common/changes/@microsoft/api-extractor/remove-const-enum_2024-02-24-20-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Replace const enums with conventional enums to allow for compatibility with JavaScript consumers.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -21,7 +21,7 @@ export class CompilerState {
 }
 
 // @public
-export const enum ConsoleMessageId {
+export enum ConsoleMessageId {
     ApiReportCopied = "console-api-report-copied",
     ApiReportCreated = "console-api-report-created",
     ApiReportFolderMissing = "console-api-report-folder-missing",
@@ -91,7 +91,7 @@ export class ExtractorConfig {
 }
 
 // @public
-export const enum ExtractorLogLevel {
+export enum ExtractorLogLevel {
     Error = "error",
     Info = "info",
     None = "none",
@@ -122,7 +122,7 @@ export class ExtractorMessage {
 }
 
 // @public
-export const enum ExtractorMessageCategory {
+export enum ExtractorMessageCategory {
     Compiler = "Compiler",
     Console = "console",
     Extractor = "Extractor",
@@ -130,7 +130,7 @@ export const enum ExtractorMessageCategory {
 }
 
 // @public
-export const enum ExtractorMessageId {
+export enum ExtractorMessageId {
     CyclicInheritDoc = "ae-cyclic-inherit-doc",
     DifferentReleaseTags = "ae-different-release-tags",
     ExtraReleaseTag = "ae-extra-release-tag",


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
When a typescript project is using [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules), referencing exported const enums is not allowed.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Setting isolatedModules to true is recommended for projects transpiled with babel or [esbuild](https://esbuild.github.io/content-types/#isolated-modules). Unlike tsc, these tools evaluate files independently. Setting the isolatedModules flag e.g. forces developers to indicate whether they are exporting a type or value, since transpilers evaluating modules independently cannot infer this information.

However, the flag also alerts when a const enum is used. It seems that tsc evaluates const enums across modules and inlines the constants at compile. No enum object is created, which is problematic of independent transpilation.

I found [this article helpful](https://ncjamieson.com/dont-export-const-enums/) for understanding the effect of specifying const.

By removing the const keyword, the enums can safely be used in projects using isolatedModules. This change is similar to https://github.com/microsoft/rushstack/pull/3060 and https://github.com/microsoft/rushstack/pull/3074.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Build passes.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
