### PR TITLE
[rush-azure-storage-build-cache-plugin] Add support for auth via microsoft/ado-codespaces-auth vscode extension

### DIFF
--- a/common/changes/@microsoft/rush/ado-codespaces-auth_2024-04-18-03-55.json
+++ b/common/changes/@microsoft/rush/ado-codespaces-auth_2024-04-18-03-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for auth via microsoft/ado-codespaces-auth vscode extension in `@rushstack/rush-azure-storage-build-cache-plugin`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -82,7 +82,6 @@ export interface IAzureAuthenticationBaseOptions {
     credentialUpdateCommandForLogging?: string | undefined;
     // (undocumented)
     loginFlow?: LoginFlowType;
-    // (undocumented)
     loginFlowFailover?: Record<LoginFlowType, LoginFlowType | undefined>;
 }
 

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -127,7 +127,7 @@ export interface ITryGetCachedCredentialOptionsThrow extends ITryGetCachedCreden
 }
 
 // @public (undocumented)
-export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser';
+export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser' | 'ado-codespaces-auth';
 
 // @public (undocumented)
 class RushAzureStorageBuildCachePlugin implements IRushPlugin {

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -31,6 +31,8 @@ export abstract class AzureAuthenticationBase {
     protected readonly _credentialUpdateCommandForLogging: string | undefined;
     // (undocumented)
     deleteCachedCredentialsAsync(terminal: ITerminal): Promise<void>;
+    // (undocumented)
+    protected readonly _failoverOrder: Record<LoginFlowType, LoginFlowType | undefined>;
     protected abstract _getCacheIdParts(): string[];
     // (undocumented)
     protected abstract _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential): Promise<ICredentialResult>;
@@ -80,6 +82,8 @@ export interface IAzureAuthenticationBaseOptions {
     credentialUpdateCommandForLogging?: string | undefined;
     // (undocumented)
     loginFlow?: LoginFlowType;
+    // (undocumented)
+    loginFlowFailover?: Record<LoginFlowType, LoginFlowType | undefined>;
 }
 
 // @public (undocumented)
@@ -127,7 +131,7 @@ export interface ITryGetCachedCredentialOptionsThrow extends ITryGetCachedCreden
 }
 
 // @public (undocumented)
