### PR TITLE
[rush] Fix an issue with skipping installs.

### DIFF
--- a/common/changes/@microsoft/rush/fix-install-skipping_2024-05-14-01-06.json
+++ b/common/changes/@microsoft/rush/fix-install-skipping_2024-05-14-01-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where skipping installs did not work if a subspace doesn't have a `pnpm-config.json` file.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -68,11 +68,10 @@ export class Subspace {
   public getPnpmOptions(): PnpmOptionsConfiguration | undefined {
     if (!this._cachedPnpmOptionsInitialized) {
       // Calculate these outside the try/catch block since their error messages shouldn't be annotated:
-      const subspaceConfigFolder: string = this.getSubspaceConfigFolder();
       const subspaceTempFolder: string = this.getSubspaceTempFolder();
       try {
         this._cachedPnpmOptions = PnpmOptionsConfiguration.loadFromJsonFileOrThrow(
-          `${subspaceConfigFolder}/${RushConstants.pnpmConfigFilename}`,
+          this.getPnpmConfigFilePath(),
           subspaceTempFolder
         );
         this._cachedPnpmOptionsInitialized = true;

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -438,8 +438,9 @@ export class RushInstallManager extends BaseInstallManager {
    *
    * @override
    */
-  protected canSkipInstall(lastModifiedDate: Date, subspace: Subspace): boolean {
-    if (!super.canSkipInstall(lastModifiedDate, subspace)) {
+  protected async canSkipInstallAsync(lastModifiedDate: Date, subspace: Subspace): Promise<boolean> {
+    const parentCanSkipInstall: boolean = await super.canSkipInstallAsync(lastModifiedDate, subspace);
+    if (!parentCanSkipInstall) {
       return false;
     }
 
@@ -454,7 +455,7 @@ export class RushInstallManager extends BaseInstallManager {
       })
     );
 
-    return Utilities.isFileTimestampCurrent(lastModifiedDate, potentiallyChangedFiles);
+    return await Utilities.isFileTimestampCurrentAsync(lastModifiedDate, potentiallyChangedFiles, true);
   }
 
   /**

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -330,12 +330,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     return { shrinkwrapIsUpToDate, shrinkwrapWarnings };
   }
 
-  protected canSkipInstall(lastModifiedDate: Date, subspace: Subspace): boolean {
-    if (!super.canSkipInstall(lastModifiedDate, subspace)) {
+  protected async canSkipInstallAsync(lastModifiedDate: Date, subspace: Subspace): Promise<boolean> {
+    const parentCanSkipInstall: boolean = await super.canSkipInstallAsync(lastModifiedDate, subspace);
+    if (!parentCanSkipInstall) {
       return false;
     }
-
-    const potentiallyChangedFiles: string[] = [];
 
     if (this.rushConfiguration.packageManager === 'pnpm') {
       // Add workspace file. This file is only modified when workspace packages change.
@@ -344,26 +343,28 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         'pnpm-workspace.yaml'
       );
 
-      if (FileSystem.exists(pnpmWorkspaceFilename)) {
-        potentiallyChangedFiles.push(pnpmWorkspaceFilename);
+      const isPnpmWorkspaceFileCurrent: boolean = await Utilities.isFileTimestampCurrentAsync(
+        lastModifiedDate,
+        [pnpmWorkspaceFilename],
+        false
+      );
+      if (!isPnpmWorkspaceFileCurrent) {
+        return false;
       }
     }
 
     // Also consider timestamps for all the project node_modules folders, as well as the package.json
     // files
     // Example: [ "C:\MyRepo\projects\projectA\node_modules", "C:\MyRepo\projects\projectA\package.json" ]
-    potentiallyChangedFiles.push(
-      ...subspace.getProjects().map((project) => {
-        return path.join(project.projectFolder, RushConstants.nodeModulesFolderName);
-      }),
-      ...subspace.getProjects().map((project) => {
-        return path.join(project.projectFolder, FileConstants.PackageJson);
-      })
-    );
+    const potentiallyChangedFiles: string[] = [];
+    for (const { projectFolder } of subspace.getProjects()) {
+      potentiallyChangedFiles.push(`${projectFolder}/${RushConstants.nodeModulesFolderName}`);
+      potentiallyChangedFiles.push(`${projectFolder}/${FileConstants.PackageJson}`);
+    }
 
     // NOTE: If any of the potentiallyChangedFiles does not exist, then isFileTimestampCurrent()
     // returns false.
-    return Utilities.isFileTimestampCurrent(lastModifiedDate, potentiallyChangedFiles);
+    return await Utilities.isFileTimestampCurrentAsync(lastModifiedDate, potentiallyChangedFiles, true);
   }
 
   /**


### PR DESCRIPTION
## Summary

Currently, if a `common/config/subspaces/<subspace>/pnpm-config.json` file doesn't exist, installs will never be skipped. In addition to some refactoring, this change allows that file to not exist.

## How it was tested

Tested in this repo.

## Impacted documentation

None.