### PR TITLE
[rush-azure-storage-build-cache-plugin] Add support for interactive browser auth.

### DIFF
--- a/common/changes/@microsoft/rush/interactive-browser-auth_2024-03-20-02-21.json
+++ b/common/changes/@microsoft/rush/interactive-browser-auth_2024-03-20-02-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING API CHANGE) Rename `AzureAuthenticationBase._getCredentialFromDeviceCodeAsync` to `AzureAuthenticationBase._getCredentialFromTokenAsync`. Adding support for InteractiveBrowserCredential.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/interactive-browser-auth_2024-03-20-02-21.json
+++ b/common/changes/@microsoft/rush/interactive-browser-auth_2024-03-20-02-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "(BREAKING API CHANGE) Rename `AzureAuthenticationBase._getCredentialFromDeviceCodeAsync` to `AzureAuthenticationBase._getCredentialFromTokenAsync`. Adding support for InteractiveBrowserCredential.",
+      "comment": "(BREAKING API CHANGE) Rename `AzureAuthenticationBase._getCredentialFromDeviceCodeAsync` to `AzureAuthenticationBase._getCredentialFromTokenAsync` in `@rushstack/rush-azure-storage-build-cache-plugin`. Adding support for InteractiveBrowserCredential.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -34,8 +34,6 @@ export abstract class AzureAuthenticationBase {
     protected abstract _getCacheIdParts(): string[];
     // (undocumented)
     protected abstract _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential): Promise<ICredentialResult>;
-    // Warning: (ae-forgotten-export) The symbol "LoginFlowType" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     protected readonly _loginFlow: LoginFlowType;
     // (undocumented)
@@ -127,6 +125,9 @@ export interface ITryGetCachedCredentialOptionsLogWarning extends ITryGetCachedC
 export interface ITryGetCachedCredentialOptionsThrow extends ITryGetCachedCredentialOptionsBase {
     expiredCredentialBehavior: 'throwError';
 }
