### PR TITLE
[rush-lib] Support PNPM injected install feature for Rush Subspace

### DIFF
--- a/common/changes/@microsoft/rush/chao-subspace-fix_2024-03-16-05-55.json
+++ b/common/changes/@microsoft/rush/chao-subspace-fix_2024-03-16-05-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix issues when use pnpm-sync in subspace projects",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/chao-subspace-fix_2024-03-16-05-55.json
+++ b/common/changes/@microsoft/rush/chao-subspace-fix_2024-03-16-05-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix issues when use pnpm-sync in subspace projects",
+      "comment": "Support PNPM injected installation in Rush subspace feature",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -147,12 +147,12 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       path.join(subspace.getSubspaceTempFolder(), 'pnpm-workspace.yaml')
     );
 
-    // For pnpm pacakge manager, we need to handle dependenciesMeta changes in package.json. See more: https://pnpm.io/package_json#dependenciesmeta
+    // For pnpm package manager, we need to handle dependenciesMeta changes in package.json. See more: https://pnpm.io/package_json#dependenciesmeta
     // If dependenciesMeta settings is different between package.json and pnpm-lock.yaml, then shrinkwrapIsUpToDate return false.
-    // Build a object for dependenciesMeta settings in projects' package.jsons
+    // Build a object for dependenciesMeta settings in projects' package.json
     // key is the package path, value is the dependenciesMeta info for that package
     const expectedDependenciesMetaByProjectRelativePath: Record<string, IDependenciesMetaTable> = {};
-    const commonTempFolder: string = this.rushConfiguration.commonTempFolder;
+    const commonTempFolder: string = subspace.getSubspaceTempFolder();
     const rushJsonFolder: string = this.rushConfiguration.rushJsonFolder;
     // get the relative path from common temp folder to repo root folder
     const relativeFromTempFolderToRootFolder: string = path.relative(commonTempFolder, rushJsonFolder);

--- a/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -22,8 +22,9 @@ export interface IPnpmfileShimSettings {
 }
 
 export interface IWorkspaceProjectInfo
