### PR TITLE
[rush] Refactor the Rush flags' disk operations to be async.

### DIFF
--- a/apps/rush/src/RushVersionSelector.ts
+++ b/apps/rush/src/RushVersionSelector.ts
@@ -34,7 +34,8 @@ export class RushVersionSelector {
       node: process.versions.node
     });
 
-    if (!installMarker.isValid()) {
+    let installIsValid: boolean = await installMarker.isValidAsync();
+    if (!installIsValid) {
       // Need to install Rush
       console.log(`Rush version ${version} is not currently installed. Installing...`);
 
@@ -43,7 +44,8 @@ export class RushVersionSelector {
       console.log(`Trying to acquire lock for ${resourceName}`);
 
       const lock: LockFile = await LockFile.acquire(expectedRushPath, resourceName);
-      if (installMarker.isValid()) {
+      installIsValid = await installMarker.isValidAsync();
+      if (installIsValid) {
         console.log('Another process performed the installation.');
       } else {
         Utilities.installPackageInDirectory({
@@ -65,7 +67,7 @@ export class RushVersionSelector {
         console.log(`Successfully installed Rush version ${version} in ${expectedRushPath}.`);
 
         // If we've made it here without exception, write the flag file
-        installMarker.create();
+        await installMarker.createAsync();
 
         lock.release();
       }

--- a/common/changes/@microsoft/rush/refactor-flags_2024-05-06-06-14.json
+++ b/common/changes/@microsoft/rush/refactor-flags_2024-05-06-06-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -859,13 +859,13 @@ export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
 // @internal
 export class _LastInstallFlag {
     constructor(folderPath: string, state?: JsonObject);
-    checkValidAndReportStoreIssues(options: _ILockfileValidityCheckOptions & {
+    checkValidAndReportStoreIssuesAsync(options: _ILockfileValidityCheckOptions & {
         rushVerb: string;
-    }): boolean;
-    clear(): void;
-    create(): void;
+    }): Promise<boolean>;
+    clearAsync(): Promise<void>;
+    createAsync(): Promise<void>;
     protected get flagName(): string;
-    isValid(options?: _ILockfileValidityCheckOptions): boolean;
+    isValidAsync(options?: _ILockfileValidityCheckOptions): Promise<boolean>;
     readonly path: string;
 }
 

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -48,8 +48,8 @@ export class LastInstallFlag {
   /**
    * Returns true if the file exists and the contents match the current state.
    */
-  public isValid(options?: ILockfileValidityCheckOptions): boolean {
-    return this._isValid(false, options);
+  public async isValidAsync(options?: ILockfileValidityCheckOptions): Promise<boolean> {
+    return await this._isValidAsync(false, options);
   }
 
   /**
@@ -58,24 +58,27 @@ export class LastInstallFlag {
    *
    * @internal
    */
-  public checkValidAndReportStoreIssues(
+  public async checkValidAndReportStoreIssuesAsync(
     options: ILockfileValidityCheckOptions & { rushVerb: string }
-  ): boolean {
-    return this._isValid(true, options);
+  ): Promise<boolean> {
+    return this._isValidAsync(true, options);
   }
 
-  private _isValid(checkValidAndReportStoreIssues: false, options?: ILockfileValidityCheckOptions): boolean;
-  private _isValid(
+  private _isValidAsync(
+    checkValidAndReportStoreIssues: false,
+    options?: ILockfileValidityCheckOptions
+  ): Promise<boolean>;
+  private _isValidAsync(
     checkValidAndReportStoreIssues: true,
     options: ILockfileValidityCheckOptions & { rushVerb: string }
-  ): boolean;
-  private _isValid(
+  ): Promise<boolean>;
+  private async _isValidAsync(
     checkValidAndReportStoreIssues: boolean,
     { rushVerb = 'update', statePropertiesToIgnore }: ILockfileValidityCheckOptions = {}
-  ): boolean {
+  ): Promise<boolean> {
     let oldState: JsonObject;
     try {
-      oldState = JsonFile.load(this.path);
+      oldState = await JsonFile.loadAsync(this.path);
     } catch (err) {
       return false;
     }
@@ -126,8 +129,8 @@ export class LastInstallFlag {
   /**
    * Writes the flag file to disk with the current state
    */
-  public create(): void {
-    JsonFile.save(this._state, this.path, {
+  public async createAsync(): Promise<void> {
+    await JsonFile.saveAsync(this._state, this.path, {
       ensureFolderExists: true
     });
   }
@@ -135,8 +138,8 @@ export class LastInstallFlag {
   /**
    * Removes the flag file
    */
-  public clear(): void {
-    FileSystem.deleteFile(this.path);
+  public async clearAsync(): Promise<void> {
+    await FileSystem.deleteFileAsync(this.path);
   }
 
   /**

--- a/libraries/rush-lib/src/api/LastLinkFlag.ts
+++ b/libraries/rush-lib/src/api/LastLinkFlag.ts
@@ -16,10 +16,10 @@ export class LastLinkFlag extends LastInstallFlag {
   /**
    * @override
    */
-  public isValid(): boolean {
+  public async isValidAsync(): Promise<boolean> {
     let oldState: JsonObject | undefined;
     try {
-      oldState = JsonFile.load(this.path);
+      oldState = await JsonFile.loadAsync(this.path);
     } catch (err) {
       // Swallow error
     }
@@ -29,7 +29,7 @@ export class LastLinkFlag extends LastInstallFlag {
   /**
    * @override
    */
-  public checkValidAndReportStoreIssues(): boolean {
+  public checkValidAndReportStoreIssuesAsync(): never {
     throw new InternalError('Not implemented');
   }
 

--- a/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
+++ b/libraries/rush-lib/src/api/test/LastInstallFlag.test.ts
@@ -22,61 +22,61 @@ describe(LastInstallFlag.name, () => {
     expect(path.basename(flag.path)).toEqual(LAST_INSTALL_FLAG_FILE_NAME);
   });
 
-  it('can create and remove a flag in an empty directory', () => {
+  it('can create and remove a flag in an empty directory', async () => {
     // preparation
     const flag: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH);
     FileSystem.deleteFile(flag.path);
 
     // test state, should be invalid since the file doesn't exist
-    expect(flag.isValid()).toEqual(false);
+    await expect(flag.isValidAsync()).resolves.toEqual(false);
 
     // test creation
-    flag.create();
+    await flag.createAsync();
     expect(FileSystem.exists(flag.path)).toEqual(true);
-    expect(flag.isValid()).toEqual(true);
+    await expect(flag.isValidAsync()).resolves.toEqual(true);
 
     // test deletion
-    flag.clear();
+    await flag.clearAsync();
     expect(FileSystem.exists(flag.path)).toEqual(false);
-    expect(flag.isValid()).toEqual(false);
+    await expect(flag.isValidAsync()).resolves.toEqual(false);
   });
 
-  it('can detect if the last flag was in a different state', () => {
+  it('can detect if the last flag was in a different state', async () => {
     // preparation
     const flag1: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, { node: '5.0.0' });
     const flag2: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, { node: '8.9.4' });
     FileSystem.deleteFile(flag1.path);
 
     // test state, should be invalid since the file doesn't exist
-    expect(flag1.isValid()).toEqual(false);
-    expect(flag2.isValid()).toEqual(false);
+    await expect(flag1.isValidAsync()).resolves.toEqual(false);
+    await expect(flag2.isValidAsync()).resolves.toEqual(false);
 
     // test creation
-    flag1.create();
+    await flag1.createAsync();
     expect(FileSystem.exists(flag1.path)).toEqual(true);
-    expect(flag1.isValid()).toEqual(true);
+    await expect(flag1.isValidAsync()).resolves.toEqual(true);
 
     // the second flag has different state and should be invalid
-    expect(flag2.isValid()).toEqual(false);
+    await expect(flag2.isValidAsync()).resolves.toEqual(false);
 
     // test deletion
-    flag1.clear();
+    await flag1.clearAsync();
     expect(FileSystem.exists(flag1.path)).toEqual(false);
-    expect(flag1.isValid()).toEqual(false);
-    expect(flag2.isValid()).toEqual(false);
+    await expect(flag1.isValidAsync()).resolves.toEqual(false);
+    await expect(flag2.isValidAsync()).resolves.toEqual(false);
   });
 
-  it('can detect if the last flag was in a corrupted state', () => {
+  it('can detect if the last flag was in a corrupted state', async () => {
     // preparation, write non-json into flag file
     const flag: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH);
     FileSystem.writeFile(flag.path, 'sdfjkaklfjksldajgfkld');
 
     // test state, should be invalid since the file is not JSON
-    expect(flag.isValid()).toEqual(false);
+    await expect(flag.isValidAsync()).resolves.toEqual(false);
     FileSystem.deleteFile(flag.path);
   });
 
-  it("throws an error if new storePath doesn't match the old one", () => {
+  it("throws an error if new storePath doesn't match the old one", async () => {
     const flag1: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, {
       packageManager: 'pnpm',
       storePath: `${TEMP_DIR_PATH}/pnpm-store`
@@ -86,13 +86,13 @@ describe(LastInstallFlag.name, () => {
       storePath: `${TEMP_DIR_PATH}/temp-store`
     });
 
-    flag1.create();
-    expect(() => {
-      flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' });
-    }).toThrowError(/PNPM store path/);
+    await flag1.createAsync();
+    await expect(async () => {
+      await flag2.checkValidAndReportStoreIssuesAsync({ rushVerb: 'install' });
+    }).rejects.toThrowError(/PNPM store path/);
   });
 
-  it("doesn't throw an error if conditions for error aren't met", () => {
+  it("doesn't throw an error if conditions for error aren't met", async () => {
     const flag1: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, {
       packageManager: 'pnpm',
       storePath: `${TEMP_DIR_PATH}/pnpm-store`
@@ -101,14 +101,12 @@ describe(LastInstallFlag.name, () => {
       packageManager: 'npm'
     });
 
-    flag1.create();
-    expect(() => {
-      flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' });
-    }).not.toThrow();
-    expect(flag2.checkValidAndReportStoreIssues({ rushVerb: 'install' })).toEqual(false);
+    await flag1.createAsync();
+    await expect(flag2.checkValidAndReportStoreIssuesAsync({ rushVerb: 'install' })).resolves.not.toThrow();
+    await expect(flag2.checkValidAndReportStoreIssuesAsync({ rushVerb: 'install' })).resolves.toEqual(false);
   });
 
-  it("ignores a specified option that doesn't match", () => {
+  it("ignores a specified option that doesn't match", async () => {
     const flag1: LastInstallFlag = new LastInstallFlag(TEMP_DIR_PATH, {
       option1: 'a',
       option2: 'b'
@@ -118,10 +116,8 @@ describe(LastInstallFlag.name, () => {
       option2: 'c'
     });
 
-    flag1.create();
-    expect(() => {
-      flag2.isValid({ statePropertiesToIgnore: ['option2'] });
-    }).not.toThrow();
-    expect(flag2.isValid({ statePropertiesToIgnore: ['option2'] })).toEqual(true);
+    await flag1.createAsync();
+    await expect(flag2.isValidAsync({ statePropertiesToIgnore: ['option2'] })).resolves.not.toThrow();
+    await expect(flag2.isValidAsync({ statePropertiesToIgnore: ['option2'] })).resolves.toEqual(true);
   });
 });

--- a/libraries/rush-lib/src/cli/actions/PurgeAction.ts
+++ b/libraries/rush-lib/src/cli/actions/PurgeAction.ts
@@ -39,7 +39,7 @@ export class PurgeAction extends BaseRushAction {
     const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
     const purgeManager: PurgeManager = new PurgeManager(this.rushConfiguration, this.rushGlobalFolder);
 
-    unlinkManager.unlink(/*force:*/ true);
+    await unlinkManager.unlinkAsync(/*force:*/ true);
 
     if (this._unsafeParameter.value!) {
       purgeManager.purgeUnsafe();

--- a/libraries/rush-lib/src/cli/actions/UnlinkAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UnlinkAction.ts
@@ -21,7 +21,7 @@ export class UnlinkAction extends BaseRushAction {
   protected async runAsync(): Promise<void> {
     const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
 
-    if (!unlinkManager.unlink()) {
+    if (!unlinkManager.unlinkAsync()) {
       // eslint-disable-next-line no-console
       console.log('Nothing to do.');
     } else {

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -294,7 +294,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         this.rushConfiguration.defaultSubspace
       );
       // Only check for a valid link flag when subspaces is not enabled
-      if (!lastLinkFlag.isValid() && !this.rushConfiguration.subspacesFeatureEnabled) {
+      if (!lastLinkFlag.isValidAsync() && !this.rushConfiguration.subspacesFeatureEnabled) {
         const useWorkspaces: boolean =
           this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
         if (useWorkspaces) {

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -104,7 +104,7 @@ async function getCommandLineParserInstanceAsync(
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid
   // TODO: Support subspaces
-  LastLinkFlagFactory.getCommonTempFlag(parser.rushConfiguration.defaultSubspace).create();
+  await LastLinkFlagFactory.getCommonTempFlag(parser.rushConfiguration.defaultSubspace).createAsync();
 
   // Mock the command
   process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', taskName];

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -125,7 +125,7 @@ export class Autoinstaller {
       // Example: ../common/autoinstallers/my-task/node_modules
       const nodeModulesFolder: string = `${autoinstallerFullPath}/${RushConstants.nodeModulesFolderName}`;
       const flagPath: string = `${nodeModulesFolder}/rush-autoinstaller.flag`;
-      const isLastInstallFlagDirty: boolean = !lastInstallFlag.isValid() || !FileSystem.exists(flagPath);
+      const isLastInstallFlagDirty: boolean = !lastInstallFlag.isValidAsync() || !FileSystem.exists(flagPath);
 
       if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
         if (FileSystem.exists(nodeModulesFolder)) {
@@ -151,7 +151,7 @@ export class Autoinstaller {
         });
 
         // Create file: ../common/autoinstallers/my-task/.rush/temp/last-install.flag
-        lastInstallFlag.create();
+        await lastInstallFlag.createAsync();
 
         FileSystem.writeFile(
           flagPath,

--- a/libraries/rush-lib/src/logic/UnlinkManager.ts
+++ b/libraries/rush-lib/src/logic/UnlinkManager.ts
@@ -26,7 +26,7 @@ export class UnlinkManager {
    *
    * Returns true if anything was deleted.
    */
-  public unlink(force: boolean = false): boolean {
+  public async unlinkAsync(force: boolean = false): Promise<boolean> {
     const useWorkspaces: boolean =
       this._rushConfiguration.pnpmOptions && this._rushConfiguration.pnpmOptions.useWorkspaces;
     if (!force && useWorkspaces) {
@@ -40,7 +40,7 @@ export class UnlinkManager {
       throw new AlreadyReportedError();
     }
 
-    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).clear();
+    await LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).clearAsync();
     return this._deleteProjectFiles();
   }
 

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -166,7 +166,7 @@ export abstract class BaseInstallManager {
       : undefined;
     const cleanInstall: boolean =
       isFilteredInstall ||
-      !commonTempInstallFlag.checkValidAndReportStoreIssues({
+      !commonTempInstallFlag.checkValidAndReportStoreIssuesAsync({
         rushVerb: allowShrinkwrapUpdates ? 'update' : 'install',
         statePropertiesToIgnore: optionsToIgnore
       });
@@ -199,11 +199,11 @@ export abstract class BaseInstallManager {
       }
 
       // Delete the successful install file to indicate the install transaction has started
-      commonTempInstallFlag.clear();
+      await commonTempInstallFlag.clearAsync();
 
       // Since we're going to be tampering with common/node_modules, delete the "rush link" flag file if it exists;
       // this ensures that a full "rush link" is required next time
-      this._commonTempLinkFlag.clear();
+      await this._commonTempLinkFlag.clearAsync();
 
       // Give plugins an opportunity to act before invoking the installation process
       if (this.options.beforeInstallAsync !== undefined) {
@@ -249,7 +249,7 @@ export abstract class BaseInstallManager {
 
     // Create the marker file to indicate a successful install if it's not a filtered install
     if (!isFilteredInstall) {
-      commonTempInstallFlag.create();
+      await commonTempInstallFlag.createAsync();
     }
 
     // Perform any post-install work the install manager requires

--- a/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -197,7 +197,7 @@ export abstract class BaseLinkManager {
     await this._linkProjects();
 
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
-    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).create();
+    await LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).createAsync();
 
     stopwatch.stop();
     // eslint-disable-next-line no-console

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -171,7 +171,7 @@ export class InstallHelpers {
 
     logIfConsoleOutputIsNotRestricted(`Acquired lock for ${packageManagerAndVersion}`);
 
-    if (!packageManagerMarker.isValid() || lock.dirtyWhenAcquired) {
+    if (!packageManagerMarker.isValidAsync() || lock.dirtyWhenAcquired) {
       logIfConsoleOutputIsNotRestricted(
         Colorize.bold(`Installing ${packageManager} version ${packageManagerVersion}\n`)
       );
@@ -201,7 +201,7 @@ export class InstallHelpers {
       );
     }
 
-    packageManagerMarker.create();
+    await packageManagerMarker.createAsync();
 
     // Example: "C:\MyRepo\common\temp"
     FileSystem.ensureFolder(rushConfiguration.commonTempFolder);

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -685,7 +685,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
     }
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
-    LastLinkFlagFactory.getCommonTempFlag(subspace).create();
+    await LastLinkFlagFactory.getCommonTempFlag(subspace).createAsync();
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR refactors the `LastInstallFlag` and `LastLinkFlag` classes to be async. This should help with some of my suggestions on https://github.com/microsoft/rushstack/pull/4653.

## How it was tested

Updated unit tests.

## Impacted documentation

None.