### PR TITLE
feat(rush,node-core-library): allow weighted async concurrency

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-weighted-graph_2024-05-01-22-51.json
+++ b/common/changes/@microsoft/rush/sennyeya-weighted-graph_2024-05-01-22-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds weighted parallelism to operations. Operations can now define an integer weight for how much parallelism they want to take up.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/sennyeya-weighted-graph_2024-05-01-22-51.json
+++ b/common/changes/@microsoft/rush/sennyeya-weighted-graph_2024-05-01-22-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Adds weighted parallelism to operations. Operations can now define an integer weight for how much parallelism they want to take up.",
+      "comment": "Add a `\"weight\"` property to the `\"operation\"` object in the project `config/rush-project.json` file that defines an integer weight for how much of the allowed parallelism the operation uses.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "A new `Async.forEachWeightedAsync` method allows weighted parallelism where operations can have more or less than a single parallelism unit.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "A new `Async.forEachWeightedAsync` method allows weighted parallelism where operations can have more or less than a single parallelism unit.",
+      "comment": "Add a new `Async.forEachWeightedAsync` method that allows each element to specify how much of the allowed parallelism the callback uses.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-01-22-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add a new `Async.forEachWeightedAsync` method that allows each element to specify how much of the allowed parallelism the callback uses.",
+      "comment": "Add a new `weighted: true` option to the `Async.forEachAsync` method that allows each element to specify how much of the allowed parallelism the callback uses.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-03-22-13.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-graph_2024-05-03-22-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a new `weighted: true` option to the `Async.mapAsync` method that allows each element to specify how much of the allowed parallelism the callback uses.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -25,16 +25,27 @@ export class AlreadyReportedError extends Error {
 
 // @public
 export class Async {
-    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions): Promise<void>;
-    static forEachAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: IAsyncParallelismOptions & {
+    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: {
+        concurrency: number;
+        weighted?: false;
+    } | undefined): Promise<void>;
+    static forEachAsync<TEntry extends IWeighted>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: {
+        concurrency: number;
         weighted: true;
     }): Promise<void>;
     static getSignal(): [Promise<void>, () => void, (err: Error) => void];
-    static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
+    static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: {
+        concurrency: number;
+        weighted?: false;
+    } | undefined): Promise<TRetVal[]>;
+    static mapAsync<TEntry extends IWeighted, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options: {
+        concurrency: number;
+        weighted: true;
+    } | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
     // (undocumented)
-    static validateWeightedIterable(operation: IWeightedIterable): void;
+    static validateWeightedIterable(operation: IWeighted): void;
 }
 
 // @public
@@ -609,7 +620,7 @@ export interface IWaitForExitWithStringOptions extends IWaitForExitOptions {
 }
 
 // @public (undocumented)
