### PR TITLE
[rush-lib] Use pnpm-sync-lib logging APIs to customize the log message for pnpm-sync operations.

### DIFF
--- a/common/changes/@microsoft/rush/chao-refactor-pnpm-sync-log-message_2024-03-21-20-16.json
+++ b/common/changes/@microsoft/rush/chao-refactor-pnpm-sync-log-message_2024-03-21-20-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use pnpm-sync-lib logging APIs to customize the log message for pnpm-sync operations",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3432,8 +3432,8 @@ importers:
         specifier: ~6.1.0
         version: 6.1.1
       pnpm-sync-lib:
-        specifier: 0.1.7
-        version: 0.1.7
+        specifier: 0.2.0
+        version: 0.2.0
       read-package-tree:
         specifier: ~5.1.5
         version: 5.1.6
@@ -22414,8 +22414,8 @@ packages:
       - typescript
     dev: true
 
-  /pnpm-sync-lib@0.1.7:
-    resolution: {integrity: sha512-KbIH2BwJ2II+MO5WCskI3JkqXFT1KIFSScf2Cn9VwhCGw3NQ52eTm4L62DR5Iebs2JF8meUUh6HA92qqUmenVA==}
+  /pnpm-sync-lib@0.2.0:
+    resolution: {integrity: sha512-3P2mmydpBHaIose+u03dBveu+hBhS7Blup6xoxVkUANABkb6l8v8nvX/RbHlM2n8s9nJF1dZQoKHyqcTAkWwbA==}
 
   /polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -27651,7 +27651,7 @@ packages:
       node-fetch: 2.6.7
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
-      pnpm-sync-lib: 0.1.7
+      pnpm-sync-lib: 0.2.0
       read-package-tree: 5.1.6
       rxjs: 6.6.7
       semver: 7.5.4

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3432,8 +3432,8 @@ importers:
         specifier: ~6.1.0
         version: 6.1.1
       pnpm-sync-lib:
-        specifier: 0.1.6
-        version: 0.1.6
+        specifier: 0.1.7
+        version: 0.1.7
       read-package-tree:
         specifier: ~5.1.5
         version: 5.1.6
@@ -22414,8 +22414,8 @@ packages:
       - typescript
     dev: true
 
-  /pnpm-sync-lib@0.1.6:
-    resolution: {integrity: sha512-02HUKAk7Aa7VyY8O3tvTSNjScbP5/SS7rCqYDCLJ8RtcjJCcImX9lE9uox2eqqaQe5K9aABfPSsHZSh8FN4EUA==}
+  /pnpm-sync-lib@0.1.7:
+    resolution: {integrity: sha512-KbIH2BwJ2II+MO5WCskI3JkqXFT1KIFSScf2Cn9VwhCGw3NQ52eTm4L62DR5Iebs2JF8meUUh6HA92qqUmenVA==}
 
   /polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -27651,7 +27651,7 @@ packages:
       node-fetch: 2.6.7
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
-      pnpm-sync-lib: 0.1.6
+      pnpm-sync-lib: 0.1.7
       read-package-tree: 5.1.6
       rxjs: 6.6.7
       semver: 7.5.4

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3432,8 +3432,8 @@ importers:
         specifier: ~6.1.0
         version: 6.1.1
       pnpm-sync-lib:
-        specifier: 0.1.4
-        version: 0.1.4
+        specifier: 0.1.6
+        version: 0.1.6
       read-package-tree:
         specifier: ~5.1.5
         version: 5.1.6
@@ -22414,8 +22414,8 @@ packages:
       - typescript
     dev: true
 
