### PR TITLE
Gracefully exit from workers instead of using process.exit(0)

### DIFF
--- a/common/changes/@rushstack/heft-typescript-plugin/graceful-worker-exit_2024-03-28-22-00.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/graceful-worker-exit_2024-03-28-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Gracefully exit transpile worker instead of using `process.exit(0)`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/module-minifier/graceful-worker-exit_2024-03-28-22-00.json
+++ b/common/changes/@rushstack/module-minifier/graceful-worker-exit_2024-03-28-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Gracefully exit minifier worker instead of using `process.exit(0)`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/worker-pool/graceful-worker-exit_2024-03-28-22-00.json
+++ b/common/changes/@rushstack/worker-pool/graceful-worker-exit_2024-03-28-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/worker-pool",
+      "comment": "Use `once` instead of `on` for `exit` event.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/worker-pool"
+}

--- a/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TranspilerWorker.ts
@@ -17,9 +17,13 @@ const typedWorkerData: ITypescriptWorkerData = workerData;
 
 const ts: ExtendedTypeScript = require(typedWorkerData.typeScriptToolPath);
 
+process.exitCode = 1;
+
 function handleMessage(message: ITranspilationRequestMessage | false): void {
   if (!message) {
-    process.exit(0);
+    parentPort!.off('message', handleMessage);
+    parentPort!.close();
+    return;
   }
 
   try {
@@ -116,4 +120,7 @@ function runTranspiler(message: ITranspilationRequestMessage): ITranspilationSuc
   return response;
 }
 
+parentPort!.once('close', () => {
+  process.exitCode = 0;
+});
 parentPort!.on('message', handleMessage);

--- a/libraries/module-minifier/src/MinifierWorker.ts
+++ b/libraries/module-minifier/src/MinifierWorker.ts
@@ -14,8 +14,8 @@ process.exitCode = 2;
 
 async function handler(message: IModuleMinificationRequest): Promise<void> {
   if (!message) {
-    parentPort?.off('postMessage', handler);
-    parentPort?.close();
+    parentPort!.off('postMessage', handler);
+    parentPort!.close();
     return;
   }
 

--- a/libraries/module-minifier/src/MinifierWorker.ts
+++ b/libraries/module-minifier/src/MinifierWorker.ts
@@ -12,12 +12,19 @@ const terserOptions: MinifyOptions = workerData;
 // Set to non-zero to help debug unexpected graceful exit
 process.exitCode = 2;
 
-parentPort!.on('message', async (message: IModuleMinificationRequest) => {
+async function handler(message: IModuleMinificationRequest): Promise<void> {
   if (!message) {
-    process.exit(0);
+    parentPort?.off('postMessage', handler);
+    parentPort?.close();
+    return;
   }
 
   const result: IModuleMinificationResult = await minifySingleFileAsync(message, terserOptions);
 
   parentPort!.postMessage(result);
+}
+
+parentPort!.once('close', () => {
+  process.exitCode = 0;
 });
+parentPort!.on('message', handler);

--- a/libraries/worker-pool/src/WorkerPool.ts
+++ b/libraries/worker-pool/src/WorkerPool.ts
@@ -206,7 +206,7 @@ export class WorkerPool {
       this._destroyWorker(worker);
     });
 
-    worker.on('exit', (exitCode) => {
+    worker.once('exit', (exitCode) => {
       if (exitCode !== 0) {
         this._onError(new Error(`Worker ${id} exited with code ${exitCode}`));
       }


### PR DESCRIPTION
## Summary
Updates various workers to properly clean up their ports instead of using `process.exit(0)`

## Details
Minifier worker (used in the module minifier plugins)
Transpiler worker (heft-typescript-plugin)
Updated WorkerPool to use `once` instead of `on` for monitoring the exit event.

## How it was tested
Local repeated runs of the build test projects that use these components.

## Impacted documentation
None