### PR TITLE
[eslint-bulk] Attempt to resolve eslint as a dependency of the current project before falling back to a globally-installed copy.

### DIFF
--- a/common/changes/@rushstack/eslint-bulk/more-robust-eslint-resolve_2024-04-09-16-56.json
+++ b/common/changes/@rushstack/eslint-bulk/more-robust-eslint-resolve_2024-04-09-16-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-bulk",
+      "comment": "Attempt to resolve eslint as a dependency of the current project before falling back to a globally-installed copy.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-bulk"
+}

--- a/eslint/eslint-bulk/src/start.ts
+++ b/eslint/eslint-bulk/src/start.ts
@@ -4,7 +4,6 @@
 import { execSync } from 'child_process';
 import * as process from 'process';
 import * as fs from 'fs';
-import * as path from 'path';
 
 interface IEslintBulkConfigurationJson {
   /**
@@ -18,12 +17,16 @@ interface IEslintBulkConfigurationJson {
 }
 
 function findPatchPath(): string {
-  let eslintrcPath: string;
-  if (fs.existsSync(path.join(process.cwd(), '.eslintrc.js'))) {
-    eslintrcPath = '.eslintrc.js';
-  } else if (fs.existsSync(path.join(process.cwd(), '.eslintrc.cjs'))) {
-    eslintrcPath = '.eslintrc.cjs';
-  } else {
+  const candidatePaths: string[] = [`${process.cwd()}/.eslintrc.js`, `${process.cwd()}/.eslintrc.cjs`];
+  let eslintrcPath: string | undefined;
+  for (const candidatePath of candidatePaths) {
+    if (fs.existsSync(candidatePath)) {
+      eslintrcPath = candidatePath;
+      break;
+    }
+  }
+
+  if (!eslintrcPath) {
     console.error(
       '@rushstack/eslint-bulk: Please run this command from the directory that contains .eslintrc.js or .eslintrc.cjs'
     );
@@ -32,9 +35,51 @@ function findPatchPath(): string {
 
   const env: NodeJS.ProcessEnv = { ...process.env, _RUSHSTACK_ESLINT_BULK_DETECT: 'true' };
 
+  let eslintPackageJsonPath: string | undefined;
+  try {
+    eslintPackageJsonPath = require.resolve('eslint/package.json', { paths: [process.cwd()] });
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      throw e;
+    }
+  }
+
+  let eslintBinPath: string | undefined;
+  if (eslintPackageJsonPath) {
+    eslintPackageJsonPath = eslintPackageJsonPath.replace(/\\/g, '/');
+    const packagePath: string = eslintPackageJsonPath.substring(0, eslintPackageJsonPath.lastIndexOf('/'));
+    const {
+      bin: { eslint: relativeEslintBinPath } = {}
+    }: { bin?: Record<string, string> } = require(eslintPackageJsonPath);
+    if (relativeEslintBinPath) {
+      eslintBinPath = `${packagePath}/${relativeEslintBinPath}`;
+    } else {
+      console.warn(
+        `@rushstack/eslint-bulk: The eslint package resolved at "${packagePath}" does not contain an eslint bin path. ` +
+          'Attempting to use a globally-installed eslint instead.'
+      );
+    }
+  } else {
+    console.log(
+      '@rushstack/eslint-bulk: Unable to resolve the eslint package as a dependency of the current project. ' +
+        'Attempting to use a globally-installed eslint instead.'
+    );
+  }
+
+  let eslintBinCommand: string;
+  if (eslintBinPath) {
+    eslintBinCommand = `${process.argv0} ${eslintBinPath}`;
+  } else {
+    eslintBinCommand = 'eslint'; // Try to use a globally-installed eslint if a local package was not found
+  }
+
   let stdout: Buffer;
   try {
-    stdout = execSync(`eslint --stdin --config ${eslintrcPath}`, { env, input: '', stdio: 'pipe' });
+    stdout = execSync(`${eslintBinCommand} --stdin --config ${eslintrcPath}`, {
+      env,
+      input: '',
+      stdio: 'pipe'
+    });
   } catch (e) {
     console.error('@rushstack/eslint-bulk: Error finding patch path: ' + e.message);
     process.exit(1);


### PR DESCRIPTION
## Summary

Right now, eslint-bulk assumes eslint is installed globally. This may or may not be the case, and the globally installed version may or may not match the version expected to be used by the local package. If the globally installed version does not match the version installed for the local package, running `eslint-bulk` can produce this error:

```
@rushstack/eslint-bulk: Error finding patch path: Command failed: eslint --stdin --config .eslintrc.js

Oops! Something went wrong! :(

ESLint: 9.0.0

Error: Failed to patch ESLint because the calling module was not recognized.
If you are using a newer ESLint version that may be unsupported, please create a GitHub issue:
https://github.com/microsoft/rushstack/issues
    at Object.<anonymous> (<path>/@rushstack/eslint-patch/lib/_patch-base.js:167:19)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12)
    at Module.require (node:internal/modules/cjs/loader:1225:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (<path>/@rushstack/eslint-patch/lib/modern-module-resolution.js:11:23)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
```

## Details

Before invoking the global copy of ESLint, try to find a locally-installed copy.

## How it was tested

Tested with and without eslint installed globally, in projects using two different versions of eslint in the same monorepo, on both Windows and Linux.

## Impacted documentation

None.