### PR TITLE
[rush] child_process.spawnSync on windows must set shell: true when targeting a .cmd file 

### DIFF
--- a/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
+++ b/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "childprocess.spawnSync on windows must set shell: true",
+      "comment": "childprocess.spawnSync on windows must set shell: true when invoking a .CMD file",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
+++ b/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "childprocess.spawnSync on windows must set shell: true",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
+++ b/common/changes/@microsoft/rush/fix-spawnsync-windows_2024-04-11-22-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "childprocess.spawnSync on windows must set shell: true when invoking a .CMD file",
+      "comment": "Adapt to Node.js behavior change when invoking a .CMD file via `child_process.spawn`. On Windows this requires setting `shell: true`.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -446,8 +446,8 @@ export function installAndRun(
   const originalEnvPath: string = process.env.PATH || '';
   let result: childProcess.SpawnSyncReturns<Buffer>;
   try {
-    // Node.js on Windows can not spawn a file when the path has a space on it
-    // unless the path gets wrapped in a cmd friendly way and shell mode is used
+    // `npm` bin stubs on Windows are `.cmd` files
+    // Node.js will not directly invoke a `.cmd` file unless `shell` is set to `true`
     const shouldUseShell: boolean = isWindows();
     const platformBinPath: string = shouldUseShell ? `"${binPath}"` : binPath;
 

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -53,7 +53,7 @@ let _npmPath: string | undefined = undefined;
 export function getNpmPath(): string {
   if (!_npmPath) {
     try {
-      if (os.platform() === 'win32') {
+      if (isWindows()) {
         // We're on Windows
         const whereOutput: string = childProcess.execSync('where npm', { stdio: [] }).toString();
         const lines: string[] = whereOutput.split(os.EOL).filter((line) => !!line);
@@ -191,13 +191,17 @@ function _resolvePackageVersion(
       // ```
       //
       // if only a single version matches.
-      const npmVersionSpawnResult: childProcess.SpawnSyncReturns<Buffer> = childProcess.spawnSync(
+
+      const spawnSyncOptions: childProcess.SpawnSyncOptions = {
+        cwd: rushTempFolder,
+        stdio: [],
+        shell: isWindows() ? true : undefined
+      };
+
+      const npmVersionSpawnResult: childProcess.SpawnSyncReturns<Buffer | string> = childProcess.spawnSync(
         npmPath,
         ['view', `${name}@${version}`, 'version', '--no-update-notifier', '--json'],
-        {
-          cwd: rushTempFolder,
-          stdio: []
-        }
+        spawnSyncOptions
       );
 
       if (npmVersionSpawnResult.status !== 0) {
@@ -375,8 +379,12 @@ function _installPackage(
  */
 function _getBinPath(packageInstallFolder: string, binName: string): string {
   const binFolderPath: string = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
-  const resolvedBinName: string = os.platform() === 'win32' ? `${binName}.cmd` : binName;
+  const resolvedBinName: string = isWindows() ? `${binName}.cmd` : binName;
   return path.resolve(binFolderPath, resolvedBinName);
+}
+
+function isWindows(): boolean {
+  return os.platform() === 'win32';
 }
 
 /**
@@ -439,7 +447,7 @@ export function installAndRun(
   try {
     // Node.js on Windows can not spawn a file when the path has a space on it
     // unless the path gets wrapped in a cmd friendly way and shell mode is used
-    const shouldUseShell: boolean = binPath.includes(' ') && os.platform() === 'win32';
+    const shouldUseShell: boolean = binPath.includes(' ') && isWindows();
     const platformBinPath: string = shouldUseShell ? `"${binPath}"` : binPath;
 
     process.env.PATH = [binFolderPath, originalEnvPath].join(path.delimiter);

--- a/libraries/rush-lib/src/scripts/install-run.ts
+++ b/libraries/rush-lib/src/scripts/install-run.ts
@@ -195,7 +195,7 @@ function _resolvePackageVersion(
       const spawnSyncOptions: childProcess.SpawnSyncOptions = {
         cwd: rushTempFolder,
         stdio: [],
-        shell: isWindows() ? true : undefined
+        shell: isWindows()
       };
 
       const npmVersionSpawnResult: childProcess.SpawnSyncReturns<Buffer | string> = childProcess.spawnSync(
@@ -361,7 +361,8 @@ function _installPackage(
     const result: childProcess.SpawnSyncReturns<Buffer> = childProcess.spawnSync(npmPath, [command], {
       stdio: 'inherit',
       cwd: packageInstallFolder,
-      env: process.env
+      env: process.env,
+      shell: isWindows()
     });
 
     if (result.status !== 0) {
@@ -447,7 +448,7 @@ export function installAndRun(
   try {
     // Node.js on Windows can not spawn a file when the path has a space on it
     // unless the path gets wrapped in a cmd friendly way and shell mode is used
-    const shouldUseShell: boolean = binPath.includes(' ') && isWindows();
+    const shouldUseShell: boolean = isWindows();
     const platformBinPath: string = shouldUseShell ? `"${binPath}"` : binPath;
 
     process.env.PATH = [binFolderPath, originalEnvPath].join(path.delimiter);


### PR DESCRIPTION
## Summary

Adapt to Node.js [security release](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2), which disallows .bat and .cmd file spawning without enabling the shell option. As @dmichon-msft notes below, Rush invokes npm bin stubs which are `.CMD` files on Windows.

Fixes #4636 

## Details

Add `shell: true` to `child_process.spawnSync` options when running in Windows, and ensure any path or binstub invoked is formatted appropriately.

## How it was tested

On both MacOS and Windows:
- Before any changes, reproduced the issue on Windows locally.
- Changes were made in rushstack repo and rebuilt. 
- Ran `node ./libraries/rush-lib/dist/scripts/run-rush-install.js install` and `node ./libraries/rush-lib/dist/scripts/run-rush-install.js rebuild` successfully.
- On Windows, initially encountered the above path issue which was resolved by formatting all windows invoked paths. 
