### PR TITLE
[eslint-bulk] Fix #4691.

### DIFF
--- a/common/changes/@rushstack/eslint-bulk/fix-eslint-bulk-escaping_2024-05-10-07-41.json
+++ b/common/changes/@rushstack/eslint-bulk/fix-eslint-bulk-escaping_2024-05-10-07-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-bulk",
+      "comment": "Fix an issue where the tool will not correctly execute if the installed eslint path contains a space.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-bulk"
+}

--- a/eslint/eslint-bulk/src/start.ts
+++ b/eslint/eslint-bulk/src/start.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { execSync } from 'child_process';
+import {
+  type ExecSyncOptionsWithBufferEncoding,
+  type SpawnSyncOptionsWithBufferEncoding,
+  execSync,
+  spawnSync
+} from 'child_process';
 import * as process from 'process';
 import * as fs from 'fs';
 
@@ -66,20 +71,24 @@ function findPatchPath(): string {
     );
   }
 
-  let eslintBinCommand: string;
+  const eslintArgs: string[] = ['--stdin', '--config'];
+  const spawnOrExecOptions: SpawnSyncOptionsWithBufferEncoding & ExecSyncOptionsWithBufferEncoding = {
+    env,
+    input: '',
+    stdio: 'pipe'
+  };
+  let runEslintFn: () => Buffer;
   if (eslintBinPath) {
-    eslintBinCommand = `${process.argv0} ${eslintBinPath}`;
+    runEslintFn = () =>
+      spawnSync(process.argv0, [eslintBinPath, ...eslintArgs, eslintrcPath], spawnOrExecOptions).stdout;
   } else {
-    eslintBinCommand = 'eslint'; // Try to use a globally-installed eslint if a local package was not found
+    // Try to use a globally-installed eslint if a local package was not found
+    runEslintFn = () => execSync(`eslint ${eslintArgs.join(' ')} "${eslintrcPath}"`, spawnOrExecOptions);
   }
 
   let stdout: Buffer;
   try {
-    stdout = execSync(`${eslintBinCommand} --stdin --config ${eslintrcPath}`, {
-      env,
-      input: '',
-      stdio: 'pipe'
-    });
+    stdout = runEslintFn();
   } catch (e) {
     console.error('@rushstack/eslint-bulk: Error finding patch path: ' + e.message);
     process.exit(1);


### PR DESCRIPTION
## Summary

Fixes #4691.

## Details

This change runs a resolved eslint with `spawnSync` instead of `execSync`, and wrap the eslintrc path in quotes.

## How it was tested

Built the `eslint-bulk-suppressions-test` project in a clone of this repo with a space in the path.