-  extends Pick<RushConfigurationProject, 'packageName' | 'projectRelativeFolder'> {
+  extends Pick<RushConfigurationProject, 'packageName' | 'projectRelativeFolder' | 'projectFolder'> {
   packageVersion: RushConfigurationProject['packageJson']['version'];
+  isInjectedInstall: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -24,7 +24,7 @@ export interface IPnpmfileShimSettings {
 export interface IWorkspaceProjectInfo
   extends Pick<RushConfigurationProject, 'packageName' | 'projectRelativeFolder' | 'projectFolder'> {
   packageVersion: RushConfigurationProject['packageJson']['version'];
-  isInjectedInstall: boolean;
+  injectedDependencies: Array<string>;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts
@@ -22,7 +22,7 @@ export interface IPnpmfileShimSettings {
 }
 
 export interface IWorkspaceProjectInfo
-  extends Pick<RushConfigurationProject, 'packageName' | 'projectRelativeFolder' | 'projectFolder'> {
+  extends Pick<RushConfigurationProject, 'packageName' | 'projectRelativeFolder'> {
   packageVersion: RushConfigurationProject['packageJson']['version'];
   injectedDependencies: Array<string>;
 }

--- a/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
@@ -11,7 +11,7 @@ import path from 'path';
 // This file can use "import type" but otherwise should not reference any other modules, since it will
 // be run from the "common/temp" directory
 import type * as TSemver from 'semver';
-import type { IPackageJson, IDependenciesMetaTable } from '@rushstack/node-core-library';
+import type { IPackageJson } from '@rushstack/node-core-library';
 
 import type {
   IPnpmfile,
@@ -67,8 +67,7 @@ function init(context: IPnpmfileContext | any): IPnpmfileContext {
 // For example: "project-a": "workspace:*" --> "project-a": "link:../../project-a"
 function rewriteRushProjectVersions(
   packageName: string,
-  dependencies: { [dependencyName: string]: string } | undefined,
-  dependenciesMeta: IDependenciesMetaTable | undefined
+  dependencies: { [dependencyName: string]: string } | undefined
 ): void {
   if (!dependencies) {
     return;
@@ -93,7 +92,7 @@ function rewriteRushProjectVersions(
       if (workspaceProjectInfo) {
         // Case 1. "<package_name>": "workspace:*"
         let workspaceVersionProtocol: string = 'link:';
-        if (dependenciesMeta && dependenciesMeta[dependencyName]?.injected) {
+        if (workspaceProjectInfo.isInjectedInstall) {
           workspaceVersionProtocol = 'file:';
         }
         const relativePath: string = path.normalize(
@@ -156,8 +155,8 @@ export const hooks: IPnpmfileHooks = {
   // Rewrite workspace protocol to link protocol for non split workspace projects
   readPackage: (pkg: IPackageJson, context: IPnpmfileContext) => {
     context = init(context);
-    rewriteRushProjectVersions(pkg.name, pkg.dependencies, pkg?.dependenciesMeta);
-    rewriteRushProjectVersions(pkg.name, pkg.devDependencies, pkg?.dependenciesMeta);
+    rewriteRushProjectVersions(pkg.name, pkg.dependencies);
+    rewriteRushProjectVersions(pkg.name, pkg.devDependencies);
     return userPnpmfile?.hooks?.readPackage ? userPnpmfile.hooks.readPackage(pkg, context) : pkg;
   },
 

--- a/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
@@ -92,7 +92,9 @@ function rewriteRushProjectVersions(
       if (workspaceProjectInfo) {
         // Case 1. "<package_name>": "workspace:*"
         let workspaceVersionProtocol: string = 'link:';
-        if (workspaceProject.injectedDependencies.includes(dependencyName)) {
+
+        const injectedDependenciesSet: ReadonlySet<string> = new Set(workspaceProject.injectedDependencies);
+        if (injectedDependenciesSet.has(dependencyName)) {
           workspaceVersionProtocol = 'file:';
         }
         const relativePath: string = path.normalize(

--- a/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
@@ -92,7 +92,7 @@ function rewriteRushProjectVersions(
       if (workspaceProjectInfo) {
         // Case 1. "<package_name>": "workspace:*"
         let workspaceVersionProtocol: string = 'link:';
-        if (workspaceProjectInfo.isInjectedInstall) {
+        if (workspaceProject.injectedDependencies.includes(dependencyName)) {
           workspaceVersionProtocol = 'file:';
         }
         const relativePath: string = path.normalize(

--- a/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
@@ -67,10 +67,9 @@ export class SubspacePnpmfileConfiguration {
       Set<string>
     > = SubspacePnpmfileConfiguration._getProjectNameToInjectedDependenciesMap(rushConfiguration, subspace);
     for (const project of rushConfiguration.projects) {
-      const { packageName, projectFolder, projectRelativeFolder, packageJson } = project;
+      const { packageName, projectRelativeFolder, packageJson } = project;
       const workspaceProjectInfo: IWorkspaceProjectInfo = {
         packageName,
-        projectFolder,
         projectRelativeFolder,
         packageVersion: packageJson.version,
         injectedDependencies: Array.from(projectNameToInjectedDependenciesMap.get(packageName) || [])
@@ -84,6 +83,7 @@ export class SubspacePnpmfileConfiguration {
       semverPath: Import.resolveModule({ modulePath: 'semver', baseFolderPath: __dirname })
     };
 
+    // common/config/subspaces/<subspace_name>/.pnpmfile-subspace.cjs
     const userPnpmfilePath: string = path.join(
       subspace.getSubspaceConfigFolder(),
       (rushConfiguration.packageManagerWrapper as PnpmPackageManager).subspacePnpmfileFilename

--- a/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
@@ -168,7 +168,7 @@ export class SubspacePnpmfileConfiguration {
 
   private static _processDependenciesForTransitiveInjectedInstall(
     projectNameToInjectedDependencies: Map<string, Set<string>>,
-    processTransitiveInjectedInstallQueue: Array<RushConfigurationProject> = [],
+    processTransitiveInjectedInstallQueue: Array<RushConfigurationProject>,
     dependencies: Record<string, string>,
     currentProject: RushConfigurationProject,
     rushConfiguration: RushConfiguration


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This PR is to support [PNPM injected installation](https://pnpm.io/package_json#dependenciesmeta) in Rush subspace feature
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Let's say we have two subspaces (S1, S2) in a Rush Monorepo, and set up is like this:
- subspace S1 / lockfile L1 contains project A and B
- subspace S2 / lockfile L2 contains project C and D
- A has an injected workspace:* dependency on C
- B has a non-injected workspace:* dependency on C
- C has a non-injected workspace:* dependency on D

Here, we have two cases:
1. A has an injected workspace:* dependency on C, the dependency graph is like A -> (injected) C ->(no-injected) D
In this case, we think If a package gets installed in the injected way then every workspace:* dependency of that package also gets injected.
Why? Recall the injected install definition from [PNPM](https://pnpm.io/package_json#dependenciesmeta), If we install a local package in the injected way, that package will be hard linked to the virtual store (node_modules/.pnpm) and symlinked from the virtual store to the modules directory. It is like we are installing that package from a NPM registry. And a package from NPM can not contain any local dependencies. 

2. In our example, A -> (injected) C, while B -> (no-injected) C, and A and B are in the same subspace, so will they conflict with each other? 
No, every package will install its dependencies in its own node_modules folder. In our case, inside A's node_modules folder, C is hard linked to virtual store (node_modules/.pnpm), inside B's node_modules, C is symlinked directly from its location in the workspace. 

Please note: If there is a case that all projects inside a dependency graph are in same subspace (no cross subspace dependencies), then we do nothing, let PNPM handle it. 
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->
## Implementation
After we understand the issue, the implementation is fairly straightforward. 
1. We can analyze the dependency graph when generating the `pnpmfileSettings.json` file, put all necessary info we need to decide if a workspace dependency should installed in the injected way or no-injected way. 
2. Inside PNPM's `readPackage` hook, rewrite the workspace dependency installation behavior based on`pnpmfileSettings.json` file.
## How it was tested
Manually tested by setting two subspaces in Rushstack repo. 
After this PR merged, a follow up PR will enable subspace feature for Rushstack repo, so we will have more tests in that PR.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