-  /pnpm-sync-lib@0.1.4:
-    resolution: {integrity: sha512-3xwsXcsu+lj2l1nTF0TcgjHuMrnPpQJqHioPj5DTL9gFU+RSsoND2nEMelOo9qAz+BlPelxXZOc5z1Tgs7gwiQ==}
+  /pnpm-sync-lib@0.1.6:
+    resolution: {integrity: sha512-02HUKAk7Aa7VyY8O3tvTSNjScbP5/SS7rCqYDCLJ8RtcjJCcImX9lE9uox2eqqaQe5K9aABfPSsHZSh8FN4EUA==}
 
   /polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -27651,7 +27651,7 @@ packages:
       node-fetch: 2.6.7
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
-      pnpm-sync-lib: 0.1.4
+      pnpm-sync-lib: 0.1.6
       read-package-tree: 5.1.6
       rxjs: 6.6.7
       semver: 7.5.4

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "97860de2d876d9d6c6d21994e36adaa2e83b06c7",
+  "pnpmShrinkwrapHash": "e7958f5fd48cecb1d8b0ff62ca2795884ec9e477",
   "preferredVersionsHash": "c3ce06bc821dea3e1fe5dbc73da35b305908795a"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ad10d70df4b7a0566f8b4275f15a636958303afb",
+  "pnpmShrinkwrapHash": "97860de2d876d9d6c6d21994e36adaa2e83b06c7",
   "preferredVersionsHash": "c3ce06bc821dea3e1fe5dbc73da35b305908795a"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1da0835844b2dddb8f340063ceb13ccf02a65dea",
+  "pnpmShrinkwrapHash": "ad10d70df4b7a0566f8b4275f15a636958303afb",
   "preferredVersionsHash": "c3ce06bc821dea3e1fe5dbc73da35b305908795a"
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -57,7 +57,7 @@
     "tar": "~6.1.11",
     "true-case-path": "~2.2.1",
     "uuid": "~8.3.2",
