### PR TITLE
fix: support subspace in package-extractor

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-04-17-09-38.json
+++ b/common/changes/@microsoft/rush/main_2024-04-17-09-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "refactor package-extractor to support subspace",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/main_2024-04-17-09-38.json
+++ b/common/changes/@microsoft/rush/main_2024-04-17-09-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "refactor package-extractor to support subspace",
+      "comment": "Fix an issue where \"rush deploy\" did not correctly deploy build outputs combining multiple Rush subspaces",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/package-extractor/main_2024-04-17-09-38.json
+++ b/common/changes/@rushstack/package-extractor/main_2024-04-17-09-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "refactor package-extractor to support subspace",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/changes/@rushstack/package-extractor/main_2024-04-17-09-38.json
+++ b/common/changes/@rushstack/package-extractor/main_2024-04-17-09-38.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/package-extractor",
-      "comment": "refactor package-extractor to support subspace",
-      "type": "patch"
+      "comment": "Add support for Rush subspaces",
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/package-extractor"

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -33,12 +33,11 @@ export interface IExtractorOptions {
     linkCreation?: 'default' | 'script' | 'none';
     mainProjectName: string;
     overwriteExisting: boolean;
-    pnpmInstallFolder?: string;
     projectConfigurations: IExtractorProjectConfiguration[];
     sourceRootFolder: string;
+    subspaces?: IExtractorSubspace[];
     targetRootFolder: string;
     terminal: ITerminal;
-    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
 }
 
 // @public
