### PR TITLE
[api-documenter] Emit HTML tags for tables instead of Markdown code.

### DIFF
--- a/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
@@ -105,13 +105,13 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
           writer.write('<thead><tr>');
           for (let i: number = 0; i < columnCount; ++i) {
             writer.write('<th>');
-            writer.writeLine();
+            writer.ensureNewLine();
             writer.writeLine();
             const cell: DocTableCell | undefined = docTable.header.cells[i];
             if (cell) {
               this.writeNode(cell.content, context, false);
             }
-            writer.writeLine();
+            writer.ensureNewLine();
             writer.writeLine();
             writer.write('</th>');
           }
@@ -124,10 +124,10 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
           writer.write('<tr>');
           for (const cell of row.cells) {
             writer.write('<td>');
-            writer.writeLine();
+            writer.ensureNewLine();
             writer.writeLine();
             this.writeNode(cell.content, context, false);
-            writer.writeLine();
+            writer.ensureNewLine();
             writer.writeLine();
             writer.write('</td>');
           }

--- a/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
@@ -135,6 +135,7 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
           writer.writeLine();
         }
         writer.write('</tbody>');
+        writer.write('</table>');
         writer.writeLine();
 
         break;

--- a/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/CustomMarkdownEmitter.ts
@@ -89,8 +89,6 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
         // whereas VS Code's renderer is totally fine with it.
         writer.ensureSkippedLine();
 
-        context.insideTable = true;
-
         // Markdown table rows can have inconsistent cell counts.  Size the table based on the longest row.
         let columnCount: number = 0;
         if (docTable.header) {
@@ -102,39 +100,42 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
           }
         }
 
-        // write the table header (which is required by Markdown)
-        writer.write('| ');
-        for (let i: number = 0; i < columnCount; ++i) {
-          writer.write(' ');
-          if (docTable.header) {
+        writer.write('<table>');
+        if (docTable.header) {
+          writer.write('<thead><tr>');
+          for (let i: number = 0; i < columnCount; ++i) {
+            writer.write('<th>');
+            writer.writeLine();
+            writer.writeLine();
             const cell: DocTableCell | undefined = docTable.header.cells[i];
             if (cell) {
               this.writeNode(cell.content, context, false);
             }
+            writer.writeLine();
+            writer.writeLine();
+            writer.write('</th>');
           }
-          writer.write(' |');
+          writer.write('</tr></thead>');
         }
         writer.writeLine();
 
-        // write the divider
-        writer.write('| ');
-        for (let i: number = 0; i < columnCount; ++i) {
-          writer.write(' --- |');
-        }
-        writer.writeLine();
-
+        writer.write('<tbody>');
         for (const row of docTable.rows) {
-          writer.write('| ');
+          writer.write('<tr>');
           for (const cell of row.cells) {
-            writer.write(' ');
+            writer.write('<td>');
+            writer.writeLine();
+            writer.writeLine();
             this.writeNode(cell.content, context, false);
-            writer.write(' |');
+            writer.writeLine();
+            writer.writeLine();
+            writer.write('</td>');
           }
+          writer.write('</tr>');
           writer.writeLine();
         }
+        writer.write('</tbody>');
         writer.writeLine();
-
-        context.insideTable = false;
 
         break;
       }

--- a/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
+++ b/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
@@ -55,11 +55,9 @@ HTML escape: &amp;quot;
 Header 1
 
 
-
 </th><th>
 
 Header 2
-
 
 
 </th></tr></thead>
@@ -68,13 +66,11 @@ Header 2
 Cell 1
 
 
-
 </td><td>
 
 Cell 2
 
 **bold text**
-
 
 
 </td></tr>

--- a/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
+++ b/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
@@ -50,9 +50,30 @@ HTML escape: &amp;quot;
 
 ## Table
 
-|  Header 1 | Header 2 |
-|  --- | --- |
-|  Cell 1 | <p>Cell 2</p><p>**bold text**</p> |
+<table><thead><tr><th>
 
+Header 1
+
+
+</th><th>
+
+Header 2
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+Cell 1
+
+
+</td><td>
+
+Cell 2
+
+**bold text**
+
+
+</td></tr>
+</tbody>
 "
 `;

--- a/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
+++ b/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
@@ -55,15 +55,18 @@ HTML escape: &amp;quot;
 Header 1
 
 
+
 </th><th>
 
 Header 2
+
 
 
 </th></tr></thead>
 <tbody><tr><td>
 
 Cell 1
+
 
 
 </td><td>
@@ -73,7 +76,8 @@ Cell 2
 **bold text**
 
 
+
 </td></tr>
-</tbody>
+</tbody></table>
 "
 `;

--- a/common/changes/@microsoft/api-documenter/main_2024-03-14-17-16.json
+++ b/common/changes/@microsoft/api-documenter/main_2024-03-14-17-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Emit HTML tags for tables instead of Markdown code.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-documenter/main_2024-03-14-17-16.json
+++ b/common/changes/@microsoft/api-documenter/main_2024-03-14-17-16.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/api-documenter",
       "comment": "Emit HTML tags for tables instead of Markdown code.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/api-documenter"


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This would fix #2950.

Currently, tables in generated Markdown do not work with multiline comments.

This PR changes over to HTML tables (which also work in Markdown and are in fact more standardized).

As a result, a lot of "emit different things in tables" code can be removed.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

As an example of a broken generated table, see the end of the "Classes" table [in this markdown file](https://github.com/apollographql/apollo-client-nextjs/blob/1e64d9ba9680d50ac35a1178bef1cf612aa130dd/docs/client-react-streaming.md)



<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Generating the code with this PR instead will result in [this diff](https://github.com/apollographql/apollo-client-nextjs/pull/240/commits/247d226a3f7ac58bd72bd2370e1f46b86ba41357) and as you can see [here](https://github.com/apollographql/apollo-client-nextjs/blob/247d226a3f7ac58bd72bd2370e1f46b86ba41357/docs/experimental-nextjs-app-support.md) the tables are not broken anymore.

## Impacted documentation

I believe this does not need any documentation changes.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
