### PR TITLE
[rush] Skip determining merge base if given git hash

### DIFF
--- a/common/changes/@microsoft/rush/kenrick-skip-merge-base_2024-03-21-02-17.json
+++ b/common/changes/@microsoft/rush/kenrick-skip-merge-base_2024-03-21-02-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Skip determining merge base if given git hash",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -595,4 +595,23 @@ export class Git {
       throw e;
     }
   }
+  /**
+   *
+   * @param ref Given a ref which can be branch name, commit hash, tag name, etc, check if it is a commit hash
+   */
+  public isRefACommit(ref: string): boolean {
+    const gitPath: string = this.getGitPathOrThrow();
+    try {
+      const output: string = this._executeGitCommandAndCaptureOutput(gitPath, ['rev-parse', '--verify', ref]);
+      const result: string = output.trim();
+
+      if (result === ref) {
+        return true;
+      }
+    } catch (e) {
+      // assume not a commit
+      return false;
+    }
+    return false;
+  }
 }

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -222,7 +222,10 @@ export class ProjectChangeAnalyzer {
     const gitPath: string = this._git.getGitPathOrThrow();
     const repoRoot: string = getRepoRoot(rushConfiguration.rushJsonFolder);
 
-    const mergeCommit: string = this._git.getMergeBase(targetBranchName, terminal, shouldFetch);
+    // if the given targetBranchName is a commit, we assume it is the merge base
+    const mergeCommit: string = this._git.isRefACommit(targetBranchName)
+      ? targetBranchName
+      : this._git.getMergeBase(targetBranchName, terminal, shouldFetch);
 
     const repoChanges: Map<string, IFileDiffStatus> = getRepoChanges(repoRoot, mergeCommit, gitPath);
 

--- a/libraries/rush-lib/src/logic/test/Git.test.ts
+++ b/libraries/rush-lib/src/logic/test/Git.test.ts
@@ -189,4 +189,33 @@ describe(Git.name, () => {
       ).toThrowErrorMatchingInlineSnapshot(`"Unexpected end of git status output after position 31"`);
     });
   });
+
+  describe(Git.prototype.isRefACommit.name, () => {
+    const commit = `d9bc1881959b9e44d846655521cd055fcf713f4d`;
+    function getMockedGitIsRefACommit(ref: string): boolean {
+      const gitInstance: Git = new Git({ rushJsonFolder: '/repo/root' } as RushConfiguration);
+      jest.spyOn(gitInstance, 'getGitPathOrThrow').mockReturnValue('/git/bin/path');
+      jest
+        .spyOn(gitInstance, '_executeGitCommandAndCaptureOutput')
+        .mockImplementation((gitPath: string, args: string[]) => {
+          expect(gitPath).toEqual('/git/bin/path');
+          expect(args).toEqual(['rev-parse', '--verify', ref]);
+          return commit;
+        });
+      return gitInstance.isRefACommit(ref);
+    }
+
+    it('Returns true for commit ref', () => {
+      expect(getMockedGitIsRefACommit(commit)).toBe(true);
+    });
+    it('Returns false for branch ref', () => {
+      expect(getMockedGitIsRefACommit('kenrick/skip-merge-base')).toBe(false);
+    });
+    it('Returns false for ref that is a tag', () => {
+      expect(getMockedGitIsRefACommit('testing-tag-v1.2.3')).toBe(false);
+    });
+    it('Returns false for ref that is other string', () => {
+      expect(getMockedGitIsRefACommit('HEAD')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #4589 

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

In `libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts`, I added a logic to skip determining merge base if the given "targetBranchName" is already a git commit hash

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I tested the local build against my own repro in #4589 and it works as expected. However I'd like some advise too on how to write test for this change.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

N/A

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
