### PR TITLE
[heft] Fix MetricsCollector has not been initialized with setStartTime() yet when run clean

### DIFF
--- a/apps/heft/src/cli/actions/CleanAction.ts
+++ b/apps/heft/src/cli/actions/CleanAction.ts
@@ -80,6 +80,8 @@ export class CleanAction extends CommandLineAction implements IHeftAction {
     const { heftConfiguration } = this._internalHeftSession;
     const abortSignal: AbortSignal = ensureCliAbortSignal(this._terminal);
 
+    // Record this as the start of task execution.
+    this._metricsCollector.setStartTime();
     initializeHeft(heftConfiguration, this._terminal, this._verboseFlag.value);
     await runWithLoggingAsync(
       this._cleanFilesAsync.bind(this),

--- a/common/changes/@rushstack/heft/patch-1_2024-03-14-12-44.json
+++ b/common/changes/@rushstack/heft/patch-1_2024-03-14-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Fix internal error when run 'heft clean'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary

When run `heft clean`, it will always throw `Internal Error: MetricsCollector has not been initialized with setStartTime() yet`.

![CleanShot 2024-03-14 at 19 37 44](https://github.com/microsoft/rushstack/assets/14089557/53efc9d1-92d5-41cc-8029-28cf42f175ab)

## Details

This only just requires call setStartTime() function before it record the time metrics.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
