### PR TITLE
[rush] Update the `rush-pnpm patch` output to reference `rush-pnpm patch-commit` instead of `pnpm patch-commit`

### DIFF
--- a/common/changes/@microsoft/rush/pnpm-patch-commit-instructions_2024-03-04-05-46.json
+++ b/common/changes/@microsoft/rush/pnpm-patch-commit-instructions_2024-03-04-05-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Intercept the output printed by `rush-pnpm patch` to update the next step's instructions to run `rush-pnpm patch-commit ...` instead of `pnpm patch-commit ...`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -5,7 +5,7 @@ import * as child_process from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
-import { PassThrough } from 'stream';
+import { Transform } from 'stream';
 import {
   JsonFile,
   type IPackageJson,
@@ -773,7 +773,7 @@ export class Utilities {
         options
       );
 
-      const inspectStream: PassThrough = new PassThrough({
+      const inspectStream: Transform = new Transform({
         transform: onStdoutStreamChunk
           ? (
               chunk: string | Buffer,


### PR DESCRIPTION
## Summary

Right now, if you run `rush-pnpm patch <pkg>@<version>`, you'll get output that looks like this:

```
Found configuration in E:\code\rushstack13\rush.json

You can now edit the following folder: <tempdir>/8262c8522370c3b357b23864fc45a0d2

Once you're done with your changes, run "pnpm patch-commit <tempdir>/8262c8522370c3b357b23864fc45a0d2"
```

Notice that the instructions are incorrect: running `pnpm patch-commit <tempdir>/8262c8522370c3b357b23864fc45a0d2` won't work as expected.

This PR intercepts pnpm's output and replaces `pnpm patch-commit` with `rush-pnpm patch-commit`, so the output becomes:

```
Found configuration in E:\code\rushstack13\rush.json

You can now edit the following folder: <tempdir>/8262c8522370c3b357b23864fc45a0d2

Once you're done with your changes, run "rush-pnpm patch-commit <tempdir>/8262c8522370c3b357b23864fc45a0d2"
```

## How it was tested

Tested in several repos, both with and without the interactive mode (i.e. - specifying a package with multiple versions in use in the repo without explicitly specifying the version). Works as expected.

## Impacted documentation

None.