### PR TITLE
[eslint-patch] Fix issues with eslint-bulk prune.

### DIFF
--- a/common/changes/@rushstack/eslint-patch/fix-bulk-suppression-prune_2024-03-27-19-05.json
+++ b/common/changes/@rushstack/eslint-patch/fix-bulk-suppression-prune_2024-03-27-19-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix an issue where `eslint-bulk prune` does not work if there are no files to lint in the project root.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-file.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-file.ts
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import fs from 'fs';
+import { VSCODE_PID_ENV_VAR_NAME } from './constants';
+
+export interface ISuppression {
+  file: string;
+  scopeId: string;
+  rule: string;
+}
+
+export interface IBulkSuppressionsConfig {
+  serializedSuppressions: Set<string>;
+  jsonObject: IBulkSuppressionsJson;
+  newSerializedSuppressions: Set<string>;
+  newJsonObject: IBulkSuppressionsJson;
+}
+
+export interface IBulkSuppressionsJson {
+  suppressions: ISuppression[];
+}
+
+const IS_RUNNING_IN_VSCODE: boolean = process.env[VSCODE_PID_ENV_VAR_NAME] !== undefined;
+const TEN_SECONDS_MS: number = 10 * 1000;
+const SUPPRESSIONS_JSON_FILENAME: string = '.eslint-bulk-suppressions.json';
+
+interface ICachedBulkSuppressionsConfig {
+  readTime: number;
+  suppressionsConfig: IBulkSuppressionsConfig;
+}
+export const suppressionsJsonByFolderPath: Map<string, ICachedBulkSuppressionsConfig> = new Map();
+export function getSuppressionsConfigForEslintrcFolderPath(
+  eslintrcFolderPath: string
+): IBulkSuppressionsConfig {
+  const cachedSuppressionsConfig: ICachedBulkSuppressionsConfig | undefined =
+    suppressionsJsonByFolderPath.get(eslintrcFolderPath);
+
+  let shouldLoad: boolean;
+  let suppressionsConfig: IBulkSuppressionsConfig;
+  if (cachedSuppressionsConfig) {
+    shouldLoad = IS_RUNNING_IN_VSCODE && cachedSuppressionsConfig.readTime < Date.now() - TEN_SECONDS_MS;
+    suppressionsConfig = cachedSuppressionsConfig.suppressionsConfig;
+  } else {
+    shouldLoad = true;
+  }
+
+  if (shouldLoad) {
+    const suppressionsPath: string = `${eslintrcFolderPath}/${SUPPRESSIONS_JSON_FILENAME}`;
+    let rawJsonFile: string | undefined;
+    try {
+      rawJsonFile = fs.readFileSync(suppressionsPath).toString();
+    } catch (e) {
+      // Throw an error if any other error than file not found
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
+
+    if (!rawJsonFile) {
+      suppressionsConfig = {
+        serializedSuppressions: new Set(),
+        jsonObject: { suppressions: [] },
+        newSerializedSuppressions: new Set(),
+        newJsonObject: { suppressions: [] }
+      };
+    } else {
+      const jsonObject: IBulkSuppressionsJson = JSON.parse(rawJsonFile);
+      validateSuppressionsJson(jsonObject);
+
+      const serializedSuppressions: Set<string> = new Set();
+      for (const suppression of jsonObject.suppressions) {
+        serializedSuppressions.add(serializeSuppression(suppression));
+      }
+
+      suppressionsConfig = {
+        serializedSuppressions,
+        jsonObject,
+        newSerializedSuppressions: new Set(),
+        newJsonObject: { suppressions: [] }
+      };
+    }
+
+    suppressionsJsonByFolderPath.set(eslintrcFolderPath, { readTime: Date.now(), suppressionsConfig });
+  }
+
+  return suppressionsConfig!;
+}
+
+export function writeSuppressionsJsonToFile(
+  eslintrcDirectory: string,
+  suppressionsConfig: IBulkSuppressionsConfig
+): void {
+  suppressionsJsonByFolderPath.set(eslintrcDirectory, { readTime: Date.now(), suppressionsConfig });
+  const suppressionsPath: string = `${eslintrcDirectory}/${SUPPRESSIONS_JSON_FILENAME}`;
+  suppressionsConfig.jsonObject.suppressions.sort(compareSuppressions);
+  fs.writeFileSync(suppressionsPath, JSON.stringify(suppressionsConfig.jsonObject, undefined, 2));
+}
+
+export function serializeSuppression({ file, scopeId, rule }: ISuppression): string {
+  return `${file}|${scopeId}|${rule}`;
+}
+
+function compareSuppressions(a: ISuppression, b: ISuppression): -1 | 0 | 1 {
+  if (a.file < b.file) {
+    return -1;
+  } else if (a.file > b.file) {
+    return 1;
+  } else if (a.scopeId < b.scopeId) {
+    return -1;
+  } else if (a.scopeId > b.scopeId) {
+    return 1;
+  } else if (a.rule < b.rule) {
+    return -1;
+  } else if (a.rule > b.rule) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+function validateSuppressionsJson(json: IBulkSuppressionsJson): json is IBulkSuppressionsJson {
+  if (typeof json !== 'object') {
+    throw new Error(`Invalid JSON object: ${JSON.stringify(json, null, 2)}`);
+  }
+
+  if (!json) {
+    throw new Error('JSON object is null.');
+  }
+
+  const EXPECTED_ROOT_PROPERTY_NAMES: Set<keyof IBulkSuppressionsJson> = new Set(['suppressions']);
+
+  for (const propertyName of Object.getOwnPropertyNames(json)) {
+    if (!EXPECTED_ROOT_PROPERTY_NAMES.has(propertyName as keyof IBulkSuppressionsJson)) {
+      throw new Error(`Unexpected property name: ${propertyName}`);
+    }
+  }
+
+  const { suppressions } = json;
+  if (!suppressions) {
+    throw new Error('Missing "suppressions" property.');
+  }
+
+  if (!Array.isArray(suppressions)) {
+    throw new Error('"suppressions" property is not an array.');
+  }
+
+  const EXPECTED_SUPPRESSION_PROPERTY_NAMES: Set<keyof ISuppression> = new Set(['file', 'scopeId', 'rule']);
+  for (const suppression of suppressions) {
+    if (typeof suppression !== 'object') {
+      throw new Error(`Invalid suppression: ${JSON.stringify(suppression, null, 2)}`);
+    }
+
+    if (!suppression) {
+      throw new Error(`Suppression is null: ${JSON.stringify(suppression, null, 2)}`);
+    }
+
+    for (const propertyName of Object.getOwnPropertyNames(suppression)) {
+      if (!EXPECTED_SUPPRESSION_PROPERTY_NAMES.has(propertyName as keyof ISuppression)) {
+        throw new Error(`Unexpected property name: ${propertyName}`);
+      }
+    }
+
+    for (const propertyName of EXPECTED_SUPPRESSION_PROPERTY_NAMES) {
+      if (!suppression.hasOwnProperty(propertyName)) {
+        throw new Error(
+          `Missing "${propertyName}" property in suppression: ${JSON.stringify(suppression, null, 2)}`
+        );
+      } else if (typeof suppression[propertyName] !== 'string') {
+        throw new Error(
+          `"${propertyName}" property in suppression is not a string: ${JSON.stringify(suppression, null, 2)}`
+        );
+      }
+    }
+  }
+
+  return true;
+}

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
@@ -10,28 +10,17 @@ import { eslintFolder } from '../_patch-base';
 import {
   ESLINT_BULK_ENABLE_ENV_VAR_NAME,
   ESLINT_BULK_PRUNE_ENV_VAR_NAME,
-  ESLINT_BULK_SUPPRESS_ENV_VAR_NAME,
-  VSCODE_PID_ENV_VAR_NAME
+  ESLINT_BULK_SUPPRESS_ENV_VAR_NAME
 } from './constants';
+import {
+  getSuppressionsConfigForEslintrcFolderPath,
+  serializeSuppression,
+  type IBulkSuppressionsConfig,
+  type ISuppression,
+  writeSuppressionsJsonToFile,
+  suppressionsJsonByFolderPath
+} from './bulk-suppressions-file';
 
-interface ISuppression {
-  file: string;
-  scopeId: string;
-  rule: string;
-}
-
-interface IBulkSuppressionsConfig {
-  serializedSuppressions: Set<string>;
-  jsonObject: IBulkSuppressionsJson;
-  newSerializedSuppressions: Set<string>;
-  newJsonObject: IBulkSuppressionsJson;
-}
-
-interface IBulkSuppressionsJson {
-  suppressions: ISuppression[];
-}
-
-const SUPPRESSIONS_JSON_FILENAME: string = '.eslint-bulk-suppressions.json';
 const ESLINTRC_FILENAMES: string[] = [
   '.eslintrc.js',
   '.eslintrc.cjs'
@@ -39,8 +28,6 @@ const ESLINTRC_FILENAMES: string[] = [
   // so we only need to check for the JS-based filenames
 ];
 const SUPPRESSION_SYMBOL: unique symbol = Symbol('suppression');
-const IS_RUNNING_IN_VSCODE: boolean = process.env[VSCODE_PID_ENV_VAR_NAME] !== undefined;
-const TEN_SECONDS_MS: number = 10 * 1000;
 const ESLINT_BULK_SUPPRESS_ENV_VAR_VALUE: string | undefined = process.env[ESLINT_BULK_SUPPRESS_ENV_VAR_NAME];
 const SUPPRESS_ALL_RULES: boolean = ESLINT_BULK_SUPPRESS_ENV_VAR_VALUE === '*';
 const RULES_TO_SUPPRESS: Set<string> | undefined = ESLINT_BULK_SUPPRESS_ENV_VAR_VALUE
@@ -144,156 +131,6 @@ function findEslintrcFolderPathForNormalizedFileAbsolutePath(normalizedFilePath:
   } else {
     throw new Error(`Cannot locate an ESLint configuration file for ${normalizedFilePath}`);
   }
-}
-
-function validateSuppressionsJson(json: IBulkSuppressionsJson): json is IBulkSuppressionsJson {
-  if (typeof json !== 'object') {
-    throw new Error(`Invalid JSON object: ${JSON.stringify(json, null, 2)}`);
-  }
-
-  if (!json) {
-    throw new Error('JSON object is null.');
-  }
-
-  const EXPECTED_ROOT_PROPERTY_NAMES: Set<keyof IBulkSuppressionsJson> = new Set(['suppressions']);
-
-  for (const propertyName of Object.getOwnPropertyNames(json)) {
-    if (!EXPECTED_ROOT_PROPERTY_NAMES.has(propertyName as keyof IBulkSuppressionsJson)) {
-      throw new Error(`Unexpected property name: ${propertyName}`);
-    }
-  }
-
-  const { suppressions } = json;
-  if (!suppressions) {
-    throw new Error('Missing "suppressions" property.');
-  }
-
-  if (!Array.isArray(suppressions)) {
-    throw new Error('"suppressions" property is not an array.');
-  }
-
-  const EXPECTED_SUPPRESSION_PROPERTY_NAMES: Set<keyof ISuppression> = new Set(['file', 'scopeId', 'rule']);
-  for (const suppression of suppressions) {
-    if (typeof suppression !== 'object') {
-      throw new Error(`Invalid suppression: ${JSON.stringify(suppression, null, 2)}`);
-    }
-
-    if (!suppression) {
-      throw new Error(`Suppression is null: ${JSON.stringify(suppression, null, 2)}`);
-    }
-
-    for (const propertyName of Object.getOwnPropertyNames(suppression)) {
-      if (!EXPECTED_SUPPRESSION_PROPERTY_NAMES.has(propertyName as keyof ISuppression)) {
-        throw new Error(`Unexpected property name: ${propertyName}`);
-      }
-    }
-
-    for (const propertyName of EXPECTED_SUPPRESSION_PROPERTY_NAMES) {
-      if (!suppression.hasOwnProperty(propertyName)) {
-        throw new Error(
-          `Missing "${propertyName}" property in suppression: ${JSON.stringify(suppression, null, 2)}`
-        );
-      } else if (typeof suppression[propertyName] !== 'string') {
-        throw new Error(
-          `"${propertyName}" property in suppression is not a string: ${JSON.stringify(suppression, null, 2)}`
-        );
-      }
-    }
-  }
-
-  return true;
-}
-
-interface ICachedBulkSuppressionsConfig {
-  readTime: number;
-  suppressionsConfig: IBulkSuppressionsConfig;
-}
-const suppressionsJsonByFolderPath: Map<string, ICachedBulkSuppressionsConfig> = new Map();
-function getSuppressionsConfigForEslintrcFolderPath(eslintrcFolderPath: string): IBulkSuppressionsConfig {
-  const cachedSuppressionsConfig: ICachedBulkSuppressionsConfig | undefined =
-    suppressionsJsonByFolderPath.get(eslintrcFolderPath);
-
-  let shouldLoad: boolean;
-  let suppressionsConfig: IBulkSuppressionsConfig;
-  if (cachedSuppressionsConfig) {
-    shouldLoad = IS_RUNNING_IN_VSCODE && cachedSuppressionsConfig.readTime < Date.now() - TEN_SECONDS_MS;
-    suppressionsConfig = cachedSuppressionsConfig.suppressionsConfig;
-  } else {
-    shouldLoad = true;
-  }
-
-  if (shouldLoad) {
-    const suppressionsPath: string = `${eslintrcFolderPath}/${SUPPRESSIONS_JSON_FILENAME}`;
-    let rawJsonFile: string | undefined;
-    try {
-      rawJsonFile = fs.readFileSync(suppressionsPath).toString();
-    } catch (e) {
-      // Throw an error if any other error than file not found
-      if (e.code !== 'ENOENT') {
-        throw e;
-      }
-    }
-
-    if (!rawJsonFile) {
-      suppressionsConfig = {
-        serializedSuppressions: new Set(),
-        jsonObject: { suppressions: [] },
-        newSerializedSuppressions: new Set(),
-        newJsonObject: { suppressions: [] }
-      };
-    } else {
-      const jsonObject: IBulkSuppressionsJson = JSON.parse(rawJsonFile);
-      validateSuppressionsJson(jsonObject);
-
-      const serializedSuppressions: Set<string> = new Set();
-      for (const suppression of jsonObject.suppressions) {
-        serializedSuppressions.add(serializeSuppression(suppression));
-      }
-
-      suppressionsConfig = {
-        serializedSuppressions,
-        jsonObject,
-        newSerializedSuppressions: new Set(),
-        newJsonObject: { suppressions: [] }
-      };
-    }
-
-    suppressionsJsonByFolderPath.set(eslintrcFolderPath, { readTime: Date.now(), suppressionsConfig });
-  }
-
-  return suppressionsConfig!;
-}
-
-function compareSuppressions(a: ISuppression, b: ISuppression): -1 | 0 | 1 {
-  if (a.file < b.file) {
-    return -1;
-  } else if (a.file > b.file) {
-    return 1;
-  } else if (a.scopeId < b.scopeId) {
-    return -1;
-  } else if (a.scopeId > b.scopeId) {
-    return 1;
-  } else if (a.rule < b.rule) {
-    return -1;
-  } else if (a.rule > b.rule) {
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
-function writeSuppressionsJsonToFile(
-  eslintrcDirectory: string,
-  suppressionsConfig: IBulkSuppressionsConfig
-): void {
-  suppressionsJsonByFolderPath.set(eslintrcDirectory, { readTime: Date.now(), suppressionsConfig });
-  const suppressionsPath: string = `${eslintrcDirectory}/${SUPPRESSIONS_JSON_FILENAME}`;
-  suppressionsConfig.jsonObject.suppressions.sort(compareSuppressions);
-  fs.writeFileSync(suppressionsPath, JSON.stringify(suppressionsConfig.jsonObject, undefined, 2));
-}
-
-function serializeSuppression({ file, scopeId, rule }: ISuppression): string {
-  return `${file}|${scopeId}|${rule}`;
 }
 
 // One-line insert into the ruleContext report method to prematurely exit if the ESLint problem has been suppressed


### PR DESCRIPTION
## Summary

There is currently an issue with `eslint-bulk prune` where it doesn't do anything if there are no files to lint in the CWD. The call to eslint has a hardcoded `.` for the linting pattern.

## Details

This change collects all of the files mentioned in the existing `.eslint-bulk-suppresions.json` file and explicitly passes those filenames to ESLint.

## How it was tested

Tested in a project with thousands of files containing suppressions.

## Impacted documentation

None.