### PR TITLE
[module-minifier] Fix missing sourceContents in Source Maps

### DIFF
--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -25,6 +25,7 @@
     "@types/webpack-env": "1.18.0",
     "eslint": "~8.7.0",
     "html-webpack-plugin": "~5.5.0",
+    "source-map-loader": "~3.0.1",
     "tslint": "~5.20.1",
     "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.3.3",

--- a/build-tests/heft-webpack5-everything-test/webpack.config.js
+++ b/build-tests/heft-webpack5-everything-test/webpack.config.js
@@ -12,6 +12,11 @@ module.exports = {
       {
         test: /\.png$/i,
         type: 'asset/resource'
+      },
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        use: ['source-map-loader']
       }
     ]
   },

--- a/common/changes/@rushstack/module-minifier/support-terser-options_2024-03-14-19-27.json
+++ b/common/changes/@rushstack/module-minifier/support-terser-options_2024-03-14-19-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/module-minifier",
-      "comment": "added includeSources: true in sourceMap option to terser",
+      "comment": "Fix an issue where the assets listed in sourcemaps were incomplete or missing.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/module-minifier/support-terser-options_2024-03-14-19-27.json
+++ b/common/changes/@rushstack/module-minifier/support-terser-options_2024-03-14-19-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "added includeSources: true in sourceMap option to terser",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2058,6 +2058,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      source-map-loader:
+        specifier: ~3.0.1
+        version: 3.0.2(webpack@5.82.1)
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.3.3)
@@ -8777,7 +8780,7 @@ packages:
     dependencies:
       '@jest/console': 29.7.0
       '@jest/types': 29.6.3
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2(@types/node@18.17.15)
       jest-haste-map: 29.7.0
       jest-resolve: 29.7.0
@@ -26004,7 +26007,7 @@ packages:
     engines: {node: '>=10.12.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.22
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
   /validate-npm-package-license@3.0.4:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "dd87795876dbd30794a0de512ac2bb8926bf8e62",
+  "pnpmShrinkwrapHash": "fb73e8abdc47f9a3da77bae8fdeb5246d1ecba04",
   "preferredVersionsHash": "40d4640a94cff77f7808a2f1960cc76231eb6f86"
 }

--- a/libraries/module-minifier/src/MinifySingleFile.ts
+++ b/libraries/module-minifier/src/MinifySingleFile.ts
@@ -50,12 +50,14 @@ export async function minifySingleFileAsync(
       mangle.reserved = mangle.reserved ? externals.concat(mangle.reserved) : externals;
     }
 
-    // SourceMap is only generated if nameForMap is provided
+    // SourceMap is only generated if nameForMap is provided- ModuleMinifierPlugin will override terserOptions.sourceMap's boolean value
     if (nameForMap) {
       finalOptions.sourceMap = {
         includeSources: true
       };
       if (typeof sourceMapOptions !== 'boolean' && sourceMapOptions !== undefined) {
+        // Include any provided sourceMap options from minifier
+        // Note that any provided terserOptions.sourceMap options must be aligned with devtool or SourceMapDevToolPlugin configuration
         finalOptions.sourceMap = { ...finalOptions.sourceMap, ...sourceMapOptions };
       }
       // Always generate source maps as an object rather than a string

--- a/libraries/module-minifier/src/MinifySingleFile.ts
+++ b/libraries/module-minifier/src/MinifySingleFile.ts
@@ -26,7 +26,6 @@ export async function minifySingleFileAsync(
       format: rawFormat,
       output: rawOutput,
       mangle: originalMangle,
-      sourceMap: sourceMapOptions,
       ...remainingOptions
     } = terserOptions;
 
@@ -50,18 +49,12 @@ export async function minifySingleFileAsync(
       mangle.reserved = mangle.reserved ? externals.concat(mangle.reserved) : externals;
     }
 
-    // SourceMap is only generated if nameForMap is provided- ModuleMinifierPlugin will override terserOptions.sourceMap's boolean value
+    // SourceMap is only generated if nameForMap is provided- overrides terserOptions.sourceMap
     if (nameForMap) {
       finalOptions.sourceMap = {
-        includeSources: true
+        includeSources: true,
+        asObject: true
       };
-      if (typeof sourceMapOptions !== 'boolean' && sourceMapOptions !== undefined) {
-        // Include any provided sourceMap options from minifier
-        // Note that any provided terserOptions.sourceMap options must be aligned with devtool or SourceMapDevToolPlugin configuration
-        finalOptions.sourceMap = { ...finalOptions.sourceMap, ...sourceMapOptions };
-      }
-      // Always generate source maps as an object rather than a string
-      finalOptions.sourceMap.asObject = true;
     } else {
       finalOptions.sourceMap = false;
     }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->
In the outputs of the ModuleMinifierPlugin, the (chunks) and (modules) assets listed in the sources array of source maps have been missing from the sourceContents array, either popluating as 'null', entries missing from the end of the array, or with the array missing entirely. I'm not sure how long this has gone on for, but a likely candidate would be a change in terser. This leads to bugs with debugging in the browser where stepping through code would often lead to blank sources not being able to load files. 

## Details
By enabling the terser source map option "includeSources: true", the listed chunks now have their contents present in the  source maps output of the module minifier. This is one option among many in [terser's SourceMapsOptions property bag](https://github.com/terser/terser/blob/0fc03ec082dde40d7fdf57ab7cf106103b1b0a3f/tools/terser.d.ts#L205), along with 'asObject' which enables further processing by the plugin.

My initial approach was to allow the module-minifier to accept options from the terserOptions.sourceMap property being passed in, but in playing around with the options available, found it very tricky to find a configuration (including tweaking settings in an additional SourceMapsDevtoolPlugin) which did not break the source maps' functionality in the ModuleMinifierPlugin's output, and determined that any use of the other parameters should probably be part of a planned feature, as it would be hard to get right and easy to get wrong. Making this simple change also avoided people's latent, ignored terserOptions.sourceMap properties from taking sudden effect and breaking things.

In addition to this change, I've removed a declaration which used to expose the SourceMapsOptions interface, which is now exported by terser directly. I've also added source-map-loader to the configuration of webpack5-module-minifier-plugin, which proved useful to myself and I hope it would for others.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

In inspecting the files output by webpack5-module-minifier-plugin, I was able to see the .map files sourceContents go from incomplete to complete by this change. 


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
