### PR TITLE
[eslint-patch] Fix a few minor issues with `eslint-bulk prune`.

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-bulk-issues_2024-03-28-17-06.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-bulk-issues_2024-03-28-17-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix an issue with running `eslint-bulk prune` in a project with suppressions that refer to deleted files.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-patch/eslint-bulk-issues_2024-03-28-17-35.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-bulk-issues_2024-03-28-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Delete the `.eslint-bulk-suppressions.json` file during pruning if all suppressions have been eliminated.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
@@ -18,7 +18,7 @@ import {
   type IBulkSuppressionsConfig,
   type ISuppression,
   writeSuppressionsJsonToFile,
-  suppressionsJsonByFolderPath
+  getAllBulkSuppressionsConfigsByEslintrcFolderPath
 } from './bulk-suppressions-file';
 
 const ESLINTRC_FILENAMES: string[] = [
@@ -169,7 +169,10 @@ export function shouldBulkSuppress(params: {
 }
 
 export function prune(): void {
-  for (const [eslintrcFolderPath, { suppressionsConfig }] of suppressionsJsonByFolderPath) {
+  for (const [
+    eslintrcFolderPath,
+    suppressionsConfig
+  ] of getAllBulkSuppressionsConfigsByEslintrcFolderPath()) {
     if (suppressionsConfig) {
       const { newSerializedSuppressions, newJsonObject } = suppressionsConfig;
       const newSuppressionsConfig: IBulkSuppressionsConfig = {
@@ -185,7 +188,10 @@ export function prune(): void {
 }
 
 export function write(): void {
-  for (const [eslintrcFolderPath, { suppressionsConfig }] of suppressionsJsonByFolderPath) {
+  for (const [
+    eslintrcFolderPath,
+    suppressionsConfig
+  ] of getAllBulkSuppressionsConfigsByEslintrcFolderPath()) {
     if (suppressionsConfig) {
       writeSuppressionsJsonToFile(eslintrcFolderPath, suppressionsConfig);
     }


### PR DESCRIPTION
## Summary

This PR fixes two issues with `eslint-bulk prune`:
- Currently the `prune` action causes the tool to crash if files that previously contained suppressions had been deleted. This is now fixed
- Updates the `prune` action logic to delete the `.eslint-bulk-suppressions.json` file if all previously-suppresses issues have been resolved.
 
## How it was tested

Tested by:
1. creating a TS file with eslint issues
2. introducing eslint issues in an existing file
3. running `eslint-bulk suppress --all src`
4. deleting the new file
5. running `eslint-bulk prune` and observing that the suppressions were trimmed only from that file
6. reverting the changes to the existing file
7. running `eslint-bulk prune` and observing that the bulk suppressions file is deleted

## Impacted documentation

Probably none.