### PR TITLE
[rush] Fix an issue where deleted patches weren't deleted from `common/temp/patches`.

### DIFF
--- a/common/changes/@microsoft/rush/patch-sync-fix_2024-03-04-04-39.json
+++ b/common/changes/@microsoft/rush/patch-sync-fix_2024-03-04-04-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where if a patch is removed from `common/pnpm-patches` after `rush install` had already been run with that patch present, pnpm would try to continue applying the patch.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

There is currently an issue where if a patch is removed from `common/pnpm-patches` after `rush install` had already been run on a machine with that patch present, pnpm would try to continue applying the patch.

This PR fixes that issue by deleting the `common/temp/patches` folder if `common/pnpm-patches` doesn't exist, and deleting items from `common/temp/patches` if they no longer exist in `common/pnpm-patches`.

## How it was tested

Tested by running `rush install` in a repo with a patch, deleting the patch, and rerunning `rush install` and observing the output.