### PR TITLE
[rush] Clarify the copyright notice in common/scripts/*.js

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-common-scripts-copyright_2024-04-05-04-44.json
+++ b/common/changes/@microsoft/rush/octogonz-common-scripts-copyright_2024-04-05-04-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Clarify the copyright notice emitted in common/scripts/*.js",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
+++ b/libraries/rush-lib/src/logic/StandardScriptUpdater.ts
@@ -21,6 +21,9 @@ const HEADER_LINES_PREFIX: string[] = [
 const HEADER_LINES_SUFFIX: string[] = [
   '//',
   '// For more information, see: https://rushjs.io/pages/maintainer/setup_new_repo/',
+  '//',
+  '// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.',
+  "// See the @microsoft/rush package's LICENSE file for details.",
   ''
 ];
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

PR https://github.com/microsoft/rushstack/pull/4348 changed the copyright notice that appears in `common/scripts/*.js` to say:

**new text**
```
// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
// See LICENSE in the project root for license information.
```

...instead of...

**old text**
```
// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
// See the @microsoft/rush package's LICENSE file for license information.
```

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

This text is misleading -- what is the "project root" for **install-run.js**?

## Details

This PR restores an appropriate copyright notice.

@iclanton 