### PR TITLE
[rush-lib] Fix a issue where rush install/update can not detect pnpm-sync.json is out of date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Ensure repo README is up-to-date
         run: node repo-scripts/repo-toolbox/lib/start.js readme --verify
 
-      - name: Rush update (rush-lib)
+      - name: Rush install (rush-lib)
         run: node apps/rush/lib/start-dev.js install
 
       - name: Rush test (rush-lib)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: node repo-scripts/repo-toolbox/lib/start.js readme --verify
 
       - name: Rush update (rush-lib)
-        run: node apps/rush/lib/start-dev.js update --recheck
+        run: node apps/rush/lib/start-dev.js install
 
       - name: Rush test (rush-lib)
         run: node apps/rush/lib/start-dev.js test --verbose --production --timeline

--- a/common/changes/@microsoft/rush/chao-fix-install_2024-05-08-18-07.json
+++ b/common/changes/@microsoft/rush/chao-fix-install_2024-05-08-18-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a issue where rush install/update can not detect pnpm-sync.json is out of date",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -29,6 +29,9 @@ steps:
     displayName: 'Rush retest (install-run-rush)'
 
   - ${{ if eq(parameters.PerformValidation, true) }}:
+      - script: 'node apps/rush/lib/start-dev.js install'
+        displayName: 'Rush install (rush-lib)'
+
       - script: 'node apps/rush/lib/start-dev.js test --verbose --production --timeline ${{ parameters.BuildParameters }}'
         displayName: 'Rush test (rush-lib)'
 

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { JsonFile, type JsonObject, Path, type IPackageJson, FileSystem } from '@rushstack/node-core-library';
+import { pnpmSyncGetJsonVersion } from 'pnpm-sync-lib';
 import type { PackageManagerName } from './packageManager/PackageManager';
 import type { RushConfiguration } from './RushConfiguration';
 import * as objectUtilities from '../utilities/objectUtilities';
@@ -56,6 +57,10 @@ export interface ILastInstallFlagJson {
    * It is undefined when full install
    */
   selectedProjectNames?: string[];
+  /**
+   * pnpm-sync-lib version
+   */
+  pnpmSync?: string;
 }
 
 interface ILockfileValidityCheckOptions {
@@ -239,6 +244,7 @@ export class LastInstallFlagFactory {
       packageManagerVersion: rushConfiguration.packageManagerToolVersion,
       rushJsonFolder: rushConfiguration.rushJsonFolder,
       ignoreScripts: false,
+      pnpmSync: pnpmSyncGetJsonVersion(),
       ...extraState
     };
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Fix a issue where rush install/update can not detect pnpm-sync.json is out of date
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
