### PR TITLE
[rush] fix: refactor tryFindRushJsonLocation && remove arbitrary numbers in loop

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-lib-imporve-tryFindRushJsonLocation_2024-04-07-03-22.json
+++ b/common/changes/@microsoft/rush/fix-rush-lib-imporve-tryFindRushJsonLocation_2024-04-07-03-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "refactor tryFindRushJsonLocation with a specific way to reliably detect when reaching the root on NTFS vs Unix filesystems",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-rush-lib-imporve-tryFindRushJsonLocation_2024-04-07-03-22.json
+++ b/common/changes/@microsoft/rush/fix-rush-lib-imporve-tryFindRushJsonLocation_2024-04-07-03-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "refactor tryFindRushJsonLocation with a specific way to reliably detect when reaching the root on NTFS vs Unix filesystems",
+      "comment": "Remove a restriction where the repo root would not be found if the CWD is >10 directory levels deep.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1011,13 +1011,14 @@ export class RushConfiguration {
     const optionsIn: ITryFindRushJsonLocationOptions = options || {};
     const verbose: boolean = optionsIn.showVerbose || false;
     let currentFolder: string = optionsIn.startingFolder || process.cwd();
+    let parentFolder: string = path.dirname(currentFolder);
 
-    // Look upwards at parent folders until we find a folder containing rush.json
-    for (let i: number = 0; i < 10; ++i) {
+    // look upwards at parent folders until we find a folder containing rush.json,
+    // or we reach the root directory without finding a rush.json file
+    while (parentFolder && parentFolder !== currentFolder) {
       const rushJsonFilename: string = path.join(currentFolder, RushConstants.rushJsonFilename);
-
       if (FileSystem.exists(rushJsonFilename)) {
-        if (i > 0 && verbose) {
+        if (currentFolder !== optionsIn.startingFolder && verbose) {
           // eslint-disable-next-line no-console
           console.log('Found configuration in ' + rushJsonFilename);
         }
@@ -1029,15 +1030,11 @@ export class RushConfiguration {
 
         return rushJsonFilename;
       }
-
-      const parentFolder: string = path.dirname(currentFolder);
-      if (parentFolder === currentFolder) {
-        break;
-      }
-
       currentFolder = parentFolder;
+      parentFolder = path.dirname(currentFolder);
     }
 
+    // no match
     return undefined;
   }
 


### PR DESCRIPTION
Remove the arbitrary numbers in "tryFindRushJsonLocation" and use a specific way to reliably detect when reaching the root on NTFS vs Unix filesystems