### PR TITLE
[api-documenter] Fix return block rendering for page markdown

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -895,6 +895,7 @@ export class MarkdownDocumenter {
     if (parametersTable.rows.length > 0) {
       output.appendNode(new DocHeading({ configuration, title: 'Parameters' }));
       output.appendNode(parametersTable);
+      output.appendNode(new DocParagraph({ configuration }));
     }
 
     if (ApiReturnTypeMixin.isBaseClassOf(apiParameterListMixin)) {

--- a/common/changes/@microsoft/api-documenter/api_documenter_markdown_return_fix_2024-04-12-21-56.json
+++ b/common/changes/@microsoft/api-documenter/api_documenter_markdown_return_fix_2024-04-12-21-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Fix return block rendering for page markdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->



## Summary

Fixes rendering of the "\*\*Returns:\*\*" markdown in generated page documentation for a function.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Noticed that a missing line break was causing a rendering of the `Returns:` section on the markdown output for a function.  You can see an example of this [here](https://github.com/salesforce/tough-cookie/blob/v5-docs/api/docs/tough-cookie.canonicaldomain.md).

The markdown is correct `**Returns:**` but because there is no line break between the end of the parameter table and the aforementioned markdown content, it is not treated as a new paragraph and is rendered as "\*\*Returns:\*\*" instead of "**Returns:**".

This is fixed by adding the required line break to the generated markdown content.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I rebuild the `api-documenter` with the included code change and regenerated the markdown pages for my project and visually compared them.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

Not applicable.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
