### PR TITLE
[ts-command-line] Allow bypassing naming restrictions on environment variable names provided to parameters

### DIFF
--- a/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/ts-command-line",
-      "comment": "Add an \"allowNonStandardEnvironmentVariable\" option to remove naming restrictions on parameter environment variables",
+      "comment": "Add an \"allowNonStandardEnvironmentVariableNames\" option to remove naming restrictions on parameter environment variables",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Remove naming restrictions on environment variables searched by parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
+++ b/common/changes/@rushstack/ts-command-line/user-danade-RemoveEnvironmentVariableRestrictions_2024-02-29-01-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/ts-command-line",
-      "comment": "Remove naming restrictions on environment variables searched by parameters",
+      "comment": "Add an \"allowNonStandardEnvironmentVariable\" option to remove naming restrictions on parameter environment variables",
       "type": "patch"
     }
   ],

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -302,7 +302,7 @@ export interface IAliasCommandLineActionOptions {
 
 // @public
 export interface IBaseCommandLineDefinition {
-    allowNonStandardEnvironmentVariable?: boolean;
+    allowNonStandardEnvironmentVariableNames?: boolean;
     description: string;
     environmentVariable?: string;
     parameterGroup?: string | typeof SCOPING_PARAMETER_GROUP;

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -119,6 +119,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
 export abstract class CommandLineParameter {
     // @internal
     constructor(definition: IBaseCommandLineDefinition);
+    readonly allowNonStandardEnvironmentVariable: boolean | undefined;
     abstract appendToArgList(argList: string[]): void;
     readonly description: string;
     readonly environmentVariable: string | undefined;
@@ -301,6 +302,7 @@ export interface IAliasCommandLineActionOptions {
 
 // @public
 export interface IBaseCommandLineDefinition {
+    allowNonStandardEnvironmentVariable?: boolean;
     description: string;
     environmentVariable?: string;
     parameterGroup?: string | typeof SCOPING_PARAMETER_GROUP;

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -119,7 +119,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
 export abstract class CommandLineParameter {
     // @internal
     constructor(definition: IBaseCommandLineDefinition);
-    readonly allowNonStandardEnvironmentVariable: boolean | undefined;
+    readonly allowNonStandardEnvironmentVariableNames: boolean | undefined;
     abstract appendToArgList(argList: string[]): void;
     readonly description: string;
     readonly environmentVariable: string | undefined;

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -47,6 +47,14 @@ const SHORT_NAME_REGEXP: RegExp = /^-[a-zA-Z]$/;
 const SCOPE_REGEXP: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /**
+ * "Environment variable names used by the utilities in the Shell and Utilities volume of
+ * IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore)
+ * from the characters defined in Portable Character Set and do not begin with a digit."
+ * Example: "THE_SETTING"
+ */
+const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
+
+/**
  * The base class for the various command-line parameter types.
  * @public
  */
@@ -82,6 +90,9 @@ export abstract class CommandLineParameter {
 
   /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
+
+  /** {@inheritDoc IBaseCommandLineDefinition.allowNonStandardEnvironmentVariable} */
+  public readonly allowNonStandardEnvironmentVariable: boolean | undefined;
 
   /** {@inheritDoc IBaseCommandLineDefinition.undocumentedSynonyms } */
   public readonly undocumentedSynonyms: string[] | undefined;
@@ -132,6 +143,16 @@ export abstract class CommandLineParameter {
         throw new Error(
           `An "environmentVariable" cannot be specified for "${this.longName}"` +
             ` because it is a required parameter`
+        );
+      }
+
+      if (
+        !this.allowNonStandardEnvironmentVariable &&
+        !ENVIRONMENT_VARIABLE_NAME_REGEXP.test(this.environmentVariable)
+      ) {
+        throw new Error(
+          `Invalid environment variable name: "${this.environmentVariable}". The name must` +
+            ` consist only of upper-case letters, numbers, and underscores. It may not start with a number.`
         );
       }
     }

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -91,8 +91,8 @@ export abstract class CommandLineParameter {
   /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
 
-  /** {@inheritDoc IBaseCommandLineDefinition.allowNonStandardEnvironmentVariable} */
-  public readonly allowNonStandardEnvironmentVariable: boolean | undefined;
+  /** {@inheritDoc IBaseCommandLineDefinition.allowNonStandardEnvironmentVariableNames} */
+  public readonly allowNonStandardEnvironmentVariableNames: boolean | undefined;
 
   /** {@inheritDoc IBaseCommandLineDefinition.undocumentedSynonyms } */
   public readonly undocumentedSynonyms: string[] | undefined;
@@ -147,7 +147,7 @@ export abstract class CommandLineParameter {
       }
 
       if (
-        !this.allowNonStandardEnvironmentVariable &&
+        !this.allowNonStandardEnvironmentVariableNames &&
         !ENVIRONMENT_VARIABLE_NAME_REGEXP.test(this.environmentVariable)
       ) {
         throw new Error(

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -47,14 +47,6 @@ const SHORT_NAME_REGEXP: RegExp = /^-[a-zA-Z]$/;
 const SCOPE_REGEXP: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /**
- * "Environment variable names used by the utilities in the Shell and Utilities volume of
- * IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore)
- * from the characters defined in Portable Character Set and do not begin with a digit."
- * Example: "THE_SETTING"
- */
-const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
-
-/**
  * The base class for the various command-line parameter types.
  * @public
  */
@@ -140,13 +132,6 @@ export abstract class CommandLineParameter {
         throw new Error(
           `An "environmentVariable" cannot be specified for "${this.longName}"` +
             ` because it is a required parameter`
-        );
-      }
-
-      if (!ENVIRONMENT_VARIABLE_NAME_REGEXP.test(this.environmentVariable)) {
-        throw new Error(
-          `Invalid environment variable name: "${this.environmentVariable}". The name must` +
-            ` consist only of upper-case letters, numbers, and underscores. It may not start with a number.`
         );
       }
     }

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -49,7 +49,9 @@ export interface IBaseCommandLineDefinition {
    *
    * @remarks
    * The environment variable name must consist only of upper-case letters, numbers,
-   * and underscores. It may not start with a number.
+   * and underscores. It may not start with a number. To disable this validation, you
+   * must set `{@link IBaseCommandLineDefinition.allowNonStandardEnvironmentVariable}`
+   * to `true`.
    *
    * This feature cannot be used when {@link IBaseCommandLineDefinition.required} is true,
    * because in that case the environmentVariable would never be used.
@@ -77,6 +79,19 @@ export interface IBaseCommandLineDefinition {
    *   ordinary String Parameter:  Any value is accepted, including an empty string.
    */
   environmentVariable?: string;
+
+  /**
+   * Allows for the use of non-standardized environment variable names. This disables
+   * the validation that is performed on the provided
+   * {@link IBaseCommandLineDefinition.environmentVariable} value by default.
+   *
+   * @remarks
+   * if this is set to `true`, environment variable discovery will vary based on the
+   * platform in use. For example, Windows environment variable names are case-insensitive,
+   * while on Linux, environment variable names are case-sensitive. It is recommended that
+   * this option be used only when necessary based on environmental constraints.
+   */
+  allowNonStandardEnvironmentVariable?: boolean;
 
   /**
    * Specifies additional names for this parameter that are accepted but not displayed

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -52,7 +52,6 @@ export interface IBaseCommandLineDefinition {
    * and underscores. It may not start with a number. To disable this validation, set
    * `{@link IBaseCommandLineDefinition.allowNonStandardEnvironmentVariableNames}`
    * to `true`.
-   * to `true`.
    *
    * This feature cannot be used when {@link IBaseCommandLineDefinition.required} is true,
    * because in that case the environmentVariable would never be used.

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -49,8 +49,9 @@ export interface IBaseCommandLineDefinition {
    *
    * @remarks
    * The environment variable name must consist only of upper-case letters, numbers,
-   * and underscores. It may not start with a number. To disable this validation, you
-   * must set `{@link IBaseCommandLineDefinition.allowNonStandardEnvironmentVariable}`
+   * and underscores. It may not start with a number. To disable this validation, set
+   * `{@link IBaseCommandLineDefinition.allowNonStandardEnvironmentVariableNames}`
+   * to `true`.
    * to `true`.
    *
    * This feature cannot be used when {@link IBaseCommandLineDefinition.required} is true,
@@ -91,7 +92,7 @@ export interface IBaseCommandLineDefinition {
    * while on Linux, environment variable names are case-sensitive. It is recommended that
    * this option be used only when necessary based on environmental constraints.
    */
-  allowNonStandardEnvironmentVariable?: boolean;
+  allowNonStandardEnvironmentVariableNames?: boolean;
 
   /**
    * Specifies additional names for this parameter that are accepted but not displayed

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -81,7 +81,8 @@ export interface IBaseCommandLineDefinition {
   environmentVariable?: string;
 
   /**
-   * Allows for the use of non-standardized environment variable names. This disables
+   * Allows for the use of environment variable names that do not conform to the standard
+   * described by the Shell and Utilities volume of IEEE Std 1003.1-2001. This disables
    * the validation that is performed on the provided
    * {@link IBaseCommandLineDefinition.environmentVariable} value by default.
    *


### PR DESCRIPTION
## Summary

This PR removes the naming restrictions on the environment variable names provided to parameters. While well-intentioned, it is sometimes not within the control of the developer as to which casing or format an environment variable name takes. Since variable naming is fundamentally limited by the platform, we should rely on the platform to determine if the environment variable specified maps to the target variable.

## How it was tested

This PR.