-    "pnpm-sync-lib": "0.1.6"
+    "pnpm-sync-lib": "0.1.7"
   },
   "devDependencies": {
     "@pnpm/logger": "4.0.0",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -57,7 +57,7 @@
     "tar": "~6.1.11",
     "true-case-path": "~2.2.1",
     "uuid": "~8.3.2",
-    "pnpm-sync-lib": "0.1.7"
+    "pnpm-sync-lib": "0.2.0"
   },
   "devDependencies": {
     "@pnpm/logger": "4.0.0",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -57,7 +57,7 @@
     "tar": "~6.1.11",
     "true-case-path": "~2.2.1",
     "uuid": "~8.3.2",
-    "pnpm-sync-lib": "0.1.4"
+    "pnpm-sync-lib": "0.1.6"
   },
   "devDependencies": {
     "@pnpm/logger": "4.0.0",

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -9,7 +9,13 @@ import {
   CommandLineHelper
 } from '@rushstack/ts-command-line';
 import { InternalError, AlreadyReportedError } from '@rushstack/node-core-library';
-import { ConsoleTerminalProvider, Terminal, PrintUtilities, Colorize } from '@rushstack/terminal';
+import {
+  ConsoleTerminalProvider,
+  Terminal,
+  PrintUtilities,
+  Colorize,
+  type ITerminal
+} from '@rushstack/terminal';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from '../logic/RushConstants';
@@ -163,6 +169,10 @@ export class RushCommandLineParser extends CommandLineParser {
 
   public get isQuiet(): boolean {
     return this._quietParameter.value;
+  }
+
+  public get terminal(): ITerminal {
+    return this._terminal;
   }
 
   /**

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -487,7 +487,8 @@ export class RushPnpmCommandLineParser {
       pnpmFilterArguments: [],
       checkOnly: false,
       // TODO: Support subspaces
-      subspace: this._rushConfiguration.defaultSubspace
+      subspace: this._rushConfiguration.defaultSubspace,
+      terminal: this._terminal
     };
 
     const installManagerFactoryModule: typeof import('../logic/InstallManagerFactory') = await import(

--- a/libraries/rush-lib/src/cli/RushXCommandLine.ts
+++ b/libraries/rush-lib/src/cli/RushXCommandLine.ts
@@ -24,7 +24,7 @@ import { EventHooksManager } from '../logic/EventHooksManager';
 import { Event } from '../api/EventHooks';
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 import { RushConstants } from '../logic/RushConstants';
-import { processLogMessage } from '../utilities/PnpmSyncUtilities';
+import { PnpmSyncUtilities } from '../utilities/PnpmSyncUtilities';
 
 interface IRushXCommandLineArguments {
   /**
@@ -240,7 +240,7 @@ export class RushXCommandLine {
             forEachAsyncWithConcurrency: Async.forEachAsync,
             getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
             logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-              processLogMessage(logMessageOptions, terminal)
+              PnpmSyncUtilities.processLogMessage(logMessageOptions, terminal)
           });
         }
       }

--- a/libraries/rush-lib/src/cli/RushXCommandLine.ts
+++ b/libraries/rush-lib/src/cli/RushXCommandLine.ts
@@ -3,7 +3,15 @@
 
 import * as path from 'path';
 import { PackageJsonLookup, type IPackageJson, Text, FileSystem, Async } from '@rushstack/node-core-library';
-import { Colorize, DEFAULT_CONSOLE_WIDTH, PrintUtilities } from '@rushstack/terminal';
+import {
+  Colorize,
+  ConsoleTerminalProvider,
+  DEFAULT_CONSOLE_WIDTH,
+  type ITerminalProvider,
+  PrintUtilities,
+  Terminal,
+  type ITerminal
+} from '@rushstack/terminal';
 import { type ILogMessageCallbackOptions, pnpmSyncCopyAsync } from 'pnpm-sync-lib';
 
 import { Utilities } from '../utilities/Utilities';
@@ -16,6 +24,7 @@ import { EventHooksManager } from '../logic/EventHooksManager';
 import { Event } from '../api/EventHooks';
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 import { RushConstants } from '../logic/RushConstants';
+import { logMessageCallback } from '../utilities/PnpmSyncUtilities';
 
 interface IRushXCommandLineArguments {
   /**
@@ -209,6 +218,12 @@ export class RushXCommandLine {
       }
     });
 
+    const terminalProvider: ITerminalProvider = new ConsoleTerminalProvider({
+      debugEnabled: rushxArguments.isDebug,
+      verboseEnabled: rushxArguments.isDebug
+    });
+    const terminal: ITerminal = new Terminal(terminalProvider);
+
     if (rushConfiguration?.packageManager === 'pnpm' && rushConfiguration?.experimentsConfiguration) {
       const { configuration: experiments } = rushConfiguration?.experimentsConfiguration;
 
@@ -224,29 +239,8 @@ export class RushXCommandLine {
             ensureFolder: FileSystem.ensureFolderAsync,
             forEachAsyncWithConcurrency: Async.forEachAsync,
             getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
-            logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) => {
-              const { message, messageKind } = logMessageOptions;
-              switch (messageKind) {
-                case 'error':
-                  // eslint-disable-next-line no-console
-                  console.error(Colorize.red(message));
-                  break;
-                case 'warning':
-                  // eslint-disable-next-line no-console
-                  console.error(Colorize.yellow(message));
-                  break;
-                case 'verbose':
-                  if (rushxArguments.isDebug) {
-                    // eslint-disable-next-line no-console
-                    console.error(message);
-                  }
-                  break;
-                default:
-                  // eslint-disable-next-line no-console
-                  console.log(message);
-                  break;
-              }
-            }
+            logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
+              logMessageCallback(logMessageOptions, terminal)
           });
         }
       }

--- a/libraries/rush-lib/src/cli/RushXCommandLine.ts
+++ b/libraries/rush-lib/src/cli/RushXCommandLine.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { PackageJsonLookup, type IPackageJson, Text, FileSystem, Async } from '@rushstack/node-core-library';
 import { Colorize, DEFAULT_CONSOLE_WIDTH, PrintUtilities } from '@rushstack/terminal';
-import { pnpmSyncCopyAsync } from 'pnpm-sync-lib';
+import { type ILogMessageCallbackOptions, pnpmSyncCopyAsync } from 'pnpm-sync-lib';
 
 import { Utilities } from '../utilities/Utilities';
 import { ProjectCommandSet } from '../logic/ProjectCommandSet';
@@ -223,7 +223,30 @@ export class RushXCommandLine {
             pnpmSyncJsonPath,
             ensureFolder: FileSystem.ensureFolderAsync,
             forEachAsyncWithConcurrency: Async.forEachAsync,
-            getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync
+            getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+            logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) => {
+              const { message, messageKind } = logMessageOptions;
+              switch (messageKind) {
+                case 'error':
+                  // eslint-disable-next-line no-console
+                  console.error(Colorize.red(message));
+                  break;
+                case 'warning':
+                  // eslint-disable-next-line no-console
+                  console.error(Colorize.yellow(message));
+                  break;
+                case 'verbose':
+                  if (rushxArguments.isDebug) {
+                    // eslint-disable-next-line no-console
+                    console.error(message);
+                  }
+                  break;
+                default:
+                  // eslint-disable-next-line no-console
+                  console.log(message);
+                  break;
+              }
+            }
           });
         }
       }

--- a/libraries/rush-lib/src/cli/RushXCommandLine.ts
+++ b/libraries/rush-lib/src/cli/RushXCommandLine.ts
@@ -24,7 +24,7 @@ import { EventHooksManager } from '../logic/EventHooksManager';
 import { Event } from '../api/EventHooks';
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 import { RushConstants } from '../logic/RushConstants';
-import { logMessageCallback } from '../utilities/PnpmSyncUtilities';
+import { processLogMessage } from '../utilities/PnpmSyncUtilities';
 
 interface IRushXCommandLineArguments {
   /**
@@ -240,7 +240,7 @@ export class RushXCommandLine {
             forEachAsyncWithConcurrency: Async.forEachAsync,
             getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
             logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-              logMessageCallback(logMessageOptions, terminal)
+              processLogMessage(logMessageOptions, terminal)
           });
         }
       }

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -8,7 +8,7 @@ import type {
   IRequiredCommandLineIntegerParameter
 } from '@rushstack/ts-command-line';
 import { AlreadyReportedError } from '@rushstack/node-core-library';
-import { ConsoleTerminalProvider, type ITerminal, Terminal, Colorize } from '@rushstack/terminal';
+import { type ITerminal, Colorize } from '@rushstack/terminal';
 
 import { BaseRushAction, type IBaseRushActionOptions } from './BaseRushAction';
 import { Event } from '../../api/EventHooks';
@@ -47,7 +47,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
   public constructor(options: IBaseRushActionOptions) {
     super(options);
 
-    this._terminal = new Terminal(new ConsoleTerminalProvider({ verboseEnabled: options.parser.isDebug }));
+    this._terminal = options.parser.terminal;
 
     this._purgeParameter = this.defineFlagParameter({
       parameterLongName: '--purge',

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -62,7 +62,8 @@ export class InstallAction extends BaseInstallAction {
       pnpmFilterArguments: await this._selectionParameters!.getPnpmFilterArgumentsAsync(this._terminal),
       checkOnly: this._checkOnlyParameter.value,
       subspace: this.getTargetSubspace(),
-      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this)
+      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this),
+      terminal: this._terminal
     };
   }
 }

--- a/libraries/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpdateAction.ts
@@ -95,7 +95,8 @@ export class UpdateAction extends BaseInstallAction {
       checkOnly: false,
       subspace: this.getTargetSubspace(),
 
-      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this)
+      beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this),
+      terminal: this._terminal
     };
   }
 }

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -407,11 +407,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         this.rushConfiguration?.packageManager === 'pnpm' &&
         experiments?.usePnpmSyncForInjectedDependencies
       ) {
-        const isVerbose: boolean = !this._verboseParameter.value || this.parser.isDebug;
         const { PnpmSyncCopyOperationPlugin } = await import(
           '../../logic/operations/PnpmSyncCopyOperationPlugin'
         );
-        new PnpmSyncCopyOperationPlugin(terminal, isVerbose).apply(this.hooks);
+        new PnpmSyncCopyOperationPlugin(terminal).apply(this.hooks);
       }
 
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -407,10 +407,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         this.rushConfiguration?.packageManager === 'pnpm' &&
         experiments?.usePnpmSyncForInjectedDependencies
       ) {
+        const isVerbose: boolean = !this._verboseParameter.value || this.parser.isDebug;
         const { PnpmSyncCopyOperationPlugin } = await import(
           '../../logic/operations/PnpmSyncCopyOperationPlugin'
         );
-        new PnpmSyncCopyOperationPlugin().apply(this.hooks);
+        new PnpmSyncCopyOperationPlugin(terminal, isVerbose).apply(this.hooks);
       }
 
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -292,7 +292,8 @@ export class PackageJsonUpdater {
       maxInstallAttempts: RushConstants.defaultMaxInstallAttempts,
       pnpmFilterArguments: [],
       checkOnly: false,
-      subspace: subspace
+      subspace: subspace,
+      terminal: this._terminal
     };
 
     const installManager: BaseInstallManager = await InstallManagerFactory.getInstallManagerAsync(

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -17,13 +17,7 @@ import {
   type FolderItem,
   Async
 } from '@rushstack/node-core-library';
-import {
-  PrintUtilities,
-  ConsoleTerminalProvider,
-  Terminal,
-  type ITerminalProvider,
-  Colorize
-} from '@rushstack/terminal';
+import { PrintUtilities, Colorize, type ITerminal } from '@rushstack/terminal';
 
 import { ApprovedPackagesChecker } from '../ApprovedPackagesChecker';
 import type { AsyncRecycler } from '../../utilities/AsyncRecycler';
@@ -69,8 +63,7 @@ export abstract class BaseInstallManager {
   private _npmSetupValidated: boolean = false;
   private _syncNpmrcAlreadyCalled: boolean = false;
 
-  private readonly _terminalProvider: ITerminalProvider;
-  protected readonly _terminal: Terminal;
+  protected readonly _terminal: ITerminal;
 
   protected readonly rushConfiguration: RushConfiguration;
   protected readonly rushGlobalFolder: RushGlobalFolder;
@@ -85,6 +78,7 @@ export abstract class BaseInstallManager {
     purgeManager: PurgeManager,
     options: IInstallManagerOptions
   ) {
+    this._terminal = options.terminal;
     this.rushConfiguration = rushConfiguration;
     this.rushGlobalFolder = rushGlobalFolder;
     this.installRecycler = purgeManager.commonTempFolderRecycler;
@@ -101,9 +95,6 @@ export abstract class BaseInstallManager {
         );
       }
     }
-
-    this._terminalProvider = new ConsoleTerminalProvider();
-    this._terminal = new Terminal(this._terminalProvider);
   }
 
   public async doInstallAsync(): Promise<void> {

--- a/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { ITerminal } from '@rushstack/terminal';
 import type { Subspace } from '../../api/Subspace';
 
 export interface IInstallManagerOptions {
@@ -94,4 +95,9 @@ export interface IInstallManagerOptions {
    * The specific subspace to install.
    */
   subspace: Subspace;
+
+  /**
+   * The terminal where output should be printed.
+   */
+  terminal: ITerminal;
 }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -519,10 +519,10 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // the pnpm-sync will generate the pnpm-sync.json based on lockfile
     if (this.rushConfiguration.packageManager === 'pnpm' && experiments?.usePnpmSyncForInjectedDependencies) {
       const pnpmLockfilePath: string = subspace.getTempShrinkwrapFilename();
-      const pnpmStorePath: string = `${subspace.getSubspaceTempFolder()}/node_modules/.pnpm`;
+      const dotPnpmFolder: string = `${subspace.getSubspaceTempFolder()}/node_modules/.pnpm`;
       await pnpmSyncPrepareAsync({
         lockfilePath: pnpmLockfilePath,
-        storePath: pnpmStorePath,
+        dotPnpmFolder,
         ensureFolder: FileSystem.ensureFolderAsync,
         readPnpmLockfile: async (lockfilePath: string) => {
           const wantedPnpmLockfile: PnpmShrinkwrapFile | undefined = await PnpmShrinkwrapFile.loadFromFile(

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -41,7 +41,7 @@ import { type ILockfile, pnpmSyncPrepareAsync, type ILogMessageCallbackOptions }
 import type { Subspace } from '../../api/Subspace';
 import { Colorize, ConsoleTerminalProvider } from '@rushstack/terminal';
 import { BaseLinkManager, SymlinkKind } from '../base/BaseLinkManager';
-import { logMessageCallback } from '../../utilities/PnpmSyncUtilities';
+import { processLogMessage } from '../../utilities/PnpmSyncUtilities';
 
 export interface IPnpmModules {
   hoistedDependencies: { [dep in string]: { [depPath in string]: string } };
@@ -535,7 +535,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           }
         },
         logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-          logMessageCallback(logMessageOptions, this._terminal)
+          processLogMessage(logMessageOptions, this._terminal)
       });
     }
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -46,7 +46,7 @@ import {
 import type { Subspace } from '../../api/Subspace';
 import { Colorize, ConsoleTerminalProvider } from '@rushstack/terminal';
 import { BaseLinkManager, SymlinkKind } from '../base/BaseLinkManager';
-import { processLogMessage } from '../../utilities/PnpmSyncUtilities';
+import { PnpmSyncUtilities } from '../../utilities/PnpmSyncUtilities';
 
 export interface IPnpmModules {
   hoistedDependencies: { [dep in string]: { [depPath in string]: string } };
@@ -555,7 +555,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           }
         },
         logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-          processLogMessage(logMessageOptions, this._terminal)
+          PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
       });
     }
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -41,6 +41,7 @@ import { type ILockfile, pnpmSyncPrepareAsync, type ILogMessageCallbackOptions }
 import type { Subspace } from '../../api/Subspace';
 import { Colorize, ConsoleTerminalProvider } from '@rushstack/terminal';
 import { BaseLinkManager, SymlinkKind } from '../base/BaseLinkManager';
