### PR TITLE
Improve decoupled local dependencies hint

### DIFF
--- a/common/changes/@microsoft/rush/improve-decoupled-local-dependencies-hint_2024-04-09-23-26.json
+++ b/common/changes/@microsoft/rush/improve-decoupled-local-dependencies-hint_2024-04-09-23-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Improve the error message when explicit versions are used for monorepo packages",
+      "comment": "Improve the error message that is printed in a repo using PNPM workspaces when a non-`workspace:` version is used for a project inside the repo.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/improve-decoupled-local-dependencies-hint_2024-04-09-23-26.json
+++ b/common/changes/@microsoft/rush/improve-decoupled-local-dependencies-hint_2024-04-09-23-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Improve the error message when explicit versions are used for monorepo packages",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -234,9 +234,9 @@ export class WorkspaceInstallManager extends BaseInstallManager {
               Colorize.red(
                 `"${rushProject.packageName}" depends on package "${name}" (${version}) which exists within ` +
                   'the workspace. Run "rush update" to update workspace references for this package. ' +
-                  `If package "${name}" is intentionally installed from remote npm registry, declare package "${name}" ` +
-                  `as a decoupled local dependency for project "${rushProject.packageName}" in rush.json ` +
-                  'to suppress this error.'
+                  `If package "${name}" is intentionally expected to be installed from an external package feed, ` +
+                  `list package "${name}" in the "decoupledLocalDependencies" field in the `+
+                  `"${rushProject.packageName}" entry in rush.json to suppress this error.`
               )
             );
             throw new AlreadyReportedError();

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -233,7 +233,10 @@ export class WorkspaceInstallManager extends BaseInstallManager {
             console.log(
               Colorize.red(
                 `"${rushProject.packageName}" depends on package "${name}" (${version}) which exists within ` +
-                  'the workspace. Run "rush update" to update workspace references for this package.'
+                  'the workspace. Run "rush update" to update workspace references for this package. ' +
+                  `If package "${name}" is intentionally installed from remote npm registry, declare package "${name}" ` +
+                  `as a decoupled local dependency for project "${rushProject.packageName}" in rush.json ` +
+                  'to suppress this error.'
               )
             );
             throw new AlreadyReportedError();


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Improve the error message when semantic version is used for a monorepo package.

## Details

When switching the version for a monorepo package from "workspace:*" to "x.y.z", rush complains 

```
"<project>" depends on package "<package_name>" (<package_version>) which exists within the workspace. Run "rush udpate" to update workspace reference for this package.
```

However, when it's intentional to make the package install from remote npm registry, the prorper way is to declare the package as a local decoupled dependency in rush.json.

This PR adds more message hints users about the "localDecoupledDependencies" property in project definition. The error message after would be

```
"<project>" depends on package "<package_name>" (<package_version>) which exists within the workspace. Run "rush udpate" to update workspace reference for this package. If package "<package_name>" is intentionally installed from remote npm registry, declare package "<package_name>" as a decoupled local dependency for project "<project>" in rush.json to suppress this error.
```

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Local

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

None

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
