### PR TITLE
[rush] Include a missing space in a logging message printed when running 'rush add'.

### DIFF
--- a/common/changes/@microsoft/rush/include-missing-space_2024-04-10-16-32.json
+++ b/common/changes/@microsoft/rush/include-missing-space_2024-04-10-16-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Include a missing space in a logging message printed when running `rush add`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -350,7 +350,7 @@ export class PackageJsonUpdater {
 
       dependenciesToAddOrUpdate[packageName] = version;
       this._terminal.writeLine(
-        Colorize.green('Updating projects to use'),
+        Colorize.green('Updating projects to use '),
         `${packageName}@`,
         Colorize.cyan(version)
       );


### PR DESCRIPTION
## Summary

Include a missing space in a logging message printed when running 'rush add'.

## How it was tested

N/A

## Impacted documentation

None.