+import { logMessageCallback } from '../../utilities/PnpmSyncUtilities';
 
 export interface IPnpmModules {
   hoistedDependencies: { [dep in string]: { [depPath in string]: string } };
@@ -533,26 +534,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
             return result;
           }
         },
-        logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) => {
-          const { message, messageKind } = logMessageOptions;
-          switch (messageKind) {
-            case 'error':
-              this._terminal.writeErrorLine(message);
-              break;
-            case 'warning':
-              this._terminal.writeWarningLine(message);
-              break;
-            case 'verbose':
-              if (this.options.debug) {
-                this._terminal.writeLine(message);
-              }
-              break;
-            default:
-              this._terminal.writeLine();
-              this._terminal.writeLine(message);
-              break;
-          }
-        }
+        logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
+          logMessageCallback(logMessageOptions, this._terminal)
       });
     }
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -514,7 +514,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm' && experiments?.usePnpmSyncForInjectedDependencies) {
       const pnpmLockfilePath: string = subspace.getTempShrinkwrapFilename();
       const pnpmStorePath: string = `${subspace.getSubspaceTempFolder()}/node_modules/.pnpm`;
-      debugger;
       await pnpmSyncPrepareAsync({
         lockfilePath: pnpmLockfilePath,
         storePath: pnpmStorePath,

--- a/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
+++ b/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
@@ -43,7 +43,8 @@ export async function doBasicInstallAsync(options: IRunInstallOptions): Promise<
       pnpmFilterArguments: [],
       maxInstallAttempts: 1,
       networkConcurrency: undefined,
-      subspace: rushConfiguration.defaultSubspace
+      subspace: rushConfiguration.defaultSubspace,
+      terminal: options.terminal
     }
   );
 

