### PR TITLE
[heft] Update timing metrics

### DIFF
--- a/apps/heft/src/cli/HeftActionRunner.ts
+++ b/apps/heft/src/cli/HeftActionRunner.ts
@@ -209,8 +209,6 @@ export class HeftActionRunner {
       // to the number of CPU cores
       this._parallelism = numberOfCores;
     }
-
-    this._metricsCollector.setStartTime();
   }
 
   protected get parameterManager(): HeftParameterManager {
@@ -350,6 +348,8 @@ export class HeftActionRunner {
     abortSignal: AbortSignal,
     requestRun?: (requestor?: string) => void
   ): Promise<OperationStatus> {
+    // Record this as the start of task execution.
+    this._metricsCollector.setStartTime();
     // Execute the action operations
     return await runWithLoggingAsync(
       () => {

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -21,20 +21,21 @@ export interface IMetricsData {
   encounteredError?: boolean;
 
   /**
-   * The amount of time the command took to execute, in milliseconds.
+   * The total execution duration of all user-defined tasks from `heft.json`, in milliseconds.
+   * This metric is for measuring the cumulative time spent on the underlying build steps for a project.
+   * If running in watch mode, this will be the duration of the most recent incremental build.
    */
   taskTotalExecutionMs: number;
 
   /**
-   * How long the process has been running before the action was first executed, in milliseconds.
-   * Broken out so that `taskTotalExecutionMs` only includes the actual task executions.
-   * This is how long Heft took to boot.
+   * The total duration before Heft started executing user-defined tasks, in milliseconds.
+   * This metric is for tracking the contribution of Heft itself to total build duration.
    */
   bootDurationMs: number;
 
   /**
    * How long the process has been alive, in milliseconds.
-   * Mostly of interest when running in watch mode, to track how long developer sessions last.
+   * This metric is for watch mode, to analyze how long developers leave individual Heft sessions running.
    */
   totalUptimeMs: number;
 

--- a/common/changes/@rushstack/heft/heft-telemetry-fix_2024-03-02-01-06.json
+++ b/common/changes/@rushstack/heft/heft-telemetry-fix_2024-03-02-01-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add new metrics value `bootDurationMs` to track the boot overhead of Heft before the action starts executing the subtasks. Update the start time used to compute `taskTotalExecutionMs` to be the beginning of operation graph execution. Fix the value of `taskTotalExecutionMs` field to be in milliseconds instead of seconds. Add new metrics value `totalUptimeMs` to track how long watch mode sessions are kept alive.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -212,6 +212,7 @@ export interface IIncrementalCopyOperation extends ICopyOperation {
 
 // @public (undocumented)
 export interface IMetricsData {
+    bootDurationMs: number;
     command: string;
     commandParameters: Record<string, string>;
     encounteredError?: boolean;
@@ -221,6 +222,7 @@ export interface IMetricsData {
     machineProcessor: string;
     machineTotalMemoryMB: number;
     taskTotalExecutionMs: number;
+    totalUptimeMs: number;
 }
 
 // @internal (undocumented)


### PR DESCRIPTION
## Summary
Updates the set of available timing metrics available to Heft plugins for organizations to analyze their build processes. These metrics are not sent anywhere by default and collection is left up to the repository manager. The metrics are:
- `taskTotalExecutionMs` is the time spent on user-defined tasks in `heft.json` for the most recent execution. This is the metric for measuring the performance of the underlying build steps for a project.
- `bootDurationMs` is the time spent dealing with Heft itself, before the start of the initial (or only if not in watch mode) `taskTotalExecutionMs` metric. This metric tracks overhead that does not perform useful work for the end user.
- `totalUptimeMs` is the total time that the Heft process has been running as of the end of the most recent execution. This metric is for analyzing watch mode sessions, e.g. to determine how long developers keep Heft running in a single session.

## Details
Fixes two issues with the `taskTotalExecutionMs` telemetry metric in Heft:
1. The value was labeled as being in milliseconds, but the reported value was in seconds.
2. When running in watch mode, the value reported the duration from initial Heft startup to the end of the most recent incremental execution, rather than the duration of the current incremental execution.

- Changes `taskTotalExecutionMs` to be the execution duration of only the operation graph (i.e. all user-defined work).
- Adds a `bootDurationMs` metric to account for the duration spent on Heft overhead before the start of the initial `taskTotalExecutionMs` measurement.
- Adds a `totalUptimeMs` metric that tracks the datum that was originally being (erroneously) reported in `taskTotalExecutionMs`, namely how long the process has been running up until the end of the most recent execution.

## How it was tested
Run under debugger and inspected metrics fields.

## Impacted documentation
Any documentation about the MetricsCollector for Heft.