### PR TITLE
[rush] Run repo analysis after initial operation creation.

### DIFF
--- a/common/changes/@microsoft/rush/refactor-createOperations-hook_2024-03-26-21-41.json
+++ b/common/changes/@microsoft/rush/refactor-createOperations-hook_2024-03-26-21-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(BREAKING API CHANGE) Refactor phased action execution to analyze the repo after the intial operations are created. This removes the `projectChangeAnalyzer` property from the context paramter passed to the `createOperations` hook.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -393,7 +393,6 @@ export interface ICreateOperationsContext {
     readonly isWatch: boolean;
     readonly phaseOriginal: ReadonlySet<IPhase>;
     readonly phaseSelection: ReadonlySet<IPhase>;
-    readonly projectChangeAnalyzer: ProjectChangeAnalyzer;
     readonly projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration>;
     readonly projectSelection: ReadonlySet<RushConfigurationProject>;
     readonly projectsInUnknownState: ReadonlySet<RushConfigurationProject>;
@@ -440,6 +439,11 @@ export interface ICustomTipsJson {
 export interface IEnvironmentConfigurationInitializeOptions {
     // (undocumented)
     doNotNormalizePaths?: boolean;
+}
+
+// @alpha
+export interface IExecuteOperationsContext extends ICreateOperationsContext {
+    readonly projectChangeAnalyzer: ProjectChangeAnalyzer;
 }
 
 // @alpha
@@ -998,13 +1002,13 @@ export class PhasedCommandHooks {
     readonly afterExecuteOperation: AsyncSeriesHook<[
     IOperationRunnerContext & IOperationExecutionResult
     ]>;
-    readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]>;
+    readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, IExecuteOperationsContext]>;
     readonly beforeExecuteOperation: AsyncSeriesBailHook<[
     IOperationRunnerContext & IOperationExecutionResult
     ], OperationStatus | undefined>;
     readonly beforeExecuteOperations: AsyncSeriesHook<[
     Map<Operation, IOperationExecutionResult>,
-    ICreateOperationsContext
+    IExecuteOperationsContext
     ]>;
     readonly beforeLog: SyncHook<ITelemetryData, void>;
     readonly createOperations: AsyncSeriesWaterfallHook<[Set<Operation>, ICreateOperationsContext]>;
@@ -1328,13 +1332,13 @@ export class _RushInternals {
 
 // @beta
 export class RushLifecycleHooks {
-    beforeInstall: AsyncSeriesHook<IGlobalCommand>;
-    flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]>;
-    initialize: AsyncSeriesHook<IRushCommand>;
-    runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand>;
-    runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand>;
-    runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>>;
-    runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>>;
+    readonly beforeInstall: AsyncSeriesHook<IGlobalCommand>;
+    readonly flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]>;
+    readonly initialize: AsyncSeriesHook<IRushCommand>;
+    readonly runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand>;
+    readonly runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand>;
+    readonly runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>>;
+    readonly runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>>;
 }
 
 // @alpha

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -12,7 +12,11 @@ import type {
 } from '@rushstack/ts-command-line';
 
 import type { IPhasedCommand } from '../../pluginFramework/RushLifeCycle';
-import { PhasedCommandHooks, type ICreateOperationsContext } from '../../pluginFramework/PhasedCommandHooks';
+import {
+  PhasedCommandHooks,
+  type ICreateOperationsContext,
+  type IExecuteOperationsContext
+} from '../../pluginFramework/PhasedCommandHooks';
 import { SetupChecks } from '../../logic/SetupChecks';
 import { Stopwatch, StopwatchState } from '../../utilities/Stopwatch';
 import { BaseScriptAction, type IBaseScriptActionOptions } from './BaseScriptAction';
@@ -64,15 +68,20 @@ export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPh
   watchDebounceMs: number | undefined;
 }
 