--- a/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
@@ -2,16 +2,24 @@
 // See LICENSE in the project root for license information.
 
 import { Async, FileSystem } from '@rushstack/node-core-library';
-import { pnpmSyncCopyAsync } from 'pnpm-sync-lib';
+import { type ILogMessageCallbackOptions, pnpmSyncCopyAsync } from 'pnpm-sync-lib';
 
 import { OperationStatus } from './OperationStatus';
 import type { IOperationRunnerContext } from './IOperationRunner';
 import type { IPhasedCommandPlugin, PhasedCommandHooks } from '../../pluginFramework/PhasedCommandHooks';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
+import type { ITerminal } from '@rushstack/terminal';
 
 const PLUGIN_NAME: 'PnpmSyncCopyOperationPlugin' = 'PnpmSyncCopyOperationPlugin';
 
 export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
+  private readonly _terminal: ITerminal;
+  private readonly _isVerbose: boolean;
+
+  public constructor(terminal: ITerminal, isVerbose: boolean) {
+    this._terminal = terminal;
+    this._isVerbose = isVerbose;
+  }
   public apply(hooks: PhasedCommandHooks): void {
     hooks.afterExecuteOperation.tapPromise(
       PLUGIN_NAME,
@@ -42,7 +50,26 @@ export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
               pnpmSyncJsonPath,
               ensureFolder: FileSystem.ensureFolderAsync,
               forEachAsyncWithConcurrency: Async.forEachAsync,
-              getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync
+              getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+              logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) => {
+                const { message, messageKind } = logMessageOptions;
+                switch (messageKind) {
+                  case 'error':
+                    this._terminal.writeErrorLine(message);
+                    break;
+                  case 'warning':
+                    this._terminal.writeWarningLine(message);
+                    break;
+                  case 'verbose':
+                    if (this._isVerbose) {
+                      this._terminal.writeVerboseLine(message);
+                    }
+                    break;
+                  default:
+                    this._terminal.writeLine(message);
+                    break;
+                }
+              }
             });
           }
         }

