### PR TITLE
[build-cache] Update how cobuilds cache builds that succeed with warnings

### DIFF
--- a/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
+++ b/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "fixes an issue where cobuilds would write success with warnings as success cache entries unexpectedly.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
+++ b/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "fixes an issue where cobuilds would write success with warnings as success cache entries unexpectedly.",
-      "type": "patch"
+      "comment": "Fixes an issue where cobuilds would write success with warnings as successful cache entries.",
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
+++ b/common/changes/@microsoft/rush/fix-cobuild-build-cache_2024-03-05-17-28.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "fixes an issue where cobuilds would write success with warnings as success cache entries unexpectedly.",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/rush"

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -471,8 +471,12 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
           if (cobuildLock && isCacheWriteAllowed) {
             const { cacheId, contextId } = cobuildLock.cobuildContext;
 
-            const finalCacheId: string =
-              status === OperationStatus.Failure ? `${cacheId}-${contextId}-failed` : cacheId;
+            let finalCacheId: string = cacheId;
+            if (status === OperationStatus.Failure) {
+              finalCacheId = `${cacheId}-${contextId}-failed`;
+            } else if (status === OperationStatus.SuccessWithWarning && !record.runner.warningsAreAllowed) {
+              finalCacheId = `${cacheId}-${contextId}-warnings`;
+            }
             switch (status) {
               case OperationStatus.SuccessWithWarning:
               case OperationStatus.Success:


### PR DESCRIPTION
## Summary

Fixes #4558.
We're been running into an issue intermittently where linting errors were getting put into the build cache in CI. This caused issues as running the CI a second time would cause the build to pass and if that code got to main, developer machines would pull that code from the build cache and get warnings for untouched code. This fix changes how cobuilds assign cacheIds to builds to separate `Success` from `SuccessWithWarnings` unless the user explicitly enables `allowWarningsOnSuccess`.

## Details

As I explain above, we've had a couple of issues with the build cache accepting builds that had warnings and then passing in later runs of the CI. Those build artifacts then get pulled into developer machines and start breaking if the developer were to run `rush rebuild`. We took an initial look at the code and for non-cobuilds everything looks good, but there's a case where we transfer the cobuild state back to the primary and write to the cache that seems to skip success with warnings and treats them as just success. From my understanding of the cobuild system, it's necessary to write the build artifact, but for non-passing outputs it shouldn't write to the same cacheID as a passing output. AFAIK there are no alternative approaches to fix this. This _could_ be a breaking change if users rely on this behavior, but I would expect users relying on this behavior to have set the `runner.warningsAreAllowed` option (`allowWarningsInSuccessfulBuild`).

## How it was tested

I monkey patched the rush version running on our CI with this fix and linting errors were not written to the build cache, subsequent retries of the same CI pipeline failed as expected.

