### PR TITLE
bug(rush-lib,operation-weighting): UNASSIGNED_OPERATION causing memory leak

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-weighting-bug-fix_2024-05-08-13-35.json
+++ b/common/changes/@microsoft/rush/sennyeya-weighting-bug-fix_2024-05-08-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes a bug where cobuilds would cause a GC error when waiting for long periods of time.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -17,7 +17,7 @@ export const UNASSIGNED_OPERATION: 'UNASSIGNED_OPERATION' = 'UNASSIGNED_OPERATIO
 
 export type IOperationIteratorResult =
   | OperationExecutionRecord
-  | { weight: 0; status: typeof UNASSIGNED_OPERATION };
+  | { weight: 1; status: typeof UNASSIGNED_OPERATION };
 
 /**
  * Implementation of the async iteration protocol for a collection of IOperation objects.
@@ -166,7 +166,7 @@ export class AsyncOperationQueue
       // remote executing operation which is not ready to process.
       if (queue.some((operation) => operation.status === OperationStatus.RemoteExecuting)) {
         waitingIterators.shift()!({
-          value: { weight: 0, status: UNASSIGNED_OPERATION },
+          value: { weight: 1, status: UNASSIGNED_OPERATION },
           done: false
         });
       }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Followup to #4672 

Having a weight of 0 for UNASSIGNED_OPERATION was causing a build up of objects for the instance that was waiting. This quickly causes a GC error, locally I can trigger it in 30 seconds, in our CI it's about 2 mins.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I tried to upgrade our cobuild instance this morning and ran into this issue. Monkeypatching the weight to 1 locally fixes the issue. 

This is caused by the weight of 0 being an immediate execution, UNASSIGNED_OPERATIONs must have an actual weight so the process is stuck waiting for some time.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested this in our internal rush instance, I also tested this with the cobuild test project by setting the timeout in the `build.js` script to a long interval (2000 seconds). The instance that is waiting will throw a GC error pretty quickly.

With this change, the waiting process is stable and doesn't cause a GC error.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

None.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