@@ -50,6 +49,16 @@ export interface IExtractorProjectConfiguration {
     patternsToInclude?: string[];
     projectFolder: string;
     projectName: string;
+}
+
+// @public
+export interface IExtractorSubspace {
+    // (undocumented)
+    pnpmInstallFolder?: string;
+    // (undocumented)
+    subspaceName: string;
+    // (undocumented)
+    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 }
 
 // @public

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -57,7 +57,7 @@ export interface IExtractorProjectConfiguration {
 export interface IExtractorSubspace {
     pnpmInstallFolder?: string;
     subspaceName: string;
-    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
+    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
 }
 
 // @public

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -53,11 +53,8 @@ export interface IExtractorProjectConfiguration {
 
 // @public
 export interface IExtractorSubspace {
-    // (undocumented)
     pnpmInstallFolder?: string;
-    // (undocumented)
     subspaceName: string;
-    // (undocumented)
     transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 }
 

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -39,7 +39,7 @@ export interface IExtractorOptions {
     subspaces?: IExtractorSubspace[];
     targetRootFolder: string;
     terminal: ITerminal;
-    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
+    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 }
 
 // @public
@@ -57,7 +57,7 @@ export interface IExtractorProjectConfiguration {
 export interface IExtractorSubspace {
     pnpmInstallFolder?: string;
     subspaceName: string;
-    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
+    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 }
 
 // @public

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -33,11 +33,13 @@ export interface IExtractorOptions {
     linkCreation?: 'default' | 'script' | 'none';
     mainProjectName: string;
     overwriteExisting: boolean;
+    pnpmInstallFolder?: string;
     projectConfigurations: IExtractorProjectConfiguration[];
     sourceRootFolder: string;
     subspaces?: IExtractorSubspace[];
     targetRootFolder: string;
     terminal: ITerminal;
+    transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
 }
 
 // @public

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -215,10 +215,13 @@ export interface IExtractorOptions {
   createArchiveOnly?: boolean;
 
   /**
-   * The pnpmfile configuration if using PNPM, otherwise undefined. The configuration will be used to
+   * The pnpmfile configuration if using PNPM, otherwise `undefined`. The configuration will be used to
    * transform the package.json prior to extraction.
-   * Can't be used with subspaces, if subspaces field is specified, we will use transformPackageJson configured
-   * for each subspace and ignore this.
+   *
+   * @remarks
+   * When Rush subspaces are enabled, this setting applies to `default` subspace only.  To configure
+   * each subspace, use the {@link IExtractorOptions.subspaces} array instead.  The two approaches
+   * cannot be combined.
    */
   transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
 
@@ -235,8 +238,11 @@ export interface IExtractorOptions {
   /**
    * The folder where the PNPM "node_modules" folder is located. This is used to resolve packages linked
    * to the PNPM virtual store.
-   * Can't be used with subspaces, if subspaces field is specified, we will use pnpmInstallFolder configured
-   * for each subspace and ignore this.
+   *
+   * @remarks
+   * When Rush subspaces are enabled, this setting applies to `default` subspace only.  To configure
+   * each subspace, use the {@link IExtractorOptions.subspaces} array instead.  The two approaches
+   * cannot be combined.
    */
   pnpmInstallFolder?: string;
 
@@ -266,8 +272,12 @@ export interface IExtractorOptions {
   dependencyConfigurations?: IExtractorDependencyConfiguration[];
 
   /**
-   * The subspace list that will be performed while extracting
+   * When using Rush subspaces, this setting can be used to provide configuration information for each
+   * individual subspace.
    *
+   * @remarks
+   * To avoid confusion, if this setting is used, then the {@link IExtractorOptions.transformPackageJson} and
+   * {@link IExtractorOptions.pnpmInstallFolder} settings must not be used.
    */
   subspaces?: IExtractorSubspace[];
 }

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -91,7 +91,7 @@ export interface IExtractorSubspace {
    * The pnpmfile configuration if using PNPM, otherwise undefined. The configuration will be used to
    * transform the package.json prior to extraction.
    */
-  transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
+  transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 }
 
 interface IExtractorState {
@@ -223,7 +223,7 @@ export interface IExtractorOptions {
    * each subspace, use the {@link IExtractorOptions.subspaces} array instead.  The two approaches
    * cannot be combined.
    */
-  transformPackageJson?: (packageJson: IPackageJson) => IPackageJson | undefined;
+  transformPackageJson?: (packageJson: IPackageJson) => IPackageJson;
 
   /**
    * If dependencies from the "devDependencies" package.json field should be included in the extraction.

--- a/libraries/package-extractor/src/index.ts
+++ b/libraries/package-extractor/src/index.ts
@@ -7,7 +7,8 @@ export {
   type IExtractorProjectConfiguration,
   type IExtractorDependencyConfiguration,
   type IExtractorMetadataJson,
-  type IProjectInfoJson
+  type IProjectInfoJson,
+  type IExtractorSubspace
 } from './PackageExtractor';
 
 export type { ILinkInfo } from './SymlinkAnalyzer';

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -2,9 +2,12 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import type { IPackageJson } from '@rushstack/node-core-library';
 import type { CommandLineFlagParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
-import type { PackageExtractor, IExtractorProjectConfiguration } from '@rushstack/package-extractor';
+import type {
+  PackageExtractor,
+  IExtractorProjectConfiguration,
+  IExtractorSubspace
+} from '@rushstack/package-extractor';
 
 import { BaseRushAction } from './BaseRushAction';
 import type { RushCommandLineParser } from '../RushCommandLineParser';
@@ -15,7 +18,6 @@ import type {
   IDeployScenarioProjectJson
 } from '../../logic/deploy/DeployScenarioConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
-import type { Subspace } from '../../api/Subspace';
 
 export class DeployAction extends BaseRushAction {
   private readonly _logger: ILogger;
@@ -101,6 +103,21 @@ export class DeployAction extends BaseRushAction {
     });
   }
 
+  private _getDependencyProjects(project: RushConfigurationProject): Set<RushConfigurationProject> {
+    const projects: Set<RushConfigurationProject> = new Set();
+    const queue: RushConfigurationProject[] = [project];
+
+    while (queue.length > 0) {
+      const _project: RushConfigurationProject = queue.shift()!;
+
+      for (const dependency of _project.dependencyProjects) {
+        queue.push(dependency);
+      }
+    }
+
+    return projects;
+  }
+
   protected async runAsync(): Promise<void> {
     const scenarioName: string | undefined = this._scenario.value;
     const { DeployScenarioConfiguration } = await import('../../logic/deploy/DeployScenarioConfiguration');
@@ -144,31 +161,40 @@ export class DeployAction extends BaseRushAction {
 
     const createArchiveOnly: boolean = this._createArchiveOnly.value;
 
-    let transformPackageJson: ((packageJson: IPackageJson) => IPackageJson) | undefined;
-    let pnpmInstallFolder: string | undefined;
+    /**
+     * Subspaces that will be involved in deploy process.
+     * Each subspace may have its own configurations
+     */
+    const subspaces: IExtractorSubspace[] = [];
 
     const rushConfigurationProject: RushConfigurationProject | undefined =
       this.rushConfiguration.getProjectByName(mainProjectName);
-     if (!rushConfigurationProject) { 
-       throw new Error(`The specified deployment project "${mainProjectName}" was not found in rush.json`); 
-     } 
+    if (!rushConfigurationProject) {
+      throw new Error(`The specified deployment project "${mainProjectName}" was not found in rush.json`);
+    }
 
-    const subspace: Subspace = rushConfigurationProject.subspace;
-
+    const projects = this._getDependencyProjects(rushConfigurationProject);
     if (this.rushConfiguration.packageManager === 'pnpm') {
-      const pnpmfileConfiguration: PnpmfileConfiguration = await PnpmfileConfiguration.initializeAsync(
-        this.rushConfiguration,
-        subspace
-      );
-      transformPackageJson = pnpmfileConfiguration.transform.bind(pnpmfileConfiguration);
-      if (!scenarioConfiguration.json.omitPnpmWorkaroundLinks) {
-        pnpmInstallFolder = subspace.getSubspaceTempFolder();
+      for (const project of projects) {
+        const pnpmfileConfiguration: PnpmfileConfiguration = await PnpmfileConfiguration.initializeAsync(
+          this.rushConfiguration,
+          project.subspace
+        );
+        const subspace: IExtractorSubspace = {
+          subspaceName: project.subspace.subspaceName,
+          transformPackageJson: pnpmfileConfiguration.transform.bind(pnpmfileConfiguration)
+        };
+
+        if (!scenarioConfiguration.json.omitPnpmWorkaroundLinks) {
+          subspace.pnpmInstallFolder = project.subspace.getSubspaceTempFolder();
+        }
+        subspaces.push(subspace);
       }
     }
 
     // Construct the project list for the deployer
     const projectConfigurations: IExtractorProjectConfiguration[] = [];
-    for (const project of subspace.getProjects()) {
+    for (const project of projects) {
       const scenarioProjectJson: IDeployScenarioProjectJson | undefined =
         scenarioConfiguration.projectJsonsByName.get(project.packageName);
       projectConfigurations.push({
@@ -202,8 +228,7 @@ export class DeployAction extends BaseRushAction {
       dependencyConfigurations: scenarioConfiguration.json.dependencySettings,
       createArchiveFilePath,
       createArchiveOnly,
-      pnpmInstallFolder,
-      transformPackageJson
+      subspaces
     });
   }
 }

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -173,7 +173,7 @@ export class DeployAction extends BaseRushAction {
       throw new Error(`The specified deployment project "${mainProjectName}" was not found in rush.json`);
     }
 
-    const projects = this._getDependencyProjects(rushConfigurationProject);
+    const projects: Set<RushConfigurationProject> = this._getDependencyProjects(rushConfigurationProject);
     if (this.rushConfiguration.packageManager === 'pnpm') {
       for (const project of projects) {
         const pnpmfileConfiguration: PnpmfileConfiguration = await PnpmfileConfiguration.initializeAsync(


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Fix issue that can't extract projects dependencies correctly if there exist multiple subspaces.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
Now only subspace that for entry project will be passed to package extractor, but if there are multiple projects belongs to different subspaces, dependencies in other subspaces can't be extract correctly. 
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Tested with in-house production project.

Also there is an example that shows what the file structure will be like after this PR merged.
Here is the example subspace repo https://github.com/william2958/rush-subspace-demo 
![image](https://github.com/microsoft/rushstack/assets/22115706/8877436d-d671-42cc-8c98-15ee02d47a8d)




<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation
The internal API for PackageExtractor has been changed to support multiple subspaces
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->

