### PR TITLE
fix(node-core-library): iterator weighting isn't fully respected by `Async#forEachAsync`

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
+++ b/common/changes/@microsoft/rush/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes a bug in `OperationExecutionRecord` where operation weights were not correctly represented.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
+++ b/common/changes/@microsoft/rush/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fixes a bug in `OperationExecutionRecord` where operation weights were not correctly represented.",
+      "comment": "Fix an issue where operation weights were not respected.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fixes a bug in `Async#forEachAsync` that caused it to not respect operation weight.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
+++ b/common/changes/@rushstack/node-core-library/sennyeya-weighted-operation-reentry_2024-05-08-23-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Fixes a bug in `Async#forEachAsync` that caused it to not respect operation weight.",
+      "comment": "Fix a bug in `Async.forEachAsync` where weight wasn't respected.",
       "type": "patch"
     }
   ],

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -179,7 +179,7 @@ export class Async {
   }
 
   private static async _forEachWeightedAsync<TReturn, TEntry extends { weight: number; element: TReturn }>(
-    iterable: Iterable<TEntry> | AsyncIterable<TEntry>,
+    iterable: AsyncIterable<TEntry>,
     callback: (entry: TReturn, arrayIndex: number) => Promise<void>,
     options?: IAsyncParallelismOptions | undefined
   ): Promise<void> {
@@ -187,10 +187,9 @@ export class Async {
       options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
     let concurrentUnitsInProgress: number = 0;
 
-    const iterator: Iterator<TEntry> | AsyncIterator<TEntry> = (
-      (iterable as Iterable<TEntry>)[Symbol.iterator] ||
-      (iterable as AsyncIterable<TEntry>)[Symbol.asyncIterator]
-    ).call(iterable);
+    const iterator: AsyncIterator<TEntry> = (iterable as AsyncIterable<TEntry>)[Symbol.asyncIterator].call(
+      iterable
+    );
 
     let arrayIndex: number = 0;
 
@@ -199,13 +198,6 @@ export class Async {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const currentIteratorResult: IteratorResult<TEntry> = await iterator.next();
-      console.log(
-        'iterator result',
-        currentIteratorResult.done,
-        currentIteratorResult.value.element?.name,
-        currentIteratorResult.value.element?.weight,
-        concurrency
-      );
       if (currentIteratorResult.done) {
         break;
       }
@@ -214,7 +206,6 @@ export class Async {
 
       concurrentUnitsInProgress += weight;
       const promise: Promise<void> = Promise.resolve(callback(element, arrayIndex++)).then(() => {
-        console.log('resolved', (element as any).name);
         concurrentUnitsInProgress -= weight;
         pending.delete(promise);
       });

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -183,43 +183,78 @@ export class Async {
     callback: (entry: TReturn, arrayIndex: number) => Promise<void>,
     options?: IAsyncParallelismOptions | undefined
   ): Promise<void> {
-    const concurrency: number =
-      options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
-    let concurrentUnitsInProgress: number = 0;
+    await new Promise<void>((resolve: () => void, reject: (error: Error) => void) => {
+      const concurrency: number =
+        options?.concurrency && options.concurrency > 0 ? options.concurrency : Infinity;
+      let concurrentUnitsInProgress: number = 0;
 
-    const iterator: AsyncIterator<TEntry> = (iterable as AsyncIterable<TEntry>)[Symbol.asyncIterator].call(
-      iterable
-    );
+      const iterator: Iterator<TEntry> | AsyncIterator<TEntry> = (iterable as AsyncIterable<TEntry>)[
+        Symbol.asyncIterator
+      ].call(iterable);
 
-    let arrayIndex: number = 0;
+      let arrayIndex: number = 0;
+      let iteratorIsComplete: boolean = false;
+      let promiseHasResolvedOrRejected: boolean = false;
 
-    const pending: Set<Promise<void>> = new Set();
+      async function queueOperationsAsync(): Promise<void> {
+        while (
+          concurrentUnitsInProgress < concurrency &&
+          !iteratorIsComplete &&
+          !promiseHasResolvedOrRejected
+        ) {
+          // Increment the concurrency while waiting for the iterator.
+          // This function is reentrant, so this ensures that at most `concurrency` executions are waiting
+          const limitedConcurrency = !Number.isFinite(concurrency) ? 1 : concurrency;
+          concurrentUnitsInProgress += limitedConcurrency;
+          const currentIteratorResult: IteratorResult<TEntry> = await iterator.next();
+          // eslint-disable-next-line require-atomic-updates
+          iteratorIsComplete = !!currentIteratorResult.done;
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const currentIteratorResult: IteratorResult<TEntry> = await iterator.next();
-      if (currentIteratorResult.done) {
-        break;
+          if (!iteratorIsComplete) {
+            const currentIteratorValue: TEntry = currentIteratorResult.value;
+            Async.validateWeightedIterable(currentIteratorValue);
+            const weight: number = Math.min(currentIteratorValue.weight, concurrency);
+            // If it's a weighted operation then add the rest of the weight, removing concurrent units if weight < 1.
+            // Cap it to the concurrency limit, otherwise higher weights can cause issues in the case where 0 weighted
+            // operations are present.
+            concurrentUnitsInProgress -= limitedConcurrency;
+            concurrentUnitsInProgress += weight;
+            Promise.resolve(callback(currentIteratorValue.element, arrayIndex++))
+              .then(async () => {
+                concurrentUnitsInProgress -= weight;
+                await onOperationCompletionAsync();
+              })
+              .catch((error) => {
+                promiseHasResolvedOrRejected = true;
+                reject(error);
+              });
+          } else {
+            // The iterator is complete and there wasn't a value, so untrack the waiting state.
+            concurrentUnitsInProgress -= limitedConcurrency;
+          }
+        }
+
+        if (iteratorIsComplete) {
+          await onOperationCompletionAsync();
+        }
       }
 
-      const { element, weight } = currentIteratorResult.value;
+      async function onOperationCompletionAsync(): Promise<void> {
+        if (!promiseHasResolvedOrRejected) {
+          if (concurrentUnitsInProgress === 0 && iteratorIsComplete) {
+            promiseHasResolvedOrRejected = true;
+            resolve();
+          } else if (!iteratorIsComplete) {
+            await queueOperationsAsync();
+          }
+        }
+      }
 
-      concurrentUnitsInProgress += weight;
-      const promise: Promise<void> = Promise.resolve(callback(element, arrayIndex++)).then(() => {
-        concurrentUnitsInProgress -= weight;
-        pending.delete(promise);
+      queueOperationsAsync().catch((error) => {
+        promiseHasResolvedOrRejected = true;
+        reject(error);
       });
-      pending.add(promise);
-
-      // eslint-disable-next-line no-unmodified-loop-condition
-      while (concurrentUnitsInProgress >= concurrency && pending.size > 0) {
-        await Promise.race(Array.from(pending));
-      }
-    }
-
-    if (pending.size > 0) {
-      await Promise.all(Array.from(pending));
-    }
+    });
   }
 
   /**

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -539,50 +539,6 @@ describe(Async.name, () => {
       resolve2({ done: true, value: undefined });
       await finalPromise;
     });
-
-    it('does not exceed the maxiumum concurrency for an async iterator when concurrency set to infinite', async () => {
-      let waitingIterators: number = 0;
-
-      let resolve2!: (value: { done: true; value: undefined }) => void;
-      const signal2: Promise<{ done: true; value: undefined }> = new Promise((resolve, reject) => {
-        resolve2 = resolve;
-      });
-
-      let iteratorIndex: number = 0;
-      const asyncIterator: AsyncIterator<{ element: number; weight: number }> = {
-        next: () => {
-          iteratorIndex++;
-          if (iteratorIndex < 20) {
-            return Promise.resolve({ done: false, value: { element: iteratorIndex, weight: 2 } });
-          } else {
-            ++waitingIterators;
-            return signal2;
-          }
-        }
-      };
-      const asyncIterable: AsyncIterable<{ element: number; weight: number }> = {
-        [Symbol.asyncIterator]: () => asyncIterator
-      };
-
-      const finalPromise: Promise<void> = Async.forEachAsync(
-        asyncIterable,
-        async (item) => {
-          // Do nothing
-        },
-        {
-          concurrency: Number.POSITIVE_INFINITY,
-          weighted: true
-        }
-      );
-
-      // Wait for all the instant resolutions to be done
-      await Async.sleep(0);
-
-      // The final iteration cycle is locked, so only 1 iterator is waiting.
-      expect(waitingIterators).toEqual(1);
-      resolve2({ done: true, value: undefined });
-      await finalPromise;
-    });
   });
 
   describe(Async.runWithRetriesAsync.name, () => {

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -93,6 +93,8 @@ export class AsyncOperationQueue
       }
     }
 
+    this.assignOperations();
+
     if (this._completedOperations.size === this._totalOperations) {
       this._isDone = true;
     }

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -138,6 +138,7 @@ export class AsyncOperationQueue
         // This task is ready to process, hand it to the iterator.
         // Needs to have queue semantics, otherwise tools that iterate it get confused
         record.status = OperationStatus.Queued;
+        console.log('queueing', record.weight, record.name);
         waitingIterators.shift()!({
           value: record,
           done: false

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -140,7 +140,6 @@ export class AsyncOperationQueue
         // This task is ready to process, hand it to the iterator.
         // Needs to have queue semantics, otherwise tools that iterate it get confused
         record.status = OperationStatus.Queued;
-        console.log('queueing', record.weight, record.name);
         waitingIterators.shift()!({
           value: record,
           done: false

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -256,6 +256,7 @@ export class OperationExecutionManager {
     await Async.forEachAsync(
       this._executionQueue,
       async (operation: IOperationIteratorResult) => {
+        console.log('queueing operation' + operation.status);
         let record: OperationExecutionRecord | undefined;
         /**
          * If the operation is UNASSIGNED_OPERATION, it means that the queue is not able to assign a operation.

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -256,7 +256,6 @@ export class OperationExecutionManager {
     await Async.forEachAsync(
       this._executionQueue,
       async (operation: IOperationIteratorResult) => {
-        console.log('queueing operation' + operation.status);
         let record: OperationExecutionRecord | undefined;
         /**
          * If the operation is UNASSIGNED_OPERATION, it means that the queue is not able to assign a operation.

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -404,6 +404,9 @@ export class OperationExecutionManager {
     if (record.status !== OperationStatus.RemoteExecuting) {
       // If the operation was not remote, then we can notify queue that it is complete
       this._executionQueue.complete(record);
+    } else {
+      // Attempt to requeue other operations if the operation was remote
+      this._executionQueue.assignOperations();
     }
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -96,7 +96,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
   public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer();
 
   public readonly runner: IOperationRunner;
-  public readonly weight: number;
   public readonly associatedPhase: IPhase | undefined;
   public readonly associatedProject: RushConfigurationProject | undefined;
   public readonly _operationMetadataManager: OperationMetadataManager | undefined;
@@ -117,7 +116,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
     this.operation = operation;
     this.runner = runner;
-    this.weight = operation.weight;
     this.associatedPhase = associatedPhase;
     this.associatedProject = associatedProject;
     if (operation.associatedPhase && operation.associatedProject) {
@@ -132,6 +130,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
 
   public get name(): string {
     return this.runner.name;
+  }
+
+  public get weight(): number {
+    return this.operation.weight;
   }
 
   public get debugMode(): boolean {

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -44,7 +44,6 @@ function weightOperations(
         operation.weight = operationSettings.weight;
       }
     }
-    console.log('Operation weight:', operation.name, operation.weight);
     Async.validateWeightedIterable(operation);
   }
   return operations;

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -44,6 +44,7 @@ function weightOperations(
         operation.weight = operationSettings.weight;
       }
     }
+    console.log('Operation weight:', operation.name, operation.weight);
     Async.validateWeightedIterable(operation);
   }
   return operations;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Followup to #4672. This PR fixes 2 bugs that I found while trying to integrate this with our CI,
1. operation weight isn't passed correctly to the execution record.
2. operation weight wasn't being respected if operations were queued at the same time.

### Before
<img width="912" alt="Screenshot 2024-05-07 at 12 24 01 PM" src="https://github.com/microsoft/rushstack/assets/159921952/d0bdab5a-3e5a-498a-aa8e-d323a328c41f">

### After
(a,b,c all have operation weight 10)
<img width="915" alt="Screenshot 2024-05-08 at 7 44 31 PM" src="https://github.com/microsoft/rushstack/assets/159921952/7257e9f4-558d-4020-9372-2ef8a770fbe7">

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

The existing `AsyncQueueManager` requires the `forEachAsync` implementation to be reentrant and to have multiple waiting iterators. Moving to a weighted operation model requires the `forEachAsync` to lock when pulling off an item from the iterator as we don't know the operation weight until after we pop the item. To correct this difference, I updated `AsyncQueueManager` to explicitly reassign operations when marking the operation as complete or after handling a remote executing operation. 

This may affect performance, but the critical zone that is now being locked should not affect performance. As seen in the graphs above, this does change the `REMOTE_EXECUTING` behavior a bit.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I tested this using the cobuilds build-tests sandbox repo and a bunch of console logs. I changed the operation weights to equal the `-p` parameter which caused sequential timelines.

I would appreciate additional testing/validation to make sure I'm on the right track 🙏 

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
