### PR TITLE
[ts-command-line] Return the "required" variants of the parameter types when define calls include the `defaultValue` option.

### DIFF
--- a/apps/api-documenter/src/cli/YamlAction.ts
+++ b/apps/api-documenter/src/cli/YamlAction.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { CommandLineFlagParameter, CommandLineChoiceParameter } from '@rushstack/ts-command-line';
+import type {
+  CommandLineFlagParameter,
+  IRequiredCommandLineChoiceParameter
+} from '@rushstack/ts-command-line';
 
 import type { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
@@ -12,7 +15,7 @@ import { OfficeYamlDocumenter } from '../documenters/OfficeYamlDocumenter';
 export class YamlAction extends BaseAction {
   private readonly _officeParameter: CommandLineFlagParameter;
   private readonly _newDocfxNamespacesParameter: CommandLineFlagParameter;
-  private readonly _yamlFormatParameter: CommandLineChoiceParameter<YamlFormat>;
+  private readonly _yamlFormatParameter: IRequiredCommandLineChoiceParameter<YamlFormat>;
 
   public constructor(parser: ApiDocumenterCommandLine) {
     super({

--- a/apps/trace-import/src/TraceImportCommandLineParser.ts
+++ b/apps/trace-import/src/TraceImportCommandLineParser.ts
@@ -5,8 +5,8 @@ import {
   CommandLineParser,
   type CommandLineFlagParameter,
   type CommandLineStringParameter,
-  type CommandLineChoiceParameter,
-  type IRequiredCommandLineStringParameter
+  type IRequiredCommandLineStringParameter,
+  type IRequiredCommandLineChoiceParameter
 } from '@rushstack/ts-command-line';
 import { InternalError } from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
@@ -17,7 +17,7 @@ export class TraceImportCommandLineParser extends CommandLineParser {
   private readonly _debugParameter: CommandLineFlagParameter;
   private readonly _pathParameter: IRequiredCommandLineStringParameter;
   private readonly _baseFolderParameter: CommandLineStringParameter;
-  private readonly _resolutionTypeParameter: CommandLineChoiceParameter<ResolutionType>;
+  private readonly _resolutionTypeParameter: IRequiredCommandLineChoiceParameter<ResolutionType>;
 
   public constructor() {
     super({
@@ -75,7 +75,7 @@ export class TraceImportCommandLineParser extends CommandLineParser {
       traceImport({
         importPath: this._pathParameter.value,
         baseFolder: this._baseFolderParameter.value,
-        resolutionType: this._resolutionTypeParameter.value ?? 'cjs'
+        resolutionType: this._resolutionTypeParameter.value
       });
     } catch (error) {
       if (this._debugParameter.value) {

--- a/build-tests/ts-command-line-test/src/PushAction.ts
+++ b/build-tests/ts-command-line-test/src/PushAction.ts
@@ -2,9 +2,9 @@
 // See LICENSE in the project root for license information.
 
 import {
-  CommandLineFlagParameter,
+  type CommandLineFlagParameter,
   CommandLineAction,
-  CommandLineChoiceParameter
+  type IRequiredCommandLineChoiceParameter
 } from '@rushstack/ts-command-line';
 import { BusinessLogic } from './BusinessLogic';
 
@@ -12,7 +12,7 @@ type Protocol = 'ftp' | 'webdav' | 'scp';
 
 export class PushAction extends CommandLineAction {
   private _force: CommandLineFlagParameter;
-  private _protocol: CommandLineChoiceParameter<Protocol>;
+  private _protocol: IRequiredCommandLineChoiceParameter<Protocol>;
 
   public constructor() {
     super({
@@ -24,7 +24,7 @@ export class PushAction extends CommandLineAction {
 
   protected onExecute(): Promise<void> {
     // abstract
-    return BusinessLogic.doTheWork(this._force.value, this._protocol.value || '(none)');
+    return BusinessLogic.doTheWork(this._force.value, this._protocol.value);
   }
 
   protected onDefineParameters(): void {

--- a/common/changes/@microsoft/api-documenter/user-ianc-default-values-required_2024-03-02-01-27.json
+++ b/common/changes/@microsoft/api-documenter/user-ianc-default-values-required_2024-03-02-01-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/rush/user-ianc-default-values-required_2024-03-02-01-27.json
+++ b/common/changes/@microsoft/rush/user-ianc-default-values-required_2024-03-02-01-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/trace-import/user-ianc-default-values-required_2024-03-02-01-27.json
+++ b/common/changes/@rushstack/trace-import/user-ianc-default-values-required_2024-03-02-01-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/trace-import"
+}

--- a/common/changes/@rushstack/ts-command-line/user-ianc-default-values-required_2024-03-02-01-27.json
+++ b/common/changes/@rushstack/ts-command-line/user-ianc-default-values-required_2024-03-02-01-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Update the return type of `defineChoiceParameter`, `defineIntegerParameter`, and `defineStringParameter` respectively when the `defaultValue` option is provided to return `IRequiredCommandLineChoiceParameter`, `IRequiredCommandLineIntegerParameter`, and `IRequiredCommandLineStringParameter` respectively, as the value will definitely be defined in these cases.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/ts-command-line/user-ianc-default-values-required_2024-03-02-01-45.json
+++ b/common/changes/@rushstack/ts-command-line/user-ianc-default-values-required_2024-03-02-01-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Include a missing `readonly` modifier on the `value` properties of `IRequiredCommandLineChoiceParameter`, `IRequiredCommandLineIntegerParameter`, and `IRequiredCommandLineStringParameter`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -168,9 +168,13 @@ export abstract class CommandLineParameterProvider {
     defineChoiceListParameter<TChoice extends string = string>(definition: ICommandLineChoiceListDefinition<TChoice>): CommandLineChoiceListParameter<TChoice>;
     defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice> & {
         required: false | undefined;
+        defaultValue: undefined;
     }): CommandLineChoiceParameter<TChoice>;
     defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice> & {
         required: true;
+    }): IRequiredCommandLineChoiceParameter<TChoice>;
+    defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice> & {
+        defaultValue: TChoice;
     }): IRequiredCommandLineChoiceParameter<TChoice>;
     defineChoiceParameter<TChoice extends string = string>(definition: ICommandLineChoiceDefinition<TChoice>): CommandLineChoiceParameter<TChoice>;
     defineCommandLineRemainder(definition: ICommandLineRemainderDefinition): CommandLineRemainder;
@@ -178,9 +182,13 @@ export abstract class CommandLineParameterProvider {
     defineIntegerListParameter(definition: ICommandLineIntegerListDefinition): CommandLineIntegerListParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition & {
         required: false | undefined;
+        defaultValue: undefined;
     }): CommandLineIntegerParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition & {
         required: true;
+    }): IRequiredCommandLineIntegerParameter;
+    defineIntegerParameter(definition: ICommandLineIntegerDefinition & {
+        defaultValue: number;
     }): IRequiredCommandLineIntegerParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
     // Warning: (ae-forgotten-export) The symbol "CommandLineParameter_2" needs to be exported by the entry point index.d.ts
@@ -190,9 +198,13 @@ export abstract class CommandLineParameterProvider {
     defineStringListParameter(definition: ICommandLineStringListDefinition): CommandLineStringListParameter;
     defineStringParameter(definition: ICommandLineStringDefinition & {
         required: false | undefined;
+        defaultValue: undefined;
     }): CommandLineStringParameter;
     defineStringParameter(definition: ICommandLineStringDefinition & {
         required: true;
+    }): IRequiredCommandLineStringParameter;
+    defineStringParameter(definition: ICommandLineStringDefinition & {
+        defaultValue: string;
     }): IRequiredCommandLineStringParameter;
     defineStringParameter(definition: ICommandLineStringDefinition): CommandLineStringParameter;
     // @internal

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -416,19 +416,19 @@ export interface _IRegisterDefinedParametersState {
 // @public
 export interface IRequiredCommandLineChoiceParameter<TChoice extends string = string> extends CommandLineChoiceParameter<TChoice> {
     // (undocumented)
-    value: TChoice;
+    readonly value: TChoice;
 }
 
 // @public
 export interface IRequiredCommandLineIntegerParameter extends CommandLineIntegerParameter {
     // (undocumented)
-    value: number;
+    readonly value: number;
 }
 
 // @public
 export interface IRequiredCommandLineStringParameter extends CommandLineStringParameter {
     // (undocumented)
-    value: string;
+    readonly value: string;
 }
 
 // @public

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -4,7 +4,8 @@
 import type {
   CommandLineFlagParameter,
   CommandLineIntegerParameter,
-  CommandLineStringParameter
+  CommandLineStringParameter,
+  IRequiredCommandLineIntegerParameter
 } from '@rushstack/ts-command-line';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
 import { ConsoleTerminalProvider, type ITerminal, Terminal, Colorize } from '@rushstack/terminal';
@@ -33,7 +34,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
   protected readonly _noLinkParameter: CommandLineFlagParameter;
   protected readonly _networkConcurrencyParameter: CommandLineIntegerParameter;
   protected readonly _debugPackageManagerParameter: CommandLineFlagParameter;
-  protected readonly _maxInstallAttempts: CommandLineIntegerParameter;
+  protected readonly _maxInstallAttempts: IRequiredCommandLineIntegerParameter;
   protected readonly _ignoreHooksParameter: CommandLineFlagParameter;
   protected readonly _offlineParameter: CommandLineFlagParameter;
   protected readonly _subspaceParameter: CommandLineStringParameter;
@@ -223,9 +224,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
       }
     }
 
-    // Because the 'defaultValue' option on the _maxInstallAttempts parameter is set,
-    // it is safe to assume that the value is not null
-    if (this._maxInstallAttempts.value! < 1) {
+    if (this._maxInstallAttempts.value < 1) {
       throw new Error(`The value of "${this._maxInstallAttempts.longName}" must be positive and nonzero.`);
     }
 

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
@@ -10,7 +10,7 @@ import { CommandLineParameterBase, CommandLineParameterKind } from './BaseClasse
  */
 export interface IRequiredCommandLineChoiceParameter<TChoice extends string = string>
   extends CommandLineChoiceParameter<TChoice> {
-  value: TChoice;
+  readonly value: TChoice;
 }
 
 /**

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
@@ -9,7 +9,7 @@ import { CommandLineParameterWithArgument, CommandLineParameterKind } from './Ba
  * @public
  */
 export interface IRequiredCommandLineIntegerParameter extends CommandLineIntegerParameter {
-  value: number;
+  readonly value: number;
 }
 
 /**

--- a/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
@@ -9,7 +9,7 @@ import { CommandLineParameterWithArgument, CommandLineParameterKind } from './Ba
  * @public
  */
 export interface IRequiredCommandLineStringParameter extends CommandLineStringParameter {
-  value: string;
+  readonly value: string;
 }
 
 /**

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -170,13 +170,22 @@ export abstract class CommandLineParameterProvider {
    * ```
    */
   public defineChoiceParameter<TChoice extends string = string>(
-    definition: ICommandLineChoiceDefinition<TChoice> & { required: false | undefined }
+    definition: ICommandLineChoiceDefinition<TChoice> & {
+      required: false | undefined;
+      defaultValue: undefined;
+    }
   ): CommandLineChoiceParameter<TChoice>;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineChoiceParameter:1)}
    */
   public defineChoiceParameter<TChoice extends string = string>(
     definition: ICommandLineChoiceDefinition<TChoice> & { required: true }
+  ): IRequiredCommandLineChoiceParameter<TChoice>;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineChoiceParameter:1)}
+   */
+  public defineChoiceParameter<TChoice extends string = string>(
+    definition: ICommandLineChoiceDefinition<TChoice> & { defaultValue: TChoice }
   ): IRequiredCommandLineChoiceParameter<TChoice>;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineChoiceParameter:1)}
@@ -267,13 +276,19 @@ export abstract class CommandLineParameterProvider {
    * ```
    */
   public defineIntegerParameter(
-    definition: ICommandLineIntegerDefinition & { required: false | undefined }
+    definition: ICommandLineIntegerDefinition & { required: false | undefined; defaultValue: undefined }
   ): CommandLineIntegerParameter;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineIntegerParameter:1)}
    */
   public defineIntegerParameter(
     definition: ICommandLineIntegerDefinition & { required: true }
+  ): IRequiredCommandLineIntegerParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineIntegerParameter:1)}
+   */
+  public defineIntegerParameter(
+    definition: ICommandLineIntegerDefinition & { defaultValue: number }
   ): IRequiredCommandLineIntegerParameter;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineIntegerParameter:1)}
@@ -337,13 +352,19 @@ export abstract class CommandLineParameterProvider {
    * ```
    */
   public defineStringParameter(
-    definition: ICommandLineStringDefinition & { required: false | undefined }
+    definition: ICommandLineStringDefinition & { required: false | undefined; defaultValue: undefined }
   ): CommandLineStringParameter;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineStringParameter:1)}
    */
   public defineStringParameter(
     definition: ICommandLineStringDefinition & { required: true }
+  ): IRequiredCommandLineStringParameter;
+  /**
+   * {@inheritdoc CommandLineParameterProvider.(defineStringParameter:1)}
+   */
+  public defineStringParameter(
+    definition: ICommandLineStringDefinition & { defaultValue: string }
   ): IRequiredCommandLineStringParameter;
   /**
    * {@inheritdoc CommandLineParameterProvider.(defineStringParameter:1)}

--- a/libraries/ts-command-line/src/providers/TabCompletionAction.ts
+++ b/libraries/ts-command-line/src/providers/TabCompletionAction.ts
@@ -3,8 +3,8 @@
 
 import stringArgv from 'string-argv';
 
-import type { CommandLineIntegerParameter } from '../parameters/CommandLineIntegerParameter';
-import type { CommandLineStringParameter } from '../parameters/CommandLineStringParameter';
+import type { IRequiredCommandLineIntegerParameter } from '../parameters/CommandLineIntegerParameter';
+import type { IRequiredCommandLineStringParameter } from '../parameters/CommandLineStringParameter';
 import {
   CommandLineParameterKind,
   type CommandLineParameterBase,
@@ -19,8 +19,8 @@ const DEFAULT_WORD_TO_AUTOCOMPLETE: string = '';
 const DEFAULT_POSITION: number = 0;
 
 export class TabCompleteAction extends CommandLineAction {
-  private readonly _wordToCompleteParameter: CommandLineStringParameter;
-  private readonly _positionParameter: CommandLineIntegerParameter;
+  private readonly _wordToCompleteParameter: IRequiredCommandLineStringParameter;
+  private readonly _positionParameter: IRequiredCommandLineIntegerParameter;
   private readonly _actions: Map<string, Map<string, CommandLineParameter>>;
   private readonly _globalParameters: Map<string, CommandLineParameter>;
 
@@ -70,8 +70,8 @@ export class TabCompleteAction extends CommandLineAction {
   }
 
   protected async onExecute(): Promise<void> {
-    const commandLine: string = this._wordToCompleteParameter.value || '';
-    const caretPosition: number = this._positionParameter.value || (commandLine && commandLine.length) || 0;
+    const commandLine: string = this._wordToCompleteParameter.value;
+    const caretPosition: number = this._positionParameter.value || commandLine.length;
 
     for await (const value of this.getCompletions(commandLine, caretPosition)) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

Update the return type of `defineChoiceParameter`, `defineIntegerParameter`, and `defineStringParameter` respectively when the `defaultValue` option is provided to return `IRequiredCommandLineChoiceParameter`, `IRequiredCommandLineIntegerParameter`, and `IRequiredCommandLineStringParameter` respectively, as the value will definitely be defined in these cases.

## How it was tested

Updated downstream projects.

## Impacted documentation

API docs need to be updated.