### PR TITLE
[eslint-patch] Fix an issue where 'eslint-bulk prune' crashes if there aren't any suppressions.

### DIFF
--- a/common/changes/@rushstack/eslint-patch/user-ianc-fix-pruning-issue_2024-03-29-04-53.json
+++ b/common/changes/@rushstack/eslint-patch/user-ianc-fix-pruning-issue_2024-03-29-04-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix an issue where the `eslint-bulk prune` command would crash if a bulk suppressions file exists that speicifies no suppressions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-patch/user-ianc-fix-pruning-issue_2024-03-29-05-11.json
+++ b/common/changes/@rushstack/eslint-patch/user-ianc-fix-pruning-issue_2024-03-29-05-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Exit with success under normal conditions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-file.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-file.ts
@@ -101,20 +101,29 @@ export function getAllBulkSuppressionsConfigsByEslintrcFolderPath(): [string, IB
 }
 
 export function writeSuppressionsJsonToFile(
-  eslintrcDirectory: string,
+  eslintrcFolderPath: string,
   suppressionsConfig: IBulkSuppressionsConfig
 ): void {
-  suppressionsJsonByFolderPath.set(eslintrcDirectory, { readTime: Date.now(), suppressionsConfig });
-  const suppressionsPath: string = `${eslintrcDirectory}/${SUPPRESSIONS_JSON_FILENAME}`;
+  suppressionsJsonByFolderPath.set(eslintrcFolderPath, { readTime: Date.now(), suppressionsConfig });
+  const suppressionsPath: string = `${eslintrcFolderPath}/${SUPPRESSIONS_JSON_FILENAME}`;
   if (suppressionsConfig.jsonObject.suppressions.length === 0) {
-    try {
-      fs.unlinkSync(suppressionsPath);
-    } catch (e) {
-      throwIfAnythingOtherThanNotExistError(e);
-    }
+    deleteFile(suppressionsPath);
   } else {
     suppressionsConfig.jsonObject.suppressions.sort(compareSuppressions);
     fs.writeFileSync(suppressionsPath, JSON.stringify(suppressionsConfig.jsonObject, undefined, 2));
+  }
+}
+
+export function deleteBulkSuppressionsFileInEslintrcFolder(eslintrcFolderPath: string): void {
+  const suppressionsPath: string = `${eslintrcFolderPath}/${SUPPRESSIONS_JSON_FILENAME}`;
+  deleteFile(suppressionsPath);
+}
+
+function deleteFile(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (e) {
+    throwIfAnythingOtherThanNotExistError(e);
   }
 }
 

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/prune.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/prune.ts
@@ -30,7 +30,7 @@ export async function pruneAsync(): Promise<void> {
     console.log(`Pruning suppressions for ${allFiles.length} files...`);
     await runEslintAsync(allFiles, 'prune');
   } else {
-    console.log('No files with existing suppressions found. Deleting the suppressions file, if one exists.');
+    console.log('No files with existing suppressions found.');
     deleteBulkSuppressionsFileInEslintrcFolder(normalizedCwd);
   }
 }

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/prune.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/prune.ts
@@ -6,7 +6,10 @@ import fs from 'fs';
 import { printPruneHelp } from './utils/print-help';
 import { runEslintAsync } from './runEslint';
 import { ESLINT_BULK_PRUNE_ENV_VAR_NAME } from '../constants';
