### PR TITLE
[ts-command-line] More ts-command-line API cleanup.

### DIFF
--- a/common/changes/@rushstack/ts-command-line/more-ts-command-line-cleanup_2024-03-02-00-30.json
+++ b/common/changes/@rushstack/ts-command-line/more-ts-command-line-cleanup_2024-03-02-00-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Use more specific types for command line parameters' `kind` properties.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -41,7 +41,7 @@ export class CommandLineChoiceListParameter<TChoice extends string = string> ext
     // @override
     appendToArgList(argList: string[]): void;
     readonly completions: (() => Promise<TChoice[]>) | undefined;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.ChoiceList;
     // @internal
     _setValue(data: unknown): void;
     get values(): ReadonlyArray<TChoice>;
@@ -58,7 +58,7 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
     readonly defaultValue: TChoice | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.Choice;
     // @internal
     _setValue(data: unknown): void;
     get value(): TChoice | undefined;
@@ -75,7 +75,7 @@ export class CommandLineFlagParameter extends CommandLineParameter {
     constructor(definition: ICommandLineFlagDefinition);
     // @override
     appendToArgList(argList: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.Flag;
     // @internal
     _setValue(data: unknown): void;
     get value(): boolean;
@@ -92,7 +92,7 @@ export class CommandLineIntegerListParameter extends CommandLineParameterWithArg
     constructor(definition: ICommandLineIntegerListDefinition);
     // @override
     appendToArgList(argList: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.IntegerList;
     // @internal
     _setValue(data: unknown): void;
     get values(): ReadonlyArray<number>;
@@ -107,7 +107,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
     readonly defaultValue: number | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.Integer;
     // @internal
     _setValue(data: unknown): void;
     get value(): number | undefined;
@@ -177,8 +177,10 @@ export abstract class CommandLineParameterProvider {
         required: true;
     }): IRequiredCommandLineIntegerParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
+    // Warning: (ae-forgotten-export) The symbol "CommandLineParameter_2" needs to be exported by the entry point index.d.ts
+    //
     // @internal (undocumented)
-    protected _defineParameter(parameter: CommandLineParameter): void;
+    protected _defineParameter(parameter: CommandLineParameter_2): void;
     defineStringListParameter(definition: ICommandLineStringListDefinition): CommandLineStringListParameter;
     defineStringParameter(definition: ICommandLineStringDefinition & {
         required: false | undefined;
@@ -210,7 +212,7 @@ export abstract class CommandLineParameterProvider {
     // @internal (undocumented)
     protected readonly _registeredParameterParserKeysByName: Map<string, string>;
     // @internal (undocumented)
-    protected _registerParameter(parameter: CommandLineParameter, useScopedLongName: boolean, ignoreShortName: boolean): void;
+    protected _registerParameter(parameter: CommandLineParameter_2, useScopedLongName: boolean, ignoreShortName: boolean): void;
     get remainder(): CommandLineRemainder | undefined;
     renderHelpText(): string;
     renderUsageText(): string;
@@ -259,7 +261,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     constructor(definition: ICommandLineStringListDefinition);
     // @override
     appendToArgList(argList: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.StringList;
     // @internal
     _setValue(data: unknown): void;
     get values(): ReadonlyArray<string>;
@@ -274,7 +276,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
     readonly defaultValue: string | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    get kind(): CommandLineParameterKind;
+    readonly kind: CommandLineParameterKind.String;
     // @internal
     _setValue(data: unknown): void;
     get value(): string | undefined;
@@ -417,7 +419,7 @@ export interface IScopedLongNameParseResult {
 export abstract class ScopedCommandLineAction extends CommandLineAction {
     constructor(options: ICommandLineActionOptions);
     // @internal (undocumented)
-    protected _defineParameter(parameter: CommandLineParameter): void;
+    protected _defineParameter(parameter: CommandLineParameter_2): void;
     // @internal
     _execute(): Promise<void>;
     // @internal

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -30,7 +30,8 @@ export type {
 
 export {
   CommandLineParameterKind,
-  CommandLineParameter,
+  // TODO: Export both `CommandLineParameter` and `CommandLineParameterBase` in the next major bump
+  CommandLineParameterBase as CommandLineParameter,
   CommandLineParameterWithArgument
 } from './parameters/BaseClasses';
 

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -6,6 +6,13 @@ import type {
   IBaseCommandLineDefinition,
   IBaseCommandLineDefinitionWithArgument
 } from './CommandLineDefinition';
+import type { CommandLineChoiceListParameter } from './CommandLineChoiceListParameter';
+import type { CommandLineChoiceParameter } from './CommandLineChoiceParameter';
+import type { CommandLineFlagParameter } from './CommandLineFlagParameter';
+import type { CommandLineIntegerListParameter } from './CommandLineIntegerListParameter';
+import type { CommandLineIntegerParameter } from './CommandLineIntegerParameter';
+import type { CommandLineStringListParameter } from './CommandLineStringListParameter';
+import type { CommandLineStringParameter } from './CommandLineStringParameter';
 
 /**
  * Identifies the kind of a CommandLineParameter.
@@ -54,11 +61,20 @@ const SCOPE_REGEXP: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
  */
 const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
 
+export type CommandLineParameter =
+  | CommandLineChoiceListParameter
+  | CommandLineChoiceParameter
+  | CommandLineFlagParameter
+  | CommandLineIntegerListParameter
+  | CommandLineIntegerParameter
+  | CommandLineStringListParameter
+  | CommandLineStringParameter;
+
 /**
  * The base class for the various command-line parameter types.
  * @public
  */
-export abstract class CommandLineParameter {
+export abstract class CommandLineParameterBase {
   private _shortNameValue: string | undefined;
 
   /**
@@ -249,7 +265,7 @@ export abstract class CommandLineParameter {
  * example "--max-count 123".
  * @public
  */
-export abstract class CommandLineParameterWithArgument extends CommandLineParameter {
+export abstract class CommandLineParameterWithArgument extends CommandLineParameterBase {
   // Matches the first character that *isn't* part of a valid upper-case argument name such as "URL_2"
   private static _invalidArgumentNameRegExp: RegExp = /[^A-Z_0-9]/;
 

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
@@ -2,14 +2,16 @@
 // See LICENSE in the project root for license information.
 
 import type { ICommandLineChoiceListDefinition } from './CommandLineDefinition';
-import { CommandLineParameter, CommandLineParameterKind } from './BaseClasses';
+import { CommandLineParameterBase, CommandLineParameterKind } from './BaseClasses';
 import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 
 /**
  * The data type returned by {@link CommandLineParameterProvider.defineChoiceListParameter}.
  * @public
  */
-export class CommandLineChoiceListParameter<TChoice extends string = string> extends CommandLineParameter {
+export class CommandLineChoiceListParameter<
+  TChoice extends string = string
+> extends CommandLineParameterBase {
   /** {@inheritDoc ICommandLineChoiceListDefinition.alternatives} */
   public readonly alternatives: ReadonlyArray<TChoice>;
 
@@ -17,6 +19,9 @@ export class CommandLineChoiceListParameter<TChoice extends string = string> ext
 
   /** {@inheritDoc ICommandLineChoiceListDefinition.completions} */
   public readonly completions: (() => Promise<TChoice[]>) | undefined;
+
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.ChoiceList = CommandLineParameterKind.ChoiceList;
 
   /** @internal */
   public constructor(definition: ICommandLineChoiceListDefinition<TChoice>) {
@@ -30,11 +35,6 @@ export class CommandLineChoiceListParameter<TChoice extends string = string> ext
 
     this.alternatives = definition.alternatives;
     this.completions = definition.completions;
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.ChoiceList;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { ICommandLineChoiceDefinition } from './CommandLineDefinition';
-import { CommandLineParameter, CommandLineParameterKind } from './BaseClasses';
+import { CommandLineParameterBase, CommandLineParameterKind } from './BaseClasses';
 
 /**
  * The data type returned by {@link CommandLineParameterProvider.(defineChoiceParameter:2)}.
@@ -17,7 +17,7 @@ export interface IRequiredCommandLineChoiceParameter<TChoice extends string = st
  * The data type returned by {@link CommandLineParameterProvider.(defineChoiceParameter:1)}.
  * @public
  */
-export class CommandLineChoiceParameter<TChoice extends string = string> extends CommandLineParameter {
+export class CommandLineChoiceParameter<TChoice extends string = string> extends CommandLineParameterBase {
   /** {@inheritDoc ICommandLineChoiceDefinition.alternatives} */
   public readonly alternatives: ReadonlyArray<TChoice>;
 
@@ -28,6 +28,9 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
 
   /** {@inheritDoc ICommandLineChoiceDefinition.completions} */
   public readonly completions: (() => Promise<TChoice[]>) | undefined;
+
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.Choice = -CommandLineParameterKind.Choice;
 
   /** @internal */
   public constructor(definition: ICommandLineChoiceDefinition<TChoice>) {
@@ -49,11 +52,6 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
     this.defaultValue = definition.defaultValue;
     this.validateDefaultValue(!!this.defaultValue);
     this.completions = definition.completions;
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.Choice;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineFlagParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineFlagParameter.ts
@@ -2,23 +2,21 @@
 // See LICENSE in the project root for license information.
 
 import type { ICommandLineFlagDefinition } from './CommandLineDefinition';
-import { CommandLineParameter, CommandLineParameterKind } from './BaseClasses';
+import { CommandLineParameterBase, CommandLineParameterKind } from './BaseClasses';
 
 /**
  * The data type returned by {@link CommandLineParameterProvider.defineFlagParameter}.
  * @public
  */
-export class CommandLineFlagParameter extends CommandLineParameter {
+export class CommandLineFlagParameter extends CommandLineParameterBase {
   private _value: boolean = false;
+
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.Flag = CommandLineParameterKind.Flag;
 
   /** @internal */
   public constructor(definition: ICommandLineFlagDefinition) {
     super(definition);
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.Flag;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
@@ -12,14 +12,12 @@ import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 export class CommandLineIntegerListParameter extends CommandLineParameterWithArgument {
   private _values: number[] = [];
 
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.IntegerList = CommandLineParameterKind.IntegerList;
+
   /** @internal */
   public constructor(definition: ICommandLineIntegerListDefinition) {
     super(definition);
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.IntegerList;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
@@ -22,16 +22,14 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
 
   private _value: number | undefined = undefined;
 
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.Integer = CommandLineParameterKind.Integer;
+
   /** @internal */
   public constructor(definition: ICommandLineIntegerDefinition) {
     super(definition);
     this.defaultValue = definition.defaultValue;
     this.validateDefaultValue(!!this.defaultValue);
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.Integer;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
@@ -12,14 +12,12 @@ import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 export class CommandLineStringListParameter extends CommandLineParameterWithArgument {
   private _values: string[] = [];
 
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.StringList = CommandLineParameterKind.StringList;
+
   /** @internal */
   public constructor(definition: ICommandLineStringListDefinition) {
     super(definition);
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.StringList;
   }
 
   /**

--- a/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
@@ -22,17 +22,15 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
 
   private _value: string | undefined = undefined;
 
+  /** {@inheritDoc CommandLineParameter.kind} */
+  public readonly kind: CommandLineParameterKind.String = CommandLineParameterKind.String;
+
   /** @internal */
   public constructor(definition: ICommandLineStringDefinition) {
     super(definition);
 
     this.defaultValue = definition.defaultValue;
     this.validateDefaultValue(!!this.defaultValue);
-  }
-
-  /** {@inheritDoc CommandLineParameter.kind} */
-  public get kind(): CommandLineParameterKind {
-    return CommandLineParameterKind.String;
   }
 
   /**

--- a/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
@@ -4,15 +4,13 @@
 import * as argparse from 'argparse';
 
 import { CommandLineAction } from './CommandLineAction';
-import { CommandLineParameterKind, type CommandLineParameterBase } from '../parameters/BaseClasses';
+import {
+  CommandLineParameterKind,
+  type CommandLineParameterBase,
+  type CommandLineParameter
+} from '../parameters/BaseClasses';
 import type { ICommandLineParserData, IRegisterDefinedParametersState } from './CommandLineParameterProvider';
 import type { ICommandLineParserOptions } from './CommandLineParser';
-import type { CommandLineChoiceParameter } from '../parameters/CommandLineChoiceParameter';
-import type { CommandLineFlagParameter } from '../parameters/CommandLineFlagParameter';
-import type { CommandLineStringParameter } from '../parameters/CommandLineStringParameter';
-import type { CommandLineIntegerParameter } from '../parameters/CommandLineIntegerParameter';
-import type { CommandLineChoiceListParameter } from '../parameters/CommandLineChoiceListParameter';
-import type { CommandLineIntegerListParameter } from '../parameters/CommandLineIntegerListParameter';
 
 /**
  * Options for the AliasCommandLineAction constructor.
@@ -89,53 +87,45 @@ export class AliasCommandLineAction extends CommandLineAction {
     /* override */
     // All parameters are going to be defined by the target action. Re-use the target action parameters
     // for this action.
-    for (const parameter of this.targetAction.parameters) {
+    for (const parameter of this.targetAction.parameters as CommandLineParameter[]) {
+      const { kind, longName, shortName } = parameter;
       let aliasParameter: CommandLineParameterBase;
       const nameOptions: { parameterLongName: string; parameterShortName: string | undefined } = {
-        parameterLongName: parameter.longName,
-        parameterShortName: parameter.shortName
+        parameterLongName: longName,
+        parameterShortName: shortName
       };
-      switch (parameter.kind) {
+      switch (kind) {
         case CommandLineParameterKind.Choice:
-          const choiceParameter: CommandLineChoiceParameter = parameter as CommandLineChoiceParameter;
           aliasParameter = this.defineChoiceParameter({
             ...nameOptions,
-            ...choiceParameter,
-            alternatives: ([] as string[]).concat(choiceParameter.alternatives)
+            ...parameter,
+            alternatives: [...parameter.alternatives]
           });
           break;
         case CommandLineParameterKind.ChoiceList:
-          const choiceListParameter: CommandLineChoiceListParameter =
-            parameter as CommandLineChoiceListParameter;
           aliasParameter = this.defineChoiceListParameter({
             ...nameOptions,
-            ...choiceListParameter,
-            alternatives: ([] as string[]).concat(choiceListParameter.alternatives)
+            ...parameter,
+            alternatives: [...parameter.alternatives]
           });
           break;
         case CommandLineParameterKind.Flag:
-          const flagParameter: CommandLineFlagParameter = parameter as CommandLineFlagParameter;
-          aliasParameter = this.defineFlagParameter({ ...nameOptions, ...flagParameter });
+          aliasParameter = this.defineFlagParameter({ ...nameOptions, ...parameter });
           break;
         case CommandLineParameterKind.Integer:
-          const integerParameter: CommandLineIntegerParameter = parameter as CommandLineIntegerParameter;
-          aliasParameter = this.defineIntegerParameter({ ...nameOptions, ...integerParameter });
+          aliasParameter = this.defineIntegerParameter({ ...nameOptions, ...parameter });
           break;
         case CommandLineParameterKind.IntegerList:
-          const integerListParameter: CommandLineIntegerListParameter =
-            parameter as CommandLineIntegerListParameter;
-          aliasParameter = this.defineIntegerListParameter({ ...nameOptions, ...integerListParameter });
+          aliasParameter = this.defineIntegerListParameter({ ...nameOptions, ...parameter });
           break;
         case CommandLineParameterKind.String:
-          const stringParameter: CommandLineStringParameter = parameter as CommandLineStringParameter;
-          aliasParameter = this.defineStringParameter({ ...nameOptions, ...stringParameter });
+          aliasParameter = this.defineStringParameter({ ...nameOptions, ...parameter });
           break;
         case CommandLineParameterKind.StringList:
-          const stringListParameter: CommandLineStringParameter = parameter as CommandLineStringParameter;
-          aliasParameter = this.defineStringListParameter({ ...nameOptions, ...stringListParameter });
+          aliasParameter = this.defineStringListParameter({ ...nameOptions, ...parameter });
           break;
         default:
-          throw new Error(`Unsupported parameter kind: ${parameter.kind}`);
+          throw new Error(`Unsupported parameter kind: ${kind}`);
       }
 
       // We know the parserKey is defined because the underlying _defineParameter method sets it,

--- a/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
@@ -4,7 +4,7 @@
 import * as argparse from 'argparse';
 
 import { CommandLineAction } from './CommandLineAction';
-import { CommandLineParameterKind, type CommandLineParameter } from '../parameters/BaseClasses';
+import { CommandLineParameterKind, type CommandLineParameterBase } from '../parameters/BaseClasses';
 import type { ICommandLineParserData, IRegisterDefinedParametersState } from './CommandLineParameterProvider';
 import type { ICommandLineParserOptions } from './CommandLineParser';
 import type { CommandLineChoiceParameter } from '../parameters/CommandLineChoiceParameter';
@@ -90,7 +90,7 @@ export class AliasCommandLineAction extends CommandLineAction {
     // All parameters are going to be defined by the target action. Re-use the target action parameters
     // for this action.
     for (const parameter of this.targetAction.parameters) {
-      let aliasParameter: CommandLineParameter;
+      let aliasParameter: CommandLineParameterBase;
       const nameOptions: { parameterLongName: string; parameterShortName: string | undefined } = {
         parameterLongName: parameter.longName,
         parameterShortName: parameter.shortName

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -5,7 +5,7 @@ import { SCOPING_PARAMETER_GROUP } from '../Constants';
 import { CommandLineAction, type ICommandLineActionOptions } from './CommandLineAction';
 import { CommandLineParser, type ICommandLineParserOptions } from './CommandLineParser';
 import { CommandLineParserExitError } from './CommandLineParserExitError';
-import type { CommandLineParameter } from '../parameters/BaseClasses';
+import type { CommandLineParameter, CommandLineParameterBase } from '../parameters/BaseClasses';
 import type {
   CommandLineParameterProvider,
   ICommandLineParserData,
@@ -120,8 +120,11 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
 
   /**
    * {@inheritDoc CommandLineParameterProvider.parameters}
+   *
+   * @internalremarks
+   * TODO: Replace this type with `CommandLineParameter` in the next major bump.
    */
-  public get parameters(): ReadonlyArray<CommandLineParameter> {
+  public get parameters(): ReadonlyArray<CommandLineParameterBase> {
     if (this._scopedCommandLineParser) {
       return [...super.parameters, ...this._scopedCommandLineParser.parameters];
     } else {
@@ -152,7 +155,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
       actionOptions: this._options,
       aliasAction: data.aliasAction,
       aliasDocumentation: data.aliasDocumentation,
-      unscopedActionParameters: this.parameters,
+      unscopedActionParameters: this.parameters as CommandLineParameter[],
       registerDefinedParametersState: this._subparserState,
       onDefineScopedParameters: this.onDefineScopedParameters.bind(this)
     });

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -3,7 +3,7 @@
 
 import { DynamicCommandLineParser } from '../providers/DynamicCommandLineParser';
 import { DynamicCommandLineAction } from '../providers/DynamicCommandLineAction';
-import { CommandLineParameter } from '../parameters/BaseClasses';
+import { CommandLineParameterBase } from '../parameters/BaseClasses';
 import type { CommandLineParser } from '../providers/CommandLineParser';
 import type { CommandLineAction } from '../providers/CommandLineAction';
 import { AnsiEscape } from '@rushstack/terminal';
@@ -150,7 +150,7 @@ const snapshotPropertyNames: string[] = [
   'values'
 ];
 
-describe(CommandLineParameter.name, () => {
+describe(CommandLineParameterBase.name, () => {
   let existingEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CommandLineParameter allows an undocumented synonym 1`] = `
+exports[`CommandLineParameterBase allows an undocumented synonym 1`] = `
 Array [
   "### --choice output: ###",
   "### --choice-with-default output: ###",
@@ -27,11 +27,11 @@ Array [
 ]
 `;
 
-exports[`CommandLineParameter choice list raises an error if env var value is json containing non-scalars 1`] = `"The [{}] environment variable value looks like a JSON array but failed to parse: The [{}] environment variable value must be a JSON  array containing only strings, numbers, and booleans."`;
+exports[`CommandLineParameterBase choice list raises an error if env var value is json containing non-scalars 1`] = `"The [{}] environment variable value looks like a JSON array but failed to parse: The [{}] environment variable value must be a JSON  array containing only strings, numbers, and booleans."`;
 
-exports[`CommandLineParameter choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
+exports[`CommandLineParameterBase choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
 
-exports[`CommandLineParameter parses an input with ALL parameters 1`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 1`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -46,13 +46,13 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 2`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 2`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
   "description": "A choice",
   "environmentVariable": "ENV_CHOICE",
-  "kind": 0,
+  "kind": -0,
   "longName": "--choice",
   "required": false,
   "shortName": "-c",
@@ -61,13 +61,13 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 3`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 3`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": "default",
   "description": "A choice with a default. This description ends with a \\"quoted word\\"",
   "environmentVariable": "ENV_CHOICE2",
-  "kind": 0,
+  "kind": -0,
   "longName": "--choice-with-default",
   "required": false,
   "shortName": undefined,
@@ -76,7 +76,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 4`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 4`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -94,7 +94,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 5`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 5`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -109,7 +109,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 6`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 6`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -124,7 +124,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 7`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 7`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": 123,
@@ -139,7 +139,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 8`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 8`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -154,7 +154,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 9`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 9`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
@@ -172,7 +172,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 10`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 10`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": undefined,
@@ -187,7 +187,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 11`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 11`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": "123",
@@ -202,7 +202,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 12`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 12`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
@@ -220,7 +220,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with ALL parameters 13`] = `
+exports[`CommandLineParameterBase parses an input with ALL parameters 13`] = `
 Array [
   "### --choice output: ###",
   "--choice",
@@ -264,7 +264,7 @@ Array [
 ]
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 1`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 1`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -279,13 +279,13 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 2`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 2`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
   "description": "A choice",
   "environmentVariable": "ENV_CHOICE",
-  "kind": 0,
+  "kind": -0,
   "longName": "--choice",
   "required": false,
   "shortName": "-c",
@@ -294,13 +294,13 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 3`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 3`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": "default",
   "description": "A choice with a default. This description ends with a \\"quoted word\\"",
   "environmentVariable": "ENV_CHOICE2",
-  "kind": 0,
+  "kind": -0,
   "longName": "--choice-with-default",
   "required": false,
   "shortName": undefined,
@@ -309,7 +309,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 4`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 4`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -324,7 +324,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 5`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 5`] = `
 Object {
   "argumentName": undefined,
   "defaultValue": undefined,
@@ -339,7 +339,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 6`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 6`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -354,7 +354,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 7`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 7`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": 123,
@@ -369,7 +369,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 8`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 8`] = `
 Object {
   "argumentName": "NUMBER",
   "defaultValue": undefined,
@@ -384,7 +384,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 9`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 9`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
@@ -399,7 +399,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 10`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 10`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": undefined,
@@ -414,7 +414,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 11`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 11`] = `
 Object {
   "argumentName": "TEXT",
   "defaultValue": "123",
@@ -429,7 +429,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 12`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 12`] = `
 Object {
   "argumentName": "LIST_ITEM",
   "defaultValue": undefined,
@@ -444,7 +444,7 @@ Object {
 }
 `;
 
-exports[`CommandLineParameter parses an input with NO parameters 13`] = `
+exports[`CommandLineParameterBase parses an input with NO parameters 13`] = `
 Array [
   "### --choice output: ###",
   "### --choice-with-default output: ###",
@@ -469,7 +469,7 @@ Array [
 ]
 `;
 
-exports[`CommandLineParameter parses each parameter from an environment variable 1`] = `
+exports[`CommandLineParameterBase parses each parameter from an environment variable 1`] = `
 Array [
   "### --choice output: ###",
   "--choice",
@@ -520,7 +520,7 @@ Array [
 ]
 `;
 
-exports[`CommandLineParameter prints the action help 1`] = `
+exports[`CommandLineParameterBase prints the action help 1`] = `
 "usage: example do:the-job [-h] [-c {one,two,three,default}]
                           [--choice-with-default {one,two,three,default}]
                           [-C {red,green,blue}] [-f] [-i NUMBER]
@@ -581,7 +581,7 @@ Optional arguments:
 "
 `;
 
-exports[`CommandLineParameter prints the global help 1`] = `
+exports[`CommandLineParameterBase prints the global help 1`] = `
 "usage: example [-h] [-g] <command> ...
 
 An example project


### PR DESCRIPTION
## Summary

This PR eliminates the need for casts when filtering on the parameter's type.

## How it was tested

Unit tests pass.

## Impacted documentation

API docs will need to be updated.