### PR TITLE
[ts-command-line] Fix an issue with allowNonStandardEnvironmentVariableNames parameter option

### DIFF
--- a/common/changes/@rushstack/ts-command-line/fix-nonstandard-env-var-names_2024-03-03-11-46.json
+++ b/common/changes/@rushstack/ts-command-line/fix-nonstandard-env-var-names_2024-03-03-11-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Fix an issue where the `allowNonStandardEnvironmentVariableNames` parameter option had no effect.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -138,6 +138,7 @@ export abstract class CommandLineParameterBase {
     this.required = !!definition.required;
     this.environmentVariable = definition.environmentVariable;
     this.undocumentedSynonyms = definition.undocumentedSynonyms;
+    this.allowNonStandardEnvironmentVariableNames = definition.allowNonStandardEnvironmentVariableNames;
 
     if (!LONG_NAME_REGEXP.test(this.longName)) {
       throw new Error(


### PR DESCRIPTION
## Summary

A mistake was made with the introduction of the `allowNonStandardEnvironmentVariableNames` option, where the property on the parameter class was never initialized, so the property never took effect. This PR fixes that.

## How it was tested

Patched the package in another repo.

## Impacted documentation

None.