--- a/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
@@ -9,7 +9,7 @@ import { OperationStatus } from './OperationStatus';
 import type { IOperationRunnerContext } from './IOperationRunner';
 import type { IPhasedCommandPlugin, PhasedCommandHooks } from '../../pluginFramework/PhasedCommandHooks';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
-import { processLogMessage } from '../../utilities/PnpmSyncUtilities';
+import { PnpmSyncUtilities } from '../../utilities/PnpmSyncUtilities';
 
 const PLUGIN_NAME: 'PnpmSyncCopyOperationPlugin' = 'PnpmSyncCopyOperationPlugin';
 
@@ -51,7 +51,7 @@ export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
               forEachAsyncWithConcurrency: Async.forEachAsync,
               getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
               logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-                processLogMessage(logMessageOptions, this._terminal)
+                PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
             });
           }
         }

--- a/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
@@ -9,7 +9,7 @@ import { OperationStatus } from './OperationStatus';
 import type { IOperationRunnerContext } from './IOperationRunner';
 import type { IPhasedCommandPlugin, PhasedCommandHooks } from '../../pluginFramework/PhasedCommandHooks';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
-import { logMessageCallback } from '../../utilities/PnpmSyncUtilities';
+import { processLogMessage } from '../../utilities/PnpmSyncUtilities';
 
 const PLUGIN_NAME: 'PnpmSyncCopyOperationPlugin' = 'PnpmSyncCopyOperationPlugin';
 
