### PR TITLE
[rush] Change getChangedFiles to pass ref only in git diff

### DIFF
--- a/common/changes/@microsoft/rush/kenrick-git-diff-without-merge-base_2024-05-06-08-09.json
+++ b/common/changes/@microsoft/rush/kenrick-git-diff-without-merge-base_2024-05-06-08-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Change getChangedFiles to pass ref only in git diff. This is to avoid git determining merge base of given ref and current head",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/Git.ts
+++ b/libraries/rush-lib/src/logic/Git.ts
@@ -287,7 +287,7 @@ export class Git {
     const gitPath: string = this.getGitPathOrThrow();
     const output: string = this._executeGitCommandAndCaptureOutput(gitPath, [
       'diff',
-      `${targetBranch}...`,
+      targetBranch,
       '--name-only',
       '--no-renames',
       '--diff-filter=A'


### PR DESCRIPTION
This is to avoid git determining merge base of given ref and current head

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Related to #4589 but for `rush change --verify --no-fetch --target-branch <ref>`

In CI, I have the SHA of merge base given by the CI runner at env variable (`$CI_MERGE_REQUEST_DIFF_BASE_SHA`), so I run the following command. 

```
$ rush change --verify --no-fetch --target-branch $CI_MERGE_REQUEST_DIFF_BASE_SHA
```

However that will fail with the following output:

```
Found configuration in /REDACTED_PATH_TO_REPO/rush.json
Rush Multi-Project Build Tool 5.122.1 - https://rushjs.io/
Node.js version is 18.20.2 (LTS)
Starting "rush change"
The target branch is <<REDACTED_MERGE_BASE_SHA>>
ERROR: The command failed with exit code 128
fatal: <<REDACTED_MERGE_BASE_SHA>>...HEAD: no merge base
```

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I figured out that the failing codes was here in the getChangedFiles function:

https://github.com/microsoft/rushstack/blob/49d93a9cdc5f844fb37f58ae83cbbae21586a75f/libraries/rush-lib/src/logic/Git.ts#L277-L294

From my understanding from reading [`git diff` docs](https://git-scm.com/docs/git-diff) and this [StackOverflow question](https://stackoverflow.com/questions/1552340/how-to-list-only-the-names-of-files-that-changed-between-two-commits), to retrieve a list of changed files between the given ref (branch/commit/tag/etc) and current HEAD, I do not need to retrieve the merge base (and hence do not need to be in the style of `A...B` which Git will determine the merge base)

From my investigation of Rush's history, it seemed like it was added this way since 2016, so I'm not sure what's the intention there:

https://github.com/microsoft/rushstack/commit/4a4de9a2ecc246854b96b5d3e1cbc5377b1e6547#diff-26c82d4767d5297bb1f9e2d6c4329b25a0f60cd6b99c5d8d59c4ac7e14a04320R22


## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Manual test: I build Rush locally with this change and able to get that command (`rush change --verify --no-fetch --target-branch <<REDACTED_MERGE_BASE>>`) working on my local repro.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
