### PR TITLE
[ts-command-line] Improve API typings

### DIFF
--- a/apps/api-documenter/src/cli/YamlAction.ts
+++ b/apps/api-documenter/src/cli/YamlAction.ts
@@ -6,13 +6,13 @@ import type { CommandLineFlagParameter, CommandLineChoiceParameter } from '@rush
 import type { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
 
-import { YamlDocumenter } from '../documenters/YamlDocumenter';
+import { YamlDocumenter, type YamlFormat } from '../documenters/YamlDocumenter';
 import { OfficeYamlDocumenter } from '../documenters/OfficeYamlDocumenter';
 
 export class YamlAction extends BaseAction {
   private readonly _officeParameter: CommandLineFlagParameter;
   private readonly _newDocfxNamespacesParameter: CommandLineFlagParameter;
-  private readonly _yamlFormatParameter: CommandLineChoiceParameter;
+  private readonly _yamlFormatParameter: CommandLineChoiceParameter<YamlFormat>;
 
   public constructor(parser: ApiDocumenterCommandLine) {
     super({
@@ -36,7 +36,7 @@ export class YamlAction extends BaseAction {
         ` adds them to the table of contents.  This will also affect file layout as namespaced items will be nested` +
         ` under a directory for the namespace instead of just within the package.`
     });
-    this._yamlFormatParameter = this.defineChoiceParameter({
+    this._yamlFormatParameter = this.defineChoiceParameter<YamlFormat>({
       parameterLongName: '--yaml-format',
       alternatives: ['udp', 'sdp'],
       defaultValue: 'sdp',

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -89,6 +89,8 @@ interface INameOptions {
   includeNamespace?: boolean;
 }
 
+export type YamlFormat = 'udp' | 'sdp';
+
 /**
  * Writes documentation in the Universal Reference YAML file format, as defined by typescript.schema.json.
  */
@@ -101,7 +103,11 @@ export class YamlDocumenter {
   private _apiItemsByCanonicalReference: Map<string, ApiItem>;
   private _yamlReferences: IYamlReferences | undefined;
 
-  public constructor(apiModel: ApiModel, newDocfxNamespaces: boolean = false, yamlFormat: string = 'sdp') {
+  public constructor(
+    apiModel: ApiModel,
+    newDocfxNamespaces: boolean = false,
+    yamlFormat: YamlFormat = 'sdp'
+  ) {
     this._apiModel = apiModel;
     this.newDocfxNamespaces = newDocfxNamespaces;
     this._yamlFormat = yamlFormat;

--- a/apps/rundown/src/cli/BaseReportAction.ts
+++ b/apps/rundown/src/cli/BaseReportAction.ts
@@ -8,11 +8,12 @@ import {
   CommandLineAction,
   type ICommandLineActionOptions,
   type CommandLineStringParameter,
-  type CommandLineFlagParameter
+  type CommandLineFlagParameter,
+  type IRequiredCommandLineStringParameter
 } from '@rushstack/ts-command-line';
 
 export abstract class BaseReportAction extends CommandLineAction {
-  protected readonly scriptParameter: CommandLineStringParameter;
+  protected readonly scriptParameter: IRequiredCommandLineStringParameter;
   protected readonly argsParameter: CommandLineStringParameter;
   protected readonly quietParameter: CommandLineFlagParameter;
   protected readonly ignoreExitCodeParameter: CommandLineFlagParameter;

--- a/apps/rundown/src/cli/InspectAction.ts
+++ b/apps/rundown/src/cli/InspectAction.ts
@@ -28,11 +28,11 @@ export class InspectAction extends BaseReportAction {
   protected async onExecute(): Promise<void> {
     const rundown: Rundown = new Rundown();
     await rundown.invokeAsync(
-      this.scriptParameter.value!,
+      this.scriptParameter.value,
       this.argsParameter.value,
-      this.quietParameter.value!!,
-      this.ignoreExitCodeParameter.value!!
+      this.quietParameter.value,
+      this.ignoreExitCodeParameter.value
     );
-    rundown.writeInspectReport(this._traceParameter.value!!);
+    rundown.writeInspectReport(this._traceParameter.value);
   }
 }

--- a/apps/rundown/src/cli/SnapshotAction.ts
+++ b/apps/rundown/src/cli/SnapshotAction.ts
@@ -19,10 +19,10 @@ export class SnapshotAction extends BaseReportAction {
   protected async onExecute(): Promise<void> {
     const rundown: Rundown = new Rundown();
     await rundown.invokeAsync(
-      this.scriptParameter.value!,
+      this.scriptParameter.value,
       this.argsParameter.value,
-      this.quietParameter.value!!,
-      this.ignoreExitCodeParameter.value!!
+      this.quietParameter.value,
+      this.ignoreExitCodeParameter.value
     );
     rundown.writeSnapshotReport();
   }

--- a/apps/trace-import/src/TraceImportCommandLineParser.ts
+++ b/apps/trace-import/src/TraceImportCommandLineParser.ts
@@ -5,7 +5,8 @@ import {
   CommandLineParser,
   type CommandLineFlagParameter,
   type CommandLineStringParameter,
-  type CommandLineChoiceParameter
+  type CommandLineChoiceParameter,
+  type IRequiredCommandLineStringParameter
 } from '@rushstack/ts-command-line';
 import { InternalError } from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
@@ -14,9 +15,9 @@ import { type ResolutionType, traceImport } from './traceImport';
 
 export class TraceImportCommandLineParser extends CommandLineParser {
   private readonly _debugParameter: CommandLineFlagParameter;
-  private readonly _pathParameter: CommandLineStringParameter;
+  private readonly _pathParameter: IRequiredCommandLineStringParameter;
   private readonly _baseFolderParameter: CommandLineStringParameter;
-  private readonly _resolutionTypeParameter: CommandLineChoiceParameter;
+  private readonly _resolutionTypeParameter: CommandLineChoiceParameter<ResolutionType>;
 
   public constructor() {
     super({
@@ -54,7 +55,7 @@ export class TraceImportCommandLineParser extends CommandLineParser {
       argumentName: 'FOLDER_PATH'
     });
 
-    this._resolutionTypeParameter = this.defineChoiceParameter({
+    this._resolutionTypeParameter = this.defineChoiceParameter<ResolutionType>({
       parameterLongName: '--resolution-type',
       parameterShortName: '-t',
       description:
@@ -72,9 +73,9 @@ export class TraceImportCommandLineParser extends CommandLineParser {
     }
     try {
       traceImport({
-        importPath: this._pathParameter.value!,
+        importPath: this._pathParameter.value,
         baseFolder: this._baseFolderParameter.value,
-        resolutionType: (this._resolutionTypeParameter.value ?? 'cjs') as ResolutionType
+        resolutionType: this._resolutionTypeParameter.value ?? 'cjs'
       });
     } catch (error) {
       if (this._debugParameter.value) {

--- a/build-tests/ts-command-line-test/src/PushAction.ts
+++ b/build-tests/ts-command-line-test/src/PushAction.ts
@@ -8,9 +8,11 @@ import {
 } from '@rushstack/ts-command-line';
 import { BusinessLogic } from './BusinessLogic';
 
+type Protocol = 'ftp' | 'webdav' | 'scp';
+
 export class PushAction extends CommandLineAction {
   private _force: CommandLineFlagParameter;
-  private _protocol: CommandLineChoiceParameter;
+  private _protocol: CommandLineChoiceParameter<Protocol>;
 
   public constructor() {
     super({
@@ -33,7 +35,7 @@ export class PushAction extends CommandLineAction {
       description: 'Push and overwrite any existing state'
     });
 
-    this._protocol = this.defineChoiceParameter({
+    this._protocol = this.defineChoiceParameter<Protocol>({
       parameterLongName: '--protocol',
       description: 'Specify the protocol to use',
       alternatives: ['ftp', 'webdav', 'scp'],

--- a/common/changes/@microsoft/api-documenter/ts-command-line-tweaks_2024-02-28-05-44.json
+++ b/common/changes/@microsoft/api-documenter/ts-command-line-tweaks_2024-02-28-05-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/rush/ts-command-line-tweaks_2024-02-28-05-44.json
+++ b/common/changes/@microsoft/rush/ts-command-line-tweaks_2024-02-28-05-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/rundown/ts-command-line-tweaks_2024-02-28-05-44.json
+++ b/common/changes/@rushstack/rundown/ts-command-line-tweaks_2024-02-28-05-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown"
+}

--- a/common/changes/@rushstack/trace-import/ts-command-line-tweaks_2024-02-28-05-44.json
+++ b/common/changes/@rushstack/trace-import/ts-command-line-tweaks_2024-02-28-05-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/trace-import"
+}

--- a/common/changes/@rushstack/ts-command-line/ts-command-line-tweaks_2024-02-28-05-26.json
+++ b/common/changes/@rushstack/ts-command-line/ts-command-line-tweaks_2024-02-28-05-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Allow choice parameters alternatives to be typed.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/ts-command-line/ts-command-line-tweaks_2024-02-28-05-30.json
+++ b/common/changes/@rushstack/ts-command-line/ts-command-line-tweaks_2024-02-28-05-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Update the return type of `defineChoiceParameter`, `defineIntegerParameter`, and `defineStringParameter` respectively when the `{ required: true }` option is set to a new type (`IRequiredCommandLineChoiceParameter`, `IRequiredCommandLineIntegerParameter`, and `IRequiredCommandLineStringParameter` respectively) with a required `value` property.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -36,34 +36,34 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 }
 
 // @public
-export class CommandLineChoiceListParameter extends CommandLineParameter {
+export class CommandLineChoiceListParameter<TChoice extends string = string> extends CommandLineParameter {
     // @internal
-    constructor(definition: ICommandLineChoiceListDefinition);
-    readonly alternatives: ReadonlyArray<string>;
+    constructor(definition: ICommandLineChoiceListDefinition<TChoice>);
+    readonly alternatives: ReadonlyArray<TChoice>;
     // @override
     appendToArgList(argList: string[]): void;
-    readonly completions: (() => Promise<string[]>) | undefined;
+    readonly completions: (() => Promise<TChoice[]>) | undefined;
     get kind(): CommandLineParameterKind;
     // @internal
     _setValue(data: any): void;
-    get values(): ReadonlyArray<string>;
+    get values(): ReadonlyArray<TChoice>;
 }
 
 // @public
-export class CommandLineChoiceParameter extends CommandLineParameter {
+export class CommandLineChoiceParameter<TChoice extends string = string> extends CommandLineParameter {
     // @internal
-    constructor(definition: ICommandLineChoiceDefinition);
-    readonly alternatives: ReadonlyArray<string>;
+    constructor(definition: ICommandLineChoiceDefinition<TChoice>);
+    readonly alternatives: ReadonlyArray<TChoice>;
     // @override
     appendToArgList(argList: string[]): void;
-    readonly completions: (() => Promise<string[]>) | undefined;
-    readonly defaultValue: string | undefined;
+    readonly completions: (() => Promise<TChoice[]>) | undefined;
+    readonly defaultValue: TChoice | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
     get kind(): CommandLineParameterKind;
     // @internal
     _setValue(data: any): void;
-    get value(): string | undefined;
+    get value(): TChoice | undefined;
 }
 
 // @public
@@ -160,15 +160,33 @@ export abstract class CommandLineParameterProvider {
     readonly _ambiguousParameterParserKeysByName: Map<string, string>;
     // @internal (undocumented)
     protected _defineAmbiguousParameter(name: string): string;
-    defineChoiceListParameter(definition: ICommandLineChoiceListDefinition): CommandLineChoiceListParameter;
-    defineChoiceParameter(definition: ICommandLineChoiceDefinition): CommandLineChoiceParameter;
+    defineChoiceListParameter<TChoice extends string = string>(definition: ICommandLineChoiceListDefinition<TChoice>): CommandLineChoiceListParameter<TChoice>;
+    defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice> & {
+        required: false | undefined;
+    }): CommandLineChoiceParameter<TChoice>;
+    defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice> & {
+        required: true;
+    }): IRequiredCommandLineChoiceParameter<TChoice>;
+    defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice>): CommandLineChoiceParameter<TChoice>;
     defineCommandLineRemainder(definition: ICommandLineRemainderDefinition): CommandLineRemainder;
     defineFlagParameter(definition: ICommandLineFlagDefinition): CommandLineFlagParameter;
     defineIntegerListParameter(definition: ICommandLineIntegerListDefinition): CommandLineIntegerListParameter;
+    defineIntegerParameter(definition: ICommandLineIntegerDefinition & {
+        required: false | undefined;
+    }): CommandLineIntegerParameter;
+    defineIntegerParameter(definition: ICommandLineIntegerDefinition & {
+        required: true;
+    }): IRequiredCommandLineIntegerParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
     // @internal (undocumented)
     protected _defineParameter(parameter: CommandLineParameter): void;
     defineStringListParameter(definition: ICommandLineStringListDefinition): CommandLineStringListParameter;
+    defineStringParameter(definition: ICommandLineStringDefinition & {
+        required: false | undefined;
+    }): CommandLineStringParameter;
+    defineStringParameter(definition: ICommandLineStringDefinition & {
+        required: true;
+    }): IRequiredCommandLineStringParameter;
     defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter;
     // @internal
     protected abstract _getArgumentParser(): argparse.ArgumentParser;
@@ -307,16 +325,16 @@ export interface ICommandLineActionOptions {
 }
 
 // @public
-export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition {
-    alternatives: string[];
-    completions?: () => Promise<string[]>;
-    defaultValue?: string;
+export interface ICommandLineChoiceDefinition<TChoice extends string = string> extends IBaseCommandLineDefinition {
+    alternatives: TChoice[];
+    completions?: () => Promise<TChoice[]>;
+    defaultValue?: TChoice;
 }
 
 // @public
-export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefinition {
-    alternatives: string[];
-    completions?: () => Promise<string[]>;
+export interface ICommandLineChoiceListDefinition<TChoice extends string = string> extends IBaseCommandLineDefinition {
+    alternatives: TChoice[];
+    completions?: () => Promise<TChoice[]>;
 }
 
 // @public
@@ -369,6 +387,24 @@ export interface ICommandLineStringListDefinition extends IBaseCommandLineDefini
 // @internal
 export interface _IRegisterDefinedParametersState {
     parentParameterNames: Set<string>;
+}
+
+// @public
+export interface IRequiredCommandLineChoiceParameter<TChoice extends string = string> extends CommandLineChoiceParameter<TChoice> {
+    // (undocumented)
+    value: TChoice;
+}
+
+// @public
+export interface IRequiredCommandLineIntegerParameter extends CommandLineIntegerParameter {
+    // (undocumented)
+    value: number;
+}
+
+// @public
+export interface IRequiredCommandLineStringParameter extends CommandLineStringParameter {
+    // (undocumented)
+    value: string;
 }
 
 // @public

--- a/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitAutoinstallerAction.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import type { IRequiredCommandLineStringParameter } from '@rushstack/ts-command-line';
 import { FileSystem, NewlineKind, type IPackageJson, JsonFile } from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
 
@@ -10,7 +10,7 @@ import type { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class InitAutoinstallerAction extends BaseRushAction {
-  private readonly _name: CommandLineStringParameter;
+  private readonly _name: IRequiredCommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -33,7 +33,7 @@ export class InitAutoinstallerAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    const autoinstallerName: string = this._name.value!;
+    const autoinstallerName: string = this._name.value;
 
     const autoinstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName,

--- a/libraries/rush-lib/src/cli/actions/InitDeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InitDeployAction.ts
@@ -2,7 +2,10 @@
 // See LICENSE in the project root for license information.
 
 import { FileSystem, NewlineKind } from '@rushstack/node-core-library';
-import type { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import type {
+  CommandLineStringParameter,
+  IRequiredCommandLineStringParameter
+} from '@rushstack/ts-command-line';
 import { Colorize } from '@rushstack/terminal';
 
 import { BaseRushAction } from './BaseRushAction';
@@ -15,7 +18,7 @@ import { RushConstants } from '../../logic/RushConstants';
 const CONFIG_TEMPLATE_PATH: string = `${assetsFolderPath}/rush-init-deploy/scenario-template.json`;
 
 export class InitDeployAction extends BaseRushAction {
-  private readonly _project: CommandLineStringParameter;
+  private readonly _project: IRequiredCommandLineStringParameter;
   private readonly _scenario: CommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
@@ -67,7 +70,7 @@ export class InitDeployAction extends BaseRushAction {
     // eslint-disable-next-line no-console
     console.log(Colorize.green('Creating scenario file: ') + scenarioFilePath);
 
-    const shortProjectName: string = this._project.value!;
+    const shortProjectName: string = this._project.value;
     const rushProject: RushConfigurationProject | undefined =
       this.rushConfiguration.findProjectByShorthandName(shortProjectName);
     if (!rushProject) {

--- a/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAutoinstallerAction.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import type { IRequiredCommandLineStringParameter } from '@rushstack/ts-command-line';
 
 import { BaseRushAction } from './BaseRushAction';
 import type { RushCommandLineParser } from '../RushCommandLineParser';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 
 export class UpdateAutoinstallerAction extends BaseRushAction {
-  private readonly _name: CommandLineStringParameter;
+  private readonly _name: IRequiredCommandLineStringParameter;
 
   public constructor(parser: RushCommandLineParser) {
     super({
@@ -28,8 +28,7 @@ export class UpdateAutoinstallerAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    const autoinstallerName: string = this._name.value!;
-
+    const autoinstallerName: string = this._name.value;
     const autoinstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName,
       rushConfiguration: this.rushConfiguration,

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -35,11 +35,20 @@ export {
 } from './parameters/BaseClasses';
 
 export { CommandLineFlagParameter } from './parameters/CommandLineFlagParameter';
-export { CommandLineStringParameter } from './parameters/CommandLineStringParameter';
+export {
+  CommandLineStringParameter,
+  type IRequiredCommandLineStringParameter
+} from './parameters/CommandLineStringParameter';
 export { CommandLineStringListParameter } from './parameters/CommandLineStringListParameter';
-export { CommandLineIntegerParameter } from './parameters/CommandLineIntegerParameter';
+export {
+  CommandLineIntegerParameter,
+  type IRequiredCommandLineIntegerParameter
+} from './parameters/CommandLineIntegerParameter';
 export { CommandLineIntegerListParameter } from './parameters/CommandLineIntegerListParameter';
-export { CommandLineChoiceParameter } from './parameters/CommandLineChoiceParameter';
+export {
+  CommandLineChoiceParameter,
+  type IRequiredCommandLineChoiceParameter
+} from './parameters/CommandLineChoiceParameter';
 export { CommandLineChoiceListParameter } from './parameters/CommandLineChoiceListParameter';
 export { CommandLineRemainder } from './parameters/CommandLineRemainder';
 

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
@@ -9,17 +9,17 @@ import { EnvironmentVariableParser } from './EnvironmentVariableParser';
  * The data type returned by {@link CommandLineParameterProvider.defineChoiceListParameter}.
  * @public
  */
-export class CommandLineChoiceListParameter extends CommandLineParameter {
+export class CommandLineChoiceListParameter<TChoice extends string = string> extends CommandLineParameter {
   /** {@inheritDoc ICommandLineChoiceListDefinition.alternatives} */
-  public readonly alternatives: ReadonlyArray<string>;
+  public readonly alternatives: ReadonlyArray<TChoice>;
 
-  private _values: string[] = [];
+  private _values: TChoice[] = [];
 
   /** {@inheritDoc ICommandLineChoiceListDefinition.completions} */
-  public readonly completions: (() => Promise<string[]>) | undefined;
+  public readonly completions: (() => Promise<TChoice[]>) | undefined;
 
   /** @internal */
-  public constructor(definition: ICommandLineChoiceListDefinition) {
+  public constructor(definition: ICommandLineChoiceListDefinition<TChoice>) {
     super(definition);
 
     if (definition.alternatives.length < 1) {
@@ -61,7 +61,7 @@ export class CommandLineChoiceListParameter extends CommandLineParameter {
       const values: string[] | undefined = EnvironmentVariableParser.parseAsList(this.environmentVariable);
       if (values) {
         for (const value of values) {
-          if (this.alternatives.indexOf(value) < 0) {
+          if (!this.alternatives.includes(value as TChoice)) {
             const choices: string = '"' + this.alternatives.join('", "') + '"';
             throw new Error(
               `Invalid value "${value}" for the environment variable` +
@@ -69,7 +69,8 @@ export class CommandLineChoiceListParameter extends CommandLineParameter {
             );
           }
         }
-        this._values = values;
+
+        this._values = values as TChoice[];
         return;
       }
     }
@@ -86,7 +87,7 @@ export class CommandLineChoiceListParameter extends CommandLineParameter {
    * The array will be empty if the command-line has not been parsed yet,
    * or if the parameter was omitted and has no default value.
    */
-  public get values(): ReadonlyArray<string> {
+  public get values(): ReadonlyArray<TChoice> {
     return this._values;
   }
 

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -119,22 +119,24 @@ export interface IBaseCommandLineDefinitionWithArgument extends IBaseCommandLine
 }
 
 /**
- * For use with {@link CommandLineParameterProvider.defineChoiceParameter},
- * this interface defines a command line parameter which is constrained to a list of possible
+ * For use with {@link CommandLineParameterProvider.(defineChoiceParameter:1)} and
+ * {@link CommandLineParameterProvider.(defineChoiceParameter:2)}, this interface
+ * defines a command line parameter which is constrained to a list of possible
  * options.
  *
  * @public
  */
-export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition {
+export interface ICommandLineChoiceDefinition<TChoice extends string = string>
+  extends IBaseCommandLineDefinition {
   /**
    * A list of strings (which contain no spaces), of possible options which can be selected
    */
-  alternatives: string[];
+  alternatives: TChoice[];
 
   /**
    * {@inheritDoc ICommandLineStringDefinition.defaultValue}
    */
-  defaultValue?: string;
+  defaultValue?: TChoice;
 
   /**
    * An optional callback that provides a list of custom choices for tab completion.
@@ -142,7 +144,7 @@ export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition
    * This option is only used when `ICommandLineParserOptions.enableTabCompletionAction`
    * is enabled.
    */
-  completions?: () => Promise<string[]>;
+  completions?: () => Promise<TChoice[]>;
 }
 
 /**
@@ -152,11 +154,12 @@ export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition
  *
  * @public
  */
-export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefinition {
+export interface ICommandLineChoiceListDefinition<TChoice extends string = string>
+  extends IBaseCommandLineDefinition {
   /**
    * A list of strings (which contain no spaces), of possible options which can be selected
    */
-  alternatives: string[];
+  alternatives: TChoice[];
 
   /**
    * An optional callback that provides a list of custom choices for tab completion.
@@ -164,7 +167,7 @@ export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefini
    * This option is only used when `ICommandLineParserOptions.enableTabCompletionAction`
    * is enabled.
    */
-  completions?: () => Promise<string[]>;
+  completions?: () => Promise<TChoice[]>;
 }
 
 /**
@@ -176,8 +179,9 @@ export interface ICommandLineChoiceListDefinition extends IBaseCommandLineDefini
 export interface ICommandLineFlagDefinition extends IBaseCommandLineDefinition {}
 
 /**
- * For use with {@link CommandLineParameterProvider.defineIntegerParameter},
- * this interface defines a command line parameter whose argument is an integer value.
+ * For use with {@link CommandLineParameterProvider.(defineIntegerParameter:1)},
+ * {@link CommandLineParameterProvider.(defineIntegerParameter:2)}, this interface
+ * defines a command line parameter whose argument is an integer value.
  *
  * @public
  */
@@ -198,8 +202,9 @@ export interface ICommandLineIntegerDefinition extends IBaseCommandLineDefinitio
 export interface ICommandLineIntegerListDefinition extends IBaseCommandLineDefinitionWithArgument {}
 
 /**
- * For use with {@link CommandLineParameterProvider.defineStringParameter},
- * this interface defines a command line parameter whose argument is a string value.
+ * For use with {@link CommandLineParameterProvider.(defineStringParameter:1)} and
+ * {@link CommandLineParameterProvider.(defineStringParameter:2)}, this interface
+ * defines a command line parameter whose argument is a string value.
  *
  * @public
  */

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
@@ -5,7 +5,15 @@ import type { ICommandLineIntegerDefinition } from './CommandLineDefinition';
 import { CommandLineParameterWithArgument, CommandLineParameterKind } from './BaseClasses';
 
 /**
- * The data type returned by {@link CommandLineParameterProvider.defineIntegerParameter}.
+ * The data type returned by {@link CommandLineParameterProvider.(defineIntegerParameter:2)}.
+ * @public
+ */
+export interface IRequiredCommandLineIntegerParameter extends CommandLineIntegerParameter {
+  value: number;
+}
+
+/**
+ * The data type returned by {@link CommandLineParameterProvider.(defineIntegerParameter:1)}.
  * @public
  */
 export class CommandLineIntegerParameter extends CommandLineParameterWithArgument {

--- a/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
@@ -5,7 +5,15 @@ import type { ICommandLineStringDefinition } from './CommandLineDefinition';
 import { CommandLineParameterWithArgument, CommandLineParameterKind } from './BaseClasses';
 
 /**
- * The data type returned by {@link CommandLineParameterProvider.defineStringParameter}.
+ * The data type returned by {@link CommandLineParameterProvider.(defineStringParameter:2)}.
+ * @public
+ */
+export interface IRequiredCommandLineStringParameter extends CommandLineStringParameter {
+  value: string;
+}
+
+/**
+ * The data type returned by {@link CommandLineParameterProvider.(defineStringParameter:1)}.
  * @public
  */
 export class CommandLineStringParameter extends CommandLineParameterWithArgument {

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -19,19 +19,28 @@ import {
   type CommandLineParameterWithArgument,
   CommandLineParameterKind
 } from '../parameters/BaseClasses';
-import { CommandLineChoiceParameter } from '../parameters/CommandLineChoiceParameter';
+import {
+  CommandLineChoiceParameter,
+  type IRequiredCommandLineChoiceParameter
+} from '../parameters/CommandLineChoiceParameter';
 import { CommandLineChoiceListParameter } from '../parameters/CommandLineChoiceListParameter';
-import { CommandLineIntegerParameter } from '../parameters/CommandLineIntegerParameter';
+import {
+  CommandLineIntegerParameter,
+  type IRequiredCommandLineIntegerParameter
+} from '../parameters/CommandLineIntegerParameter';
 import { CommandLineIntegerListParameter } from '../parameters/CommandLineIntegerListParameter';
 import { CommandLineFlagParameter } from '../parameters/CommandLineFlagParameter';
-import { CommandLineStringParameter } from '../parameters/CommandLineStringParameter';
+import {
+  CommandLineStringParameter,
+  type IRequiredCommandLineStringParameter
+} from '../parameters/CommandLineStringParameter';
 import { CommandLineStringListParameter } from '../parameters/CommandLineStringListParameter';
 import { CommandLineRemainder } from '../parameters/CommandLineRemainder';
 import { SCOPING_PARAMETER_GROUP } from '../Constants';
 import { CommandLineParserExitError } from './CommandLineParserExitError';
 
 /**
- * The result containing the parsed paramter long name and scope. Returned when calling
+ * The result containing the parsed parameter long name and scope. Returned when calling
  * {@link CommandLineParameterProvider.parseScopedLongName}.
  *
  * @public
@@ -148,8 +157,25 @@ export abstract class CommandLineParameterProvider {
    * example-tool --log-level warn
    * ```
    */
-  public defineChoiceParameter(definition: ICommandLineChoiceDefinition): CommandLineChoiceParameter {
-    const parameter: CommandLineChoiceParameter = new CommandLineChoiceParameter(definition);
+  public defineChoiceParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceDefinition<TChoice> & { required: false | undefined }
+  ): CommandLineChoiceParameter<TChoice>;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineChoiceParameter:1)}
+   */
+  public defineChoiceParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceDefinition<TChoice> & { required: true }
+  ): IRequiredCommandLineChoiceParameter<TChoice>;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineChoiceParameter:1)}
+   */
+  public defineChoiceParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceDefinition<TChoice>
+  ): CommandLineChoiceParameter<TChoice>;
+  public defineChoiceParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceDefinition<TChoice>
+  ): CommandLineChoiceParameter<TChoice> {
+    const parameter: CommandLineChoiceParameter<TChoice> = new CommandLineChoiceParameter(definition);
     this._defineParameter(parameter);
     return parameter;
   }
@@ -174,10 +200,10 @@ export abstract class CommandLineParameterProvider {
    * example-tool --allow-color red --allow-color green
    * ```
    */
-  public defineChoiceListParameter(
-    definition: ICommandLineChoiceListDefinition
-  ): CommandLineChoiceListParameter {
-    const parameter: CommandLineChoiceListParameter = new CommandLineChoiceListParameter(definition);
+  public defineChoiceListParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceListDefinition<TChoice>
+  ): CommandLineChoiceListParameter<TChoice> {
+    const parameter: CommandLineChoiceListParameter<TChoice> = new CommandLineChoiceListParameter(definition);
     this._defineParameter(parameter);
     return parameter;
   }
@@ -228,6 +254,19 @@ export abstract class CommandLineParameterProvider {
    * example-tool --max-attempts 5
    * ```
    */
+  public defineIntegerParameter(
+    definition: ICommandLineIntegerDefinition & { required: false | undefined }
+  ): CommandLineIntegerParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineIntegerParameter:1)}
+   */
+  public defineIntegerParameter(
+    definition: ICommandLineIntegerDefinition & { required: true }
+  ): IRequiredCommandLineIntegerParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineIntegerParameter:1)}
+   */
+  public defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
   public defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter {
     const parameter: CommandLineIntegerParameter = new CommandLineIntegerParameter(definition);
     this._defineParameter(parameter);
@@ -285,6 +324,19 @@ export abstract class CommandLineParameterProvider {
    * example-tool --message "Hello, world!"
    * ```
    */
+  public defineStringParameter(
+    definition: ICommandLineStringDefinition & { required: false | undefined }
+  ): CommandLineStringParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineStringParameter:1)}
+   */
+  public defineStringParameter(
+    definition: ICommandLineStringDefinition & { required: true }
+  ): IRequiredCommandLineStringParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineStringParameter:1)}
+   */
+  public defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter;
   public defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter {
     const parameter: CommandLineStringParameter = new CommandLineStringParameter(definition);
     this._defineParameter(parameter);


### PR DESCRIPTION
## Summary

This PR makes to minor changes to ts-command-line's types:
- Choice and choice list parameters can now take a type argument to provide more specificity for the alternatives' types.
- There is now an overload for the `define___Parameter` functions when the `{ required: true }` option is passed which returns a new type with a non-nullable `value` property. This avoids needing a non-null assertion when the required value is used.

## How it was tested

Updated consuming projects to use these new types.

## Impacted documentation

API docs will need to be updated.