@@ -51,7 +51,7 @@ export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
               forEachAsyncWithConcurrency: Async.forEachAsync,
               getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
               logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-                logMessageCallback(logMessageOptions, this._terminal)
+                processLogMessage(logMessageOptions, this._terminal)
             });
           }
         }

--- a/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
+++ b/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { ConsoleTerminalProvider } from '@rushstack/terminal';
+import { ConsoleTerminalProvider, type ITerminal, Terminal } from '@rushstack/terminal';
 
 import { PurgeManager } from '../PurgeManager';
 import { BaseInstallManager, pnpmIgnoreCompatibilityDbParameter } from '../base/BaseInstallManager';
@@ -51,11 +51,14 @@ describe('BaseInstallManager Test', () => {
       RushConfiguration.loadFromConfigurationFile(rushJsonFilePnpmV6);
     const rushConfigurationV7: RushConfiguration =
       RushConfiguration.loadFromConfigurationFile(rushJsonFilePnpmV7);
+    const terminal: ITerminal = new Terminal(new ConsoleTerminalProvider());
     const options6: IInstallManagerOptions = {
-      subspace: rushConfigurationV6.defaultSubspace
+      subspace: rushConfigurationV6.defaultSubspace,
+      terminal
     } as IInstallManagerOptions;
     const options7: IInstallManagerOptions = {
-      subspace: rushConfigurationV7.defaultSubspace
+      subspace: rushConfigurationV7.defaultSubspace,
+      terminal
     } as IInstallManagerOptions;
     const purgeManager6: typeof PurgeManager.prototype = new PurgeManager(
       rushConfigurationV6,

--- a/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
+++ b/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
@@ -1,23 +1,53 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { ITerminal } from '@rushstack/terminal';
-import type { ILogMessageCallbackOptions } from 'pnpm-sync-lib';
+import { AlreadyReportedError } from '@rushstack/node-core-library';
+import { Colorize, type ITerminal } from '@rushstack/terminal';
+import {
+  type ILogMessageCallbackOptions,
+  LogMessageIdentifier,
+  type LogMessageDetails,
+  LogMessageKind
+} from 'pnpm-sync-lib';
 
-export function processLogMessage(logMessageOptions: ILogMessageCallbackOptions, terminal: ITerminal): void {
-  const { message, messageKind } = logMessageOptions;
-  switch (messageKind) {
-    case 'error':
-      terminal.writeErrorLine(message);
-      break;
-    case 'warning':
-      terminal.writeWarningLine(message);
-      break;
-    case 'verbose':
-      terminal.writeVerboseLine(message);
-      break;
-    default:
-      terminal.writeLine(message);
-      break;
+export function processLogMessage(options: ILogMessageCallbackOptions, terminal: ITerminal): void {
+  const message: string = options.message;
+  const details: LogMessageDetails = options.details;
+
+  // Special formatting for interested messages
+  switch (details.messageIdentifier) {
+    case LogMessageIdentifier.PREPARE_FINISHING:
+      terminal.writeVerboseLine(
+        Colorize.cyan(`pnpm-sync: `) +
+          `Regenerated .pnpm-sync.json in ${Math.round(details.executionTimeInMs)} ms`
+      );
+      return;
+
+    case LogMessageIdentifier.COPY_FINISHING:
+      {
+        const customMessage: string =
+          `Synced ${details.fileCount} ` +
+          (details.fileCount === 1 ? 'file' : 'files') +
+          ` in ${Math.round(details.executionTimeInMs)} ms`;
+
+        terminal.writeVerboseLine(Colorize.cyan(`pnpm-sync: `) + customMessage);
+      }
+      return;
+  }
+
+  // Default handling for other messages
+  switch (options.messageKind) {
+    case LogMessageKind.ERROR:
+      terminal.writeErrorLine(Colorize.red('ERROR: pnpm-sync: ' + message));
+      throw new AlreadyReportedError();
+
+    case LogMessageKind.WARNING:
+      terminal.writeWarningLine(Colorize.yellow('pnpm-sync: ' + message));
+      return;
+
+    case LogMessageKind.INFO:
+    case LogMessageKind.VERBOSE:
+      terminal.writeDebugLine(Colorize.cyan(`pnpm-sync: `) + message);
+      return;
   }
 }

--- a/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
+++ b/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
@@ -4,7 +4,7 @@
 import type { ITerminal } from '@rushstack/terminal';
 import type { ILogMessageCallbackOptions } from 'pnpm-sync-lib';
 
-export function logMessageCallback(logMessageOptions: ILogMessageCallbackOptions, terminal: ITerminal): void {
+export function processLogMessage(logMessageOptions: ILogMessageCallbackOptions, terminal: ITerminal): void {
   const { message, messageKind } = logMessageOptions;
   switch (messageKind) {
     case 'error':

--- a/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
+++ b/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { ITerminal } from '@rushstack/terminal';
+import type { ILogMessageCallbackOptions } from 'pnpm-sync-lib';
+
+export function logMessageCallback(logMessageOptions: ILogMessageCallbackOptions, terminal: ITerminal): void {
+  const { message, messageKind } = logMessageOptions;
+  switch (messageKind) {
+    case 'error':
+      terminal.writeErrorLine(message);
+      break;
+    case 'warning':
+      terminal.writeWarningLine(message);
+      break;
+    case 'verbose':
+      terminal.writeVerboseLine(message);
+      break;
+    default:
+      terminal.writeLine(message);
+      break;
+  }
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
`pnpm-sync-lib` now have a logMessage API which allow us to customize the log message printing behavior. Check [here](https://github.com/tiktok/pnpm-sync/pull/15) to see how it implemented.

So, on Rush side, we can use this API to preventing unexpected log message and customize the log message format. 

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Generally, there will be four types of message coming from `pnpm-sync-lib`, there are `'info' | 'warning' | 'error' | 'verbose'`.
1. Normally, we will only print out `info` message. 
2. `error` and `warning` will be printed if there are errors or warnings. 
3. The `verbose` will be printed out if we pass `--debug` or `--vebose` flag to the rush commands.

The `pnpm-sync-lib` also provides operation metadata in the API, so if don't want the message content from `pnpm-sync-lib`, we can utilize that metadata to fully customize the log message on the Rush side. 

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually tested on local.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation
N/A

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
