### PR TITLE
[rush] Add codespace keep-alive support

### DIFF
--- a/common/changes/@microsoft/rush/keep-alive_2024-04-30-21-23.json
+++ b/common/changes/@microsoft/rush/keep-alive_2024-04-30-21-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add an experiment \"keepCodespacesSessionAliveInWatchMode\" that, in watch mode commands, periodically refreshes the watch status prompt to reset the GitHub Codespaces inactivity timer.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -93,5 +93,11 @@
    * of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist
    * across invocations.
    */
-  // "useIPCScriptsInWatchMode": true
+  // "useIPCScriptsInWatchMode": true,
+
+  /**
+   * If set to true, when running a command in watch mode, Rush will periodically refresh the terminal prompt to keep a
+   * GitHub Codespaces session from timing out from inactivity.
+   */
+  // "keepCodespacesSessionAliveInWatchMode": true
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -461,6 +461,7 @@ export interface IExperimentsJson {
     cleanInstallAfterNpmrcChanges?: boolean;
     forbidPhantomResolvableNodeModulesFolders?: boolean;
     generateProjectImpactGraphDuringRushUpdate?: boolean;
+    keepCodespacesSessionAliveInWatchMode?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
     phasedCommands?: boolean;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -88,10 +88,17 @@
    * If set to true, Rush will generate a `project-impact-graph.yaml` file in the repository root during `rush update`.
    */
   /*[LINE "HYPOTHETICAL"]*/ "generateProjectImpactGraphDuringRushUpdate": true,
+
   /**
    * If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead
    * of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist
    * across invocations.
    */
-  /*[LINE "HYPOTHETICAL"]*/ "useIPCScriptsInWatchMode": true
+  /*[LINE "HYPOTHETICAL"]*/ "useIPCScriptsInWatchMode": true,
+
+  /**
+   * If set to true, when running a command in watch mode, Rush will periodically refresh the terminal prompt to keep a
+   * GitHub Codespaces session from timing out from inactivity.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "keepCodespacesSessionAliveInWatchMode": true
 }

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -101,6 +101,12 @@ export interface IExperimentsJson {
    * across invocations.
    */
   useIPCScriptsInWatchMode?: boolean;
+
+  /**
+   * If set to true, when running a command in watch mode, Rush will periodically refresh the terminal prompt to keep a
+   * GitHub Codespaces session from timing out from inactivity.
+   */
+  keepCodespacesSessionAliveInWatchMode?: boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -620,6 +620,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const projectWatcher: ProjectWatcher = new ProjectWatcher({
       debounceMs: this._watchDebounceMs,
+      keepCodespaceAlive:
+        this.rushConfiguration.experimentsConfiguration.configuration.keepCodespacesSessionAliveInWatchMode,
       rushConfiguration: this.rushConfiguration,
       projectsToWatch,
       terminal,

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -65,6 +65,10 @@
     "useIPCScriptsInWatchMode": {
       "description": "If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist across invocations.",
       "type": "boolean"
+    },
+    "keepCodespacesSessionAliveInWatchMode": {
+      "description": "If set to true, when running a command in watch mode, Rush will periodically refresh the terminal prompt to keep a GitHub Codespaces session from timing out from inactivity.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
Adds a new experiment flag `keepCodespacesSessionAliveInWatchMode` that, when set to `true`, causes watch mode Rush commands (i.e. those invoked with `--watch` or for which `alwaysWatch` is set to `true` in `command-line.json`) to periodically refresh the terminal status prompt. This causes GitHub Codespaces to reset the inactivity timer for the machine.

## Details
Refreshes the prompt every 60 seconds if the process is waiting on the watcher. If Rush is currently executing operations, it is assumed that it will write to the terminal often enough to reset the timer of its own accord.

## How it was tested
- [x] Validated the terminal refresh via running under debugger, since it isn't visibly changed.
- [ ] Validated that the session is kept alive via leaving a codespace running for several hours with `rush start` running in `rushstack`.

## Impacted documentation
Just the experiment.