### PR TITLE
[node-core-library] Add writeBuffersToFile and writeBuffersToFileAsync to FileSystem

### DIFF
--- a/common/changes/@rushstack/node-core-library/writev-async_2024-04-09-20-30.json
+++ b/common/changes/@rushstack/node-core-library/writev-async_2024-04-09-20-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add 'writeBuffersToFile' and 'writeBuffersToFileAsync' methods to FileSystem for efficient writing of concatenated files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/writev-async_2024-04-09-20-30.json
+++ b/common/changes/@rushstack/node-core-library/writev-async_2024-04-09-20-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add 'writeBuffersToFile' and 'writeBuffersToFileAsync' methods to FileSystem for efficient writing of concatenated files.",
+      "comment": "Add `writeBuffersToFile` and `writeBuffersToFileAsync` methods to `FileSystem` for efficient writing of concatenated files.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -189,6 +189,8 @@ export class FileSystem {
     static readLinkAsync(path: string): Promise<string>;
     static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
     static updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void>;
+    static writeBuffersToFile(filePath: string, contents: Iterable<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): void;
+    static writeBuffersToFileAsync(filePath: string, contents: Iterable<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): Promise<void>;
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
     static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void>;
 }
@@ -336,10 +338,14 @@ export interface IFileSystemUpdateTimeParameters {
 }
 
 // @public