+
+// @public (undocumented)
+export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser';
 
 // @public (undocumented)
 class RushAzureStorageBuildCachePlugin implements IRushPlugin {

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -5,19 +5,22 @@
 ```ts
 
 import { AzureAuthorityHosts } from '@azure/identity';
-import { DeviceCodeCredential } from '@azure/identity';
 import { DeviceCodeCredentialOptions } from '@azure/identity';
 import type { ICredentialCacheEntry } from '@rushstack/rush-sdk';
+import { InteractiveBrowserCredentialNodeOptions } from '@azure/identity';
 import type { IRushPlugin } from '@rushstack/rush-sdk';
 import type { ITerminal } from '@rushstack/terminal';
 import type { RushConfiguration } from '@rushstack/rush-sdk';
 import type { RushSession } from '@rushstack/rush-sdk';
+import { TokenCredential } from '@azure/identity';
 
 // @public (undocumented)
 export abstract class AzureAuthenticationBase {
     constructor(options: IAzureAuthenticationBaseOptions);
     // (undocumented)
     protected readonly _additionalDeviceCodeCredentialOptions: DeviceCodeCredentialOptions | undefined;
+    // (undocumented)
+    protected readonly _additionalInteractiveCredentialOptions: InteractiveBrowserCredentialNodeOptions | undefined;
     // (undocumented)
     protected readonly _azureEnvironment: AzureEnvironmentName;
     // (undocumented)
@@ -30,7 +33,11 @@ export abstract class AzureAuthenticationBase {
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
     protected abstract _getCacheIdParts(): string[];
     // (undocumented)
-    protected abstract _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
+    protected abstract _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential): Promise<ICredentialResult>;
+    // Warning: (ae-forgotten-export) The symbol "LoginFlowType" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected readonly _loginFlow: LoginFlowType;
     // (undocumented)
     tryGetCachedCredentialAsync(options?: ITryGetCachedCredentialOptionsThrow | ITryGetCachedCredentialOptionsIgnore): Promise<ICredentialCacheEntry | undefined>;
     // (undocumented)
@@ -53,7 +60,7 @@ export class AzureStorageAuthentication extends AzureAuthenticationBase {
     // (undocumented)
     protected _getCacheIdParts(): string[];
     // (undocumented)
-    protected _getCredentialFromDeviceCodeAsync(terminal: ITerminal, deviceCodeCredential: DeviceCodeCredential): Promise<ICredentialResult>;
+    protected _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential): Promise<ICredentialResult>;
     // (undocumented)
     protected readonly _isCacheWriteAllowedByConfiguration: boolean;
     // (undocumented)
@@ -73,6 +80,8 @@ export interface IAzureAuthenticationBaseOptions {
     azureEnvironment?: AzureEnvironmentName;
     // (undocumented)
     credentialUpdateCommandForLogging?: string | undefined;
+    // (undocumented)
+    loginFlow?: LoginFlowType;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -263,13 +263,14 @@ export abstract class AzureAuthenticationBase {
 
     let tokenCredential: TokenCredential;
     switch (loginFlow) {
-      case 'InteractiveBrowser':
+      case 'InteractiveBrowser': {
         tokenCredential = new InteractiveBrowserCredential({
           ...this._additionalInteractiveCredentialOptions,
           authorityHost: authorityHost
         });
         break;
-      default:
+      }
+      case 'DeviceCode': {
         tokenCredential = new DeviceCodeCredential({
           ...this._additionalDeviceCodeCredentialOptions,
           authorityHost: authorityHost,
@@ -278,6 +279,10 @@ export abstract class AzureAuthenticationBase {
           }
         });
         break;
+      }
+      default: {
+        throw new Error(`Unsupported login flow: ${loginFlow}`);
+      }
     }
 
     return await this._getCredentialFromTokenAsync(terminal, tokenCredential);

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -6,6 +6,7 @@ import {
   type DeviceCodeInfo,
   AzureAuthorityHosts,
   type DeviceCodeCredentialOptions,
+  type InteractiveBrowserCredentialInBrowserOptions,
   InteractiveBrowserCredential,
   type InteractiveBrowserCredentialNodeOptions,
   type TokenCredential
@@ -262,18 +263,24 @@ export abstract class AzureAuthenticationBase {
     }
 
     let tokenCredential: TokenCredential;
+
+    const interactiveCredentialOptions: (
+      | InteractiveBrowserCredentialNodeOptions
+      | InteractiveBrowserCredentialInBrowserOptions
+    ) &
+      DeviceCodeCredentialOptions = {
+      ...this._additionalInteractiveCredentialOptions,
+      authorityHost
+    };
+
     switch (loginFlow) {
       case 'InteractiveBrowser': {
-        tokenCredential = new InteractiveBrowserCredential({
-          ...this._additionalInteractiveCredentialOptions,
-          authorityHost: authorityHost
-        });
+        tokenCredential = new InteractiveBrowserCredential(interactiveCredentialOptions);
         break;
       }
       case 'DeviceCode': {
         tokenCredential = new DeviceCodeCredential({
-          ...this._additionalDeviceCodeCredentialOptions,
-          authorityHost: authorityHost,
+          ...interactiveCredentialOptions,
           userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
             PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
           }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -254,7 +254,7 @@ export abstract class AzureAuthenticationBase {
 
   private async _getCredentialAsync(
     terminal: ITerminal,
-    loginFlow: 'DeviceCode' | 'InteractiveBrowser'
+    loginFlow: LoginFlowType
   ): Promise<ICredentialResult> {
     const authorityHost: string | undefined = AzureAuthorityHosts[this._azureEnvironment];
     if (!authorityHost) {

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -262,19 +262,22 @@ export abstract class AzureAuthenticationBase {
     }
 
     let tokenCredential: TokenCredential;
-    if (loginFlow === 'InteractiveBrowser') {
-      tokenCredential = new InteractiveBrowserCredential({
-        ...this._additionalInteractiveCredentialOptions,
-        authorityHost: authorityHost
-      });
-    } else {
-      tokenCredential = new DeviceCodeCredential({
-        ...this._additionalDeviceCodeCredentialOptions,
-        authorityHost: authorityHost,
-        userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
-          PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
-        }
-      });
+    switch (loginFlow) {
+      case 'InteractiveBrowser':
+        tokenCredential = new InteractiveBrowserCredential({
+          ...this._additionalInteractiveCredentialOptions,
+          authorityHost: authorityHost
+        });
+        break;
+      default:
+        tokenCredential = new DeviceCodeCredential({
+          ...this._additionalDeviceCodeCredentialOptions,
+          authorityHost: authorityHost,
+          userPromptCallback: (deviceCodeInfo: DeviceCodeInfo) => {
+            PrintUtilities.printMessageInBox(deviceCodeInfo.message, terminal);
+          }
+        });
+        break;
     }
 
     return await this._getCredentialFromTokenAsync(terminal, tokenCredential);

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureStorageAuthentication.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { DeviceCodeCredential } from '@azure/identity';
+import type { TokenCredential } from '@azure/identity';
 import {
   BlobServiceClient,
   ContainerSASPermissions,
@@ -57,13 +57,13 @@ export class AzureStorageAuthentication extends AzureAuthenticationBase {
     return cacheIdParts;
   }
 
-  protected async _getCredentialFromDeviceCodeAsync(
+  protected async _getCredentialFromTokenAsync(
     terminal: ITerminal,
-    deviceCodeCredential: DeviceCodeCredential
+    tokenCredential: TokenCredential
   ): Promise<ICredentialResult> {
     const blobServiceClient: BlobServiceClient = new BlobServiceClient(
       this._storageAccountUrl,
-      deviceCodeCredential
+      tokenCredential
     );
 
     const startsOn: Date = new Date();

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IRushPlugin, RushSession, RushConfiguration, ILogger } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentName } from './AzureAuthenticationBase';
+import type { AzureEnvironmentName, LoginFlowType } from './AzureAuthenticationBase';
 
 const PLUGIN_NAME: 'AzureInteractiveAuthPlugin' = 'AzureInteractiveAuthPlugin';
 
@@ -24,6 +24,12 @@ export interface IAzureInteractiveAuthOptions {
    * The Azure environment the storage account exists in. Defaults to AzureCloud.
    */
   readonly azureEnvironment?: AzureEnvironmentName;
+
+  /**
+   * Login flow to use for interactive authentication.
+   * @defaultValue 'deviceCode'
+   */
+  readonly loginFlow?: LoginFlowType;
 
   /**
    * If specified and a credential exists that will be valid for at least this many minutes from the time
@@ -79,7 +85,8 @@ export default class RushAzureInteractieAuthPlugin implements IRushPlugin {
         storageAccountName,
         storageContainerName,
         azureEnvironment = 'AzurePublicCloud',
-        minimumValidityInMinutes
+        minimumValidityInMinutes,
+        loginFlow = 'DeviceCode'
       } = options;
 
       const logger: ILogger = rushSession.getLogger(PLUGIN_NAME);
@@ -95,8 +102,9 @@ export default class RushAzureInteractieAuthPlugin implements IRushPlugin {
       await new AzureStorageAuthentication({
         storageAccountName: storageAccountName,
         storageContainerName: storageContainerName,
-        azureEnvironment: options.azureEnvironment,
-        isCacheWriteAllowed: true
+        azureEnvironment: azureEnvironment,
+        isCacheWriteAllowed: true,
+        loginFlow: loginFlow
       }).updateCachedCredentialInteractiveAsync(logger.terminal, minimumExpiry);
     };
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/index.ts
@@ -7,6 +7,7 @@ export {
   type IAzureAuthenticationBaseOptions,
   type ICredentialResult,
   type AzureEnvironmentName,
+  type LoginFlowType,
   type ITryGetCachedCredentialOptionsBase,
   type ITryGetCachedCredentialOptionsLogWarning,
   type ITryGetCachedCredentialOptionsThrow,


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Add support for interactive browser auth. Defaults to device code auth.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Copy pasting the device code token gets pretty annoying when using codesapces/devcontainers. This change adds support for interactive browser login flow that creates a popup browser window which completes with a local server callback.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
