### PR TITLE
fix(timeline,cobuilds): cobuilt operations should reflect the cobuild time and not cache restore time

### DIFF
--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
@@ -4,16 +4,13 @@
     {
       "operationName": "_phase:build",
       "outputFolderNames": ["dist"],
-      "allowCobuildOrchestration": true,
-      "disableBuildCacheForOperation": true,
       "sharding": {
         "count": 75
       }
     },
     {
       "operationName": "_phase:build:shard",
-      "weight": 10,
-      "allowCobuildOrchestration": true
+      "weight": 10
     }
   ]
 }

--- a/common/changes/@microsoft/rush/sennyeya-operation-timings_2024-05-07-16-36.json
+++ b/common/changes/@microsoft/rush/sennyeya-operation-timings_2024-05-07-16-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Operations that were cobuilt now have the cobuild time correct reflected across all agents.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/sennyeya-operation-timings_2024-05-07-16-36.json
+++ b/common/changes/@microsoft/rush/sennyeya-operation-timings_2024-05-07-16-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Operations that were cobuilt now have the cobuild time correct reflected across all agents.",
+      "comment": "Operations that were cobuilt now have the cobuild time correctly reflected across all agents.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -590,6 +590,7 @@ export interface IOperationExecutionResult {
     getStateHashComponents(): ReadonlyArray<string>;
     readonly logFilePaths: ILogFilePaths | undefined;
     readonly metadataFolderPath: string | undefined;