-export interface IFileSystemWriteFileOptions {
+export interface IFileSystemWriteBinaryFileOptions {
+    ensureFolderExists?: boolean;
+}
+
+// @public
+export interface IFileSystemWriteFileOptions extends IFileSystemWriteBinaryFileOptions {
     convertLineEndings?: NewlineKind;
     encoding?: Encoding;
-    ensureFolderExists?: boolean;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -189,8 +189,8 @@ export class FileSystem {
     static readLinkAsync(path: string): Promise<string>;
     static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
     static updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void>;
-    static writeBuffersToFile(filePath: string, contents: Iterable<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): void;
-    static writeBuffersToFileAsync(filePath: string, contents: Iterable<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): Promise<void>;
+    static writeBuffersToFile(filePath: string, contents: ReadonlyArray<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): void;
+    static writeBuffersToFileAsync(filePath: string, contents: ReadonlyArray<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): Promise<void>;
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
     static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void>;
 }

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -828,7 +828,6 @@ export class FileSystem {
       }
 
       let position: number = 0;
-      let buffersToSkip: number = 0;
       try {
         // In practice this loop will have exactly 1 iteration, but the spec allows
         // for a writev call to write fewer bytes than requested
@@ -838,6 +837,7 @@ export class FileSystem {
             position = 0;
           }
           position += fsx.writevSync(fd, toCopy);
+          let buffersToSkip: number = 0;
           while (buffersToSkip < toCopy.length && position >= toCopy[buffersToSkip].byteLength) {
             position -= toCopy[buffersToSkip].byteLength;
             buffersToSkip++;
@@ -846,7 +846,6 @@ export class FileSystem {
           if (buffersToSkip > 0) {
             // Avoid cost of shifting the array more than needed.
             toCopy.splice(0, buffersToSkip);
-            buffersToSkip = 0;
           }
         }
       } finally {
@@ -918,7 +917,6 @@ export class FileSystem {
       }
 
       let position: number = 0;
-      let buffersToSkip: number = 0;
       try {
         // In practice this loop will have exactly 1 iteration, but the spec allows
         // for a writev call to write fewer bytes than requested
@@ -928,6 +926,8 @@ export class FileSystem {
             position = 0;
           }
           position += (await handle.writev(toCopy)).bytesWritten;
+
+          let buffersToSkip: number = 0;
           while (buffersToSkip < toCopy.length && position >= toCopy[buffersToSkip].byteLength) {
             position -= toCopy[buffersToSkip].byteLength;
             buffersToSkip++;
@@ -936,7 +936,6 @@ export class FileSystem {
           if (buffersToSkip > 0) {
             // Avoid cost of shifting the array more than needed.
             toCopy.splice(0, buffersToSkip);
-            buffersToSkip = 0;
           }
         }
       } finally {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -838,7 +838,7 @@ export class FileSystem {
             position = 0;
           }
           position += fsx.writevSync(fd, toCopy);
-          while (buffersToSkip < toCopy.length && position > toCopy[buffersToSkip].byteLength) {
+          while (buffersToSkip < toCopy.length && position >= toCopy[buffersToSkip].byteLength) {
             position -= toCopy[buffersToSkip].byteLength;
             buffersToSkip++;
           }
@@ -846,6 +846,7 @@ export class FileSystem {
           if (buffersToSkip > 0) {
             // Avoid cost of shifting the array more than needed.
             toCopy.splice(0, buffersToSkip);
+            buffersToSkip = 0;
           }
         }
       } finally {
@@ -927,7 +928,7 @@ export class FileSystem {
             position = 0;
           }
           position += (await handle.writev(toCopy)).bytesWritten;
-          while (buffersToSkip < toCopy.length && position > toCopy[buffersToSkip].byteLength) {
+          while (buffersToSkip < toCopy.length && position >= toCopy[buffersToSkip].byteLength) {
             position -= toCopy[buffersToSkip].byteLength;
             buffersToSkip++;
           }
@@ -935,6 +936,7 @@ export class FileSystem {
           if (buffersToSkip > 0) {
             // Avoid cost of shifting the array more than needed.
             toCopy.splice(0, buffersToSkip);
+            buffersToSkip = 0;
           }
         }
       } finally {

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -95,6 +95,7 @@ export {
   IFileSystemReadFileOptions,
   IFileSystemReadFolderOptions,
   IFileSystemUpdateTimeParameters,
+  IFileSystemWriteBinaryFileOptions,
   IFileSystemWriteFileOptions
 } from './FileSystem';
 export { FileWriter, IFileWriterFlags } from './FileWriter';

--- a/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
+++ b/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const openHandle: jest.Mock<{}> = jest.fn();
+
+const closeSync: jest.Mock<{}> = jest.fn();
+const ensureDir: jest.Mock<{}> = jest.fn();
+const ensureDirSync: jest.Mock<{}> = jest.fn();
+const openSync: jest.Mock<{}> = jest.fn();
+const writevSync: jest.Mock<{}> = jest.fn();
+
+jest.mock('fs-extra', () => {
+  return {
+    closeSync,
+    ensureDir,
+    ensureDirSync,
+    openSync,
+    writevSync
+  };
+});
+jest.mock('../Text', () => {
+  return {
+    Encoding: {
+      Utf8: 'utf8'
+    }
+  };
+});
+
+import { getRandomValues } from 'node:crypto';
+import fs from 'node:fs';
+
+jest.spyOn(fs, 'promises', 'get').mockImplementation(() => {
+  return {
+    open: openHandle
+  } as unknown as typeof fs.promises;
+});
+
+describe('FileSystem', () => {
+  const content: Uint8Array[] = [];
+  let totalBytes: number = 0;
+  let FileSystem: typeof import('../FileSystem').FileSystem;
+
+  beforeAll(async () => {
+    FileSystem = (await import('../FileSystem')).FileSystem;
+    totalBytes = 0;
+    for (let i = 0; i < 10; i++) {
+      content[i] = getRandomValues(new Uint8Array(i + 1));
+      totalBytes += content[i].length;
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('writeBuffersToFile', () => {
+    it('handles a single-shot write', () => {
+      const sampleFd: number = 42;
+      openSync.mockReturnValue(sampleFd);
+      writevSync.mockImplementation((fd: number, buffers: Uint8Array[]) => {
+        expect(fd).toEqual(sampleFd);
+        expect(buffers).toEqual(content);
+        return totalBytes;
+      });
+
+      FileSystem.writeBuffersToFile('/fake/path', content);
+      expect(openSync).toHaveBeenCalledWith('/fake/path', 'w');
+      expect(closeSync).toHaveBeenCalledWith(sampleFd);
+      expect(writevSync).toHaveBeenCalledTimes(1);
+    });
+
+    for (let i = 0; i < totalBytes; i++) {
+      const increment: number = i;
+      const expectedCallCount = Math.ceil(totalBytes / increment);
+      const expectedData = Buffer.concat(content);
+      const sampleFd: number = 42;
+
+      it(`handles a multi-shot write writing ${increment} bytes at a time`, () => {
+        const actual = Buffer.alloc(totalBytes);
+        let written: number = 0;
+        openSync.mockReturnValue(sampleFd);
+        writevSync.mockImplementation((fd: number, buffers: Uint8Array[]) => {
+          expect(fd).toEqual(sampleFd);
+          const writtenThisTime: number = Math.min(increment, totalBytes - written);
+          let bufIndex: number = 0;
+          let bufOffset: number = 0;
+          for (let j = 0; j < writtenThisTime; j++) {
+            actual[written] = buffers[bufIndex][bufOffset];
+            bufOffset++;
+            written++;
+            if (bufOffset === buffers[bufIndex].length) {
+              bufIndex++;
+              bufOffset = 0;
+            }
+          }
+          return writtenThisTime;
+        });
+
+        FileSystem.writeBuffersToFile('/fake/path', content);
+        expect(openSync).toHaveBeenCalledWith('/fake/path', 'w');
+        expect(closeSync).toHaveBeenCalledWith(sampleFd);
+        expect(writevSync).toHaveBeenCalledTimes(expectedCallCount);
+        expect(actual.equals(expectedData)).toBeTruthy();
+      });
+    }
+  });
+
+  describe('writeBuffersToFileAsync', () => {
+    it('handles a single-shot write', async () => {
+      const sampleHandle = {
+        close: jest.fn(),
+        writev: jest.fn()
+      };
+      openHandle.mockReturnValue(sampleHandle);
+      sampleHandle.writev.mockImplementation((buffers: Uint8Array[]) => {
+        expect(buffers).toEqual(content);
+        return { bytesWritten: totalBytes };
+      });
+
+      await FileSystem.writeBuffersToFileAsync('/fake/path', content);
+      expect(openHandle).toHaveBeenCalledWith('/fake/path', 'w');
+      expect(sampleHandle.close).toHaveBeenCalledTimes(1);
+      expect(sampleHandle.writev).toHaveBeenCalledTimes(1);
+    });
+
+    for (let i = 0; i < totalBytes; i++) {
+      const increment: number = i;
+      const expectedCallCount = Math.ceil(totalBytes / increment);
+      const expectedData = Buffer.concat(content);
+      it(`handles a multi-shot write writing ${increment} bytes at a time`, async () => {
+        const sampleHandle = {
+          close: jest.fn(),
+          writev: jest.fn()
+        };
+        const actual = Buffer.alloc(totalBytes);
+        let written: number = 0;
+        openHandle.mockReturnValue(sampleHandle);
+        sampleHandle.writev.mockImplementation((buffers: Uint8Array[]) => {
+          const writtenThisTime: number = Math.min(increment, totalBytes - written);
+          let bufIndex: number = 0;
+          let bufOffset: number = 0;
+          for (let j = 0; j < writtenThisTime; j++) {
+            actual[written] = buffers[bufIndex][bufOffset];
+            bufOffset++;
+            written++;
+            if (bufOffset === buffers[bufIndex].length) {
+              bufIndex++;
+              bufOffset = 0;
+            }
+          }
+          return { bytesWritten: writtenThisTime };
+        });
+
+        await FileSystem.writeBuffersToFileAsync('/fake/path', content);
+        expect(openHandle).toHaveBeenCalledWith('/fake/path', 'w');
+        expect(sampleHandle.close).toHaveBeenCalledTimes(1);
+        expect(sampleHandle.writev).toHaveBeenCalledTimes(expectedCallCount);
+        expect(actual.equals(expectedData)).toBeTruthy();
+      });
+    }
+  });
+});

--- a/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
+++ b/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
@@ -26,7 +26,6 @@ jest.mock('../Text', () => {
   };
 });
 
-import { getRandomValues } from 'node:crypto';
 import fs from 'node:fs';
 
 jest.spyOn(fs, 'promises', 'get').mockImplementation(() => {
@@ -43,9 +42,18 @@ describe('FileSystem', () => {
   beforeAll(async () => {
     FileSystem = (await import('../FileSystem')).FileSystem;
     totalBytes = 0;
+    let nextValue = 37;
     for (let i = 0; i < 10; i++) {
-      content[i] = getRandomValues(new Uint8Array(i + 1));
-      totalBytes += content[i].length;
+      const arr: Uint8Array = new Uint8Array(i + 1);
+      content[i] = arr;
+      for (let j = 0; j < arr.length; j++) {
+        arr[j] = nextValue;
+        // 256 and 11 are coprime, so this sequence will cover all 256 values.
+        // These are deliberately not the ordinal index just to ensure that an index isn't accidentally being written to the file.
+        // eslint-disable-next-line no-bitwise
+        nextValue = (nextValue + 11) & 0xff;
+      }
+      totalBytes += arr.length;
     }
   });
 


### PR DESCRIPTION
## Summary
Adds two new methods to the `FileSystem` API for efficient writing of bulk binary data:
- `writeBuffersToFile`
- `writeBuffersToFileAsync`

## Details
These APIs take as their content parameter an `Iterable<Uint8Array>` (which means they accept, e.g. `Buffer[]`) and write them in sequence to the target file. This allows for a couple of use cases that `FileSystem.writeFile` does not cover:
- Can write more than `Buffer.constants.MAX_LENGTH` (4GiB on 64-bit, 2GiB on 32-bit) to a file.
- If the file is being constructed by concatenating multiple chunks from separate sources, avoid the overhead of allocating a single buffer to store the result and copying in the chunks

## How it was tested
Used Node REPL to allocate several Uint8Array instances and fill them with random values, then round trip them to disk and confirm that the results matched expectations.
Added unit tests for when the write doesn't finish in a single shot.

## Impacted documentation
FileSystem docs.