-import { getSuppressionsConfigForEslintrcFolderPath } from '../bulk-suppressions-file';
+import {
+  deleteBulkSuppressionsFileInEslintrcFolder,
+  getSuppressionsConfigForEslintrcFolderPath
+} from '../bulk-suppressions-file';
 
 export async function pruneAsync(): Promise<void> {
   const args: string[] = process.argv.slice(3);
@@ -20,16 +23,21 @@ export async function pruneAsync(): Promise<void> {
     throw new Error(`@rushstack/eslint-bulk: Unknown arguments: ${args.join(' ')}`);
   }
 
-  process.env[ESLINT_BULK_PRUNE_ENV_VAR_NAME] = '1';
-
-  const allFiles: string[] = await getAllFilesWithExistingSuppressionsForCwdAsync();
-  await runEslintAsync(allFiles, 'prune');
+  const normalizedCwd: string = process.cwd().replace(/\\/g, '/');
+  const allFiles: string[] = await getAllFilesWithExistingSuppressionsForCwdAsync(normalizedCwd);
+  if (allFiles.length > 0) {
+    process.env[ESLINT_BULK_PRUNE_ENV_VAR_NAME] = '1';
+    console.log(`Pruning suppressions for ${allFiles.length} files...`);
+    await runEslintAsync(allFiles, 'prune');
+  } else {
+    console.log('No files with existing suppressions found. Deleting the suppressions file, if one exists.');
+    deleteBulkSuppressionsFileInEslintrcFolder(normalizedCwd);
+  }
 }
 
-async function getAllFilesWithExistingSuppressionsForCwdAsync(): Promise<string[]> {
-  const { jsonObject: bulkSuppressionsConfigJson } = getSuppressionsConfigForEslintrcFolderPath(
-    process.cwd().replace(/\\/g, '/')
-  );
+async function getAllFilesWithExistingSuppressionsForCwdAsync(normalizedCwd: string): Promise<string[]> {
+  const { jsonObject: bulkSuppressionsConfigJson } =
+    getSuppressionsConfigForEslintrcFolderPath(normalizedCwd);
   const allFiles: Set<string> = new Set();
   for (const { file: filePath } of bulkSuppressionsConfigJson.suppressions) {
     allFiles.add(filePath);
@@ -55,8 +63,6 @@ async function getAllFilesWithExistingSuppressionsForCwdAsync(): Promise<string[
   if (deletedCount > 0) {
     console.log(`${deletedCount} files with suppressions were deleted.`);
   }
-
-  console.log(`Pruning suppressions for ${allExistingFiles.length} files...`);
 
   return allExistingFiles;
 }

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/runEslint.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/cli/runEslint.ts
@@ -5,11 +5,12 @@ import type { ESLint } from 'eslint';
 import { getEslintPath } from './utils/get-eslint-cli';
 
 export async function runEslintAsync(files: string[], mode: 'suppress' | 'prune'): Promise<void> {
-  const eslintPath: string = getEslintPath(process.cwd());
+  const cwd: string = process.cwd();
+  const eslintPath: string = getEslintPath(cwd);
   const { ESLint }: typeof import('eslint') = require(eslintPath);
   const eslint: ESLint = new ESLint({
     useEslintrc: true,
-    cwd: process.cwd()
+    cwd
   });
 
   let results: ESLint.LintResult[];
@@ -32,14 +33,14 @@ export async function runEslintAsync(files: string[], mode: 'suppress' | 'prune'
     }
   }
 
-  const stylishFormatter: ESLint.Formatter = await eslint.loadFormatter();
-  const formattedResults: string = stylishFormatter.format(results);
-  if (formattedResults) {
+  if (results.length > 0) {
+    const stylishFormatter: ESLint.Formatter = await eslint.loadFormatter();
+    const formattedResults: string = stylishFormatter.format(results);
     console.log(formattedResults);
-    throw new Error(`@rushstack/eslint-bulk ESLint errors`);
-  } else {
-    console.log(
-      `@rushstack/eslint-bulk: Successfully pruned unused suppressions in all .eslint-bulk-suppressions.json files under directory ${process.cwd()}`
-    );
   }
+
+  console.log(
+    '@rushstack/eslint-bulk: Successfully pruned unused suppressions in all .eslint-bulk-suppressions.json ' +
+      `files under directory ${cwd}`
+  );
 }


### PR DESCRIPTION
## Summary

`eslint-bulk prune` currently fails if no suppressions file exists, or if the file is empty. This PR updates the tool to instead delete the file.

## How it was tested

1. Introduced an eslint issue
2. Ran `eslint-bulk suppress --all src`
3. Fixed the issue and deleted the issue in the suppression file
4. Ran `eslint-bulk prune`

## Impacted documentation

None.