-export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser' | 'ado-codespaces-auth';
+export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser' | 'AdoCodespacesAuth';
 
 // @public (undocumented)
 class RushAzureStorageBuildCachePlugin implements IRushPlugin {

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -1,28 +1,79 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
+import { Executable } from '@rushstack/node-core-library';
 import type { AccessToken, GetTokenOptions } from '@azure/identity';
 
-export class AdoCodespacesAuthCredential {
-  // eslint-disable-next-line @rushstack/no-new-null
-  public async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null> {
-    if (!Array.isArray(scopes)) {
-      scopes = [scopes];
-    }
-    const { resolve } = await import('path');
-    const homeDir: string | undefined = process.env.HOME;
-    if (!homeDir) {
-      throw new Error('Could not determine the home directory');
-    }
-    const azureAuthHelperExec: string = resolve(homeDir, 'azure-auth-helper');
-    const { spawnSync } = await import('child_process');
+interface IDecodedJwt {
+  header: {
+    type?: string;
+    alg?: string;
+    kid?: string;
+  };
+  payload: {
+    aud?: string;
+    iss?: string;
+    iat?: number;
+    nbf?: number;
+    exp?: number;
+    appid?: string;
+    scp?: string;
+    upn?: string;
+    unique_name?: string;
+    tid?: string;
+    sub?: string;
+    ver?: string;
+  };
+  signature: string;
+}
 
-    const result: string = spawnSync(azureAuthHelperExec, ['get-access-token', ...scopes], {
-      encoding: 'utf8'
-    }).stdout;
+/**
+ * AdoCodespacesAuthCredential uses "Azure Devops Codespaces Authentication" VSCode extension to get the access
+ * tokens for AAD in Codespaces.
+ * https://github.com/microsoft/ado-codespaces-auth
+ */
+export class AdoCodespacesAuthCredential {
+  public async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken> {
+    if (Array.isArray(scopes) && scopes.length > 1) {
+      throw new Error('Only one scope is supported');
+    }
+    const scope: string = Array.isArray(scopes) ? scopes[0] : scopes;
+    const azureAuthHelperExec: string = 'azure-auth-helper';
+
+    const token: string = Executable.spawnSync(azureAuthHelperExec, ['get-access-token', scope]).stdout;
+
+    let expiresOnTimestamp: number;
+
+    try {
+      const decodedToken: IDecodedJwt = this._decodeToken(token);
+      if (decodedToken?.payload?.exp) {
+        expiresOnTimestamp = decodedToken.payload.exp * 1000;
+      } else {
+        expiresOnTimestamp = Date.now() + 3600000;
+      }
+    } catch (error) {
+      throw new Error(`Failed to decode the token: ${error}`);
+    }
 
     return {
-      token: result,
-      expiresOnTimestamp: Date.now() + 3600 * 1000
+      token,
+      expiresOnTimestamp
+    };
+  }
+
+  private _decodeToken(token: string): IDecodedJwt {
+    const parts: string[] = token.split('.');
+    if (parts.length !== 3) {
+      throw new Error('Invalid token');
+    }
+
+    const header: string = Buffer.from(parts[0], 'base64').toString();
+    const payload: string = Buffer.from(parts[1], 'base64').toString();
+    const signature: string = parts[2];
+
+    return {
+      header: JSON.parse(header),
+      payload: JSON.parse(payload),
+      signature
     };
   }
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+import type { AccessToken, GetTokenOptions } from '@azure/identity';
+
+export class AdoCodespacesAuthCredential {
+  // eslint-disable-next-line @rushstack/no-new-null
+  public async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null> {
+    if (!Array.isArray(scopes)) {
+      scopes = [scopes];
+    }
+    const { resolve } = await import('path');
+    const homeDir: string | undefined = process.env.HOME;
+    if (!homeDir) {
+      throw new Error('Could not determine the home directory');
+    }
+    const azureAuthHelperExec: string = resolve(homeDir, 'azure-auth-helper');
+    const { spawnSync } = await import('child_process');
+
+    const result: string = spawnSync(azureAuthHelperExec, ['get-access-token', ...scopes], {
+      encoding: 'utf8'
+    }).stdout;
+
+    return {
+      token: result,
+      expiresOnTimestamp: Date.now() + 3600 * 1000
+    };
+  }
+}

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -32,11 +32,19 @@ interface IDecodedJwt {
  * https://github.com/microsoft/ado-codespaces-auth
  */
 export class AdoCodespacesAuthCredential {
-  public async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken> {
-    if (Array.isArray(scopes) && scopes.length > 1) {
-      throw new Error('Only one scope is supported');
+  public async getToken(scopes: string | [string], options?: GetTokenOptions): Promise<AccessToken> {
+    let scope: string;
+    if (Array.isArray(scopes)) {
+      if (scopes.length > 1) {
+        throw new Error('Only one scope is supported');
+      } else if ((scopes as string[]).length === 0) {
+        throw new Error('A scope must be provided.');
+      } else {
+        scope = scopes[0];
+      }
+    } else {
+      scope = scopes;
     }
-    const scope: string = Array.isArray(scopes) ? scopes[0] : scopes;
     const azureAuthHelperExec: string = 'azure-auth-helper';
 
     const token: string = Executable.spawnSync(azureAuthHelperExec, ['get-access-token', scope]).stdout;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -89,6 +89,20 @@ export interface IAzureAuthenticationBaseOptions {
   azureEnvironment?: AzureEnvironmentName;
   credentialUpdateCommandForLogging?: string | undefined;
   loginFlow?: LoginFlowType;
+  /**
+   * A map to define the failover order for login flows. When a login flow fails to get a credential,
+   * the next login flow in the map will be attempted. If the login flow fails and there is no next
+   * login flow, the error will be thrown.
+   *
+   * @defaultValue
+   * ```json
+   * {
+   *   "AdoCodespacesAuth": "InteractiveBrowser",
+   *   "InteractiveBrowser": "DeviceCode",
+   *   "DeviceCode": null
+   * }
+   * ```
+   */
   loginFlowFailover?: Record<LoginFlowType, LoginFlowType | undefined>;
 }
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -17,6 +17,7 @@ import { CredentialCache } from '@rushstack/rush-sdk';
 // See https://github.com/microsoft/rushstack/issues/3432
 import type { ICredentialCacheEntry } from '@rushstack/rush-sdk';
 import { PrintUtilities } from '@rushstack/terminal';
+import { AdoCodespacesAuthCredential } from './AdoCodespacesAuthCredential';
 
 /**
  * @public
@@ -79,7 +80,7 @@ export type AzureEnvironmentName = keyof typeof AzureAuthorityHosts;
 /**
  * @public
  */
-export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser';
+export type LoginFlowType = 'DeviceCode' | 'InteractiveBrowser' | 'ado-codespaces-auth';
 
 /**
  * @public
@@ -274,6 +275,10 @@ export abstract class AzureAuthenticationBase {
     };
 
     switch (loginFlow) {
+      case 'ado-codespaces-auth': {
+        tokenCredential = new AdoCodespacesAuthCredential();
+        break;
+      }
       case 'InteractiveBrowser': {
         tokenCredential = new InteractiveBrowserCredential(interactiveCredentialOptions);
         break;


### PR DESCRIPTION
## Summary

- Add support for auth via [microsoft/ado-codespaces-auth](https://github.com/microsoft/ado-codespaces-auth) vscode extension
- Add support for login flow failover

## Details

Add new AdoCodespacesAuthCredential with returns TokenCredential compatible with other Credentials from `@azure/identity`.

Add option to failover to other loginFlow types. Defaults to `AdoCodespacesAuth` -> `InteractiveBrowser` -> `DeviceCode`

