### PR TITLE
[rush] Fix publishing pipeline to publish Rush 5.124.0

### DIFF
--- a/common/changes/@microsoft/rush/octogonz-publish-rush-5.122.0_2024-05-08-18-04.json
+++ b/common/changes/@microsoft/rush/octogonz-publish-rush-5.122.0_2024-05-08-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/octogonz-publish-rush-5.122.0_2024-05-08-18-04.json
+++ b/common/changes/@microsoft/rush/octogonz-publish-rush-5.122.0_2024-05-08-18-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "",
+      "comment": "Improve the error message when the pnpm-sync version is outdated",
       "type": "none"
     }
   ],

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -2,9 +2,6 @@ parameters:
   - name: BuildParameters
     type: string
     default: ''
-  - name: PerformValidation
-    type: boolean
-    default: true
 
 steps:
   - script: 'git config --local user.email rushbot@users.noreply.github.com'
@@ -27,10 +24,3 @@ steps:
 
   - script: 'node common/scripts/install-run-rush.js retest --verbose --production ${{ parameters.BuildParameters }}'
     displayName: 'Rush retest (install-run-rush)'
-
-  - ${{ if eq(parameters.PerformValidation, true) }}:
-      - script: 'node apps/rush/lib/start-dev.js test --verbose --production --timeline ${{ parameters.BuildParameters }}'
-        displayName: 'Rush test (rush-lib)'
-
-      - script: 'node repo-scripts/repo-toolbox/lib/start.js readme --verify'
-        displayName: 'Ensure repo README is up-to-date'

--- a/common/config/azure-pipelines/vscode-extension-publish.yaml
+++ b/common/config/azure-pipelines/vscode-extension-publish.yaml
@@ -32,7 +32,6 @@ extends:
                 parameters:
                   BuildParameters: >
                     --to rushstack
-                  PerformValidation: false
 
               - script: node $(Build.SourcesDirectory)/common/scripts/install-run-rushx.js package
                 workingDirectory: $(Build.SourcesDirectory)/vscode-extensions/rush-vscode-extension

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -9,7 +9,7 @@ import {
   ConsoleTerminalProvider
 } from '@rushstack/terminal';
 import { StreamCollator, type CollatedTerminal, type CollatedWriter } from '@rushstack/stream-collator';
-import { NewlineKind, Async, InternalError } from '@rushstack/node-core-library';
+import { NewlineKind, Async, InternalError, AlreadyReportedError } from '@rushstack/node-core-library';
 
 import {
   AsyncOperationQueue,
@@ -313,7 +313,13 @@ export class OperationExecutionManager {
       case OperationStatus.Failure: {
         // Failed operations get reported, even if silent.
         // Generally speaking, silent operations shouldn't be able to fail, so this is a safety measure.
-        const message: string | undefined = record.error?.message;
+        let message: string | undefined = undefined;
+        if (record.error) {
+          if (!(record.error instanceof AlreadyReportedError)) {
+            message = record.error.message;
+          }
+        }
+
         // This creates the writer, so don't do this globally
         const { terminal } = record.collatedWriter;
         if (message) {

--- a/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
@@ -30,7 +30,11 @@ export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
         } = record;
 
         //skip if the phase is skipped or no operation
-        if (status === OperationStatus.Skipped || status === OperationStatus.NoOp) {
+        if (
+          status === OperationStatus.Skipped ||
+          status === OperationStatus.NoOp ||
+          status === OperationStatus.Failure
+        ) {
           return;
         }
 

--- a/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
+++ b/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
@@ -46,7 +46,7 @@ export class PnpmSyncUtilities {
       case LogMessageIdentifier.PREPARE_REPLACING_FILE:
         {
           const customMessage: string =
-            `excepted .pnpm-sync.json version: ${details.expectedVersion}; ` +
+            `Expected .pnpm-sync.json version: ${details.expectedVersion}; ` +
             `actual .pnpm-sync.json version: ${details.actualVersion}; `;
 
           terminal.writeVerboseLine(PnpmSyncUtilities._addLinePrefix(message));
@@ -57,7 +57,7 @@ export class PnpmSyncUtilities {
       // don't return this error case, pass to default handler
       case LogMessageIdentifier.COPY_ERROR_INCOMPATIBLE_SYNC_FILE: {
         const customMessage: string =
-          `excepted .pnpm-sync.json version: ${details.expectedVersion}; ` +
+          `Expected .pnpm-sync.json version: ${details.expectedVersion}; ` +
           `actual .pnpm-sync.json version: ${details.actualVersion}; `;
 
         terminal.writeErrorLine(PnpmSyncUtilities._addLinePrefix(customMessage));

--- a/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
+++ b/libraries/rush-lib/src/utilities/PnpmSyncUtilities.ts
@@ -46,21 +46,30 @@ export class PnpmSyncUtilities {
       case LogMessageIdentifier.PREPARE_REPLACING_FILE:
         {
           const customMessage: string =
-            `Expected .pnpm-sync.json version: ${details.expectedVersion}; ` +
-            `actual .pnpm-sync.json version: ${details.actualVersion}; `;
+            `Expecting .pnpm-sync.json version ${details.expectedVersion}, ` +
+            `but found version ${details.actualVersion}`;
 
           terminal.writeVerboseLine(PnpmSyncUtilities._addLinePrefix(message));
           terminal.writeVerboseLine(PnpmSyncUtilities._addLinePrefix(customMessage));
         }
         return;
 
-      // don't return this error case, pass to default handler
       case LogMessageIdentifier.COPY_ERROR_INCOMPATIBLE_SYNC_FILE: {
-        const customMessage: string =
-          `Expected .pnpm-sync.json version: ${details.expectedVersion}; ` +
-          `actual .pnpm-sync.json version: ${details.actualVersion}; `;
+        terminal.writeErrorLine(
+          PnpmSyncUtilities._addLinePrefix(
+            `The workspace was installed using an incompatible version of pnpm-sync.\n` +
+              `Please run "rush install" or "rush update" again.`
+          )
+        );
 
-        terminal.writeErrorLine(PnpmSyncUtilities._addLinePrefix(customMessage));
+        terminal.writeLine(
+          PnpmSyncUtilities._addLinePrefix(
+            `Expecting .pnpm-sync.json version ${details.expectedVersion}, ` +
+              `but found version ${details.actualVersion}\n` +
+              `Affected folder: ${details.pnpmSyncJsonPath}`
+          )
+        );
+        throw new AlreadyReportedError();
       }
     }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

The publishing pipeline was failing with this error:

![image](https://github.com/microsoft/rushstack/assets/4673363/8b1b2f86-78c4-49c7-98d7-ab1f55575609)

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

The publishing pipeline seems actually incorrect:  It makes sense that the Rush CI would try rebuilding/reinstalling itself using the current branch to see if the CI passes, because ultimately we discard the output.  Whereas when publishing to NPM, the correctness of the build output is very important.  But this "test" is effectively upgrading Rush in-place without any review, and the output of that test is what gets published to NPM.  It's probably safe in most cases, but in principle it seems not a good practice.  Thus, I have removed this pipeline step entirely.


I also improved the error message format and fixed a problem where the error message was getting printed twice.

The new error looks like this:

![image](https://github.com/microsoft/rushstack/assets/4673363/39f505c5-44d2-4852-b628-32f232da3925)

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->
Manually edited `.pnpm-sync.json` to force the error to occur.
 