### PR TITLE
[ts-command-line] Fix an issue where tab completions wouldn't fill values correctly.

### DIFF
--- a/common/changes/@microsoft/rush/user-ianc-fix-tab-completion_2024-05-08-05-43.json
+++ b/common/changes/@microsoft/rush/user-ianc-fix-tab-completion_2024-05-08-05-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where tab competions did not suggest parameter values.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/ts-command-line/user-ianc-fix-tab-completion_2024-05-08-05-43.json
+++ b/common/changes/@rushstack/ts-command-line/user-ianc-fix-tab-completion_2024-05-08-05-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Fix an issue where tab completions did not suggest parameter values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/libraries/ts-command-line/src/providers/TabCompletionAction.ts
+++ b/libraries/ts-command-line/src/providers/TabCompletionAction.ts
@@ -103,7 +103,8 @@ export class TabCompleteAction extends CommandLineAction {
     const lastToken: string = tokens[tokens.length - 1];
     const secondLastToken: string = tokens[tokens.length - 2];
 
-    const completePartialWord: boolean = caretPosition === commandLine.length;
+    const lastCharacterIsWhitespace: boolean = !commandLine.slice(-1).trim();
+    const completePartialWord: boolean = caretPosition === commandLine.length && !lastCharacterIsWhitespace;
 
     if (completePartialWord && tokens.length === 2 + globalParameterOffset) {
       for (const actionName of actions.keys()) {

--- a/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
+++ b/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
@@ -207,7 +207,7 @@ describe(TabCompleteAction.name, () => {
   it(`gets completion(s) for rush <tab>`, async () => {
     const commandLine: string = 'rush ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -225,7 +225,7 @@ Array [
   it(`gets completion(s) for rush a<tab>`, async () => {
     const commandLine: string = 'rush a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -238,7 +238,7 @@ Array [
   it(`gets completion(s) for rush -d a<tab>`, async () => {
     const commandLine: string = 'rush -d a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -251,17 +251,12 @@ Array [
   it(`gets completion(s) for rush build <tab>`, async () => {
     const commandLine: string = 'rush build ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "--from",
-  "--parallelism",
-  "--to",
-  "-f",
-  "-p",
-  "-t",
+  "build",
 ]
 `);
   });
@@ -269,7 +264,7 @@ Array [
   it(`gets completion(s) for rush build -<tab>`, async () => {
     const commandLine: string = 'rush build -';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -287,14 +282,12 @@ Array [
   it(`gets completion(s) for rush build -t <tab>`, async () => {
     const commandLine: string = 'rush build -t ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "abc",
-  "def",
-  "hij",
+  "-t",
 ]
 `);
   });
@@ -302,7 +295,7 @@ Array [
   it(`gets completion(s) for rush build -t a<tab>`, async () => {
     const commandLine: string = 'rush build -t a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -315,7 +308,7 @@ Array [
   it(`gets completion(s) for rush --debug build -t a<tab>`, async () => {
     const commandLine: string = 'rush --debug build -t a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -328,15 +321,12 @@ Array [
   it(`gets completion(s) for rush change --bump-type <tab>`, async () => {
     const commandLine: string = 'rush change --bump-type ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "major",
-  "minor",
-  "none",
-  "patch",
+  "--bump-type",
 ]
 `);
   });
@@ -344,21 +334,12 @@ Array [
   it(`gets completion(s) for rush change --bulk <tab>`, async () => {
     const commandLine: string = 'rush change --bulk ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
   "--bulk",
-  "--bump-type",
-  "--email",
-  "--message",
-  "--no-fetch",
-  "--overwrite",
-  "--target-branch",
-  "--verify",
-  "-b",
-  "-v",
 ]
 `);
   });
@@ -366,7 +347,7 @@ Array [
   it(`gets completion(s) for rush change --bump-type m<tab>`, async () => {
     const commandLine: string = 'rush change --bump-type m';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -380,24 +361,25 @@ Array [
   it(`gets completion(s) for rush change --message <tab>`, async () => {
     const commandLine: string = 'rush change --message ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
-    expect(actual.sort()).toMatchInlineSnapshot(`Array []`);
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "--message",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --message "my change log message" --bump-type <tab>`, async () => {
     const commandLine: string = 'rush change --message "my change log message" --bump-type ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "major",
-  "minor",
-  "none",
-  "patch",
+  "--bump-type",
 ]
 `);
   });
@@ -405,7 +387,7 @@ Array [
   it(`gets completion(s) for rush change --message "my change log message" --bump-type m<tab>`, async () => {
     const commandLine: string = 'rush change --message "my change log message" --bump-type m';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine.trim(), commandLine.length)
+      tc.getCompletions(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -420,7 +402,7 @@ Array [
 describe(TabCompleteAction.prototype.tokenizeCommandLine.name, () => {
   it(`tokenizes "rush change -"`, () => {
     const commandLine: string = 'rush change -';
-    const actual: string[] = tc.tokenizeCommandLine(commandLine.trim());
+    const actual: string[] = tc.tokenizeCommandLine(commandLine);
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
@@ -433,7 +415,7 @@ Array [
 
   it(`tokenizes 'rush change -m "my change log"'`, () => {
     const commandLine: string = 'rush change -m "my change log"';
-    const actual: string[] = tc.tokenizeCommandLine(commandLine.trim());
+    const actual: string[] = tc.tokenizeCommandLine(commandLine);
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [

--- a/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
+++ b/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
@@ -210,9 +210,16 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['add', 'build', 'change', 'install', '--debug', '-d'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "--debug",
+  "-d",
+  "add",
+  "build",
+  "change",
+  "install",
+]
+`);
   });
 
   it(`gets completion(s) for rush a<tab>`, async () => {
@@ -221,9 +228,11 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['add'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "add",
+]
+`);
   });
 
   it(`gets completion(s) for rush -d a<tab>`, async () => {
@@ -232,9 +241,11 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['add'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "add",
+]
+`);
   });
 
   it(`gets completion(s) for rush build <tab>`, async () => {
@@ -243,10 +254,16 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    expect(actual.indexOf('-t') !== -1).toBe(true);
-    expect(actual.indexOf('--to') !== -1).toBe(true);
-    expect(actual.indexOf('-f') !== -1).toBe(true);
-    expect(actual.indexOf('--from') !== -1).toBe(true);
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "--from",
+  "--parallelism",
+  "--to",
+  "-f",
+  "-p",
+  "-t",
+]
+`);
   });
 
   it(`gets completion(s) for rush build -<tab>`, async () => {
@@ -255,10 +272,16 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    expect(actual.indexOf('-t') !== -1).toBe(true);
-    expect(actual.indexOf('--to') !== -1).toBe(true);
-    expect(actual.indexOf('-f') !== -1).toBe(true);
-    expect(actual.indexOf('--from') !== -1).toBe(true);
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "--from",
+  "--parallelism",
+  "--to",
+  "-f",
+  "-p",
+  "-t",
+]
+`);
   });
 
   it(`gets completion(s) for rush build -t <tab>`, async () => {
@@ -267,9 +290,13 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['abc', 'def', 'hij'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "abc",
+  "def",
+  "hij",
+]
+`);
   });
 
   it(`gets completion(s) for rush build -t a<tab>`, async () => {
@@ -278,9 +305,11 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['abc'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "abc",
+]
+`);
   });
 
   it(`gets completion(s) for rush --debug build -t a<tab>`, async () => {
@@ -289,9 +318,11 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['abc'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "abc",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --bump-type <tab>`, async () => {
@@ -300,9 +331,14 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['major', 'minor', 'patch', 'none'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "major",
+  "minor",
+  "none",
+  "patch",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --bulk <tab>`, async () => {
@@ -311,10 +347,20 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    expect(actual.indexOf('--bulk') !== -1).toBe(true);
-    expect(actual.indexOf('--message') !== -1).toBe(true);
-    expect(actual.indexOf('--bump-type') !== -1).toBe(true);
-    expect(actual.indexOf('--verify') !== -1).toBe(true);
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "--bulk",
+  "--bump-type",
+  "--email",
+  "--message",
+  "--no-fetch",
+  "--overwrite",
+  "--target-branch",
+  "--verify",
+  "-b",
+  "-v",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --bump-type m<tab>`, async () => {
@@ -323,9 +369,12 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['major', 'minor'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "major",
+  "minor",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --message <tab>`, async () => {
@@ -334,9 +383,7 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = [];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`Array []`);
   });
 
   it(`gets completion(s) for rush change --message "my change log message" --bump-type <tab>`, async () => {
@@ -345,9 +392,14 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['major', 'minor', 'patch', 'none'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "major",
+  "minor",
+  "none",
+  "patch",
+]
+`);
   });
 
   it(`gets completion(s) for rush change --message "my change log message" --bump-type m<tab>`, async () => {
@@ -356,9 +408,12 @@ describe(TabCompleteAction.name, () => {
       tc.getCompletions(commandLine.trim(), commandLine.length)
     );
 
-    const expected: string[] = ['major', 'minor'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "major",
+  "minor",
+]
+`);
   });
 });
 
@@ -367,17 +422,26 @@ describe(TabCompleteAction.prototype.tokenizeCommandLine.name, () => {
     const commandLine: string = 'rush change -';
     const actual: string[] = tc.tokenizeCommandLine(commandLine.trim());
 
-    const expected: string[] = ['rush', 'change', '-'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "-",
+  "change",
+  "rush",
+]
+`);
   });
 
   it(`tokenizes 'rush change -m "my change log"'`, () => {
     const commandLine: string = 'rush change -m "my change log"';
     const actual: string[] = tc.tokenizeCommandLine(commandLine.trim());
 
-    const expected: string[] = ['rush', 'change', '-m', 'my change log'];
-
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(actual.sort()).toMatchInlineSnapshot(`
+Array [
+  "-m",
+  "change",
+  "my change log",
+  "rush",
+]
+`);
   });
 });

--- a/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
+++ b/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
@@ -256,7 +256,12 @@ Array [
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "build",
+  "--from",
+  "--parallelism",
+  "--to",
+  "-f",
+  "-p",
+  "-t",
 ]
 `);
   });
@@ -287,7 +292,9 @@ Array [
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "-t",
+  "abc",
+  "def",
+  "hij",
 ]
 `);
   });
@@ -326,7 +333,10 @@ Array [
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "--bump-type",
+  "major",
+  "minor",
+  "none",
+  "patch",
 ]
 `);
   });
@@ -340,6 +350,15 @@ Array [
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
   "--bulk",
+  "--bump-type",
+  "--email",
+  "--message",
+  "--no-fetch",
+  "--overwrite",
+  "--target-branch",
+  "--verify",
+  "-b",
+  "-v",
 ]
 `);
   });
@@ -364,11 +383,7 @@ Array [
       tc.getCompletions(commandLine, commandLine.length)
     );
 
-    expect(actual.sort()).toMatchInlineSnapshot(`
-Array [
-  "--message",
-]
-`);
+    expect(actual.sort()).toMatchInlineSnapshot(`Array []`);
   });
 
   it(`gets completion(s) for rush change --message "my change log message" --bump-type <tab>`, async () => {
@@ -379,7 +394,10 @@ Array [
 
     expect(actual.sort()).toMatchInlineSnapshot(`
 Array [
-  "--bump-type",
+  "major",
+  "minor",
+  "none",
+  "patch",
 ]
 `);
   });


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/4649.

## Details

The tab completion action misidentified a command that ended with a space as partial-word completion, and the unit tests did not test this correctly. This PR specifically handles the case where the tab completion request ends with whitespace.

## How it was tested

Stopped trimming the command passed in unit tests and confirmed that they work correctly.

## Impacted documentation

None.
