### PR TITLE
[rush] Fix rush build for subspaces

### DIFF
--- a/common/changes/@microsoft/rush/will-subspace-patch-4_2024-02-27-22-23.json
+++ b/common/changes/@microsoft/rush/will-subspace-patch-4_2024-02-27-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix issue where rush looks through all projects instead of subspace projects",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/will-subspace-patch-4_2024-02-27-22-23.json
+++ b/common/changes/@microsoft/rush/will-subspace-patch-4_2024-02-27-22-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix issue where rush looks through all projects instead of subspace projects",
+      "comment": "Fix an issue where, when the experimental subspaces feature was enabled, the lockfile validation would check irrelevant subspaces",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -409,27 +409,27 @@ export class ProjectChangeAnalyzer {
         const additionalFilesToHash: string[] = [];
 
         if (this._rushConfiguration.packageManager === 'pnpm') {
-          const absoluteFilePathsToCheck: string[] = [];
-
-          for (const project of this._rushConfiguration.projects) {
-            const projectShrinkwrapFilePath: string =
-              BaseProjectShrinkwrapFile.getFilePathForProject(project);
-            absoluteFilePathsToCheck.push(projectShrinkwrapFilePath);
-            const relativeProjectShrinkwrapFilePath: string = Path.convertToSlashes(
-              path.relative(rootDir, projectShrinkwrapFilePath)
-            );
-
-            additionalFilesToHash.push(relativeProjectShrinkwrapFilePath);
-          }
-
-          await Async.forEachAsync(absoluteFilePathsToCheck, async (filePath: string) => {
-            if (!(await FileSystem.existsAsync(filePath))) {
-              throw new Error(
-                `A project dependency file (${filePath}) is missing. You may need to run ` +
-                  '"rush install" or "rush update".'
+          await Async.forEachAsync(
+            this._rushConfiguration.projects,
+            async (project: RushConfigurationProject) => {
+              const projectShrinkwrapFilePath: string =
+                BaseProjectShrinkwrapFile.getFilePathForProject(project);
+              if (!(await FileSystem.existsAsync(projectShrinkwrapFilePath))) {
+                // Missing shrinkwrap of subspace project is allowed because subspace projects can be partial installed
+                if (this._rushConfiguration.subspacesFeatureEnabled) {
+                  return;
+                }
+                throw new Error(
+                  `A project dependency file (${projectShrinkwrapFilePath}) is missing. You may need to run ` +
+                    '"rush install" or "rush update".'
+                );
+              }
+              const relativeProjectShrinkwrapFilePath: string = Path.convertToSlashes(
+                path.relative(rootDir, projectShrinkwrapFilePath)
               );
+              additionalFilesToHash.push(relativeProjectShrinkwrapFilePath);
             }
-          });
+          );
         }
 
         const hashes: Map<string, string> = await getRepoStateAsync(rootDir, additionalFilesToHash, gitPath);


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Currently in the rush build step, when subspaces is enabled and you are trying to build to a single project, rush will incorrectly try to validate every project in the monorepo as opposed to the subspace you are installing for.

When building for a particular subspace, the project change analyzer tries to determine if every project in the monorepo has a valid installation shrinkwrap, however this will not be the case for subspaces as subspaces can be partially installed. This skips that validation check if subspaces is enabled.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually Tested:
In a monorepo with subspaces installed and has multiple subspaces A and B, for example.
If we only install dependencies for subspace A, and try to run `rush build -t <project_in_subspace_A>`, it will fail as it thinks subspace B has not been installed, but in this case it does not need to be as there are no projects in subspace A that depend on projects in subspace B.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
