### PR TITLE
Add support for implicit versions within subspaces

### DIFF
--- a/common/changes/@microsoft/rush/will-subspace-patch-14_2024-04-09-18-21.json
+++ b/common/changes/@microsoft/rush/will-subspace-patch-14_2024-04-09-18-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Load implicit versions correctly for subspaces.",
+      "comment": "Fix an issue with loading of implicitly preferred versions when the experimental subspaces feature is enabled",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/will-subspace-patch-14_2024-04-09-18-21.json
+++ b/common/changes/@microsoft/rush/will-subspace-patch-14_2024-04-09-18-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Load implicit versions correctly for subspaces.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1162,7 +1162,7 @@ export class RushConfiguration {
     getCommonVersions(subspace?: Subspace): CommonVersionsConfiguration;
     // @deprecated (undocumented)
     getCommonVersionsFilePath(subspace?: Subspace): string;
-    getImplicitlyPreferredVersions(): Map<string, string>;
+    getImplicitlyPreferredVersions(subspace?: Subspace): Map<string, string>;
     // @deprecated (undocumented)
     getPnpmfilePath(subspace?: Subspace): string;
     getProjectByName(projectName: string): RushConfigurationProject | undefined;

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1370,7 +1370,7 @@ export class RushConfiguration {
    *
    * @returns A map of dependency name --\> version specifier for implicitly preferred versions.
    */
-  public getImplicitlyPreferredVersions(subspace: Subspace): Map<string, string> {
+  public getImplicitlyPreferredVersions(subspace?: Subspace): Map<string, string> {
     // TODO: During the next major release of Rush, replace this `require` call with a dynamic import, and
     // change this function to be async.
     const DependencyAnalyzerModule: typeof DependencyAnalyzerModuleType = require('../logic/DependencyAnalyzer');

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -1370,14 +1370,14 @@ export class RushConfiguration {
    *
    * @returns A map of dependency name --\> version specifier for implicitly preferred versions.
    */
-  public getImplicitlyPreferredVersions(): Map<string, string> {
+  public getImplicitlyPreferredVersions(subspace: Subspace): Map<string, string> {
     // TODO: During the next major release of Rush, replace this `require` call with a dynamic import, and
     // change this function to be async.
     const DependencyAnalyzerModule: typeof DependencyAnalyzerModuleType = require('../logic/DependencyAnalyzer');
     const dependencyAnalyzer: DependencyAnalyzerModuleType.DependencyAnalyzer =
       DependencyAnalyzerModule.DependencyAnalyzer.forRushConfiguration(this);
     const dependencyAnalysis: DependencyAnalyzerModuleType.IDependencyAnalysis =
-      dependencyAnalyzer.getAnalysis();
+      dependencyAnalyzer.getAnalysis(subspace);
     return dependencyAnalysis.implicitlyPreferredVersionByPackageName;
   }
 

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -6,6 +6,7 @@ import type { CommonVersionsConfiguration } from '../api/CommonVersionsConfigura
 import { DependencyType, type PackageJsonDependency } from '../api/PackageJsonEditor';
 import type { RushConfiguration } from '../api/RushConfiguration';
 import type { RushConfigurationProject } from '../api/RushConfigurationProject';
+import { Subspace } from '../api/Subspace';
 
 export interface IDependencyAnalysis {
   /**
@@ -53,9 +54,9 @@ export class DependencyAnalyzer {
     return analyzer;
   }
 
-  public getAnalysis(): IDependencyAnalysis {
+  public getAnalysis(subspace?: Subspace | undefined): IDependencyAnalysis {
     if (!this._analysis) {
-      this._analysis = this._getAnalysisInternal();
+      this._analysis = this._getAnalysisInternal(subspace || this._rushConfiguration.defaultSubspace);
     }
 
     return this._analysis;
@@ -67,9 +68,8 @@ export class DependencyAnalyzer {
    * @remarks
    * The result of this function is not cached.
    */
-  private _getAnalysisInternal(): IDependencyAnalysis {
-    const commonVersionsConfiguration: CommonVersionsConfiguration =
-      this._rushConfiguration.getCommonVersions();
+  private _getAnalysisInternal(subspace: Subspace): IDependencyAnalysis {
+    const commonVersionsConfiguration: CommonVersionsConfiguration = subspace.getCommonVersions();
     const allVersionsByPackageName: Map<string, Set<string>> = new Map();
     const allowedAlternativeVersions: Map<
       string,

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -6,7 +6,7 @@ import type { CommonVersionsConfiguration } from '../api/CommonVersionsConfigura
 import { DependencyType, type PackageJsonDependency } from '../api/PackageJsonEditor';
 import type { RushConfiguration } from '../api/RushConfiguration';
 import type { RushConfigurationProject } from '../api/RushConfigurationProject';
-import { Subspace } from '../api/Subspace';
+import type { Subspace } from '../api/Subspace';
 
 export interface IDependencyAnalysis {
   /**
@@ -54,7 +54,7 @@ export class DependencyAnalyzer {
     return analyzer;
   }
 
-  public getAnalysis(subspace?: Subspace | undefined): IDependencyAnalysis {
+  public getAnalysis(subspace?: Subspace): IDependencyAnalysis {
     if (!this._analysis) {
       this._analysis = this._getAnalysisInternal(subspace || this._rushConfiguration.defaultSubspace);
     }

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -167,7 +167,7 @@ export class RushInstallManager extends BaseInstallManager {
     // dependency name --> version specifier
     const commonDependencies: Map<string, string> = new Map([
       ...allExplicitPreferredVersions,
-      ...this.rushConfiguration.getImplicitlyPreferredVersions()
+      ...this.rushConfiguration.getImplicitlyPreferredVersions(subspace)
     ]);
 
     // To make the common/package.json file more readable, sort alphabetically

--- a/libraries/rush-lib/src/logic/pnpm/PnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmfileConfiguration.ts
@@ -91,7 +91,10 @@ export class PnpmfileConfiguration {
       const commonVersionsConfiguration: CommonVersionsConfiguration = subspace.getCommonVersions();
       const preferredVersions: Map<string, string> = new Map();
       MapExtensions.mergeFromMap(preferredVersions, commonVersionsConfiguration.getAllPreferredVersions());
-      MapExtensions.mergeFromMap(preferredVersions, rushConfiguration.getImplicitlyPreferredVersions());
+      MapExtensions.mergeFromMap(
+        preferredVersions,
+        rushConfiguration.getImplicitlyPreferredVersions(subspace)
+      );
       allPreferredVersions = MapExtensions.toObject(preferredVersions);
       allowedAlternativeVersions = MapExtensions.toObject(
         commonVersionsConfiguration.allowedAlternativeVersions


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
This MR fixes an edge case where the subspace is not being passed when the implicit versions are being loaded.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
