### PR TITLE
Support lockfile-explorer for subspace feature

### DIFF
--- a/apps/lockfile-explorer-web/src/parsing/LockfileEntry.ts
+++ b/apps/lockfile-explorer-web/src/parsing/LockfileEntry.ts
@@ -4,8 +4,6 @@
 import { Path } from '@lifaon/path';
 import { type ILockfileNode, LockfileDependency } from './LockfileDependency';
 
-const ROOT_PACKAGE_PATH: string = 'common/temp/package.json';
-
 export enum LockfileEntryFilter {
   Project,
   Package,
@@ -18,6 +16,7 @@ interface IProps {
   kind: LockfileEntryFilter;
   rawYamlData: ILockfileNode;
   duplicates?: Set<string>;
+  subspaceName?: string;
 }
 
 /**
@@ -62,7 +61,7 @@ export class LockfileEntry {
   public entrySuffix: string = '';
 
   public constructor(data: IProps) {
-    const { rawEntryId, kind, rawYamlData, duplicates } = data;
+    const { rawEntryId, kind, rawYamlData, duplicates, subspaceName } = data;
     this.rawEntryId = rawEntryId;
     this.kind = kind;
 
@@ -72,7 +71,7 @@ export class LockfileEntry {
     }
 
     if (kind === LockfileEntryFilter.Project) {
-      const rootPackageJsonFolderPath = new Path(ROOT_PACKAGE_PATH).dirname() || '';
+      const rootPackageJsonFolderPath = new Path(`common/temp/${subspaceName}/package.json`).dirname() || '';
       const packageJsonFolderPath = new Path('.').relative(
         new Path(rootPackageJsonFolderPath).concat(rawEntryId)
       );
@@ -124,11 +123,11 @@ export class LockfileEntry {
       }
 
       // Example:
-      //   common/temp/node_modules/.pnpm
+      //   common/temp/default/node_modules/.pnpm
       //     /@babel+register@7.17.7_@babel+core@7.17.12
       //     /node_modules/@babel/register
       this.packageJsonFolderPath =
-        'common/temp/node_modules/.pnpm/' +
+        `common/temp/${subspaceName}/node_modules/.pnpm/` +
         this.entryPackageName.replace('/', '+') +
         '@' +
         this.entryPackageVersion +

--- a/apps/lockfile-explorer-web/src/parsing/readLockfile.ts
+++ b/apps/lockfile-explorer-web/src/parsing/readLockfile.ts
@@ -90,7 +90,7 @@ function getImporterValue(
  *
  * @returns A list of all the LockfileEntries in the lockfile.
  */
-export function generateLockfileGraph(lockfile: ILockfilePackageType): LockfileEntry[] {
+export function generateLockfileGraph(lockfile: ILockfilePackageType, subspaceName: string): LockfileEntry[] {
   let pnpmLockfileVersion: PnpmLockfileVersion = PnpmLockfileVersion.V5;
   if (`${lockfile.lockfileVersion}`.startsWith('6')) {
     pnpmLockfileVersion = PnpmLockfileVersion.V6;
@@ -122,7 +122,8 @@ export function generateLockfileGraph(lockfile: ILockfilePackageType): LockfileE
         rawEntryId: importerKey,
         kind: LockfileEntryFilter.Project,
         rawYamlData: getImporterValue(importerValue, pnpmLockfileVersion),
-        duplicates
+        duplicates,
+        subspaceName
       });
       allImporters.push(importer);
       allEntries.push(importer);
@@ -179,7 +180,7 @@ export function generateLockfileGraph(lockfile: ILockfilePackageType): LockfileE
 
 export async function readLockfileAsync(): Promise<LockfileEntry[]> {
   const response = await fetch(`${serviceUrl}/api/lockfile`);
-  const lockfile: ILockfilePackageType = await response.json();
+  const lockfile: { doc: ILockfilePackageType; subspaceName: string } = await response.json();
 
-  return generateLockfileGraph(lockfile);
+  return generateLockfileGraph(lockfile.doc, lockfile.subspaceName);
 }

--- a/apps/lockfile-explorer-web/src/parsing/readLockfile.ts
+++ b/apps/lockfile-explorer-web/src/parsing/readLockfile.ts
@@ -90,7 +90,10 @@ function getImporterValue(
  *
  * @returns A list of all the LockfileEntries in the lockfile.
  */
-export function generateLockfileGraph(lockfile: ILockfilePackageType, subspaceName: string): LockfileEntry[] {
+export function generateLockfileGraph(
+  lockfile: ILockfilePackageType,
+  subspaceName?: string
+): LockfileEntry[] {
   let pnpmLockfileVersion: PnpmLockfileVersion = PnpmLockfileVersion.V5;
   if (`${lockfile.lockfileVersion}`.startsWith('6')) {
     pnpmLockfileVersion = PnpmLockfileVersion.V6;

--- a/apps/lockfile-explorer-web/src/parsing/test/lockfile.test.ts
+++ b/apps/lockfile-explorer-web/src/parsing/test/lockfile.test.ts
@@ -18,7 +18,7 @@ describe('LockfileGeneration', () => {
     const exampleLockfileImporter = resolvedPackagesMap.testApp1;
 
     // Ensure validity of the example lockfile entry
-    expect(exampleLockfileImporter.rawEntryId).toBe('../../apps/testApp1');
+    expect(exampleLockfileImporter.rawEntryId).toBe('../../../apps/testApp1');
     expect(exampleLockfileImporter.entryId).toBe('project:./apps/testApp1');
 
     // Test that dependencies are linked in the importer project

--- a/apps/lockfile-explorer-web/src/parsing/test/testLockfile.ts
+++ b/apps/lockfile-explorer-web/src/parsing/test/testLockfile.ts
@@ -7,7 +7,7 @@ export const TEST_LOCKFILE = {
     '.': {
       specifiers: {}
     },
-    '../../apps/testApp1': {
+    '../../../apps/testApp1': {
       specifiers: {
         '@testPackage/core': '1.7.1',
         '@testPackage2/core': '1.7.1'

--- a/apps/lockfile-explorer/src/commandLine.ts
+++ b/apps/lockfile-explorer/src/commandLine.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export interface ICommandLine {
+  showedHelp: boolean;
+  error: string | undefined;
+  subspace: string | undefined;
+}
+
+function showHelp(): void {
+  console.log(
+    `
+Usage: lockfile-explorer [--subspace SUBSPACE]
+       lockfile-explorer [--help]
+
+Launches the Lockfile Explorer app.  You can also use "lfx" as shorthand alias
+for "lockfile-explorer".
+
+Parameters:
+
+--help, -h
+       Show command line help
+
+--subspace SUBSPACE, -s SUBSPACE
+       Load the lockfile for the specified Rush subspace.
+`.trim()
+  );
+}
+
+export function parseCommandLine(args: string[]): ICommandLine {
+  const result: ICommandLine = { showedHelp: false, error: undefined, subspace: undefined };
+
+  let i: number = 0;
+
+  while (i < args.length) {
+    const parameter: string = args[i];
+    ++i;
+
+    switch (parameter) {
+      case '--help':
+      case '-h':
+      case '/?':
+        showHelp();
+        result.showedHelp = true;
+        return result;
+
+      case '--subspace':
+      case '-s':
+        if (i >= args.length || args[i].startsWith('-')) {
+          result.error = `Expecting argument after "${parameter}"`;
+          return result;
+        }
+        result.subspace = args[i];
+        ++i;
+        break;
+
+      default:
+        result.error = 'Unknown parameter ' + JSON.stringify(parameter);
+        return result;
+    }
+  }
+
+  return result;
+}

--- a/apps/lockfile-explorer/src/init.ts
+++ b/apps/lockfile-explorer/src/init.ts
@@ -4,11 +4,8 @@
 // This function will read the current directory and try to figure out if it's a rush project or regular pnpm workspace
 // Currently it will throw error if neither can be determined
 
-import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
-import {
-  type IRushConfigurationJson,
-  RushConfiguration
-} from '@microsoft/rush-lib/lib/api/RushConfiguration';
+import { FileSystem, Path } from '@rushstack/node-core-library';
+import { RushConfiguration } from '@microsoft/rush-lib/lib/api/RushConfiguration';
 import type { Subspace } from '@microsoft/rush-lib/lib/api/Subspace';
 import path from 'path';
 
@@ -56,8 +53,7 @@ export const init = (options: {
         rush: {
           rushJsonPath,
           projectsByProjectFolder
-        },
-        subspaceName
+        }
       };
       break;
     } else if (FileSystem.exists(pnpmLockPath)) {

--- a/apps/lockfile-explorer/src/init.ts
+++ b/apps/lockfile-explorer/src/init.ts
@@ -38,8 +38,8 @@ export const init = (options: {
   let currExploredDir = Path.convertToSlashes(currDir);
   while (currExploredDir.includes('/')) {
     // Look for a rush.json [rush project] or pnpm-lock.yaml file [regular pnpm workspace]
-    const rushJsonPath: string = path.join(currExploredDir, 'rush.json');
-    const pnpmLockPath: string = path.join(currExploredDir, 'pnpm-lock.yaml');
+    const rushJsonPath: string = path.resolve(currExploredDir, 'rush.json');
+    const pnpmLockPath: string = path.resolve(currExploredDir, 'pnpm-lock.yaml');
     if (FileSystem.exists(rushJsonPath)) {
       console.log('Found a Rush workspace: ', rushJsonPath);
       // Load the rush projects

--- a/apps/lockfile-explorer/src/init.ts
+++ b/apps/lockfile-explorer/src/init.ts
@@ -20,7 +20,7 @@ export const init = (options: {
   debugMode: boolean;
   subspaceName: string;
 }): IAppState => {
-  const { lockfileExplorerProjectRoot, appVersion, debugMode } = options;
+  const { lockfileExplorerProjectRoot, appVersion, debugMode, subspaceName } = options;
   const currDir = process.cwd();
 
   let appState: IAppState | undefined;

--- a/apps/lockfile-explorer/src/init.ts
+++ b/apps/lockfile-explorer/src/init.ts
@@ -31,19 +31,18 @@ export const init = (options: {
     const pnpmLockPath: string = path.resolve(currExploredDir, 'pnpm-lock.yaml');
     if (FileSystem.exists(rushJsonPath)) {
       console.log('Found a Rush workspace: ', rushJsonPath);
-      // Load the rush projects
-      const rushJson: IRushConfigurationJson = JsonFile.load(rushJsonPath);
+
+      const rushConfiguration: RushConfiguration = RushConfiguration.tryLoadFromDefaultLocation()!;
+      const subspace: Subspace = rushConfiguration.getSubspace(subspaceName);
+      const workspaceFolder: string = subspace.getSubspaceTempFolder();
+
       const projectsByProjectFolder: Map<string, IRushProjectDetails> = new Map();
-      for (const project of rushJson.projects) {
+      for (const project of rushConfiguration.projects) {
         projectsByProjectFolder.set(project.projectFolder, {
           projectName: project.packageName,
           projectFolder: project.projectFolder
         });
       }
-
-      const rushConfiguration: RushConfiguration = RushConfiguration.tryLoadFromDefaultLocation()!;
-      const subspace: Subspace = rushConfiguration.getSubspace(subspaceName);
-      const workspaceFolder: string = subspace.getSubspaceTempFolder();
 
       appState = {
         currDir,

--- a/apps/lockfile-explorer/src/init.ts
+++ b/apps/lockfile-explorer/src/init.ts
@@ -18,21 +18,10 @@ export const init = (options: {
   lockfileExplorerProjectRoot: string;
   appVersion: string;
   debugMode: boolean;
+  subspaceName: string;
 }): IAppState => {
   const { lockfileExplorerProjectRoot, appVersion, debugMode } = options;
   const currDir = process.cwd();
-
-  let subspaceName: string = 'default';
-
-  if (process.argv.indexOf('--subspace') >= 0) {
-    if (process.argv[2] !== '--subspace') {
-      throw new Error(
-        'If you want to specify a subspace, you should place "--subspace <subspace_name>" immediately after the "lockfile-explorer" command'
-      );
-    }
-
-    subspaceName = process.argv[3];
-  }
 
   let appState: IAppState | undefined;
   let currExploredDir = Path.convertToSlashes(currDir);

--- a/apps/lockfile-explorer/src/start.ts
+++ b/apps/lockfile-explorer/src/start.ts
@@ -42,7 +42,19 @@ function startApp(debugMode: boolean): void {
   // Must not have a trailing slash
   const SERVICE_URL: string = `http://localhost:${PORT}`;
 
-  const appState: IAppState = init({ lockfileExplorerProjectRoot, appVersion, debugMode });
+  let subspaceName: string = 'default';
+
+  if (process.argv.indexOf('--subspace') >= 0) {
+    if (process.argv[2] !== '--subspace') {
+      throw new Error(
+        'If you want to specify a subspace, you should place "--subspace <subspace_name>" immediately after the "lockfile-explorer" command'
+      );
+    }
+
+    subspaceName = process.argv[3];
+  }
+
+  const appState: IAppState = init({ lockfileExplorerProjectRoot, appVersion, debugMode, subspaceName });
 
   // Important: This must happen after init() reads the current working directory
   process.chdir(appState.lockfileExplorerProjectRoot);

--- a/apps/lockfile-explorer/src/start.ts
+++ b/apps/lockfile-explorer/src/start.ts
@@ -97,7 +97,10 @@ function startApp(debugMode: boolean): void {
   app.get('/api/lockfile', async (req: express.Request, res: express.Response) => {
     const pnpmLockfileText: string = await FileSystem.readFileAsync(appState.pnpmLockfileLocation);
     const doc = yaml.load(pnpmLockfileText);
-    res.send(doc);
+    res.send({
+      doc,
+      subspaceName: appState.subspaceName
+    });
   });
 
   app.get('/api/health', (req: express.Request, res: express.Response) => {

--- a/apps/lockfile-explorer/src/start.ts
+++ b/apps/lockfile-explorer/src/start.ts
@@ -42,15 +42,6 @@ function startApp(debugMode: boolean): void {
   // Must not have a trailing slash
   const SERVICE_URL: string = `http://localhost:${PORT}`;
 
-  // TODO: Later if we introduce more CLI parameters, switch to a proper CLI parser
-  const args: string[] = process.argv.slice(2);
-  if (args.length > 0 && args[0] !== '--debug') {
-    console.log('Usage: lockfile-explorer [--debug]\n');
-    console.log('The "lfx" command is a shorthand alias for "lockfile-explorer".');
-    console.log('See the project website for documentation and support.\n');
-    throw new AlreadyReportedError();
-  }
-
   const appState: IAppState = init({ lockfileExplorerProjectRoot, appVersion, debugMode });
 
   // Important: This must happen after init() reads the current working directory

--- a/apps/lockfile-explorer/src/start.ts
+++ b/apps/lockfile-explorer/src/start.ts
@@ -102,7 +102,7 @@ function startApp(debugMode: boolean): void {
     const doc = yaml.load(pnpmLockfileText);
     res.send({
       doc,
-      subspaceName: appState.subspaceName
+      subspaceName
     });
   });
 

--- a/apps/lockfile-explorer/src/state/index.ts
+++ b/apps/lockfile-explorer/src/state/index.ts
@@ -20,6 +20,7 @@ export interface IAppStateBase {
   pnpmfileLocation: string;
   appVersion: string;
   debugMode: boolean;
+  subspaceName?: string;
 }
 
 export interface IRushAppState extends IAppStateBase {

--- a/apps/lockfile-explorer/src/state/index.ts
+++ b/apps/lockfile-explorer/src/state/index.ts
@@ -20,7 +20,6 @@ export interface IAppStateBase {
   pnpmfileLocation: string;
   appVersion: string;
   debugMode: boolean;
-  subspaceName?: string;
 }
 
 export interface IRushAppState extends IAppStateBase {

--- a/common/changes/@rushstack/lockfile-explorer/main_2024-04-26-06-56.json
+++ b/common/changes/@rushstack/lockfile-explorer/main_2024-04-26-06-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "Support lockfile-explore for subspace future",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer"
+}

--- a/common/changes/@rushstack/lockfile-explorer/main_2024-04-26-06-56.json
+++ b/common/changes/@rushstack/lockfile-explorer/main_2024-04-26-06-56.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/lockfile-explorer",
-      "comment": "Support lockfile-explore for subspace future",
-      "type": "patch"
+      "comment": "Add `--subspace` command-line parameter to support Rush subspaces",
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/lockfile-explorer"


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Currently, if a repo is enabled with subspace feature, the lockfile-explorer command is no longer working. It complains that Error: [Error: File does not exist

This is due to that in subspace, we moved the common/temp folder as well as the pnpm-workspace.yaml file location.

This PR is to address this issue. Users now will be able to input the subspace name when calling the  lockfile-explorer command, like lockfile-explorer --subspace <subspace_name>. The command will use the default subspace if it is not provided.

![image](https://github.com/microsoft/rushstack/assets/68707557/9bee5505-8f8d-446d-bc35-0c87742ad8ea)


<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Manually tested with Rushstack repo locally.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