+    readonly executedOnThisAgent: boolean;
     readonly nonCachedDurationMs: number | undefined;
     readonly operation: Operation;
     readonly silent: boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -584,9 +584,7 @@ export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
 
 // @alpha
 export interface IOperationExecutionResult {
-    readonly cobuildRunnerId: string | undefined;
     readonly error: Error | undefined;
-    readonly executedOnThisAgent: boolean;
     getStateHash(): string;
     getStateHashComponents(): ReadonlyArray<string>;
     readonly logFilePaths: ILogFilePaths | undefined;
@@ -959,11 +957,17 @@ export class _OperationMetadataManager {
     // (undocumented)
     readonly stateFile: _OperationStateFile;
     // (undocumented)
-    tryRestoreAsync({ terminal, terminalProvider, errorLogPath }: {
+    tryRestoreAsync({ terminal, terminalProvider, errorLogPath, cobuildContextId, cobuildRunnerId }: {
         terminalProvider: ITerminalProvider;
         terminal: ITerminal;
         errorLogPath: string;
+        cobuildContextId?: string;
+        cobuildRunnerId?: string;
     }): Promise<void>;
+    // (undocumented)
+    tryRestoreStopwatch(originalStopwatch: IStopwatchResult): IStopwatchResult;
+    // (undocumented)
+    wasCobuilt: boolean;
 }
 
 // @internal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -586,11 +586,11 @@ export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
 export interface IOperationExecutionResult {
     readonly cobuildRunnerId: string | undefined;
     readonly error: Error | undefined;
+    readonly executedOnThisAgent: boolean;
     getStateHash(): string;
     getStateHashComponents(): ReadonlyArray<string>;
     readonly logFilePaths: ILogFilePaths | undefined;
     readonly metadataFolderPath: string | undefined;
-    readonly executedOnThisAgent: boolean;
     readonly nonCachedDurationMs: number | undefined;
     readonly operation: Operation;
     readonly silent: boolean;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -59,7 +59,6 @@ import { getVariantAsync, VARIANT_PARAMETER } from '../../api/Variants';
 import { Selection } from '../../logic/Selection';
 import { NodeDiagnosticDirPlugin } from '../../logic/operations/NodeDiagnosticDirPlugin';
 import { DebugHashesPlugin } from '../../logic/operations/DebugHashesPlugin';
-import type { IOperationStateJson } from '../../logic/operations/OperationStateFile';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -901,7 +900,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       executionManagerOptions
     );
 
-    const { isInitial, isWatch, cobuildConfiguration } = options.executeOperationsContext;
+    const { isInitial, isWatch } = options.executeOperationsContext;
 
     let success: boolean = false;
     let result: IExecutionResult | undefined;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -1008,7 +1008,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
             startTimestampMs: startTime,
             endTimestampMs: endTime,
             nonCachedDurationMs: operationResult.nonCachedDurationMs,
-            wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt ?? false,
+            wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt !== true,
             result: operationResult.status,
             dependencies: Array.from(getNonSilentDependencies(operation)).sort()
           };

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -1003,18 +1003,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
           const { _operationMetadataManager: operationMetadataManager } =
             operationResult as OperationExecutionRecord;
-          const metadataState: IOperationStateJson | undefined = operationMetadataManager?.stateFile.state;
 
           const { startTime, endTime } = operationResult.stopwatch;
-          const wasExecutedOnThisMachine: boolean = cobuildConfiguration?.cobuildFeatureEnabled
-            ? metadataState?.cobuildContextId === cobuildConfiguration?.cobuildContextId &&
-              metadataState?.cobuildRunnerId === cobuildConfiguration?.cobuildRunnerId
-            : true;
           jsonOperationResults[operation.name!] = {
             startTimestampMs: startTime,
             endTimestampMs: endTime,
             nonCachedDurationMs: operationResult.nonCachedDurationMs,
-            wasExecutedOnThisMachine,
+            wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt ?? false,
             result: operationResult.status,
             dependencies: Array.from(getNonSilentDependencies(operation)).sort()
           };

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -676,7 +676,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         `  Press <${quitKey}> to gracefully exit.`,
         `  Press <${toggleWatcherKey}> to ${isPaused ? 'resume' : 'pause'}.`,
         `  Press <${invalidateKey}> to invalidate all projects.`,
-        `  Press <${changedProjectsOnlyKey}> to ${this._changedProjectsOnly ? 'disable' : 'enable'} changed-projects-only mode (${this._changedProjectsOnly ? 'ENABLED' : 'DISABLED'}).`
+        `  Press <${changedProjectsOnlyKey}> to ${
+          this._changedProjectsOnly ? 'disable' : 'enable'
+        } changed-projects-only mode (${this._changedProjectsOnly ? 'ENABLED' : 'DISABLED'}).`
       ];
       if (isPaused) {
         promptLines.push(`  Press <${buildOnceKey}> to build once.`);
@@ -820,8 +822,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     // eslint-disable-next-line no-constant-condition
     while (!abortSignal.aborted) {
       // On the initial invocation, this promise will return immediately with the full set of projects
-      const { changedProjects, inputsSnapshot: state } =
-        await projectWatcher.waitForChangeAsync(onWaitingForChanges);
+      const { changedProjects, inputsSnapshot: state } = await projectWatcher.waitForChangeAsync(
+        onWaitingForChanges
+      );
 
       if (abortSignal.aborted) {
         return;

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -324,7 +324,9 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
                   await operationMetadataManager?.tryRestoreAsync({
                     terminalProvider,
                     terminal: buildCacheTerminal,
-                    errorLogPath
+                    errorLogPath,
+                    cobuildContextId: cobuildConfiguration?.cobuildContextId,
+                    cobuildRunnerId: cobuildConfiguration?.cobuildRunnerId
                   });
                 },
                 { createLogFile: false }

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -160,12 +160,6 @@ export async function _printTimeline({ terminal, result }: IPrintTimelineParamet
     let { endTime, duration } = stopwatch;
 
     if (startTime && endTime) {
-      // If this operation is cobuilt, print the cobuild time instead of the cache restore time.
-      if (isExecutedByOtherCobuildRunner) {
-        endTime = startTime + (operationResult.nonCachedDurationMs ?? 0);
-        duration = (endTime - startTime) / 1000.0;
-      }
-
       const nameLength: number = operation.name?.length || 0;
       if (nameLength > longestNameLength) {
         longestNameLength = nameLength;

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -52,9 +52,9 @@ export class ConsoleTimelinePlugin implements IPhasedCommandPlugin {
   }
 
   public apply(hooks: PhasedCommandHooks): void {
-    hooks.afterExecuteOperations.tapPromise(
+    hooks.afterExecuteOperations.tap(
       PLUGIN_NAME,
-      async (result: IExecutionResult, context: ICreateOperationsContext): Promise<void> => {
+      (result: IExecutionResult, context: ICreateOperationsContext): void => {
         _printTimeline({
           terminal: this._terminal,
           result

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -55,7 +55,7 @@ export class ConsoleTimelinePlugin implements IPhasedCommandPlugin {
     hooks.afterExecuteOperations.tapPromise(
       PLUGIN_NAME,
       async (result: IExecutionResult, context: ICreateOperationsContext): Promise<void> => {
-        await _printTimeline({
+        _printTimeline({
           terminal: this._terminal,
           result
         });
@@ -131,7 +131,7 @@ export interface IPrintTimelineParameters {
  * Print a more detailed timeline and analysis of CPU usage for the build.
  * @internal
  */
-export async function _printTimeline({ terminal, result }: IPrintTimelineParameters): Promise<void> {
+export function _printTimeline({ terminal, result }: IPrintTimelineParameters): void {
   //
   // Gather the operation records we'll be displaying. Do some inline max()
   // finding to reduce the number of times we need to loop through operations.

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -156,8 +156,7 @@ export async function _printTimeline({ terminal, result }: IPrintTimelineParamet
 
     const { stopwatch } = operationResult;
 
-    const { startTime } = stopwatch;
-    let { endTime, duration } = stopwatch;
+    const { startTime, endTime, duration } = stopwatch;
 
     if (startTime && endTime) {
       const nameLength: number = operation.name?.length || 0;

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -12,6 +12,8 @@ import type {
 } from '../../pluginFramework/PhasedCommandHooks';
 import type { IExecutionResult } from './IOperationExecutionResult';
 import { OperationStatus } from './OperationStatus';
+import type { CobuildConfiguration } from '../../api/CobuildConfiguration';
+import type { OperationExecutionRecord } from './OperationExecutionRecord';
 
 const PLUGIN_NAME: 'ConsoleTimelinePlugin' = 'ConsoleTimelinePlugin';
 
@@ -57,7 +59,8 @@ export class ConsoleTimelinePlugin implements IPhasedCommandPlugin {
       (result: IExecutionResult, context: ICreateOperationsContext): void => {
         _printTimeline({
           terminal: this._terminal,
-          result
+          result,
+          cobuildConfiguration: context.cobuildConfiguration
         });
       }
     );
@@ -116,7 +119,7 @@ interface ITimelineRecord {
   durationString: string;
   name: string;
   status: OperationStatus;
-  isExecutedByOtherCobuildRunner: boolean;
+  isExecuteByOtherCobuildRunner: boolean;
 }
 
 /**
@@ -125,6 +128,12 @@ interface ITimelineRecord {
 export interface IPrintTimelineParameters {
   terminal: ITerminal;
   result: IExecutionResult;
+  cobuildConfiguration?: CobuildConfiguration;
+}
+
+interface ICachedDuration {
+  cached?: number;
+  uncached: number;
 }
 
 /**
@@ -137,7 +146,7 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
   // finding to reduce the number of times we need to loop through operations.
   //
 
-  const durationByPhase: Map<IPhase, number> = new Map();
+  const durationByPhase: Map<IPhase, ICachedDuration> = new Map();
 
   const data: ITimelineRecord[] = [];
   let longestNameLength: number = 0;
@@ -151,20 +160,35 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
       continue;
     }
 
-    const isExecutedByOtherCobuildRunner: boolean =
-      !!operationResult.cobuildRunnerId && !operationResult.executedOnThisAgent;
-
     const { stopwatch } = operationResult;
+    const { _operationMetadataManager: operationMetadataManager } =
+      operationResult as OperationExecutionRecord;
 
-    const { startTime, endTime, duration } = stopwatch;
+    let { startTime } = stopwatch;
+    const { endTime } = stopwatch;
+
+    const duration: ICachedDuration = { cached: undefined, uncached: stopwatch.duration };
 
     if (startTime && endTime) {
       const nameLength: number = operation.name?.length || 0;
       if (nameLength > longestNameLength) {
         longestNameLength = nameLength;
       }
+      const wasCobuilt: boolean = !!operationMetadataManager?.wasCobuilt;
+      if (
+        operationResult.status !== OperationStatus.FromCache &&
+        operationMetadataManager &&
+        wasCobuilt &&
+        operationResult.nonCachedDurationMs
+      ) {
+        duration.cached = stopwatch.duration;
+        startTime = Math.max(0, endTime - operationResult.nonCachedDurationMs);
+        duration.uncached = (endTime - startTime) / 1000;
+      }
 
-      const durationString: string = duration.toFixed(1);
+      workDuration += stopwatch.duration;
+
+      const durationString: string = duration.uncached.toFixed(1);
       const durationLength: number = durationString.length;
       if (durationLength > longestDurationLength) {
         longestDurationLength = durationLength;
@@ -176,11 +200,21 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
       if (startTime < allStart) {
         allStart = startTime;
       }
-      workDuration += duration;
 
       const { associatedPhase } = operation;
 
-      durationByPhase.set(associatedPhase, (durationByPhase.get(associatedPhase) || 0) + duration);
+      if (associatedPhase) {
+        const previousDuration: ICachedDuration = durationByPhase.get(associatedPhase) ?? {
+          cached: undefined,
+          uncached: 0
+        };
+        const cachedDuration: number | undefined =
+          duration.cached !== undefined
+            ? duration.cached + (previousDuration.cached ?? 0)
+            : previousDuration.cached;
+        const uncachedDuration: number = duration.uncached + previousDuration.uncached;
+        durationByPhase.set(associatedPhase, { cached: cachedDuration, uncached: uncachedDuration });
+      }
 
       data.push({
         startTime,
@@ -188,7 +222,7 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
         durationString,
         name: operation.name,
         status: operationResult.status,
-        isExecutedByOtherCobuildRunner
+        isExecuteByOtherCobuildRunner: wasCobuilt
       });
     }
   }
@@ -231,8 +265,8 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
   let hasCobuildSymbol: boolean = false;
 
   function getChartSymbol(record: ITimelineRecord): string {
-    const { isExecutedByOtherCobuildRunner, status } = record;
-    if (isExecutedByOtherCobuildRunner && COBUILD_REPORTABLE_STATUSES.has(status)) {
+    const { isExecuteByOtherCobuildRunner, status } = record;
+    if (isExecuteByOtherCobuildRunner && COBUILD_REPORTABLE_STATUSES.has(status)) {
       hasCobuildSymbol = true;
       return 'C';
     }
@@ -307,7 +341,10 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
     }
 
     for (const [phase, duration] of durationByPhase.entries()) {
-      terminal.writeLine(`  ${Colorize.cyan(phase.name.padStart(maxPhaseName))} ${duration.toFixed(1)}s`);
+      const durationString: string = duration.cached
+        ? `${duration.uncached.toFixed(1)}s, from cache: ${duration.cached.toFixed(1)}s`
+        : `${duration.uncached.toFixed(1)}s`;
+      terminal.writeLine(`  ${Colorize.cyan(phase.name.padStart(maxPhaseName))} ${durationString}`);
     }
   }
 

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -203,7 +203,7 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
       const { associatedPhase } = operation;
 
       if (associatedPhase) {
-        let durationRecord: ICachedDuration = durationByPhase.get(associatedPhase);
+        let durationRecord: ICachedDuration | undefined = durationByPhase.get(associatedPhase);
         if (!durationRecord) {
           durationRecord = {
             cached: undefined,
@@ -342,7 +342,9 @@ export function _printTimeline({ terminal, result }: IPrintTimelineParameters): 
     }
 
     for (const [phase, duration] of durationByPhase.entries()) {
-      const cachedDurationString: string = duration.cached ? `, from cache: ${duration.cached.toFixed(1)}s` : '';
+      const cachedDurationString: string = duration.cached
+        ? `, from cache: ${duration.cached.toFixed(1)}s`
+        : '';
       const durationString: string = `${duration.uncached.toFixed(1)}s${cachedDurationString}`;
       terminal.writeLine(`  ${Colorize.cyan(phase.name.padStart(maxPhaseName))} ${durationString}`);
     }

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -56,6 +56,10 @@ export interface IOperationExecutionResult {
    * The paths to the log files, if applicable.
    */
   readonly logFilePaths: ILogFilePaths | undefined;
+  /**
+   * Returns true if this operation was co-built using this machine, false if cobuilds are disabled or it was executed on another agent.
+   */
+  readonly executedOnThisAgent: boolean;
 
   /**
    * Gets the hash of the state of all registered inputs to this operation.

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -45,10 +45,6 @@ export interface IOperationExecutionResult {
    */
   readonly nonCachedDurationMs: number | undefined;
   /**
-   * The id of the runner which actually runs the building process in cobuild mode.
-   */
-  readonly cobuildRunnerId: string | undefined;
-  /**
    * The relative path to the folder that contains operation metadata. This folder will be automatically included in cache entries.
    */
   readonly metadataFolderPath: string | undefined;
@@ -56,10 +52,6 @@ export interface IOperationExecutionResult {
    * The paths to the log files, if applicable.
    */
   readonly logFilePaths: ILogFilePaths | undefined;
-  /**
-   * Returns true if this operation was co-built using this machine or cobuilds are disabled, false it was executed on another agent.
-   */
-  readonly executedOnThisAgent: boolean;
 
   /**
    * Gets the hash of the state of all registered inputs to this operation.

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -57,7 +57,7 @@ export interface IOperationExecutionResult {
    */
   readonly logFilePaths: ILogFilePaths | undefined;
   /**
-   * Returns true if this operation was co-built using this machine, false if cobuilds are disabled or it was executed on another agent.
+   * Returns true if this operation was co-built using this machine or cobuilds are disabled, false it was executed on another agent.
    */
   readonly executedOnThisAgent: boolean;
 

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -26,6 +26,7 @@ export interface IOperationExecutionManagerOptions {
   parallelism: number;
   inputsSnapshot?: IInputsSnapshot;
   destination?: TerminalWritable;
+  cobuildConfiguration?: CobuildConfiguration;
 
   beforeExecuteOperationAsync?: (operation: OperationExecutionRecord) => Promise<OperationStatus | undefined>;
   afterExecuteOperationAsync?: (operation: OperationExecutionRecord) => Promise<void>;
@@ -109,6 +110,7 @@ export class OperationExecutionManager {
     this._hasAnyFailures = false;
     this._hasAnyNonAllowedWarnings = false;
     this._parallelism = parallelism;
+    this._cobuildConfiguration = cobuildConfiguration;
 
     this._beforeExecuteOperation = beforeExecuteOperation;
     this._afterExecuteOperation = afterExecuteOperation;
@@ -144,7 +146,8 @@ export class OperationExecutionManager {
       createEnvironment: this._createEnvironmentForOperation,
       inputsSnapshot,
       debugMode,
-      quietMode
+      quietMode,
+      cobuildConfiguration: this._cobuildConfiguration
     };
 
     // Sort the operations by name to ensure consistency and readability.
@@ -295,8 +298,8 @@ export class OperationExecutionManager {
     const status: OperationStatus = this._hasAnyFailures
       ? OperationStatus.Failure
       : this._hasAnyNonAllowedWarnings
-        ? OperationStatus.SuccessWithWarning
-        : OperationStatus.Success;
+      ? OperationStatus.SuccessWithWarning
+      : OperationStatus.Success;
 
     return {
       operationResults: this._executionRecords,

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -296,8 +296,8 @@ export class OperationExecutionManager {
     const status: OperationStatus = this._hasAnyFailures
       ? OperationStatus.Failure
       : this._hasAnyNonAllowedWarnings
-      ? OperationStatus.SuccessWithWarning
-      : OperationStatus.Success;
+        ? OperationStatus.SuccessWithWarning
+        : OperationStatus.Success;
 
     return {
       operationResults: this._executionRecords,
@@ -331,7 +331,7 @@ export class OperationExecutionManager {
   /**
    * Handles the result of the operation and propagates any relevant effects.
    */
-  private async _onOperationComplete(record: OperationExecutionRecord): Promise<void> {
+  private _onOperationComplete(record: OperationExecutionRecord): void {
     const { runner, name, status, silent } = record;
 
     switch (status) {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -284,7 +284,7 @@ export class OperationExecutionManager {
         await record.executeAsync({
           onStart: onOperationStartAsync,
           beforeResult: beforeOperationResult,
-          onResult: this._onOperationComplete
+          onResult: this._onOperationComplete.bind(this)
         });
       },
       {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -284,8 +284,7 @@ export class OperationExecutionManager {
         await record.executeAsync({
           onStart: onOperationStartAsync,
           beforeResult: beforeOperationResult,
-          onResult: async (finishedRecord: OperationExecutionRecord) =>
-            this._onOperationComplete(finishedRecord)
+          onResult: this._onOperationComplete
         });
       },
       {
@@ -332,7 +331,7 @@ export class OperationExecutionManager {
   /**
    * Handles the result of the operation and propagates any relevant effects.
    */
-  private _onOperationComplete(record: OperationExecutionRecord): void {
+  private async _onOperationComplete(record: OperationExecutionRecord): Promise<void> {
     const { runner, name, status, silent } = record;
 
     switch (status) {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -260,9 +260,7 @@ export class OperationExecutionManager {
 
     await this._beforeExecuteOperations?.(this._executionRecords);
 
-    // This function is a callback because it may write to the collatedWriter before
-    // operation.executeAsync returns (and cleans up the writer)
-    const onOperationCompleteAsync: (record: OperationExecutionRecord) => Promise<void> = async (
+    const beforeOperationResult: (record: OperationExecutionRecord) => Promise<void> = async (
       record: OperationExecutionRecord
     ) => {
       try {
@@ -272,7 +270,6 @@ export class OperationExecutionManager {
         record.error = e;
         record.status = OperationStatus.Failure;
       }
-      this._onOperationComplete(record);
     };
 
     const onOperationStartAsync: (

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -283,7 +283,9 @@ export class OperationExecutionManager {
       async (record: OperationExecutionRecord) => {
         await record.executeAsync({
           onStart: onOperationStartAsync,
-          onResult: onOperationCompleteAsync
+          beforeResult: beforeOperationResult,
+          onResult: async (finishedRecord: OperationExecutionRecord) =>
+            this._onOperationComplete(finishedRecord)
         });
       },
       {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -191,11 +191,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   }
 
   public get executedOnThisAgent(): boolean {
-    console.log(
-      'this._context.cobuildConfiguration',
-      this._context.cobuildConfiguration?.cobuildRunnerId,
-      this.cobuildRunnerId
-    );
     return (
       !!this._context.cobuildConfiguration &&
       // this can happen if this property is retrieved before `beforeResult` is called.
@@ -406,11 +401,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
         this.stopwatch.stop();
-        console.log(
-          `Operation ${this.operation.name} took ${this.stopwatch.duration}ms`,
-          this.nonCachedDurationMs,
-          this.executedOnThisAgent
-        );
         if (!this.executedOnThisAgent && this.nonCachedDurationMs) {
           const { startTime } = this.stopwatch;
           if (startTime) {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -28,6 +28,12 @@ import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { IInputsSnapshot } from '../incremental/InputsSnapshot';
 import { RushConstants } from '../RushConstants';
 import type { IEnvironment } from '../../utilities/Utilities';
+import type { CobuildConfiguration } from '../../api/CobuildConfiguration';
+import {
+  getProjectLogFilePaths,
+  type ILogFilePaths,
+  initializeProjectLogFilesAsync
+} from './ProjectLogWritable';
 
 export interface IOperationExecutionRecordContext {
   streamCollator: StreamCollator;
@@ -424,12 +430,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
             });
           }
         }
-      }
-      // Delegate global state reporting
-      await onResult(this);
-      if (this.status !== OperationStatus.RemoteExecuting) {
-        this._collatedWriter?.close();
-        this.stdioSummarizer.close();
       }
     }
   }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -387,8 +387,8 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     beforeResult: (record: OperationExecutionRecord) => Promise<void>;
     onResult: (record: OperationExecutionRecord) => Promise<void> | void;
   }): Promise<void> {
-    if (!this.isTerminal) {
-      this.stopwatch.reset();
+    if (this.stopwatch.startTime === undefined) {
+      this.stopwatch.start();
     }
     this.status = OperationStatus.Executing;
 
@@ -413,8 +413,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
       // We may need to clean up and finalize resources (_operationMetadataManager for example needs to be saved by CacheableOperationPlugin)
       await beforeResult(this);
       if (this.isTerminal) {
-        this._collatedWriter?.close();
-        this.stdioSummarizer.close();
         this.stopwatch.stop();
         if (
           !this.executedOnThisAgent &&
@@ -430,6 +428,11 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
             });
           }
         }
+      }
+      await onResult(this);
+      if (this.isTerminal) {
+        this._collatedWriter?.close();
+        this.stdioSummarizer.close();
       }
     }
   }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -99,7 +99,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
    */
   public readonly consumers: Set<OperationExecutionRecord> = new Set();
 
-  public readonly stopwatch: Stopwatch = new Stopwatch();
+  private _stopwatch: Stopwatch = new Stopwatch();
   public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer({
     // Allow writing to this object after transforms have been closed. We clean it up manually in a finally block.
     preventAutoclose: true
@@ -158,6 +158,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
 
   public get quietMode(): boolean {
     return this._context.quietMode;
+  }
+
+  public get stopwatch(): Stopwatch {
+    return this._stopwatch;
   }
 
   public get collatedWriter(): CollatedWriter {
@@ -409,7 +413,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         ) {
           const { startTime } = this.stopwatch;
           if (startTime) {
-            this.stopwatch = Stopwatch.fromState({
+            this._stopwatch = Stopwatch.fromState({
               // use endtime as it's the more accurate version of when this operation was marked as complete.
               startTime,
               endTime: startTime + this.nonCachedDurationMs

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -379,7 +379,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   }: {
     onStart: (record: OperationExecutionRecord) => Promise<OperationStatus | undefined>;
     beforeResult: (record: OperationExecutionRecord) => Promise<void>;
-    onResult: (record: OperationExecutionRecord) => Promise<void>;
+    onResult: (record: OperationExecutionRecord) => Promise<void> | void;
   }): Promise<void> {
     if (!this.isTerminal) {
       this.stopwatch.reset();

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -191,9 +191,16 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   }
 
   public get executedOnThisAgent(): boolean {
+    console.log(
+      'this._context.cobuildConfiguration',
+      this._context.cobuildConfiguration?.cobuildRunnerId,
+      this.cobuildRunnerId
+    );
     return (
       !!this._context.cobuildConfiguration &&
-      this._context.cobuildConfiguration?.cobuildRunnerId !== this.cobuildRunnerId
+      // this can happen if this property is retrieved before `beforeResult` is called.
+      this.cobuildRunnerId !== undefined &&
+      this._context.cobuildConfiguration?.cobuildRunnerId === this.cobuildRunnerId
     );
   }
 
@@ -362,9 +369,11 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
 
   public async executeAsync({
     onStart,
-    onResult
+    onResult,
+    beforeResult
   }: {
     onStart: (record: OperationExecutionRecord) => Promise<OperationStatus | undefined>;
+    beforeResult: (record: OperationExecutionRecord) => Promise<void>;
     onResult: (record: OperationExecutionRecord) => Promise<void>;
   }): Promise<void> {
     if (!this.isTerminal) {
@@ -391,10 +400,17 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
       this.status = OperationStatus.Failure;
       this.error = error;
     } finally {
+      // We may need to clean up and finalize resources (_operationMetadataManager for example needs to be saved by CacheableOperationPlugin)
+      await beforeResult(this);
       if (this.isTerminal) {
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
         this.stopwatch.stop();
+        console.log(
+          `Operation ${this.operation.name} took ${this.stopwatch.duration}ms`,
+          this.nonCachedDurationMs,
+          this.executedOnThisAgent
+        );
         if (!this.executedOnThisAgent && this.nonCachedDurationMs) {
           const { startTime } = this.stopwatch;
           if (startTime) {
@@ -404,8 +420,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
             });
           }
         }
-        // Delegate global state reporting
-        await onResult(this);
+      }
+      // Delegate global state reporting
+      await onResult(this);
+      if (this.status !== OperationStatus.RemoteExecuting) {
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
       }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -395,7 +395,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
         this.stopwatch.stop();
-        console.warn('stopping', this.executedOnThisAgent, this.nonCachedDurationMs, this.stopwatch.duration);
         if (!this.executedOnThisAgent && this.nonCachedDurationMs) {
           const { startTime } = this.stopwatch;
           if (startTime) {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -384,19 +384,18 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
           ? OperationStatus.NoOp
           : OperationStatus.Skipped;
       }
-      this.stopwatch.stop();
       // Delegate global state reporting
       await onResult(this);
     } catch (error) {
       this.status = OperationStatus.Failure;
       this.error = error;
-      this.stopwatch.stop();
       // Delegate global state reporting
       await onResult(this);
     } finally {
       if (this.isTerminal) {
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
+        this.stopwatch.stop();
       }
     }
   }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -99,6 +99,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
    */
   public readonly consumers: Set<OperationExecutionRecord> = new Set();
 
+  /**
+   * The stopwatch used to measure the duration of this operation. This is purposefully not
+   *  readonly as we want to override it in the case of a cache hit.
+   */
   private _stopwatch: Stopwatch = new Stopwatch();
   public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer({
     // Allow writing to this object after transforms have been closed. We clean it up manually in a finally block.

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -384,18 +384,21 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
           ? OperationStatus.NoOp
           : OperationStatus.Skipped;
       }
+      // Make sure that the stopwatch is stopped before reporting the result, otherwise endTime is undefined.
+      this.stopwatch.stop();
       // Delegate global state reporting
       await onResult(this);
     } catch (error) {
       this.status = OperationStatus.Failure;
       this.error = error;
+      // Make sure that the stopwatch is stopped before reporting the result, otherwise endTime is undefined.
+      this.stopwatch.stop();
       // Delegate global state reporting
       await onResult(this);
     } finally {
       if (this.isTerminal) {
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
-        this.stopwatch.stop();
       }
     }
   }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -376,7 +376,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     if (!this.isTerminal) {
       this.stopwatch.reset();
     }
-    this.stopwatch.start();
     this.status = OperationStatus.Executing;
 
     try {
@@ -403,10 +402,15 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
         this.stopwatch.stop();
-        if (!this.executedOnThisAgent && this.nonCachedDurationMs) {
+        if (
+          !this.executedOnThisAgent &&
+          this.nonCachedDurationMs &&
+          this.status !== OperationStatus.FromCache
+        ) {
           const { startTime } = this.stopwatch;
           if (startTime) {
             this.stopwatch = Stopwatch.fromState({
+              // use endtime as it's the more accurate version of when this operation was marked as complete.
               startTime,
               endTime: startTime + this.nonCachedDurationMs
             });

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -191,8 +191,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   }
 
   public get executedOnThisAgent(): boolean {
+    if (!this._context.cobuildConfiguration) {
+      return this.cobuildRunnerId === undefined;
+    }
     return (
-      !!this._context.cobuildConfiguration &&
       // this can happen if this property is retrieved before `beforeResult` is called.
       this.cobuildRunnerId !== undefined &&
       this._context.cobuildConfiguration?.cobuildRunnerId === this.cobuildRunnerId

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -387,18 +387,15 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
           ? OperationStatus.NoOp
           : OperationStatus.Skipped;
       }
-      // Delegate global state reporting
-      await onResult(this);
     } catch (error) {
       this.status = OperationStatus.Failure;
       this.error = error;
-      // Delegate global state reporting
-      await onResult(this);
     } finally {
       if (this.isTerminal) {
         this._collatedWriter?.close();
         this.stdioSummarizer.close();
         this.stopwatch.stop();
+        console.warn('stopping', this.executedOnThisAgent, this.nonCachedDurationMs, this.stopwatch.duration);
         if (!this.executedOnThisAgent && this.nonCachedDurationMs) {
           const { startTime } = this.stopwatch;
           if (startTime) {
@@ -408,6 +405,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
             });
           }
         }
+        // Delegate global state reporting
+        await onResult(this);
+        this._collatedWriter?.close();
+        this.stdioSummarizer.close();
       }
     }
   }

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -244,7 +244,7 @@ function writeDetailedSummary(
     const leftPartLength: number = 4 + subheadingText.length + 1;
 
     // rightPart: " 5.07 seconds ]--"
-    const stopwatch =
+    const stopwatch: IStopwatchResult =
       operationMetadataManager?.tryRestoreStopwatch(operationResult.stopwatch) ?? operationResult.stopwatch;
     const time: string = stopwatch.toString();
     const rightPartLength: number = 1 + time.length + 1 + 3;

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -12,6 +12,8 @@ import type {
 import type { IExecutionResult, IOperationExecutionResult } from './IOperationExecutionResult';
 import type { Operation } from './Operation';
 import { OperationStatus } from './OperationStatus';
+import type { OperationExecutionRecord } from './OperationExecutionRecord';
+import type { IStopwatchResult } from '../../utilities/Stopwatch';
 
 const PLUGIN_NAME: 'OperationResultSummarizerPlugin' = 'OperationResultSummarizerPlugin';
 
@@ -179,14 +181,23 @@ function writeCondensedSummary(
   }
 
   for (const [operation, operationResult] of operations) {
+    const { _operationMetadataManager: operationMetadataManager } =
+      operationResult as OperationExecutionRecord;
+    const stopwatch: IStopwatchResult =
+      operationMetadataManager?.tryRestoreStopwatch(operationResult.stopwatch) ?? operationResult.stopwatch;
     if (
-      operationResult.stopwatch.duration !== 0 &&
+      stopwatch.duration !== 0 &&
       operation.runner!.reportTiming &&
       operationResult.status !== OperationStatus.Skipped
     ) {
-      const time: string = operationResult.stopwatch.toString();
-      const padding: string = ' '.repeat(longestTaskName - operation.name.length);
-      terminal.writeLine(`  ${operation.name}${padding}    ${time}`);
+      const time: string = stopwatch.toString();
+      const padding: string = ' '.repeat(longestTaskName - (operation.name || '').length);
+      const cacheString: string = operationMetadataManager?.wasCobuilt
+        ? ` (restore ${(
+            (operationResult.stopwatch.endTime ?? 0) - (operationResult.stopwatch.startTime ?? 0)
+          ).toFixed(1)}ms)`
+        : '';
+      terminal.writeLine(`  ${operation.name}${padding}    ${time}${cacheString}`);
     } else {
       terminal.writeLine(`  ${operation.name}`);
     }
@@ -221,6 +232,8 @@ function writeDetailedSummary(
   }
 
   for (const [operation, operationResult] of operations) {
+    const { _operationMetadataManager: operationMetadataManager } =
+      operationResult as OperationExecutionRecord;
     // Format a header like this
     //
     // --[ WARNINGS: f ]------------------------------------[ 5.07 seconds ]--
@@ -231,7 +244,9 @@ function writeDetailedSummary(
     const leftPartLength: number = 4 + subheadingText.length + 1;
 
     // rightPart: " 5.07 seconds ]--"
-    const time: string = operationResult.stopwatch.toString();
+    const stopwatch =
+      operationMetadataManager?.tryRestoreStopwatch(operationResult.stopwatch) ?? operationResult.stopwatch;
+    const time: string = stopwatch.toString();
     const rightPartLength: number = 1 + time.length + 1 + 3;
 
     // middlePart: "]----------------------["

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -285,7 +285,7 @@ describe(OperationExecutionManager.name, () => {
         );
 
         const result: IExecutionResult = await executionManager.executeAsync();
-        _printTimeline({ terminal: mockTerminal, result, cobuildConfiguration: undefined });
+        await _printTimeline({ terminal: mockTerminal, result });
         _printOperationStatus(mockTerminal, result);
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Build step 1');

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -36,8 +36,6 @@ import { MockOperationRunner } from './MockOperationRunner';
 import type { IExecutionResult, IOperationExecutionResult } from '../IOperationExecutionResult';
 import { CollatedTerminalProvider } from '../../../utilities/CollatedTerminalProvider';
 import type { CobuildConfiguration } from '../../../api/CobuildConfiguration';
-import type { RushConfigurationProject } from '../../../api/RushConfigurationProject';
-import type { IPhase } from '../../../api/CommandLineConfiguration';
 import type { OperationStateFile } from '../OperationStateFile';
 
 const mockGetTimeInMs: jest.Mock = jest.fn();

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -285,7 +285,7 @@ describe(OperationExecutionManager.name, () => {
         );
 
         const result: IExecutionResult = await executionManager.executeAsync();
-        await _printTimeline({ terminal: mockTerminal, result });
+        _printTimeline({ terminal: mockTerminal, result });
         _printOperationStatus(mockTerminal, result);
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Build step 1');

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -3,6 +3,7 @@
 
 // The TaskExecutionManager prints "x.xx seconds" in TestRunner.test.ts.snap; ensure that the Stopwatch timing is deterministic
 jest.mock('../../../utilities/Utilities');
+jest.mock('../OperationStateFile');
 
 jest.mock('@rushstack/terminal', () => {
   const originalModule = jest.requireActual('@rushstack/terminal');
@@ -34,6 +35,10 @@ import type { IOperationRunner } from '../IOperationRunner';
 import { MockOperationRunner } from './MockOperationRunner';
 import type { IExecutionResult, IOperationExecutionResult } from '../IOperationExecutionResult';
 import { CollatedTerminalProvider } from '../../../utilities/CollatedTerminalProvider';
+import type { CobuildConfiguration } from '../../../api/CobuildConfiguration';
+import { RushConfigurationProject } from '../../../api/RushConfigurationProject';
+import { IPhase } from '../../../api/CommandLineConfiguration';
+import { IOperationStateJson, OperationStateFile } from '../OperationStateFile';
 
 const mockGetTimeInMs: jest.Mock = jest.fn();
 Utilities.getTimeInMs = mockGetTimeInMs;
@@ -285,13 +290,116 @@ describe(OperationExecutionManager.name, () => {
         );
 
         const result: IExecutionResult = await executionManager.executeAsync();
-        _printTimeline({ terminal: mockTerminal, result });
+        _printTimeline({ terminal: mockTerminal, result, cobuildConfiguration: undefined });
         _printOperationStatus(mockTerminal, result);
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Build step 1');
         expect(allMessages).toContain('Warning: step 1 succeeded with warnings');
         expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
       });
+    });
+  });
+
+  describe('Cobuild logging', () => {
+    beforeEach(() => {
+      let mockTimeInMs: number = 0;
+      mockGetTimeInMs.mockImplementation(() => {
+        mockTimeInMs += 10_000;
+        return mockTimeInMs;
+      });
+    });
+    function createExecutionManager(
+      executionManagerOptions: IOperationExecutionManagerOptions,
+      operationRunnerFactory: (name: string) => IOperationRunner,
+      phase: IPhase,
+      project: RushConfigurationProject
+    ): OperationExecutionManager {
+      const operation: Operation = new Operation({
+        runner: operationRunnerFactory('operation'),
+        logFilenameIdentifier: 'operation',
+        phase,
+        project
+      });
+
+      const operation2: Operation = new Operation({
+        runner: operationRunnerFactory('operation2'),
+        logFilenameIdentifier: 'operation2',
+        phase,
+        project
+      });
+
+      return new OperationExecutionManager(new Set([operation, operation2]), {
+        afterExecuteOperationAsync: async (operation) => {
+          if (!operation._operationMetadataManager) {
+            throw new Error('OperationMetadataManager is not defined');
+          }
+          // Mock the readonly state property.
+          (operation._operationMetadataManager as any).stateFile = {
+            state: {
+              cobuildContextId: '123',
+              cobuildRunnerId: '456',
+              nonCachedDurationMs: 15_000
+            }
+          } as unknown as OperationStateFile;
+          operation._operationMetadataManager.wasCobuilt = true;
+        },
+        ...executionManagerOptions
+      });
+    }
+    it('logs cobuilt operations correctly with --timeline option', async () => {
+      executionManager = createExecutionManager(
+        executionManagerOptions,
+        (name) =>
+          new MockOperationRunner(
+            `${name} (success)`,
+            async () => {
+              return OperationStatus.Success;
+            },
+            /* warningsAreAllowed */ true
+          ),
+        { name: 'my-name' } as unknown as IPhase,
+        {} as unknown as RushConfigurationProject
+      );
+
+      const result: IExecutionResult = await executionManager.executeAsync();
+      _printTimeline({
+        terminal: mockTerminal,
+        result,
+        cobuildConfiguration: {
+          cobuildRunnerId: '123',
+          cobuildContextId: '123'
+        } as unknown as CobuildConfiguration
+      });
+      _printOperationStatus(mockTerminal, result);
+      expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
+    });
+    it('logs warnings correctly with --timeline option', async () => {
+      executionManager = createExecutionManager(
+        executionManagerOptions,
+        (name) =>
+          new MockOperationRunner(`${name} (success with warnings)`, async (terminal: CollatedTerminal) => {
+            terminal.writeStdoutLine('Build step 1\n');
+            terminal.writeStdoutLine('Warning: step 1 succeeded with warnings\n');
+            return OperationStatus.SuccessWithWarning;
+          }),
+        { name: 'my-name' } as unknown as IPhase,
+        {} as unknown as RushConfigurationProject
+      );
+
+      const result: IExecutionResult = await executionManager.executeAsync();
+      _printTimeline({
+        terminal: mockTerminal,
+        result,
+        cobuildConfiguration: {
+          cobuildRunnerId: '123',
+          cobuildContextId: '123'
+        } as unknown as CobuildConfiguration
+      });
+      _printOperationStatus(mockTerminal, result);
+      const allMessages: string = mockWritable.getAllOutput();
+      expect(allMessages).toContain('Build step 1');
+      expect(allMessages).toContain('Warning: step 1 succeeded with warnings');
+      expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
     });
   });
 });

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -1,5 +1,357 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OperationExecutionManager Cobuild logging logs cobuilt operations correctly with --timeline option 1`] = `
+Array [
+  Object {
+    "kind": "O",
+    "text": "Selected 2 operations:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation (success)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation2 (success)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Executing a maximum of 1 simultaneous processes...
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]operation2 (success)[default] [gray]]=========================================[[default] [white]1 of 2[default] [gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[green]\\"operation2 (success)\\" completed successfully in 15.00 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]operation (success)[default] [gray]]==========================================[[default] [white]2 of 2[default] [gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[green]\\"operation (success)\\" completed successfully in 15.00 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "==========================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[cyan]operation2 (success)[default] [gray][default][green]CCCCCCCCCCCCCCCCCCCCCCCCCCC[default][gray]------------------------------------[default] [white]15.0s[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[cyan] operation (success)[default] [gray]-----------------------------------[default][green]CCCCCCCCCCCCCCCCCCCCCCCCCCCC[default][gray][default] [white]15.0s[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "==========================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "LEGEND:                                                                  Total Work: 20.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op             Wall Clock: 35.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [C] Cobuild                                                      Max Parallelism Used: 1
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "                                                                 Avg Parallelism Used: 0.6
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "BY PHASE:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [cyan]         my-name[default] 30.0s, from cache: 20.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]==[[default] [green]SUCCESS: 2 operations[default] [gray]]====================================================[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "These operations completed successfully:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation (success)     15.00 seconds (restore 10000.0ms)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation2 (success)    15.00 seconds (restore 10000.0ms)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+]
+`;
+
+exports[`OperationExecutionManager Cobuild logging logs warnings correctly with --timeline option 1`] = `
+Array [
+  Object {
+    "kind": "O",
+    "text": "Selected 2 operations:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation (success with warnings)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  operation2 (success with warnings)
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Executing a maximum of 1 simultaneous processes...
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]operation2 (success with warnings)[default] [gray]]===========================[[default] [white]1 of 2[default] [gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Build step 1
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Warning: step 1 succeeded with warnings
+
+",
+  },
+  Object {
+    "kind": "E",
+    "text": "[yellow]\\"operation2 (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]operation (success with warnings)[default] [gray]]============================[[default] [white]2 of 2[default] [gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Build step 1
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "Warning: step 1 succeeded with warnings
+
+",
+  },
+  Object {
+    "kind": "E",
+    "text": "[yellow]\\"operation (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "==========================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[cyan]operation2 (success with warnings)[default] [gray][default][yellow]CCCCCCCCCCCCCCCCCCCCC[default][gray]----------------------------[default] [white]15.0s[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[cyan] operation (success with warnings)[default] [gray]---------------------------[default][yellow]CCCCCCCCCCCCCCCCCCCCCC[default][gray][default] [white]15.0s[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "==========================================================================================
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "LEGEND:                                                                  Total Work: 20.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op             Wall Clock: 35.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [C] Cobuild                                                      Max Parallelism Used: 1
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "                                                                 Avg Parallelism Used: 0.6
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "BY PHASE:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [cyan]         my-name[default] 30.0s, from cache: 20.0s
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 2 operations[default] [gray]]======================================[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]--[[default] [yellow]WARNING: operation (success with warnings)[default] [gray]]------------[[default] [white]15.00 seconds[default] [gray]]--[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "[gray]--[[default] [yellow]WARNING: operation2 (success with warnings)[default] [gray]]-----------[[default] [white]15.00 seconds[default] [gray]]--[default]
+
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "E",
+    "text": "[yellow]Operations succeeded with warnings.
+[default]
+",
+  },
+]
+`;
+
 exports[`OperationExecutionManager Error logging printedStderrAfterError 1`] = `
 Array [
   Object {

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -241,7 +241,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -329,7 +329,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -408,7 +408,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[cyan]success with warnings (success)[default] [gray][default][yellow]!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!![default][gray][default] [white]0.2s[default]
+    "text": "[cyan]success with warnings (success)[default] [gray][default][yellow]!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!![default][gray][default] [white]0.1s[default]
 ",
   },
   Object {
@@ -418,12 +418,12 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "LEGEND:                                                                   Total Work: 0.2s
+    "text": "LEGEND:                                                                   Total Work: 0.1s
 ",
   },
   Object {
     "kind": "O",
-    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op              Wall Clock: 0.2s
+    "text": "  [#] Success  [!] Failed/warnings  [%] Skipped/cached/no-op              Wall Clock: 0.1s
 ",
   },
   Object {
@@ -466,7 +466,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.20 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -795,7 +795,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "  [cyan]           phase[default] 0.2s
+    "text": "  [cyan]           phase[default] 0.1s
 ",
   },
   Object {

--- a/libraries/rush-lib/src/utilities/Stopwatch.ts
+++ b/libraries/rush-lib/src/utilities/Stopwatch.ts
@@ -52,6 +52,14 @@ export class Stopwatch implements IStopwatchResult {
     this._state = StopwatchState.Stopped;
   }
 
+  public static fromState({ startTime, endTime }: { startTime: number; endTime: number }): Stopwatch {
+    const stopwatch: Stopwatch = new Stopwatch();
+    stopwatch._startTime = startTime;
+    stopwatch._endTime = endTime;
+    stopwatch._state = StopwatchState.Stopped;
+    return stopwatch;
+  }
+
   /**
    * Static helper function which creates a stopwatch which is immediately started
    */


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

`OperationExecutionRecord` is currently only tracking cache restore time for cobuilt operations that are marked as `RemoteOperating` and are then restored from cache. This is a confusing UX and causes developers + maintainers to have to search across multiple machine logs to determine operation run times. This PR adjusts that to use the `nonCachedDurationMs` from the state file. This felt like something that #3649 was intending to do or is in a similar vein.

### Before:
<img width="912" alt="Screenshot 2024-05-07 at 12 24 12 PM" src="https://github.com/microsoft/rushstack/assets/159921952/c198600d-a56f-4d16-b752-d74677d3e67b">
<img width="912" alt="Screenshot 2024-05-07 at 12 24 01 PM" src="https://github.com/microsoft/rushstack/assets/159921952/1d3aa35e-abca-4792-9bea-db6783e794aa">


### After:
<img width="912" alt="Screenshot 2024-05-07 at 12 23 31 PM" src="https://github.com/microsoft/rushstack/assets/159921952/736a0ba6-754f-4874-abfb-11019c70b240">
<img width="872" alt="Screenshot 2024-05-07 at 12 23 18 PM" src="https://github.com/microsoft/rushstack/assets/159921952/03e0316c-b1bb-428d-88f1-6dfb28ea1f33">



## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

This overwrites the existing stopwatch for operations that were not cobuilt on the specific agent. It adds a new `beforeResult` method to `OperationExecutionRecord#executeAsync` to handle the `afterExecuteOperation` hook instead of passing that work into the `onResult` method which ended up receiving running stopwatches and had other assumptions of state (collated terminal not closed). This does add possibly breaking behavior where cobuilds were showing cache times which might be useful, but I don't think those are as useful as having the cobuild time available across all agents. That also has the secondary effect of making the timeline views of all agents much more cohesive - though as we see above they're not the exact same across agents.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I tested this locally using the `build-tests/rush-redis-cobuild-plugin-integration-test` sandbox repo with 2 runners, confirmed that timings generally matched across the instances. There's about 10ms (rounded up) of difference between the agents, but this already seems much more useful.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

None

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