-interface IRunPhasesOptions {
+interface IInitialRunPhasesOptions {
+  executionManagerOptions: Omit<IOperationExecutionManagerOptions, 'beforeExecuteOperations'>;
   initialCreateOperationsContext: ICreateOperationsContext;
-  executionManagerOptions: IOperationExecutionManagerOptions;
   stopwatch: Stopwatch;
   terminal: ITerminal;
 }
 
+interface IRunPhasesOptions extends IInitialRunPhasesOptions {
+  initialState: ProjectChangeAnalyzer;
+  executionManagerOptions: IOperationExecutionManagerOptions;
+}
+
 interface IExecutionOperationsOptions {
-  createOperationsContext: ICreateOperationsContext;
+  executeOperationsContext: IExecuteOperationsContext;
   executionManagerOptions: IOperationExecutionManagerOptions;
   ignoreHooks: boolean;
   operations: Set<Operation>;
@@ -418,7 +427,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         ? new Map()
         : await RushProjectConfiguration.tryLoadForProjectsAsync(projectSelection, terminal);
 
-      const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
       const initialCreateOperationsContext: ICreateOperationsContext = {
         buildCacheConfiguration,
         cobuildConfiguration,
@@ -429,13 +437,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         rushConfiguration: this.rushConfiguration,
         phaseOriginal: new Set(this._originalPhases),
         phaseSelection: new Set(this._initialPhases),
-        projectChangeAnalyzer,
         projectSelection,
         projectConfigurations,
         projectsInUnknownState: projectSelection
       };
 
-      const executionManagerOptions: IOperationExecutionManagerOptions = {
+      const executionManagerOptions: Omit<IOperationExecutionManagerOptions, 'beforeExecuteOperations'> = {
         quietMode: isQuietMode,
         debugMode: this.parser.isDebug,
         parallelism,
@@ -446,30 +453,19 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         afterExecuteOperation: async (record: OperationExecutionRecord) => {
           await this.hooks.afterExecuteOperation.promise(record);
         },
-        beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
-          await this.hooks.beforeExecuteOperations.promise(records, initialCreateOperationsContext);
-        },
         onOperationStatusChanged: (record: OperationExecutionRecord) => {
           this.hooks.onOperationStatusChanged.call(record);
         }
       };
 
-      const internalOptions: IRunPhasesOptions = {
+      const initialInternalOptions: IInitialRunPhasesOptions = {
         initialCreateOperationsContext,
         executionManagerOptions,
         stopwatch,
         terminal
       };
 
-      terminal.write('Analyzing repo state... ');
-      const repoStateStopwatch: Stopwatch = new Stopwatch();
-      repoStateStopwatch.start();
-      await projectChangeAnalyzer._ensureInitializedAsync(terminal);
-      repoStateStopwatch.stop();
-      terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
-      terminal.writeLine();
-
-      await this._runInitialPhases(internalOptions);
+      const internalOptions: IRunPhasesOptions = await this._runInitialPhases(initialInternalOptions);
 
       if (isWatch) {
         if (buildCacheConfiguration) {
@@ -484,16 +480,43 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
   }
 
-  private async _runInitialPhases(options: IRunPhasesOptions): Promise<void> {
-    const { initialCreateOperationsContext, executionManagerOptions, stopwatch, terminal } = options;
+  private async _runInitialPhases(options: IInitialRunPhasesOptions): Promise<IRunPhasesOptions> {
+    const {
+      initialCreateOperationsContext,
+      executionManagerOptions: partialExecutionManagerOptions,
+      stopwatch,
+      terminal
+    } = options;
 
     const operations: Set<Operation> = await this.hooks.createOperations.promise(
       new Set(),
       initialCreateOperationsContext
     );
 
+    const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
+
+    terminal.write('Analyzing repo state... ');
+    const repoStateStopwatch: Stopwatch = new Stopwatch();
+    repoStateStopwatch.start();
+    await projectChangeAnalyzer._ensureInitializedAsync(terminal);
+    repoStateStopwatch.stop();
+    terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
+    terminal.writeLine();
+
+    const initialExecuteOperationsContext: IExecuteOperationsContext = {
+      ...initialCreateOperationsContext,
+      projectChangeAnalyzer
+    };
+
+    const executionManagerOptions: IOperationExecutionManagerOptions = {
+      ...partialExecutionManagerOptions,
+      beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
+        await this.hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext);
+      }
+    };
+
     const initialOptions: IExecutionOperationsOptions = {
-      createOperationsContext: initialCreateOperationsContext,
+      executeOperationsContext: initialExecuteOperationsContext,
       ignoreHooks: false,
       operations,
       stopwatch,
@@ -502,6 +525,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     };
 
     await this._executeOperations(initialOptions);
+
+    return {
+      ...options,
+      executionManagerOptions,
+      initialState: projectChangeAnalyzer
+    };
   }
 
   private _registerWatchModeInterface(projectWatcher: ProjectWatcher): void {
@@ -575,13 +604,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
    * 3) Goto (1)
    */
   private async _runWatchPhases(options: IRunPhasesOptions): Promise<void> {
-    const { initialCreateOperationsContext, executionManagerOptions, stopwatch, terminal } = options;
+    const { initialState, initialCreateOperationsContext, executionManagerOptions, stopwatch, terminal } =
+      options;
 
     const phaseOriginal: Set<IPhase> = new Set(this._watchPhases);
     const phaseSelection: Set<IPhase> = new Set(this._watchPhases);
 
-    const { projectChangeAnalyzer: initialState, projectSelection: projectsToWatch } =
-      initialCreateOperationsContext;
+    const { projectSelection: projectsToWatch } = initialCreateOperationsContext;
 
     // Use async import so that we don't pay the cost for sync builds
     const { ProjectWatcher } = await import(
@@ -644,7 +673,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       }
 
       // Account for consumer relationships
-      const createOperationsContext: ICreateOperationsContext = {
+      const createOperationsContext: IExecuteOperationsContext = {
         ...initialCreateOperationsContext,
         isInitial: false,
         projectChangeAnalyzer: state,
@@ -660,7 +689,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       );
 
       const executeOptions: IExecutionOperationsOptions = {
-        createOperationsContext,
+        executeOperationsContext: {
+          ...initialCreateOperationsContext,
+          projectChangeAnalyzer: initialState
+        },
         // For now, don't run pre-build or post-build in watch mode
         ignoreHooks: true,
         operations,
@@ -697,7 +729,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       executionManagerOptions
     );
 
-    const { isInitial, isWatch } = options.createOperationsContext;
+    const { isInitial, isWatch } = options.executeOperationsContext;
 
     let success: boolean = false;
     let result: IExecutionResult | undefined;
@@ -706,7 +738,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       result = await executionManager.executeAsync();
       success = result.status === OperationStatus.Success;
 
-      await this.hooks.afterExecuteOperations.promise(result, options.createOperationsContext);
+      await this.hooks.afterExecuteOperations.promise(result, options.executeOperationsContext);
 
       stopwatch.stop();
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -673,7 +673,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       }
 
       // Account for consumer relationships
-      const createOperationsContext: IExecuteOperationsContext = {
+      const executeOperationsContext: IExecuteOperationsContext = {
         ...initialCreateOperationsContext,
         isInitial: false,
         projectChangeAnalyzer: state,
@@ -685,14 +685,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
       const operations: Set<Operation> = await this.hooks.createOperations.promise(
         new Set(),
-        createOperationsContext
+        executeOperationsContext
       );
 
       const executeOptions: IExecutionOperationsOptions = {
-        executeOperationsContext: {
-          ...initialCreateOperationsContext,
-          projectChangeAnalyzer: initialState
-        },
+        executeOperationsContext,
         // For now, don't run pre-build or post-build in watch mode
         ignoreHooks: true,
         operations,
@@ -700,7 +697,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         executionManagerOptions: {
           ...executionManagerOptions,
           beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
-            await this.hooks.beforeExecuteOperations.promise(records, createOperationsContext);
+            await this.hooks.beforeExecuteOperations.promise(records, executeOperationsContext);
           }
         },
         terminal

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -142,7 +142,11 @@ export {
   RushLifecycleHooks
 } from './pluginFramework/RushLifeCycle';
 
-export { ICreateOperationsContext, PhasedCommandHooks } from './pluginFramework/PhasedCommandHooks';
+export {
+  ICreateOperationsContext,
+  IExecuteOperationsContext,
+  PhasedCommandHooks
+} from './pluginFramework/PhasedCommandHooks';
 
 export { IRushPlugin } from './pluginFramework/IRushPlugin';
 export { IBuiltInPluginConfiguration as _IBuiltInPluginConfiguration } from './pluginFramework/PluginLoader/BuiltInPluginLoader';

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -24,7 +24,7 @@ import type { Operation } from './Operation';
 import type { IOperationRunnerContext } from './IOperationRunner';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type {
-  ICreateOperationsContext,
+  IExecuteOperationsContext,
   IPhasedCommandPlugin,
   PhasedCommandHooks
 } from '../../pluginFramework/PhasedCommandHooks';
@@ -90,7 +90,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
       PLUGIN_NAME,
       async (
         recordByOperation: Map<Operation, IOperationExecutionResult>,
-        context: ICreateOperationsContext
+        context: IExecuteOperationsContext
       ): Promise<void> => {
         const { isIncrementalBuildAllowed, projectChangeAnalyzer, projectConfigurations, isInitial } =
           context;

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -8,8 +8,8 @@ import {
   AsyncSeriesWaterfallHook,
   SyncHook
 } from 'tapable';
-
 import type { CommandLineParameter } from '@rushstack/ts-command-line';
+
 import type { BuildCacheConfiguration } from '../api/BuildCacheConfiguration';
 import type { IPhase } from '../api/CommandLineConfiguration';
 import type { RushConfiguration } from '../api/RushConfiguration';
@@ -77,10 +77,7 @@ export interface ICreateOperationsContext {
    * The set of phases selected for the current command execution.
    */
   readonly phaseSelection: ReadonlySet<IPhase>;
-  /**
-   * The current state of the repository
-   */
-  readonly projectChangeAnalyzer: ProjectChangeAnalyzer;
+
   /**
    * The set of Rush projects selected for the current command execution.
    */
@@ -107,6 +104,19 @@ export interface ICreateOperationsContext {
 }
 
 /**
+ * Context used for executing operations.
+ * @alpha
+ */
+export interface IExecuteOperationsContext extends ICreateOperationsContext {
+  /**
+   * The current state of the repository.
+   *
+   * Note that this is not defined during the initial operation creation.
+   */
+  readonly projectChangeAnalyzer: ProjectChangeAnalyzer;
+}
+
+/**
  * Hooks into the execution process for phased commands
  * @alpha
  */
@@ -123,7 +133,7 @@ export class PhasedCommandHooks {
    * Hook is series for stable output.
    */
   public readonly beforeExecuteOperations: AsyncSeriesHook<
-    [Map<Operation, IOperationExecutionResult>, ICreateOperationsContext]
+    [Map<Operation, IOperationExecutionResult>, IExecuteOperationsContext]
   > = new AsyncSeriesHook(['records', 'context']);
 
   /**
@@ -137,7 +147,7 @@ export class PhasedCommandHooks {
    * Use the context to distinguish between the initial run and phased runs.
    * Hook is series for stable output.
    */
-  public readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, ICreateOperationsContext]> =
+  public readonly afterExecuteOperations: AsyncSeriesHook<[IExecutionResult, IExecuteOperationsContext]> =
     new AsyncSeriesHook(['results', 'context']);
 
   /**

--- a/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -46,7 +46,7 @@ export class RushLifecycleHooks {
   /**
    * The hook to run before executing any Rush CLI Command.
    */
-  public initialize: AsyncSeriesHook<IRushCommand> = new AsyncSeriesHook<IRushCommand>(
+  public readonly initialize: AsyncSeriesHook<IRushCommand> = new AsyncSeriesHook<IRushCommand>(
     ['command'],
     'initialize'
   );
@@ -54,22 +54,23 @@ export class RushLifecycleHooks {
   /**
    * The hook to run before executing any global Rush CLI Command (defined in command-line.json).
    */
-  public runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand> = new AsyncSeriesHook<IGlobalCommand>(
-    ['command'],
-    'runAnyGlobalCustomCommand'
-  );
+  public readonly runAnyGlobalCustomCommand: AsyncSeriesHook<IGlobalCommand> =
+    new AsyncSeriesHook<IGlobalCommand>(['command'], 'runAnyGlobalCustomCommand');
 
   /**
    * A hook map to allow plugins to hook specific named global commands (defined in command-line.json) before execution.
    */
-  public runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>> = new HookMap((key: string) => {
-    return new AsyncSeriesHook<IGlobalCommand>(['command'], key);
-  }, 'runGlobalCustomCommand');
+  public readonly runGlobalCustomCommand: HookMap<AsyncSeriesHook<IGlobalCommand>> = new HookMap(
+    (key: string) => {
+      return new AsyncSeriesHook<IGlobalCommand>(['command'], key);
+    },
+    'runGlobalCustomCommand'
+  );
 
   /**
    * The hook to run before executing any phased Rush CLI Command (defined in command-line.json, or the default "build" or "rebuild").
    */
-  public runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand> = new AsyncSeriesHook<IPhasedCommand>(
+  public readonly runAnyPhasedCommand: AsyncSeriesHook<IPhasedCommand> = new AsyncSeriesHook<IPhasedCommand>(
     ['command'],
     'runAnyPhasedCommand'
   );
@@ -77,14 +78,14 @@ export class RushLifecycleHooks {
   /**
    * A hook map to allow plugins to hook specific named phased commands (defined in command-line.json) before execution.
    */
-  public runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>> = new HookMap((key: string) => {
+  public readonly runPhasedCommand: HookMap<AsyncSeriesHook<IPhasedCommand>> = new HookMap((key: string) => {
     return new AsyncSeriesHook<IPhasedCommand>(['command'], key);
   }, 'runPhasedCommand');
 
   /**
    * The hook to run between preparing the common/temp folder and invoking the package manager during "rush install" or "rush update".
    */
-  public beforeInstall: AsyncSeriesHook<IGlobalCommand> = new AsyncSeriesHook<IGlobalCommand>(
+  public readonly beforeInstall: AsyncSeriesHook<IGlobalCommand> = new AsyncSeriesHook<IGlobalCommand>(
     ['command'],
     'beforeInstall'
   );
@@ -92,7 +93,7 @@ export class RushLifecycleHooks {
   /**
    * A hook to allow plugins to hook custom logic to process telemetry data.
    */
-  public flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]> = new AsyncParallelHook(
+  public readonly flushTelemetry: AsyncParallelHook<[ReadonlyArray<ITelemetryData>]> = new AsyncParallelHook(
     ['telemetryData'],
     'flushTelemetry'
   );


### PR DESCRIPTION
## Summary

Refactor `PhasedScriptAction` to run repo analysis after initial operation creation.

This removes the `projectChangeAnalyzer` property from the context passed to `createOperations`.

## How it was tested

Ran `rush build` with the change in the rushstack repo and observed that projects came from cache.

## Impacted documentation

API docs will need to be updated.