-export interface IWeightedIterable {
+export interface IWeighted {
     weight: number;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -25,23 +25,19 @@ export class AlreadyReportedError extends Error {
 
 // @public
 export class Async {
-    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: {
-        concurrency: number;
+    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: (IAsyncParallelismOptions & {
         weighted?: false;
-    } | undefined): Promise<void>;
-    static forEachAsync<TEntry extends IWeighted>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: {
-        concurrency: number;
+    }) | undefined): Promise<void>;
+    static forEachAsync<TEntry extends IWeighted>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: IAsyncParallelismOptions & {
         weighted: true;
     }): Promise<void>;
     static getSignal(): [Promise<void>, () => void, (err: Error) => void];
-    static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: {
-        concurrency: number;
+    static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: (IAsyncParallelismOptions & {
         weighted?: false;
-    } | undefined): Promise<TRetVal[]>;
-    static mapAsync<TEntry extends IWeighted, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options: {
-        concurrency: number;
+    }) | undefined): Promise<TRetVal[]>;
+    static mapAsync<TEntry extends IWeighted, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options: IAsyncParallelismOptions & {
         weighted: true;
-    } | undefined): Promise<TRetVal[]>;
+    }): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
     // (undocumented)

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -609,7 +609,7 @@ export interface IWaitForExitWithStringOptions extends IWaitForExitOptions {
 // @public (undocumented)
 export interface IWeightedIterable {
     // (undocumented)
-    weight?: number;
+    weight: number;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -26,7 +26,6 @@ export class AlreadyReportedError extends Error {
 // @public
 export class Async {
     static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
-    // (undocumented)
     static forEachWeightedAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
     static getSignal(): [Promise<void>, () => void, (err: Error) => void];
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -40,7 +40,6 @@ export class Async {
     }): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
-    // (undocumented)
     static validateWeightedIterable(operation: IWeighted): void;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -26,6 +26,8 @@ export class AlreadyReportedError extends Error {
 // @public
 export class Async {
     static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
+    // (undocumented)
+    static forEachWeightedAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
     static getSignal(): [Promise<void>, () => void, (err: Error) => void];
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
@@ -600,6 +602,12 @@ export interface IWaitForExitWithBufferOptions extends IWaitForExitOptions {
 // @public
 export interface IWaitForExitWithStringOptions extends IWaitForExitOptions {
     encoding: BufferEncoding;
+}
+
+// @public (undocumented)
+export interface IWeightedIterable {
+    // (undocumented)
+    weight: number;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -33,6 +33,8 @@ export class Async {
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
     static sleep(ms: number): Promise<void>;
+    // (undocumented)
+    static validateWeightedIterable(operation: IWeightedIterable): void;
 }
 
 // @public
@@ -228,6 +230,8 @@ export type FolderItem = fs.Dirent;
 // @public
 export interface IAsyncParallelismOptions {
     concurrency?: number;
+    // (undocumented)
+    weighted?: boolean;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -26,7 +26,6 @@ export class AlreadyReportedError extends Error {
 // @public
 export class Async {
     static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions): Promise<void>;
-    // (undocumented)
     static forEachAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: IAsyncParallelismOptions & {
         weighted: true;
     }): Promise<void>;
@@ -608,7 +607,6 @@ export interface IWaitForExitWithStringOptions extends IWaitForExitOptions {
 
 // @public (undocumented)
 export interface IWeightedIterable {
-    // (undocumented)
     weight: number;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -230,7 +230,6 @@ export type FolderItem = fs.Dirent;
 // @public
 export interface IAsyncParallelismOptions {
     concurrency?: number;
-    // (undocumented)
     weighted?: boolean;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -25,8 +25,11 @@ export class AlreadyReportedError extends Error {
 
 // @public
 export class Async {
-    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
-    static forEachWeightedAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions | undefined): Promise<void>;
+    static forEachAsync<TEntry>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options?: IAsyncParallelismOptions): Promise<void>;
+    // (undocumented)
+    static forEachAsync<TEntry extends IWeightedIterable>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<void>, options: IAsyncParallelismOptions & {
+        weighted: true;
+    }): Promise<void>;
     static getSignal(): [Promise<void>, () => void, (err: Error) => void];
     static mapAsync<TEntry, TRetVal>(iterable: Iterable<TEntry> | AsyncIterable<TEntry>, callback: (entry: TEntry, arrayIndex: number) => Promise<TRetVal>, options?: IAsyncParallelismOptions | undefined): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
@@ -606,7 +609,7 @@ export interface IWaitForExitWithStringOptions extends IWaitForExitOptions {
 // @public (undocumented)
 export interface IWeightedIterable {
     // (undocumented)
-    weight: number;
+    weight?: number;
 }
 
 // @public

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -619,6 +619,7 @@ export interface IOperationSettings {
     disableBuildCacheForOperation?: boolean;
     operationName: string;
     outputFolderNames?: string[];
+    weight?: number;
 }
 
 // @internal (undocumented)

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -39,7 +39,7 @@ export interface IRunWithRetriesOptions<TResult> {
 
 /**
  * @remarks
- * Used with {@link (Async:class).(forEachAsync:2)}.
+ * Used with {@link (Async:class).(forEachAsync:2)} and {@link (Async:class).(mapAsync:2)}.
  *
  * @public
  */
@@ -322,6 +322,10 @@ export class Async {
     }
   }
 
+  /**
+   * Ensures that the argument is a valid {@link IWeighted}, with a `weight` argument that
+   * is a positive integer or 0.
+   */
   public static validateWeightedIterable(operation: IWeighted): void {
     if (operation.weight < 0) {
       throw new Error('Weight must be a whole number greater than or equal to 0');

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -16,6 +16,10 @@ export interface IAsyncParallelismOptions {
    */
   concurrency?: number;
 
+  /**
+   * Optionally used with the {@link (Async:class).(forEachAsync:2)} to enable weighted operations where an operation can
+   * take up more or less than one concurrency unit.
+   */
   weighted?: boolean;
 }
 

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -227,18 +227,12 @@ export class Async {
    * @param callback - a function that starts an asynchronous promise for an element
    *   from the array
    * @param options - options for customizing the control flow
-   *
-   *  {@label UNWEIGHTED}
    */
   public static async forEachAsync<TEntry>(
     iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
     callback: (entry: TEntry, arrayIndex: number) => Promise<void>,
     options?: IAsyncParallelismOptions
   ): Promise<void>;
-
-  /**
-   *  {@label WEIGHTED}
-   */
   public static async forEachAsync<TEntry extends IWeightedIterable>(
     iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
     callback: (entry: TEntry, arrayIndex: number) => Promise<void>,

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -47,7 +47,8 @@ function getWeight<T>(element: T): number | undefined {
 }
 
 function toWeightedIterator<TEntry>(
-  iterable: Iterable<TEntry> | AsyncIterable<TEntry>
+  iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
+  useWeights: boolean = false
 ): AsyncIterable<{ element: TEntry; weighted?: number }> {
   const iterator: Iterator<TEntry> | AsyncIterator<TEntry> = (
     (iterable as Iterable<TEntry>)[Symbol.iterator] ||
@@ -58,8 +59,8 @@ function toWeightedIterator<TEntry>(
       next: async () => {
         const { value, done } = await Promise.resolve(iterator.next());
         return {
-          value: { element: value, weight: getWeight(value) },
-          done: done ?? false
+          value: { element: value, weight: useWeights ? getWeight(value) : 1 },
+          done
         };
       }
     })
@@ -244,7 +245,7 @@ export class Async {
     options?: IAsyncParallelismOptions & { weighted?: true }
   ): Promise<void> {
     if (options?.weighted) {
-      return Async._forEachWeightedAsync(toWeightedIterator(iterable), callback, options);
+      return Async._forEachWeightedAsync(toWeightedIterator(iterable, true), callback, options);
     }
 
     return Async._forEachWeightedAsync(toWeightedIterator(iterable), callback, options);

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -149,8 +149,10 @@ export class Async {
 
           if (!iteratorIsComplete) {
             const currentIteratorValue: TEntry = currentIteratorResult.value;
-            const weight: number = currentIteratorValue.weight ?? 1;
+            const weight: number = Math.min(currentIteratorValue.weight ?? 1, concurrency);
             // If it's a weighted operation then add the rest of the weight, removing concurrent units if weight < 1.
+            // Cap it to the concurrency limit, otherwise higher weights can cause issues in the case where 0 weighted
+            // operations are present.
             concurrentUnitsInProgress += weight - 1;
             Promise.resolve(callback(currentIteratorValue.element, arrayIndex++))
               .then(async () => {

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -36,7 +36,7 @@ export interface IRunWithRetriesOptions<TResult> {
  * @public
  */
 export interface IWeightedIterable {
-  weight?: number;
+  weight: number;
 }
 
 function getWeight<T>(element: T): number | undefined {

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -38,7 +38,7 @@ export interface IRunWithRetriesOptions<TResult> {
 export interface IWeightedIterable {
   /**
    * The weight of the element, used to determine the concurrency units that it will take up.
-   *  Must be a whole number >= 0.
+   *  Must be a whole number greater than or equal to 0.
    */
   weight: number;
 }

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -8,7 +8,13 @@
  */
 
 export { AlreadyReportedError } from './AlreadyReportedError';
-export { Async, AsyncQueue, IAsyncParallelismOptions, IRunWithRetriesOptions } from './Async';
+export {
+  Async,
+  AsyncQueue,
+  IAsyncParallelismOptions,
+  IRunWithRetriesOptions,
+  IWeightedIterable
+} from './Async';
 export { Brand } from './PrimitiveTypes';
 export { FileConstants, FolderConstants } from './Constants';
 export { Enum } from './Enum';

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -8,13 +8,7 @@
  */
 
 export { AlreadyReportedError } from './AlreadyReportedError';
-export {
-  Async,
-  AsyncQueue,
-  IAsyncParallelismOptions,
-  IRunWithRetriesOptions,
-  IWeightedIterable
-} from './Async';
+export { Async, AsyncQueue, IAsyncParallelismOptions, IRunWithRetriesOptions, IWeighted } from './Async';
 export { Brand } from './PrimitiveTypes';
 export { FileConstants, FolderConstants } from './Constants';
 export { Enum } from './Enum';

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -354,6 +354,24 @@ describe(Async.name, () => {
       expect(maxRunning).toEqual(3);
     });
 
+    it('if concurrency is set but weighted is not, ensures no more than N operations occur in parallel and ignores operation weight', async () => {
+      let running: number = 0;
+      let maxRunning: number = 0;
+
+      const array: INumberWithWeight[] = [1, 2, 3, 4, 5, 6, 7, 8].map((n) => ({ weight: 2, n }));
+
+      const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
+        running++;
+        await Async.sleep(0);
+        maxRunning = Math.max(maxRunning, running);
+        running--;
+      });
+
+      await Async.forEachAsync(array, fn, { concurrency: 3 });
+      expect(fn).toHaveBeenCalledTimes(8);
+      expect(maxRunning).toEqual(3);
+    });
+
     it.each([
       {
         concurrency: 4,

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -456,6 +456,28 @@ describe(Async.name, () => {
       expect(fn).toHaveBeenCalledTimes(8);
       expect(maxRunning).toEqual(2);
     });
+
+    it('allows operations with a weight of 0 and schedules them accordingly', async () => {
+      let running: number = 0;
+      let maxRunning: number = 0;
+
+      const array: INumberWithWeight[] = [1, 2, 3, 4, 5, 6, 7, 8].map((n) => ({ n, weight: 0 }));
+
+      array.unshift({ n: 9, weight: 3 });
+
+      array.push({ n: 10, weight: 3 });
+
+      const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
+        running++;
+        await Async.sleep(0);
+        maxRunning = Math.max(maxRunning, running);
+        running--;
+      });
+
+      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      expect(fn).toHaveBeenCalledTimes(10);
+      expect(maxRunning).toEqual(9);
+    });
   });
 
   describe(Async.runWithRetriesAsync.name, () => {

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -312,9 +312,7 @@ describe(Async.name, () => {
         Async.forEachAsync(syncIterable, async (item) => await Async.sleep(0))
       ).rejects.toThrow(expectedError);
     });
-  });
 
-  describe(Async.forEachWeightedAsync.name, () => {
     interface INumberWithWeight {
       n: number;
       weight: number;
@@ -333,7 +331,7 @@ describe(Async.name, () => {
         running--;
       });
 
-      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      await Async.forEachAsync(array, fn, { concurrency: 3, weighted: true });
       expect(fn).toHaveBeenCalledTimes(0);
       expect(maxRunning).toEqual(0);
     });
@@ -351,7 +349,7 @@ describe(Async.name, () => {
         running--;
       });
 
-      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      await Async.forEachAsync(array, fn, { concurrency: 3, weighted: true });
       expect(fn).toHaveBeenCalledTimes(8);
       expect(maxRunning).toEqual(3);
     });
@@ -397,7 +395,7 @@ describe(Async.name, () => {
           running--;
         });
 
-        await Async.forEachWeightedAsync(array, fn, { concurrency });
+        await Async.forEachAsync(array, fn, { concurrency, weighted: true });
         expect(fn).toHaveBeenCalledTimes(8);
         expect(maxRunning).toEqual(expectedConcurrency);
       }
@@ -425,7 +423,7 @@ describe(Async.name, () => {
         running--;
       });
 
-      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      await Async.forEachAsync(array, fn, { concurrency: 3, weighted: true });
       expect(fn).toHaveBeenCalledTimes(8);
       expect(maxRunning).toEqual(3);
     });
@@ -452,7 +450,7 @@ describe(Async.name, () => {
         running--;
       });
 
-      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      await Async.forEachAsync(array, fn, { concurrency: 3, weighted: true });
       expect(fn).toHaveBeenCalledTimes(8);
       expect(maxRunning).toEqual(2);
     });
@@ -474,7 +472,7 @@ describe(Async.name, () => {
         running--;
       });
 
-      await Async.forEachWeightedAsync(array, fn, { concurrency: 3 });
+      await Async.forEachAsync(array, fn, { concurrency: 3, weighted: true });
       expect(fn).toHaveBeenCalledTimes(10);
       expect(maxRunning).toEqual(9);
     });

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -92,6 +92,12 @@ export interface IOperationSettings {
    * calculating final hash value when reading and writing the build cache
    */
   dependsOnAdditionalFiles?: string[];
+
+  /**
+   * How many concurrency units this operation should take up during execution. The maximum concurrent units is
+   *  determined by the -p flag.
+   */
+  weight?: number;
 }
 
 interface IOldRushProjectJson {

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -48,6 +48,7 @@ import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { LegacySkipPlugin } from '../../logic/operations/LegacySkipPlugin';
 import { ValidateOperationsPlugin } from '../../logic/operations/ValidateOperationsPlugin';
 import type { ProjectWatcher } from '../../logic/ProjectWatcher';
+import { WeightedOperationPlugin } from '../../logic/operations/WeightedOperationPlugin';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -165,6 +166,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     new PhasedOperationPlugin().apply(this.hooks);
     // Applies the Shell Operation Runner to selected operations
     new ShellOperationRunnerPlugin().apply(this.hooks);
+
+    new WeightedOperationPlugin().apply(this.hooks);
     new ValidateOperationsPlugin(terminal).apply(this.hooks);
 
     if (this._enableParallelism) {

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -15,7 +15,9 @@ import { RushConstants } from '../RushConstants';
  */
 export const UNASSIGNED_OPERATION: 'UNASSIGNED_OPERATION' = 'UNASSIGNED_OPERATION';
 
-export type IOperationIteratorResult = OperationExecutionRecord | typeof UNASSIGNED_OPERATION;
+export type IOperationIteratorResult =
+  | OperationExecutionRecord
+  | { weight: 0; status: typeof UNASSIGNED_OPERATION };
 
 /**
  * Implementation of the async iteration protocol for a collection of IOperation objects.
@@ -164,7 +166,7 @@ export class AsyncOperationQueue
       // remote executing operation which is not ready to process.
       if (queue.some((operation) => operation.status === OperationStatus.RemoteExecuting)) {
         waitingIterators.shift()!({
-          value: UNASSIGNED_OPERATION,
+          value: { weight: 0, status: UNASSIGNED_OPERATION },
           done: false
         });
       }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -253,7 +253,7 @@ export class OperationExecutionManager {
       return await this._beforeExecuteOperation?.(record);
     };
 
-    await Async.forEachAsync(
+    await Async.forEachWeightedAsync(
       this._executionQueue,
       async (operation: IOperationIteratorResult) => {
         let record: OperationExecutionRecord | undefined;
@@ -262,7 +262,7 @@ export class OperationExecutionManager {
          * This happens when some operations run remotely. So, we should try to get a remote executing operation
          * from the queue manually here.
          */
-        if (operation === UNASSIGNED_OPERATION) {
+        if (operation.status === UNASSIGNED_OPERATION) {
           // Pause for a few time
           await Async.sleep(5000);
           record = this._executionQueue.tryGetRemoteExecutingOperation();

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -253,7 +253,7 @@ export class OperationExecutionManager {
       return await this._beforeExecuteOperation?.(record);
     };
 
-    await Async.forEachWeightedAsync(
+    await Async.forEachAsync(
       this._executionQueue,
       async (operation: IOperationIteratorResult) => {
         let record: OperationExecutionRecord | undefined;
@@ -281,7 +281,8 @@ export class OperationExecutionManager {
         }
       },
       {
-        concurrency: maxParallelism
+        concurrency: maxParallelism,
+        weighted: true
       }
     );
 

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -10,6 +10,7 @@ import type {
 import type { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
+import { Async } from '@rushstack/node-core-library';
 
 const PLUGIN_NAME: 'WeightedOperationPlugin' = 'WeightedOperationPlugin';
 
@@ -43,11 +44,7 @@ function weightOperations(
         operation.weight = operationSettings.weight;
       }
     }
-    if (operation.weight < 0) {
-      throw new Error(`The weight of the operation '${operation.name}' cannot be negative.`);
-    } else if (operation.weight % 1 !== 0) {
-      throw new Error(`The weight of the operation '${operation.name}' cannot be a decimal.`);
-    }
+    Async.validateWeightedIterable(operation);
   }
   return operations;
 }

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { Operation } from './Operation';
+import type {
+  ICreateOperationsContext,
+  IPhasedCommandPlugin,
+  PhasedCommandHooks
+} from '../../pluginFramework/PhasedCommandHooks';
+import type { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+
+const PLUGIN_NAME: 'WeightedOperationPlugin' = 'WeightedOperationPlugin';
+
+/**
+ * Add weights to operations based on the operation settings in rush-project.json.
+ *
+ * This also sets the weight of no-op operations to 0.01.
+ */
+export class WeightedOperationPlugin implements IPhasedCommandPlugin {
+  public apply(hooks: PhasedCommandHooks): void {
+    hooks.createOperations.tap(PLUGIN_NAME, weightOperations);
+  }
+}
+
+function weightOperations(operations: Set<Operation>, context: ICreateOperationsContext): Set<Operation> {
+  const { projectConfigurations } = context;
+
+  for (const operation of operations) {
+    const { associatedProject: project, associatedPhase: phase } = operation;
+    if (operation.runner?.isNoOp) {
+      operation.weight = 0.01;
+    } else if (project && phase) {
+      const projectConfiguration: RushProjectConfiguration | undefined = projectConfigurations.get(project);
+      const operationSettings: IOperationSettings | undefined =
+        projectConfiguration?.operationSettingsByOperationName.get(phase.name);
+      if (operationSettings?.weight) {
+        operation.weight = operationSettings.weight;
+      }
+    }
+  }
+  return operations;
+}

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -8,8 +8,8 @@ import type {
   PhasedCommandHooks
 } from '../../pluginFramework/PhasedCommandHooks';
 import type { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
-import { IOperationExecutionResult } from './IOperationExecutionResult';
-import { OperationExecutionRecord } from './OperationExecutionRecord';
+import type { IOperationExecutionResult } from './IOperationExecutionResult';
+import type { OperationExecutionRecord } from './OperationExecutionRecord';
 
 const PLUGIN_NAME: 'WeightedOperationPlugin' = 'WeightedOperationPlugin';
 

--- a/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
@@ -47,7 +47,7 @@ describe(AsyncOperationQueue.name, () => {
     const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, nullSort);
     for await (const operation of queue) {
       actualOrder.push(operation);
-      if (operation === UNASSIGNED_OPERATION) {
+      if (operation.status === UNASSIGNED_OPERATION) {
         hasUnassignedOperation = true;
         continue;
       }
@@ -76,7 +76,7 @@ describe(AsyncOperationQueue.name, () => {
     const queue: AsyncOperationQueue = new AsyncOperationQueue(operations, customSort);
     for await (const operation of queue) {
       actualOrder.push(operation);
-      if (operation === UNASSIGNED_OPERATION) {
+      if (operation.status === UNASSIGNED_OPERATION) {
         hasUnassignedOperation = true;
         continue;
       }
@@ -135,7 +135,7 @@ describe(AsyncOperationQueue.name, () => {
     await Promise.all(
       Array.from({ length: 3 }, async () => {
         for await (const operation of queue) {
-          if (operation === UNASSIGNED_OPERATION) {
+          if (operation.status === UNASSIGNED_OPERATION) {
             hasUnassignedOperation = true;
             continue;
           }
@@ -184,7 +184,7 @@ describe(AsyncOperationQueue.name, () => {
     let remoteExecuted: boolean = false;
     for await (const operation of queue) {
       let record: OperationExecutionRecord | undefined;
-      if (operation === UNASSIGNED_OPERATION) {
+      if (operation.status === UNASSIGNED_OPERATION) {
         await Async.sleep(100);
         record = queue.tryGetRemoteExecutingOperation();
       } else {

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -76,7 +76,8 @@
 
           "weight": {
             "description": "The number of concurrency units that this operation should take up. The maximum concurrency units is determined by the -p flag.",
-            "type": "number"
+            "type": "integer",
+            "minimum": 0
           }
         }
       }

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -72,6 +72,11 @@
           "disableBuildCacheForOperation": {
             "description": "Disable caching for this operation. The operation will never be restored from cache. This may be useful if this operation affects state outside of its folder.",
             "type": "boolean"
+          },
+
+          "weight": {
+            "description": "The number of concurrency units that this operation should take up. The maximum concurrency units is determined by the -p flag.",
+            "type": "number"
           }
         }
       }


### PR DESCRIPTION
## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Followup to #4092. The goal of this PR is to allow rush users to define the weight of an operation, this is especially useful for operations that do not take a fair share of the available concurrency (either CPU or memory). Examples include jest's `max-workers` or other CPU intensive tasks, as well as memory intensive tasks where you may want to only run one heavy task without parallelism but you don't want to drop the overall rush parallelism.

This code is very similar to David's original PR, with a few modifications
1. the implementation is now very similar to Async.forEachAsync()
2. Operation weight can only be whole numbers.
3. A new WeightedOperationPlugin that adds the weight to the operation and validates that the weight is in fact a whole number and >= 0.

There was some original discussion around the name of weight, I think it's a decent name and the one I would reach for when naming this as well. I reference concurrencyUnits in my PR as the weighted sum of the current active operations.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

The decision to use whole numbers for concurrency is both for maintainer sanity and because I was running into a deadlock with concurrency 1 and various weights < 1. Whole numbers seems to fix this as there's no longer any risk of floating point math causing weird issues. Definitely looking for additional use cases to test that theory on though.

I didn't do it in this PR, but theoretically, `Async.forEachAsync` could be reimplemented in terms of `Async.forEachAsync` with each item having a weight of 1.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Added unit tests and tested that this runs on the cobuild sandbox repo.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

Any references to rush parallelism may benefit from this.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
