### PR TITLE
Normalize the naming of async functions to end with `Async`.

### DIFF
--- a/apps/api-documenter/src/start.ts
+++ b/apps/api-documenter/src/start.ts
@@ -19,4 +19,4 @@ console.log(
 
 const parser: ApiDocumenterCommandLine = new ApiDocumenterCommandLine();
 
-parser.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise
+parser.executeAsync().catch(console.error); // CommandLineParser.executeAsync() should never reject the promise

--- a/apps/api-extractor/src/start.ts
+++ b/apps/api-extractor/src/start.ts
@@ -16,7 +16,7 @@ console.log(
 
 const parser: ApiExtractorCommandLine = new ApiExtractorCommandLine();
 
-parser.execute().catch((error) => {
+parser.executeAsync().catch((error) => {
   console.error(Colorize.red(`An unexpected error occurred: ${error}`));
   process.exit(1);
 });

--- a/apps/heft/src/cli/HeftCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftCommandLineParser.ts
@@ -95,7 +95,7 @@ export class HeftCommandLineParser extends CommandLineParser {
     this._metricsCollector = new MetricsCollector();
   }
 
-  public async execute(args?: string[]): Promise<boolean> {
+  public async executeAsync(args?: string[]): Promise<boolean> {
     // Defensively set the exit code to 1 so if the tool crashes for whatever reason,
     // we'll have a nonzero exit code.
     process.exitCode = 1;
@@ -166,9 +166,9 @@ export class HeftCommandLineParser extends CommandLineParser {
         this.addAction(aliasAction);
       }
 
-      return await super.execute(args);
+      return await super.executeAsync(args);
     } catch (e) {
-      await this._reportErrorAndSetExitCode(e as Error);
+      await this._reportErrorAndSetExitCodeAsync(e as Error);
       return false;
     }
   }
@@ -195,7 +195,7 @@ export class HeftCommandLineParser extends CommandLineParser {
       };
       await super.onExecute();
     } catch (e) {
-      await this._reportErrorAndSetExitCode(e as Error);
+      await this._reportErrorAndSetExitCodeAsync(e as Error);
     }
 
     // If we make it here, things are fine and reset the exit code back to 0
@@ -235,7 +235,7 @@ export class HeftCommandLineParser extends CommandLineParser {
     };
   }
 
-  private async _reportErrorAndSetExitCode(error: Error): Promise<void> {
+  private async _reportErrorAndSetExitCodeAsync(error: Error): Promise<void> {
     if (!(error instanceof AlreadyReportedError)) {
       this.globalTerminal.writeErrorLine(error.toString());
     }

--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -120,7 +120,7 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
     );
   }
 
-  private async _loadStageConfiguration(
+  private async _loadStageConfigurationAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration
   ): Promise<void> {
@@ -187,7 +187,7 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration
   ): Promise<void> {
-    await this._loadStageConfiguration(taskSession, heftConfiguration);
+    await this._loadStageConfigurationAsync(taskSession, heftConfiguration);
     if (!this._pluginEnabled) {
       return;
     }

--- a/apps/heft/src/start.ts
+++ b/apps/heft/src/start.ts
@@ -8,7 +8,7 @@ import { HeftCommandLineParser } from './cli/HeftCommandLineParser';
 const parser: HeftCommandLineParser = new HeftCommandLineParser();
 
 parser
-  .execute()
+  .executeAsync()
   .then(() => {
     // This should be removed when the issue with aria not tearing down
     process.exit(process.exitCode === undefined ? 0 : process.exitCode);

--- a/apps/rundown/src/start.ts
+++ b/apps/rundown/src/start.ts
@@ -12,6 +12,6 @@ console.log(`Rundown ${toolVersion} - https://rushstack.io`);
 console.log();
 
 const commandLine: RundownCommandLine = new RundownCommandLine();
-commandLine.execute().catch((error) => {
+commandLine.executeAsync().catch((error) => {
   console.error(error);
 });

--- a/apps/trace-import/src/start.ts
+++ b/apps/trace-import/src/start.ts
@@ -13,6 +13,6 @@ console.log(Colorize.bold(`trace-import ${toolVersion}`) + ' - ' + Colorize.cyan
 console.log();
 
 const commandLine: TraceImportCommandLineParser = new TraceImportCommandLineParser();
-commandLine.execute().catch((error) => {
+commandLine.executeAsync().catch((error) => {
   console.error(error);
 });

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/src/runRush.ts
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/src/runRush.ts
@@ -36,9 +36,9 @@ async function rushRush(args: string[]): Promise<void> {
   // eslint-disable-next-line no-console
   console.log(`Executing: rush ${args.join(' ')}`);
   await parser
-    .execute(args)
+    .executeAsync(args)
     // eslint-disable-next-line no-console
-    .catch(console.error); // CommandLineParser.execute() should never reject the promise
+    .catch(console.error); // CommandLineParser.executeAsync() should never reject the promise
 }
 
 // eslint-disable-next-line no-console

--- a/build-tests/ts-command-line-test/src/BusinessLogic.ts
+++ b/build-tests/ts-command-line-test/src/BusinessLogic.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 export class BusinessLogic {
-  public static async doTheWork(force: boolean, protocol: string): Promise<void> {
+  public static async doTheWorkAsync(force: boolean, protocol: string): Promise<void> {
     console.log(`Received parameters: force=${force}, protocol="${protocol}"`);
     console.log(`Business logic did the work.`);
   }

--- a/build-tests/ts-command-line-test/src/PushAction.ts
+++ b/build-tests/ts-command-line-test/src/PushAction.ts
@@ -24,7 +24,7 @@ export class PushAction extends CommandLineAction {
 
   protected onExecute(): Promise<void> {
     // abstract
-    return BusinessLogic.doTheWork(this._force.value, this._protocol.value);
+    return BusinessLogic.doTheWorkAsync(this._force.value, this._protocol.value);
   }
 
   protected onDefineParameters(): void {

--- a/build-tests/ts-command-line-test/src/start.ts
+++ b/build-tests/ts-command-line-test/src/start.ts
@@ -4,4 +4,4 @@
 import { WidgetCommandLine } from './WidgetCommandLine';
 
 const commandLine: WidgetCommandLine = new WidgetCommandLine();
-commandLine.execute();
+commandLine.executeAsync();

--- a/common/changes/@microsoft/api-documenter/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@microsoft/api-documenter/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@microsoft/api-extractor/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/rush/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@microsoft/rush/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/eslint-config/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/eslint-config/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/heft-jest-plugin/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/heft-sass-plugin/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/heft/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/module-minifier/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/module-minifier/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Rename `IMinifierConnection.disconnect` to `IMinifierConnection.disconnectAsync` and `IModuleMinifier.connect` to `IModuleMinifier.connectAsync`. The old functions are marked as `@deprecated`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/node-core-library/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/node-core-library/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Rename `Async.sleep` to `Async.sleepAsync`. The old function is marked as `@deprecated`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/operation-graph/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/operation-graph/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/common/changes/@rushstack/rundown/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/rundown/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown"
+}

--- a/common/changes/@rushstack/trace-import/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/trace-import/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/trace-import"
+}

--- a/common/changes/@rushstack/ts-command-line/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/ts-command-line/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Rename `CommandLineParser.execute` to `CommandLineParser.executeAsync` and `CommandLineParser.executeWithoutErrorHandling` to `CommandLineParser.executeWithoutErrorHandlingAsync`. The old functions are marked as `@deprecated`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/typings-generator/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/typings-generator/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/typings-generator"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/async-naming_2024-05-14-02-29.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/async-naming_2024-05-14-02-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/common/reviews/api/module-minifier.api.md
+++ b/common/reviews/api/module-minifier.api.md
@@ -22,7 +22,9 @@ export interface ILocalMinifierOptions {
 // @public
 export interface IMinifierConnection {
     configHash: string;
+    // @deprecated (undocumented)
     disconnect(): Promise<void>;
+    disconnectAsync(): Promise<void>;
 }
 
 // @public
@@ -60,7 +62,9 @@ export interface IModuleMinificationSuccessResult {
 
 // @public
 export interface IModuleMinifier {
+    // @deprecated (undocumented)
     connect(): Promise<IMinifierConnection>;
+    connectAsync(): Promise<IMinifierConnection>;
     minify: IModuleMinifierFunction;
 }
 
@@ -80,16 +84,18 @@ export interface IWorkerPoolMinifierOptions {
 // @public
 export class LocalMinifier implements IModuleMinifier {
     constructor(options: ILocalMinifierOptions);
-    // (undocumented)
+    // @deprecated (undocumented)
     connect(): Promise<IMinifierConnection>;
+    connectAsync(): Promise<IMinifierConnection>;
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
 }
 
 // @public
 export class MessagePortMinifier implements IModuleMinifier {
     constructor(port: MessagePort_2);
-    // (undocumented)
+    // @deprecated (undocumented)
     connect(): Promise<IMinifierConnection>;
+    connectAsync(): Promise<IMinifierConnection>;
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
     // (undocumented)
     readonly port: MessagePort_2;
@@ -102,16 +108,18 @@ export function _minifySingleFileAsync(request: IModuleMinificationRequest, ters
 
 // @public
 export class NoopMinifier implements IModuleMinifier {
-    // (undocumented)
+    // @deprecated (undocumented)
     connect(): Promise<IMinifierConnection>;
+    connectAsync(): Promise<IMinifierConnection>;
     minify(request: IModuleMinificationRequest, callback: IModuleMinificationCallback): void;
 }
 
 // @public
 export class WorkerPoolMinifier implements IModuleMinifier {
     constructor(options: IWorkerPoolMinifierOptions);
-    // (undocumented)
+    // @deprecated (undocumented)
     connect(): Promise<IMinifierConnection>;
+    connectAsync(): Promise<IMinifierConnection>;
     // (undocumented)
     get maxThreads(): number;
     set maxThreads(threads: number);

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -39,7 +39,9 @@ export class Async {
         weighted: true;
     }): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
+    // @deprecated (undocumented)
     static sleep(ms: number): Promise<void>;
+    static sleepAsync(ms: number): Promise<void>;
     static validateWeightedIterable(operation: IWeighted): void;
 }
 

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -26,7 +26,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
     _buildParser(actionsSubParser: argparse.SubParser): void;
     readonly documentation: string;
     // @internal
-    _execute(): Promise<void>;
+    _executeAsync(): Promise<void>;
     // @internal
     _getArgumentParser(): argparse.ArgumentParser;
     protected abstract onExecute(): Promise<void>;
@@ -253,8 +253,12 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
     constructor(options: ICommandLineParserOptions);
     get actions(): ReadonlyArray<CommandLineAction>;
     addAction(action: CommandLineAction): void;
+    // @deprecated (undocumented)
     execute(args?: string[]): Promise<boolean>;
+    executeAsync(args?: string[]): Promise<boolean>;
+    // @deprecated (undocumented)
     executeWithoutErrorHandling(args?: string[]): Promise<void>;
+    executeWithoutErrorHandlingAsync(args?: string[]): Promise<void>;
     getAction(actionName: string): CommandLineAction;
     // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
@@ -443,7 +447,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
     // @internal (undocumented)
     protected _defineParameter(parameter: CommandLineParameter_2): void;
     // @internal
-    _execute(): Promise<void>;
+    _executeAsync(): Promise<void>;
     // @internal
     protected _getScopedCommandLineParser(): CommandLineParser;
     protected onDefineParameters(): void;

--- a/eslint/eslint-config/profile/_common.js
+++ b/eslint/eslint-config/profile/_common.js
@@ -3,6 +3,161 @@
 
 const macros = require('./_macros');
 
+const namingConventionRuleOptions = [
+  {
+    // We should be stricter about 'enumMember', but it often functions legitimately as an ad hoc namespace.
+    selectors: ['variable', 'enumMember', 'function'],
+
+    format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+    leadingUnderscore: 'allow',
+
+    filter: {
+      regex: [
+        // This is a special exception for naming patterns that use an underscore to separate two camel-cased
+        // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
+        '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
+      ]
+        .map((x) => `(${x})`)
+        .join('|'),
+      match: false
+    }
+  },
+
+  {
+    selectors: ['parameter'],
+
+    format: ['camelCase'],
+
+    filter: {
+      regex: [
+        // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
+        // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
+        '^__'
+      ]
+        .map((x) => `(${x})`)
+        .join('|'),
+      match: false
+    }
+  },
+
+  // Genuine properties
+  {
+    selectors: ['parameterProperty', 'accessor'],
+    enforceLeadingUnderscoreWhenPrivate: true,
+
+    format: ['camelCase', 'UPPER_CASE'],
+
+    filter: {
+      regex: [
+        // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
+        // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
+        '^__',
+        // Ignore quoted identifiers such as { "X+Y": 123 }.  Currently @typescript-eslint/naming-convention
+        // cannot detect whether an identifier is quoted or not, so we simply assume that it is quoted
+        // if-and-only-if it contains characters that require quoting.
+        '[^a-zA-Z0-9_]',
+        // This is a special exception for naming patterns that use an underscore to separate two camel-cased
+        // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
+        '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
+      ]
+        .map((x) => `(${x})`)
+        .join('|'),
+      match: false
+    }
+  },
+
+  // Properties that incorrectly match other contexts
+  // See issue https://github.com/typescript-eslint/typescript-eslint/issues/2244
+  {
+    selectors: ['property'],
+    enforceLeadingUnderscoreWhenPrivate: true,
+
+    // The @typescript-eslint/naming-convention "property" selector matches cases like this:
+    //
+    //   someLegacyApiWeCannotChange.invokeMethod({ SomeProperty: 123 });
+    //
+    // and this:
+    //
+    //   const { CONSTANT1, CONSTANT2 } = someNamespace.constants;
+    //
+    // Thus for now "property" is more like a variable than a class member.
+    format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+    leadingUnderscore: 'allow',
+
+    filter: {
+      regex: [
+        // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
+        // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
+        '^__',
+        // Ignore quoted identifiers such as { "X+Y": 123 }.  Currently @typescript-eslint/naming-convention
+        // cannot detect whether an identifier is quoted or not, so we simply assume that it is quoted
+        // if-and-only-if it contains characters that require quoting.
+        '[^a-zA-Z0-9_]',
+        // This is a special exception for naming patterns that use an underscore to separate two camel-cased
+        // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
+        '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
+      ]
+        .map((x) => `(${x})`)
+        .join('|'),
+      match: false
+    }
+  },
+
+  {
+    selectors: ['method'],
+    enforceLeadingUnderscoreWhenPrivate: true,
+
+    // A PascalCase method can arise somewhat legitimately in this way:
+    //
+    // class MyClass {
+    //    public static MyReactButton(props: IButtonProps): JSX.Element {
+    //      . . .
+    //    }
+    // }
+    format: ['camelCase', 'PascalCase'],
+    leadingUnderscore: 'allow',
+
+    filter: {
+      regex: [
+        // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
+        // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
+        '^__',
+        // This is a special exception for naming patterns that use an underscore to separate two camel-cased
+        // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
+        '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
+      ]
+        .map((x) => `(${x})`)
+        .join('|'),
+      match: false
+    }
+  },
+
+  // Types should use PascalCase
+  {
+    // Group selector for: class, interface, typeAlias, enum, typeParameter
+    selectors: ['class', 'typeAlias', 'enum', 'typeParameter'],
+    format: ['PascalCase'],
+    leadingUnderscore: 'allow'
+  },
+
+  {
+    selectors: ['interface'],
+
+    // It is very common for a class to implement an interface of the same name.
+    // For example, the Widget class may implement the IWidget interface.  The "I" prefix
+    // avoids the need to invent a separate name such as "AbstractWidget" or "WidgetInterface".
+    // In TypeScript it is also common to declare interfaces that are implemented by primitive
+    // objects, here the "I" prefix also helps by avoiding spurious conflicts with classes
+    // by the same name.
+    format: ['PascalCase'],
+
+    custom: {
+      regex: '^_?I[A-Z]',
+      match: true
+    }
+  }
+];
+
 // Rule severity guidelines
 // ------------------------
 //
@@ -207,160 +362,7 @@ function buildRules(profile) {
           // Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md
           '@typescript-eslint/naming-convention': [
             'warn',
-            ...macros.expandNamingConventionSelectors([
-              {
-                // We should be stricter about 'enumMember', but it often functions legitimately as an ad hoc namespace.
-                selectors: ['variable', 'enumMember', 'function'],
-
-                format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
-                leadingUnderscore: 'allow',
-
-                filter: {
-                  regex: [
-                    // This is a special exception for naming patterns that use an underscore to separate two camel-cased
-                    // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
-                    '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
-                  ]
-                    .map((x) => `(${x})`)
-                    .join('|'),
-                  match: false
-                }
-              },
-
-              {
-                selectors: ['parameter'],
-
-                format: ['camelCase'],
-
-                filter: {
-                  regex: [
-                    // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
-                    // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
-                    '^__'
-                  ]
-                    .map((x) => `(${x})`)
-                    .join('|'),
-                  match: false
-                }
-              },
-
-              // Genuine properties
-              {
-                selectors: ['parameterProperty', 'accessor'],
-                enforceLeadingUnderscoreWhenPrivate: true,
-
-                format: ['camelCase', 'UPPER_CASE'],
-
-                filter: {
-                  regex: [
-                    // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
-                    // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
-                    '^__',
-                    // Ignore quoted identifiers such as { "X+Y": 123 }.  Currently @typescript-eslint/naming-convention
-                    // cannot detect whether an identifier is quoted or not, so we simply assume that it is quoted
-                    // if-and-only-if it contains characters that require quoting.
-                    '[^a-zA-Z0-9_]',
-                    // This is a special exception for naming patterns that use an underscore to separate two camel-cased
-                    // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
-                    '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
-                  ]
-                    .map((x) => `(${x})`)
-                    .join('|'),
-                  match: false
-                }
-              },
-
-              // Properties that incorrectly match other contexts
-              // See issue https://github.com/typescript-eslint/typescript-eslint/issues/2244
-              {
-                selectors: ['property'],
-                enforceLeadingUnderscoreWhenPrivate: true,
-
-                // The @typescript-eslint/naming-convention "property" selector matches cases like this:
-                //
-                //   someLegacyApiWeCannotChange.invokeMethod({ SomeProperty: 123 });
-                //
-                // and this:
-                //
-                //   const { CONSTANT1, CONSTANT2 } = someNamespace.constants;
-                //
-                // Thus for now "property" is more like a variable than a class member.
-                format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
-                leadingUnderscore: 'allow',
-
-                filter: {
-                  regex: [
-                    // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
-                    // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
-                    '^__',
-                    // Ignore quoted identifiers such as { "X+Y": 123 }.  Currently @typescript-eslint/naming-convention
-                    // cannot detect whether an identifier is quoted or not, so we simply assume that it is quoted
-                    // if-and-only-if it contains characters that require quoting.
-                    '[^a-zA-Z0-9_]',
-                    // This is a special exception for naming patterns that use an underscore to separate two camel-cased
-                    // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
-                    '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
-                  ]
-                    .map((x) => `(${x})`)
-                    .join('|'),
-                  match: false
-                }
-              },
-
-              {
-                selectors: ['method'],
-                enforceLeadingUnderscoreWhenPrivate: true,
-
-                // A PascalCase method can arise somewhat legitimately in this way:
-                //
-                // class MyClass {
-                //    public static MyReactButton(props: IButtonProps): JSX.Element {
-                //      . . .
-                //    }
-                // }
-                format: ['camelCase', 'PascalCase'],
-                leadingUnderscore: 'allow',
-
-                filter: {
-                  regex: [
-                    // Silently accept names with a double-underscore prefix; we would like to be more strict about this,
-                    // pending a fix for https://github.com/typescript-eslint/typescript-eslint/issues/2240
-                    '^__',
-                    // This is a special exception for naming patterns that use an underscore to separate two camel-cased
-                    // parts.  Example:  "checkBox1_onChanged" or "_checkBox1_onChanged"
-                    '^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$'
-                  ]
-                    .map((x) => `(${x})`)
-                    .join('|'),
-                  match: false
-                }
-              },
-
-              // Types should use PascalCase
-              {
-                // Group selector for: class, interface, typeAlias, enum, typeParameter
-                selectors: ['class', 'typeAlias', 'enum', 'typeParameter'],
-                format: ['PascalCase'],
-                leadingUnderscore: 'allow'
-              },
-
-              {
-                selectors: ['interface'],
-
-                // It is very common for a class to implement an interface of the same name.
-                // For example, the Widget class may implement the IWidget interface.  The "I" prefix
-                // avoids the need to invent a separate name such as "AbstractWidget" or "WidgetInterface".
-                // In TypeScript it is also common to declare interfaces that are implemented by primitive
-                // objects, here the "I" prefix also helps by avoiding spurious conflicts with classes
-                // by the same name.
-                format: ['PascalCase'],
-
-                custom: {
-                  regex: '^_?I[A-Z]',
-                  match: true
-                }
-              }
-            ])
+            ...macros.expandNamingConventionSelectors(namingConventionRuleOptions)
           ],
 
           // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
@@ -834,4 +836,6 @@ function buildRules(profile) {
     ]
   };
 }
+
 exports.buildRules = buildRules;
+exports.namingConventionRuleOptions = namingConventionRuleOptions;

--- a/eslint/eslint-config/profile/_macros.js
+++ b/eslint/eslint-config/profile/_macros.js
@@ -86,7 +86,7 @@ function expandNamingConventionSelectors(inputBlocks) {
 
       const expandedBlock2 = {
         ...block,
-        modifiers: ['private'],
+        modifiers: [...(block.modifiers ?? []), 'private'],
         leadingUnderscore: 'require'
       };
       delete expandedBlock2.enforceLeadingUnderscoreWhenPrivate;

--- a/eslint/local-eslint-config/profile/_common.js
+++ b/eslint/local-eslint-config/profile/_common.js
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+const macros = require('@rushstack/eslint-config/profile/_macros');
+const { namingConventionRuleOptions } = require('@rushstack/eslint-config/profile/_common');
+
 function buildRules(profile) {
   let profileMixins;
   switch (profile) {
@@ -99,6 +102,36 @@ function buildRules(profile) {
               ' Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.',
               ' See LICENSE in the project root for license information.'
             ]
+          ],
+
+          // Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md
+          '@typescript-eslint/naming-convention': [
+            'warn',
+            ...macros.expandNamingConventionSelectors([
+              ...namingConventionRuleOptions,
+              {
+                selectors: ['method'],
+                modifiers: ['async'],
+                enforceLeadingUnderscoreWhenPrivate: true,
+
+                format: null,
+                custom: {
+                  regex: '^_?[a-zA-Z]\\w*Async$',
+                  match: true
+                },
+                leadingUnderscore: 'allow',
+
+                filter: {
+                  regex: [
+                    // Specifically allow ts-command-line's "onExecute" function.
+                    '^onExecute$'
+                  ]
+                    .map((x) => `(${x})`)
+                    .join('|'),
+                  match: false
+                }
+              }
+            ])
           ],
 
           ...profileMixins

--- a/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
+++ b/heft-plugins/heft-jest-plugin/src/HeftJestReporter.ts
@@ -44,6 +44,7 @@ export default class HeftJestReporter implements Reporter {
     this._debugMode = options.debugMode;
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async onTestStart(test: Test): Promise<void> {
     this._terminal.writeLine(
       Colorize.whiteBackground(Colorize.black('START')),
@@ -51,6 +52,7 @@ export default class HeftJestReporter implements Reporter {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async onTestResult(
     test: Test,
     testResult: TestResult,
@@ -174,6 +176,7 @@ export default class HeftJestReporter implements Reporter {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async onRunStart(
     aggregatedResult: AggregatedResult,
     options: ReporterOnStartOptions
@@ -186,6 +189,7 @@ export default class HeftJestReporter implements Reporter {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async onRunComplete(contexts: Set<TestContext>, results: AggregatedResult): Promise<void> {
     const { numPassedTests, numFailedTests, numTotalTests, numRuntimeErrorTestSuites } = results;
 

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -156,6 +156,7 @@ export class SassProcessor extends StringValuesTypingsGenerator {
       getAdditionalOutputFiles: getCssPaths,
 
       // Generate typings function
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       parseAndGenerateTypings: async (fileContents: string, filePath: string, relativePath: string) => {
         if (this._isSassPartial(filePath)) {
           // Do not generate typings for Sass partials.

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -248,7 +248,7 @@ export default class TypeScriptPlugin implements IHeftTaskPlugin {
         // all source files to this set of static assets. This would allow us to avoid
         // having to copy the static assets multiple times, increasing build times and
         // package size.
-        for (const copyOperation of await this._getStaticAssetCopyOperations(
+        for (const copyOperation of await this._getStaticAssetCopyOperationsAsync(
           taskSession,
           heftConfiguration
         )) {
@@ -285,7 +285,7 @@ export default class TypeScriptPlugin implements IHeftTaskPlugin {
     );
   }
 
-  private async _getStaticAssetCopyOperations(
+  private async _getStaticAssetCopyOperationsAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration
   ): Promise<ICopyOperation[]> {

--- a/libraries/module-minifier/src/LocalMinifier.ts
+++ b/libraries/module-minifier/src/LocalMinifier.ts
@@ -84,12 +84,25 @@ export class LocalMinifier implements IModuleMinifier {
       });
   }
 
-  public async connect(): Promise<IMinifierConnection> {
+  /**
+   * {@inheritdoc IModuleMinifier.connectAsync}
+   */
+  public async connectAsync(): Promise<IMinifierConnection> {
+    const disconnectAsync: IMinifierConnection['disconnectAsync'] = async () => {
+      // Do nothing.
+    };
     return {
       configHash: this._configHash,
-      disconnect: async () => {
-        // Do nothing.
-      }
+      disconnectAsync,
+      disconnect: disconnectAsync
     };
+  }
+
+  /**
+   * @deprecated Use {@link LocalMinifier.connectAsync} instead.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async connect(): Promise<IMinifierConnection> {
+    return await this.connectAsync();
   }
 }

--- a/libraries/module-minifier/src/MessagePortMinifier.ts
+++ b/libraries/module-minifier/src/MessagePortMinifier.ts
@@ -45,7 +45,10 @@ export class MessagePortMinifier implements IModuleMinifier {
     this.port.postMessage(request);
   }
 
-  public async connect(): Promise<IMinifierConnection> {
+  /**
+   * {@inheritdoc IModuleMinifier.connectAsync}
+   */
+  public async connectAsync(): Promise<IMinifierConnection> {
     const configHashPromise: Promise<string> = once(this.port, 'message') as unknown as Promise<string>;
     this.port.postMessage('initialize');
     const configHash: string = await configHashPromise;
@@ -63,12 +66,22 @@ export class MessagePortMinifier implements IModuleMinifier {
     }
 
     this.port.on('message', handler);
+    const disconnectAsync: IMinifierConnection['disconnectAsync'] = async () => {
+      this.port.off('message', handler);
+      this.port.close();
+    };
     return {
       configHash,
-      disconnect: async () => {
-        this.port.off('message', handler);
-        this.port.close();
-      }
+      disconnectAsync,
+      disconnect: disconnectAsync
     };
+  }
+
+  /**
+   * @deprecated Use {@link MessagePortMinifier.connectAsync} instead
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async connect(): Promise<IMinifierConnection> {
+    return await this.connectAsync();
   }
 }

--- a/libraries/module-minifier/src/NoopMinifier.ts
+++ b/libraries/module-minifier/src/NoopMinifier.ts
@@ -40,13 +40,26 @@ export class NoopMinifier implements IModuleMinifier {
     });
   }
 
-  public async connect(): Promise<IMinifierConnection> {
+  /**
+   * {@inheritdoc IModuleMinifier.connectAsync}
+   */
+  public async connectAsync(): Promise<IMinifierConnection> {
+    const disconnectAsync: IMinifierConnection['disconnectAsync'] = async () => {
+      // Do nothing.
+    };
+
     return {
       configHash: NoopMinifier.name,
-
-      disconnect: async () => {
-        // Do nothing.
-      }
+      disconnectAsync,
+      disconnect: disconnectAsync
     };
+  }
+
+  /**
+   * @deprecated Use {@link NoopMinifier.connectAsync} instead
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async connect(): Promise<IMinifierConnection> {
+    return await this.connectAsync();
   }
 }

--- a/libraries/module-minifier/src/test/LocalMinifier.test.ts
+++ b/libraries/module-minifier/src/test/LocalMinifier.test.ts
@@ -29,10 +29,10 @@ describe('LocalMinifier', () => {
       }
     });
 
-    const connection1: IMinifierConnection = await minifier1.connect();
-    await connection1.disconnect();
-    const connection2: IMinifierConnection = await minifier2.connect();
-    await connection2.disconnect();
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await connection1.disconnectAsync();
+    const connection2: IMinifierConnection = await minifier2.connectAsync();
+    await connection2.disconnectAsync();
 
     expect(connection1.configHash).toMatchSnapshot('ecma5');
     expect(connection2.configHash).toMatchSnapshot('ecma2015');
@@ -49,10 +49,10 @@ describe('LocalMinifier', () => {
     terserVersion = '5.16.2';
     const minifier2: LocalMinifier = new LocalMinifier({});
 
-    const connection1: IMinifierConnection = await minifier1.connect();
-    await connection1.disconnect();
-    const connection2: IMinifierConnection = await minifier2.connect();
-    await connection2.disconnect();
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await connection1.disconnectAsync();
+    const connection2: IMinifierConnection = await minifier2.connectAsync();
+    await connection2.disconnectAsync();
 
     expect(connection1.configHash).toMatchSnapshot('terser-5.9.1');
     expect(connection2.configHash).toMatchSnapshot('terser-5.16.1');

--- a/libraries/module-minifier/src/test/WorkerPoolMinifier.test.ts
+++ b/libraries/module-minifier/src/test/WorkerPoolMinifier.test.ts
@@ -29,10 +29,10 @@ describe('WorkerPoolMinifier', () => {
       }
     });
 
-    const connection1: IMinifierConnection = await minifier1.connect();
-    await connection1.disconnect();
-    const connection2: IMinifierConnection = await minifier2.connect();
-    await connection2.disconnect();
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await connection1.disconnectAsync();
+    const connection2: IMinifierConnection = await minifier2.connectAsync();
+    await connection2.disconnectAsync();
 
     expect(connection1.configHash).toMatchSnapshot('ecma5');
     expect(connection2.configHash).toMatchSnapshot('ecma2015');
@@ -49,10 +49,10 @@ describe('WorkerPoolMinifier', () => {
     terserVersion = '5.16.2';
     const minifier2: WorkerPoolMinifier = new WorkerPoolMinifier({});
 
-    const connection1: IMinifierConnection = await minifier1.connect();
-    await connection1.disconnect();
-    const connection2: IMinifierConnection = await minifier2.connect();
-    await connection2.disconnect();
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await connection1.disconnectAsync();
+    const connection2: IMinifierConnection = await minifier2.connectAsync();
+    await connection2.disconnectAsync();
 
     expect(connection1.configHash).toMatchSnapshot('terser-5.9.1');
     expect(connection2.configHash).toMatchSnapshot('terser-5.16.1');

--- a/libraries/module-minifier/src/types.ts
+++ b/libraries/module-minifier/src/types.ts
@@ -103,10 +103,16 @@ export interface IMinifierConnection {
    * Hash of the configuration of this minifier, for cache busting.
    */
   configHash: string;
+
+  /**
+   * @deprecated Use {@link IMinifierConnection.disconnectAsync} instead.
+   */
+  disconnect(): Promise<void>;
+
   /**
    * Callback to be invoked when done with the minifier
    */
-  disconnect(): Promise<void>;
+  disconnectAsync(): Promise<void>;
 }
 
 /**
@@ -120,9 +126,14 @@ export interface IModuleMinifier {
   minify: IModuleMinifierFunction;
 
   /**
+   * @deprecated Use {@link IModuleMinifier.connectAsync} instead.
+   */
+  connect(): Promise<IMinifierConnection>;
+
+  /**
    * Prevents the minifier from shutting down until the returned `disconnect()` callback is invoked.
    * The callback may be used to surface errors encountered by the minifier that may not be relevant to a specific file.
    * It should be called to allow the minifier to cleanup
    */
-  connect(): Promise<IMinifierConnection>;
+  connectAsync(): Promise<IMinifierConnection>;
 }

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -61,6 +61,7 @@ function toWeightedIterator<TEntry>(
   ).call(iterable);
   return {
     [Symbol.asyncIterator]: () => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       next: async () => {
         // The await is necessary here, but TS will complain - it's a false positive.
         const { value, done } = await iterator.next();
@@ -298,10 +299,18 @@ export class Async {
   /**
    * Return a promise that resolves after the specified number of milliseconds.
    */
-  public static async sleep(ms: number): Promise<void> {
+  public static async sleepAsync(ms: number): Promise<void> {
     await new Promise((resolve) => {
       setTimeout(resolve, ms);
     });
+  }
+
+  /**
+   * @deprecated Use {@link Async.sleepAsync} instead.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public static async sleep(ms: number): Promise<void> {
+    await Async.sleepAsync(ms);
   }
 
   /**
@@ -321,7 +330,7 @@ export class Async {
         if (++retryCounter > maxRetries) {
           throw e;
         } else if (retryDelayMs > 0) {
-          await Async.sleep(retryDelayMs);
+          await Async.sleepAsync(retryDelayMs);
         }
       }
     }

--- a/libraries/node-core-library/src/LockFile.ts
+++ b/libraries/node-core-library/src/LockFile.ts
@@ -231,7 +231,7 @@ export class LockFile {
         throw new Error(`Exceeded maximum wait time to acquire lock for resource "${resourceName}"`);
       }
 
-      await Async.sleep(interval);
+      await Async.sleepAsync(interval);
       return retryLoop();
     };
 

--- a/libraries/node-core-library/src/test/Async.test.ts
+++ b/libraries/node-core-library/src/test/Async.test.ts
@@ -42,7 +42,7 @@ describe(Async.name, () => {
 
       const fn: (item: number) => Promise<string> = async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
         return `result ${item}`;
@@ -137,7 +137,7 @@ describe(Async.name, () => {
 
       const fn: (item: number) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -155,7 +155,7 @@ describe(Async.name, () => {
 
       const fn: (item: number) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -171,14 +171,14 @@ describe(Async.name, () => {
         array.push(i);
       }
 
-      await Async.forEachAsync(array, async () => await Async.sleep(0), { concurrency: 3 });
+      await Async.forEachAsync(array, async () => await Async.sleepAsync(0), { concurrency: 3 });
     });
 
     it('rejects if any operation rejects', async () => {
       const array: number[] = [1, 2, 3];
 
       const fn: (item: number) => Promise<void> = jest.fn(async (item) => {
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         if (item === 3) throw new Error('Something broke');
       });
 
@@ -223,7 +223,7 @@ describe(Async.name, () => {
       };
 
       await expect(() =>
-        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(0))
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleepAsync(0))
       ).rejects.toThrow(expectedError);
     });
 
@@ -245,7 +245,7 @@ describe(Async.name, () => {
       };
 
       await expect(() =>
-        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(0))
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleepAsync(0))
       ).rejects.toThrow(expectedError);
     });
 
@@ -284,7 +284,7 @@ describe(Async.name, () => {
       );
 
       // Wait for all the instant resolutions to be done
-      await Async.sleep(0);
+      await Async.sleepAsync(0);
 
       // The final iteration cycle is locked, so only 1 iterator is waiting.
       expect(waitingIterators).toEqual(1);
@@ -310,7 +310,7 @@ describe(Async.name, () => {
       };
 
       await expect(() =>
-        Async.forEachAsync(syncIterable, async (item) => await Async.sleep(0))
+        Async.forEachAsync(syncIterable, async (item) => await Async.sleepAsync(0))
       ).rejects.toThrow(expectedError);
     });
 
@@ -327,7 +327,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -345,7 +345,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -363,7 +363,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -409,7 +409,7 @@ describe(Async.name, () => {
 
         const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
           running++;
-          await Async.sleep(0);
+          await Async.sleepAsync(0);
           maxRunning = Math.max(maxRunning, running);
           running--;
         });
@@ -437,7 +437,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -464,7 +464,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -486,7 +486,7 @@ describe(Async.name, () => {
 
       const fn: (item: INumberWithWeight) => Promise<void> = jest.fn(async (item) => {
         running++;
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         maxRunning = Math.max(maxRunning, running);
         running--;
       });
@@ -532,7 +532,7 @@ describe(Async.name, () => {
       );
 
       // Wait for all the instant resolutions to be done
-      await Async.sleep(0);
+      await Async.sleepAsync(0);
 
       // The final iteration cycle is locked, so only 1 iterator is waiting.
       expect(waitingIterators).toEqual(1);
@@ -551,6 +551,7 @@ describe(Async.name, () => {
     it('Correctly handles an async function that succeeds the first time', async () => {
       const expectedResult: string = 'RESULT';
       const result: string = await Async.runWithRetriesAsync({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         action: async () => expectedResult,
         maxRetries: 0
       });
@@ -573,6 +574,7 @@ describe(Async.name, () => {
       await expect(
         async () =>
           await Async.runWithRetriesAsync({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             action: async () => {
               throw new Error('error');
             },
@@ -597,6 +599,7 @@ describe(Async.name, () => {
       await expect(
         async () =>
           await Async.runWithRetriesAsync({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             action: async () => {
               throw new Error('error');
             },
@@ -641,7 +644,7 @@ describe(Async.name, () => {
       const expectedResult: string = 'RESULT';
       let callCount: number = 0;
       const sleepSpy: jest.SpyInstance = jest
-        .spyOn(Async, 'sleep')
+        .spyOn(Async, 'sleepAsync')
         .mockImplementation(() => Promise.resolve());
 
       const resultPromise: Promise<string> = Async.runWithRetriesAsync({
@@ -665,10 +668,11 @@ describe(Async.name, () => {
       const expectedResult: string = 'RESULT';
       let callCount: number = 0;
       const sleepSpy: jest.SpyInstance = jest
-        .spyOn(Async, 'sleep')
+        .spyOn(Async, 'sleepAsync')
         .mockImplementation(() => Promise.resolve());
 
       const resultPromise: Promise<string> = Async.runWithRetriesAsync({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         action: async () => {
           if (callCount++ === 0) {
             throw new Error('error');
@@ -743,7 +747,7 @@ describe(AsyncQueue.name, () => {
       queue,
       async ([item, callback]) => {
         // Add an async tick to ensure that the queue is actually running concurrently
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         seenItems++;
         expect(expectedItems.has(item)).toBe(true);
         expectedItems.delete(item);
@@ -770,7 +774,7 @@ describe(AsyncQueue.name, () => {
       queue,
       async ([item, callback]) => {
         // Add an async tick to ensure that the queue is actually running concurrently
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         seenItems++;
         if (item < 4) {
           expect(expectedItems.has(item)).toBe(true);
@@ -804,7 +808,7 @@ describe(AsyncQueue.name, () => {
       queue,
       async ([item, callback]) => {
         // Add an async tick to ensure that the queue is actually running concurrently
-        await Async.sleep(0);
+        await Async.sleepAsync(0);
         seenItems++;
         if (item < 4) {
           expect(expectedItems.has(item)).toBe(true);

--- a/libraries/operation-graph/src/test/OperationExecutionManager.test.ts
+++ b/libraries/operation-graph/src/test/OperationExecutionManager.test.ts
@@ -287,7 +287,7 @@ describe(OperationExecutionManager.name, () => {
         const run: ExecuteAsyncMock = jest.fn(
           async (context: IOperationRunnerContext): Promise<OperationStatus> => {
             ++concurrency;
-            await Async.sleep(0);
+            await Async.sleepAsync(0);
             if (concurrency > maxConcurrency) {
               maxConcurrency = concurrency;
             }

--- a/libraries/operation-graph/src/test/WorkQueue.test.ts
+++ b/libraries/operation-graph/src/test/WorkQueue.test.ts
@@ -128,7 +128,7 @@ describe(WorkQueue.name, () => {
 
     const fn: () => Promise<OperationStatus> = jest.fn(async () => {
       running++;
-      await Async.sleep(0);
+      await Async.sleepAsync(0);
       maxRunning = Math.max(maxRunning, running);
       running--;
       return OperationStatus.Success;

--- a/libraries/rush-lib/src/api/Rush.ts
+++ b/libraries/rush-lib/src/api/Rush.ts
@@ -94,7 +94,7 @@ export class Rush {
       builtInPluginConfigurations: options.builtInPluginConfigurations
     });
     // eslint-disable-next-line no-console
-    parser.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise
+    parser.executeAsync().catch(console.error); // CommandLineParser.executeAsync() should never reject the promise
   }
 
   /**
@@ -106,7 +106,7 @@ export class Rush {
     options = Rush._normalizeLaunchOptions(options);
     Rush._assignRushInvokedFolder();
     // eslint-disable-next-line no-console
-    RushXCommandLine.launchRushXAsync(launcherVersion, options).catch(console.error); // CommandLineParser.execute() should never reject the promise
+    RushXCommandLine.launchRushXAsync(launcherVersion, options).catch(console.error); // CommandLineParser.executeAsync() should never reject the promise
   }
 
   /**

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -197,14 +197,14 @@ export class RushCommandLineParser extends CommandLineParser {
     this.telemetry?.flush();
   }
 
-  public async execute(args?: string[]): Promise<boolean> {
-    // debugParameter will be correctly parsed during super.execute(), so manually parse here.
+  public async executeAsync(args?: string[]): Promise<boolean> {
+    // debugParameter will be correctly parsed during super.executeAsync(), so manually parse here.
     this._terminalProvider.verboseEnabled = this._terminalProvider.debugEnabled =
       process.argv.indexOf('--debug') >= 0;
 
     await this.pluginManager.tryInitializeUnassociatedPluginsAsync();
 
-    return await super.execute(args);
+    return await super.executeAsync(args);
   }
 
   protected async onExecute(): Promise<void> {
@@ -459,9 +459,7 @@ export class RushCommandLineParser extends CommandLineParser {
     };
 
     if (this.telemetry && this.rushSession.hooks.flushTelemetry.isUsed()) {
-      this.telemetry.ensureFlushedAsync()
-        .then(handleExit)
-        .catch(handleExit);
+      this.telemetry.ensureFlushedAsync().then(handleExit).catch(handleExit);
     } else {
       handleExit();
     }

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -272,11 +272,15 @@ export abstract class BaseInstallAction extends BaseRushAction {
             };
           }
 
-          await this._doInstall(installManagerFactoryModule, purgeManager, installManagerOptionsForInstall);
+          await this._doInstallAsync(
+            installManagerFactoryModule,
+            purgeManager,
+            installManagerOptionsForInstall
+          );
         }
       } else {
         // Simple case when subspacesFeatureEnabled=false
-        await this._doInstall(installManagerFactoryModule, purgeManager, {
+        await this._doInstallAsync(installManagerFactoryModule, purgeManager, {
           ...installManagerOptions,
           subspace: this.rushConfiguration.defaultSubspace
         });
@@ -314,7 +318,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
     );
   }
 
-  private async _doInstall(
+  private async _doInstallAsync(
     installManagerFactoryModule: typeof import('../../logic/InstallManagerFactory'),
     purgeManager: PurgeManager,
     installManagerOptions: IInstallManagerOptions

--- a/libraries/rush-lib/src/cli/actions/LinkAction.ts
+++ b/libraries/rush-lib/src/cli/actions/LinkAction.ts
@@ -40,6 +40,6 @@ export class LinkAction extends BaseRushAction {
     const linkManager: BaseLinkManager = linkManagerFactoryModule.LinkManagerFactory.getLinkManager(
       this.rushConfiguration
     );
-    await linkManager.createSymlinksForProjects(this._force.value);
+    await linkManager.createSymlinksForProjectsAsync(this._force.value);
   }
 }

--- a/libraries/rush-lib/src/cli/actions/SetupAction.ts
+++ b/libraries/rush-lib/src/cli/actions/SetupAction.ts
@@ -26,6 +26,6 @@ export class SetupAction extends BaseRushAction {
       isDebug: this.parser.isDebug,
       syncNpmrcAlreadyCalled: false
     });
-    await setupPackageRegistry.checkAndSetup();
+    await setupPackageRegistry.checkAndSetupAsync();
   }
 }

--- a/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
+++ b/libraries/rush-lib/src/cli/actions/UpgradeInteractiveAction.ts
@@ -61,7 +61,7 @@ export class UpgradeInteractiveAction extends BaseRushAction {
     const shouldMakeConsistent: boolean =
       this.rushConfiguration.ensureConsistentVersions || this._makeConsistentFlag.value;
 
-    const { projects, depsToUpgrade } = await interactiveUpgrader.upgrade();
+    const { projects, depsToUpgrade } = await interactiveUpgrader.upgradeAsync();
 
     await packageJsonUpdater.doRushUpgradeAsync({
       projects: projects,

--- a/libraries/rush-lib/src/cli/actions/test/AddAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/AddAction.test.ts
@@ -51,7 +51,7 @@ describe(AddAction.name, () => {
         // Mock the command
         process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', 'add', '-p', 'assert'];
 
-        await expect(parser.execute()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
         expect(doRushAddMock).toHaveBeenCalledTimes(1);
         const doRushAddOptions: IPackageJsonUpdaterRushAddOptions = doRushAddMock.mock.calls[0][0];
         expect(doRushAddOptions.projects).toHaveLength(1);
@@ -85,7 +85,7 @@ describe(AddAction.name, () => {
         // Mock the command
         process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', 'add', '-p', 'assert', '--all'];
 
-        await expect(parser.execute()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
         expect(doRushAddMock).toHaveBeenCalledTimes(1);
         const doRushAddOptions: IPackageJsonUpdaterRushAddOptions = doRushAddMock.mock.calls[0][0];
         expect(doRushAddOptions.projects).toHaveLength(2);

--- a/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
+++ b/libraries/rush-lib/src/cli/actions/test/RemoveAction.test.ts
@@ -55,7 +55,7 @@ describe(RemoveAction.name, () => {
         // Mock the command
         process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', 'remove', '-p', 'assert', '-s'];
 
-        await expect(parser.execute()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
         expect(removeDependencyMock).toHaveBeenCalledTimes(2);
         const packageName: string = removeDependencyMock.mock.calls[0][0];
         expect(packageName).toEqual('assert');
@@ -83,7 +83,7 @@ describe(RemoveAction.name, () => {
         // Mock the command
         process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', 'remove', '-p', 'assert'];
 
-        await expect(parser.execute()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
         expect(doRushRemoveMock).toHaveBeenCalledTimes(1);
         const doRushRemoveOptions: IPackageJsonUpdaterRushRemoveOptions = doRushRemoveMock.mock.calls[0][0];
         expect(doRushRemoveOptions.projects).toHaveLength(1);
@@ -126,8 +126,7 @@ describe(RemoveAction.name, () => {
           '--all'
         ];
 
-        // const a = await parser.execute();
-        await expect(parser.execute()).resolves.toEqual(true);
+        await expect(parser.executeAsync()).resolves.toEqual(true);
         expect(doRushRemoveMock).toHaveBeenCalledTimes(1);
         const doRushRemoveOptions: IPackageJsonUpdaterRushRemoveOptions = doRushRemoveMock.mock.calls[0][0];
         expect(doRushRemoveOptions.projects).toHaveLength(3);

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -92,7 +92,7 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
     this.defineScriptParameters();
   }
 
-  private async _prepareAutoinstallerName(): Promise<void> {
+  private async _prepareAutoinstallerNameAsync(): Promise<void> {
     const autoInstaller: Autoinstaller = new Autoinstaller({
       autoinstallerName: this._autoinstallerName,
       rushConfiguration: this.rushConfiguration,
@@ -120,7 +120,7 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
       this.commandLineConfiguration?.additionalPathFolders.slice() || [];
 
     if (this._autoinstallerName) {
-      await this._prepareAutoinstallerName();
+      await this._prepareAutoinstallerNameAsync();
 
       const autoinstallerNameBinPath: string = path.join(this._autoinstallerFullPath, 'node_modules', '.bin');
       additionalPathFolders.push(autoinstallerNameBinPath);

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -455,13 +455,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         debugMode: this.parser.isDebug,
         parallelism,
         changedProjectsOnly,
-        beforeExecuteOperation: async (record: OperationExecutionRecord) => {
+        beforeExecuteOperationAsync: async (record: OperationExecutionRecord) => {
           return await this.hooks.beforeExecuteOperation.promise(record);
         },
-        afterExecuteOperation: async (record: OperationExecutionRecord) => {
+        afterExecuteOperationAsync: async (record: OperationExecutionRecord) => {
           await this.hooks.afterExecuteOperation.promise(record);
         },
-        onOperationStatusChanged: (record: OperationExecutionRecord) => {
+        onOperationStatusChangedAsync: (record: OperationExecutionRecord) => {
           this.hooks.onOperationStatusChanged.call(record);
         }
       };
@@ -473,7 +473,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         terminal
       };
 
-      const internalOptions: IRunPhasesOptions = await this._runInitialPhases(initialInternalOptions);
+      const internalOptions: IRunPhasesOptions = await this._runInitialPhasesAsync(initialInternalOptions);
 
       if (isWatch) {
         if (buildCacheConfiguration) {
@@ -481,14 +481,14 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           buildCacheConfiguration.cacheWriteEnabled = false;
         }
 
-        await this._runWatchPhases(internalOptions);
+        await this._runWatchPhasesAsync(internalOptions);
       }
     } finally {
       await cobuildConfiguration?.destroyLockProviderAsync();
     }
   }
 
-  private async _runInitialPhases(options: IInitialRunPhasesOptions): Promise<IRunPhasesOptions> {
+  private async _runInitialPhasesAsync(options: IInitialRunPhasesOptions): Promise<IRunPhasesOptions> {
     const {
       initialCreateOperationsContext,
       executionManagerOptions: partialExecutionManagerOptions,
@@ -518,7 +518,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const executionManagerOptions: IOperationExecutionManagerOptions = {
       ...partialExecutionManagerOptions,
-      beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
+      beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
         await this.hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext);
       }
     };
@@ -532,7 +532,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       terminal
     };
 
-    await this._executeOperations(initialOptions);
+    await this._executeOperationsAsync(initialOptions);
 
     return {
       ...options,
@@ -611,7 +611,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
    *    Uses the same algorithm as --impacted-by
    * 3) Goto (1)
    */
-  private async _runWatchPhases(options: IRunPhasesOptions): Promise<void> {
+  private async _runWatchPhasesAsync(options: IRunPhasesOptions): Promise<void> {
     const { initialState, initialCreateOperationsContext, executionManagerOptions, stopwatch, terminal } =
       options;
 
@@ -664,7 +664,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       // On the initial invocation, this promise will return immediately with the full set of projects
-      const { changedProjects, state } = await projectWatcher.waitForChange(onWaitingForChanges);
+      const { changedProjects, state } = await projectWatcher.waitForChangeAsync(onWaitingForChanges);
 
       if (stopwatch.state === StopwatchState.Stopped) {
         // Clear and reset the stopwatch so that we only report time from a single execution at a time
@@ -704,7 +704,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         stopwatch,
         executionManagerOptions: {
           ...executionManagerOptions,
-          beforeExecuteOperations: async (records: Map<Operation, OperationExecutionRecord>) => {
+          beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
             await this.hooks.beforeExecuteOperations.promise(records, executeOperationsContext);
           }
         },
@@ -713,7 +713,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
       try {
         // Delegate the the underlying command, for only the projects that need reprocessing
-        await this._executeOperations(executeOptions);
+        await this._executeOperationsAsync(executeOptions);
       } catch (err) {
         // In watch mode, we want to rebuild even if the original build failed.
         if (!(err instanceof AlreadyReportedError)) {
@@ -726,7 +726,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   /**
    * Runs a set of operations and reports the results.
    */
-  private async _executeOperations(options: IExecutionOperationsOptions): Promise<void> {
+  private async _executeOperationsAsync(options: IExecutionOperationsOptions): Promise<void> {
     const { executionManagerOptions, ignoreHooks, operations, stopwatch, terminal } = options;
 
     const executionManager: OperationExecutionManager = new OperationExecutionManager(

--- a/libraries/rush-lib/src/cli/test/CommandLineHelp.test.ts
+++ b/libraries/rush-lib/src/cli/test/CommandLineHelp.test.ts
@@ -26,7 +26,7 @@ describe('CommandLineHelp', () => {
     // TODO Remove the calls to process.exit() or override them for testing.
     parser = new RushCommandLineParser();
     // eslint-disable-next-line no-console
-    parser.execute().catch(console.error);
+    parser.executeAsync().catch(console.error);
   });
 
   afterEach(() => {

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -17,7 +17,7 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
 
 import './mockRushCommandLineParser';
 
-import { FileSystem, JsonFile, Path, } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
 import type { IParserTestInstance } from './TestUtils';
@@ -46,7 +46,7 @@ describe('RushCommandLineParser', () => {
           const repoName: string = 'basicAndRunBuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
 
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -78,7 +78,7 @@ describe('RushCommandLineParser', () => {
           const repoName: string = 'basicAndRunRebuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
 
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -112,7 +112,7 @@ describe('RushCommandLineParser', () => {
           const repoName: string = 'overrideRebuildAndRunBuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
 
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -144,7 +144,7 @@ describe('RushCommandLineParser', () => {
           const repoName: string = 'overrideRebuildAndRunRebuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
 
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -177,7 +177,7 @@ describe('RushCommandLineParser', () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'overrideAndDefaultBuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -209,7 +209,7 @@ describe('RushCommandLineParser', () => {
           // broken
           const repoName: string = 'overrideAndDefaultRebuildActionRepo';
           const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'rebuild');
-          await expect(instance.parser.execute()).resolves.toEqual(true);
+          await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
           // There should be 1 build per package
           const packageCount: number = instance.spawnMock.mock.calls.length;
@@ -297,7 +297,7 @@ describe('RushCommandLineParser', () => {
          */
         jest.spyOn(Autoinstaller.prototype, 'prepareAsync').mockImplementation(async function () {});
 
-        await expect(instance.parser.execute()).resolves.toEqual(true);
+        await expect(instance.parser.executeAsync()).resolves.toEqual(true);
 
         expect(FileSystem.exists(telemetryFilePath)).toEqual(true);
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
@@ -51,7 +51,7 @@ describe('RushCommandLineParserFailureCases', () => {
         jest.spyOn(Autoinstaller.prototype, 'prepareAsync').mockImplementation(async function () {});
 
         setSpawnMock({ emitError: false, returnCode: 1 });
-        await instance.parser.execute();
+        await instance.parser.executeAsync();
         await procProm;
         expect(process.exit).toHaveBeenCalledWith(1);
 

--- a/libraries/rush-lib/src/cli/test/RushPluginCommandLineParameters.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushPluginCommandLineParameters.test.ts
@@ -73,7 +73,7 @@ describe('PluginCommandLineParameters', () => {
     mockProcessArgv(['fake-node', 'fake-rush', 'cmd-parameters-test', '--mystring', '123']);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
 
@@ -85,7 +85,7 @@ describe('PluginCommandLineParameters', () => {
     mockProcessArgv(['fake-node', 'fake-rush', 'cmd-parameters-test', '--myinteger', '1']);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
 
@@ -97,7 +97,7 @@ describe('PluginCommandLineParameters', () => {
     mockProcessArgv(['fake-node', 'fake-rush', 'cmd-parameters-test', '--myflag']);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
 
@@ -109,7 +109,7 @@ describe('PluginCommandLineParameters', () => {
     mockProcessArgv(['fake-node', 'fake-rush', 'cmd-parameters-test', '--mychoice', 'a']);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
 
@@ -129,7 +129,7 @@ describe('PluginCommandLineParameters', () => {
     ]);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
 
@@ -149,7 +149,7 @@ describe('PluginCommandLineParameters', () => {
     ]);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
     expect(action?.getIntegerListParameter('--myintegerlist').values).toStrictEqual([1, 2]);
@@ -168,7 +168,7 @@ describe('PluginCommandLineParameters', () => {
     ]);
     const parser = new RushCommandLineParser({ cwd: currentCWD });
 
-    await expect(parser.execute()).resolves.toEqual(true);
+    await expect(parser.executeAsync()).resolves.toEqual(true);
 
     const action = parser.actions.find((ac) => ac.actionName === 'cmd-parameters-test');
     expect(action?.getChoiceListParameter('--mychoicelist').values).toStrictEqual(['a', 'c']);

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -86,7 +86,7 @@ export class Autoinstaller {
       );
     }
 
-    await InstallHelpers.ensureLocalPackageManager(
+    await InstallHelpers.ensureLocalPackageManagerAsync(
       this._rushConfiguration,
       this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts,
@@ -170,7 +170,7 @@ export class Autoinstaller {
   }
 
   public async updateAsync(): Promise<void> {
-    await InstallHelpers.ensureLocalPackageManager(
+    await InstallHelpers.ensureLocalPackageManagerAsync(
       this._rushConfiguration,
       this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts,

--- a/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
+++ b/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
@@ -24,26 +24,26 @@ export class InteractiveUpgrader {
     this._rushConfiguration = rushConfiguration;
   }
 
-  public async upgrade(): Promise<IUpgradeInteractiveDeps> {
-    const rushProject: RushConfigurationProject = await this._getUserSelectedProjectForUpgrade();
+  public async upgradeAsync(): Promise<IUpgradeInteractiveDeps> {
+    const rushProject: RushConfigurationProject = await this._getUserSelectedProjectForUpgradeAsync();
 
-    const dependenciesState: NpmCheck.INpmCheckPackage[] = await this._getPackageDependenciesStatus(
+    const dependenciesState: NpmCheck.INpmCheckPackage[] = await this._getPackageDependenciesStatusAsync(
       rushProject
     );
 
-    const depsToUpgrade: IDepsToUpgradeAnswers = await this._getUserSelectedDependenciesToUpgrade(
+    const depsToUpgrade: IDepsToUpgradeAnswers = await this._getUserSelectedDependenciesToUpgradeAsync(
       dependenciesState
     );
     return { projects: [rushProject], depsToUpgrade };
   }
 
-  private async _getUserSelectedDependenciesToUpgrade(
+  private async _getUserSelectedDependenciesToUpgradeAsync(
     packages: NpmCheck.INpmCheckPackage[]
   ): Promise<IDepsToUpgradeAnswers> {
     return upgradeInteractive(packages);
   }
 
-  private async _getUserSelectedProjectForUpgrade(): Promise<RushConfigurationProject> {
+  private async _getUserSelectedProjectForUpgradeAsync(): Promise<RushConfigurationProject> {
     const projects: RushConfigurationProject[] | undefined = this._rushConfiguration.projects;
     const ui: Prompt = new Prompt({
       list: SearchListPrompt
@@ -67,7 +67,7 @@ export class InteractiveUpgrader {
     return selectProject;
   }
 
-  private async _getPackageDependenciesStatus(
+  private async _getPackageDependenciesStatusAsync(
     rushProject: RushConfigurationProject
   ): Promise<NpmCheck.INpmCheckPackage[]> {
     const { projectFolder } = rushProject;

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -144,7 +144,7 @@ export class PackageJsonUpdater {
       const explicitlyPreferredVersion: string | undefined =
         commonVersionsConfiguration.preferredVersions.get(moduleName);
 
-      const version: string = await this._getNormalizedVersionSpec(
+      const version: string = await this._getNormalizedVersionSpecAsync(
         projects,
         moduleName,
         latestVersion,
@@ -235,10 +235,10 @@ export class PackageJsonUpdater {
           options.projects
         );
         for (const subspace of subspaceSet) {
-          await this._doUpdate(debugInstall, subspace);
+          await this._doUpdateAsync(debugInstall, subspace);
         }
       } else {
-        await this._doUpdate(debugInstall, this._rushConfiguration.defaultSubspace);
+        await this._doUpdateAsync(debugInstall, this._rushConfiguration.defaultSubspace);
       }
     }
   }
@@ -265,15 +265,15 @@ export class PackageJsonUpdater {
           options.projects
         );
         for (const subspace of subspaceSet) {
-          await this._doUpdate(debugInstall, subspace);
+          await this._doUpdateAsync(debugInstall, subspace);
         }
       } else {
-        await this._doUpdate(debugInstall, this._rushConfiguration.defaultSubspace);
+        await this._doUpdateAsync(debugInstall, this._rushConfiguration.defaultSubspace);
       }
     }
   }
 
-  private async _doUpdate(debugInstall: boolean, subspace: Subspace): Promise<void> {
+  private async _doUpdateAsync(debugInstall: boolean, subspace: Subspace): Promise<void> {
     this._terminal.writeLine();
     this._terminal.writeLine(Colorize.green('Running "rush update"'));
     this._terminal.writeLine();
@@ -330,13 +330,13 @@ export class PackageJsonUpdater {
     const subspaceSet: ReadonlySet<Subspace> = this._rushConfiguration.getSubspacesForProjects(projects);
     for (const subspace of subspaceSet) {
       // Projects for this subspace
-      allPackageUpdates.push(...(await this._updateProjects(subspace, dependencyAnalyzer, options)));
+      allPackageUpdates.push(...(await this._updateProjectsAsync(subspace, dependencyAnalyzer, options)));
     }
 
     return allPackageUpdates;
   }
 
-  private async _updateProjects(
+  private async _updateProjectsAsync(
     subspace: Subspace,
     dependencyAnalyzer: DependencyAnalyzer,
     options: IPackageJsonUpdaterRushAddOptions
@@ -363,7 +363,7 @@ export class PackageJsonUpdater {
       const explicitlyPreferredVersion: string | undefined =
         commonVersionsConfiguration.preferredVersions.get(packageName);
 
-      const version: string = await this._getNormalizedVersionSpec(
+      const version: string = await this._getNormalizedVersionSpecAsync(
         subspaceProjects,
         packageName,
         initialVersion,
@@ -545,7 +545,7 @@ export class PackageJsonUpdater {
    * @param rangeStyle - if this version is selected by querying registry, then this range specifier is prepended to
    *   the selected version.
    */
-  private async _getNormalizedVersionSpec(
+  private async _getNormalizedVersionSpecAsync(
     projects: RushConfigurationProject[],
     packageName: string,
     initialSpec: string | undefined,
@@ -607,7 +607,7 @@ export class PackageJsonUpdater {
       }
     }
 
-    await InstallHelpers.ensureLocalPackageManager(
+    await InstallHelpers.ensureLocalPackageManagerAsync(
       this._rushConfiguration,
       this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -130,8 +130,8 @@ export class ProjectWatcher {
    * If no change is currently present, watches the source tree of all selected projects for file changes.
    * `waitForChange` is not allowed to be called multiple times concurrently.
    */
-  public async waitForChange(onWatchingFiles?: () => void): Promise<IProjectChangeResult> {
-    const initialChangeResult: IProjectChangeResult = await this._computeChanged();
+  public async waitForChangeAsync(onWatchingFiles?: () => void): Promise<IProjectChangeResult> {
+    const initialChangeResult: IProjectChangeResult = await this._computeChangedAsync();
     // Ensure that the new state is recorded so that we don't loop infinitely
     this._commitChanges(initialChangeResult.state);
     if (initialChangeResult.changedProjects.size) {
@@ -209,7 +209,7 @@ export class ProjectWatcher {
             }
 
             this._setStatus(`Evaluating changes to tracked files...`);
-            const result: IProjectChangeResult = await this._computeChanged();
+            const result: IProjectChangeResult = await this._computeChangedAsync();
             this._setStatus(`Finished analyzing.`);
 
             // Need an async tick to allow for more file system events to be handled
@@ -391,7 +391,7 @@ export class ProjectWatcher {
   /**
    * Determines which, if any, projects (within the selection) have new hashes for files that are not in .gitignore
    */
-  private async _computeChanged(): Promise<IProjectChangeResult> {
+  private async _computeChangedAsync(): Promise<IProjectChangeResult> {
     const state: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this._rushConfiguration);
 
     const previousState: ProjectChangeAnalyzer | undefined = this._previousState;

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -194,11 +194,11 @@ export abstract class BaseInstallManager {
     if (cleanInstall || !shrinkwrapIsUpToDate || !canSkipInstall() || !projectImpactGraphIsUpToDate) {
       // eslint-disable-next-line no-console
       console.log();
-      await this.validateNpmSetup();
+      await this.validateNpmSetupAsync();
 
       let publishedRelease: boolean | undefined;
       try {
-        publishedRelease = await this._checkIfReleaseIsPublished();
+        publishedRelease = await this._checkIfReleaseIsPublishedAsync();
       } catch {
         // If the user is working in an environment that can't reach the registry,
         // don't bother them with errors.
@@ -343,7 +343,7 @@ export abstract class BaseInstallManager {
     }
 
     // Ensure that the package manager is installed
-    await InstallHelpers.ensureLocalPackageManager(
+    await InstallHelpers.ensureLocalPackageManagerAsync(
       this.rushConfiguration,
       this.rushGlobalFolder,
       this.options.maxInstallAttempts
@@ -857,7 +857,7 @@ ${gitLfsHookHandling}
     }
   }
 
-  private async _checkIfReleaseIsPublished(): Promise<boolean> {
+  private async _checkIfReleaseIsPublishedAsync(): Promise<boolean> {
     const lastCheckFile: string = path.join(
       this.rushGlobalFolder.nodeSpecificPath,
       'rush-' + Rush.version,
@@ -983,7 +983,7 @@ ${gitLfsHookHandling}
     }
   }
 
-  protected async validateNpmSetup(): Promise<void> {
+  protected async validateNpmSetupAsync(): Promise<void> {
     if (this._npmSetupValidated) {
       return;
     }
@@ -994,7 +994,7 @@ ${gitLfsHookHandling}
         isDebug: this.options.debug,
         syncNpmrcAlreadyCalled: this._syncNpmrcAlreadyCalled
       });
-      const valid: boolean = await setupPackageRegistry.checkOnly();
+      const valid: boolean = await setupPackageRegistry.checkOnlyAsync();
       if (!valid) {
         // eslint-disable-next-line no-console
         console.error();

--- a/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -190,12 +190,12 @@ export abstract class BaseLinkManager {
    * @param force - Normally the operation will be skipped if the links are already up to date;
    *   if true, this option forces the links to be recreated.
    */
-  public async createSymlinksForProjects(force: boolean): Promise<void> {
+  public async createSymlinksForProjectsAsync(force: boolean): Promise<void> {
     // eslint-disable-next-line no-console
     console.log('\n' + Colorize.bold('Linking local projects'));
     const stopwatch: Stopwatch = Stopwatch.start();
 
-    await this._linkProjects();
+    await this._linkProjectsAsync();
 
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
     await new FlagFile(
@@ -211,5 +211,5 @@ export abstract class BaseLinkManager {
     console.log('\nNext you should probably run "rush build" or "rush rebuild"');
   }
 
-  protected abstract _linkProjects(): Promise<void>;
+  protected abstract _linkProjectsAsync(): Promise<void>;
 }

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -83,10 +83,10 @@ export class ProjectBuildCache {
     return this._cacheId;
   }
 
-  public static async tryGetProjectBuildCache(
+  public static async tryGetProjectBuildCacheAsync(
     options: IProjectBuildCacheOptions
   ): Promise<ProjectBuildCache | undefined> {
-    const cacheId: string | undefined = await ProjectBuildCache._getCacheId(options);
+    const cacheId: string | undefined = await ProjectBuildCache._getCacheIdAsync(options);
     return new ProjectBuildCache(cacheId, options);
   }
 
@@ -375,7 +375,7 @@ export class ProjectBuildCache {
     return path.join(this._project.projectRushTempFolder, `${this._cacheId}.${mode}.log`);
   }
 
-  private static async _getCacheId({
+  private static async _getCacheIdAsync({
     projectChangeAnalyzer,
     project,
     terminal,

--- a/libraries/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
+++ b/libraries/rush-lib/src/logic/buildCache/test/ProjectBuildCache.test.ts
@@ -26,7 +26,7 @@ describe(ProjectBuildCache.name, () => {
       }
     } as unknown as ProjectChangeAnalyzer;
 
-    const subject: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCache({
+    const subject: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCacheAsync({
       buildCacheConfiguration: {
         buildCacheEnabled: options.hasOwnProperty('enabled') ? options.enabled : true,
         getCacheEntryId: (opts: IGenerateCacheEntryIdOptions) =>
@@ -51,7 +51,7 @@ describe(ProjectBuildCache.name, () => {
     return subject;
   }
 
-  describe(ProjectBuildCache.tryGetProjectBuildCache.name, () => {
+  describe(ProjectBuildCache.tryGetProjectBuildCacheAsync.name, () => {
     it('returns a ProjectBuildCache with a calculated cacheId value', async () => {
       const subject: ProjectBuildCache = (await prepareSubject({}))!;
       expect(subject['_cacheId']).toMatchInlineSnapshot(

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -128,7 +128,7 @@ export class InstallHelpers {
    * If the "(p)npm-local" symlink hasn't been set up yet, this creates it, installing the
    * specified (P)npm version in the user's home directory if needed.
    */
-  public static async ensureLocalPackageManager(
+  public static async ensureLocalPackageManagerAsync(
     rushConfiguration: RushConfiguration,
     rushGlobalFolder: RushGlobalFolder,
     maxInstallAttempts: number,

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -649,7 +649,7 @@ export class RushInstallManager extends BaseInstallManager {
   protected async postInstallAsync(subspace: Subspace): Promise<void> {
     if (!this.options.noLink) {
       const linkManager: BaseLinkManager = LinkManagerFactory.getLinkManager(this.rushConfiguration);
-      await linkManager.createSymlinksForProjects(false);
+      await linkManager.createSymlinksForProjectsAsync(false);
     } else {
       // eslint-disable-next-line no-console
       console.log(

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -526,6 +526,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         lockfilePath: pnpmLockfilePath,
         dotPnpmFolder,
         ensureFolderAsync: FileSystem.ensureFolderAsync,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         readPnpmLockfile: async (lockfilePath: string) => {
           const wantedPnpmLockfile: PnpmShrinkwrapFile | undefined = await PnpmShrinkwrapFile.loadFromFile(
             lockfilePath,

--- a/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -28,7 +28,7 @@ interface IQueueItem {
 }
 
 export class NpmLinkManager extends BaseLinkManager {
-  protected async _linkProjects(): Promise<void> {
+  protected async _linkProjectsAsync(): Promise<void> {
     const npmPackage: readPackageTree.Node = await LegacyAdapters.convertCallbackToPromise<
       readPackageTree.Node,
       Error,

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -615,7 +615,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
       });
 
       // eslint-disable-next-line require-atomic-updates -- This is guaranteed to not be concurrent
-      buildCacheContext.projectBuildCache = await ProjectBuildCache.tryGetProjectBuildCache({
+      buildCacheContext.projectBuildCache = await ProjectBuildCache.tryGetProjectBuildCacheAsync({
         project: rushProject,
         projectOutputFolderNames,
         additionalProjectOutputFilePaths,
@@ -678,17 +678,18 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
       });
     }
 
-    const projectBuildCache: ProjectBuildCache | undefined = await ProjectBuildCache.tryGetProjectBuildCache({
-      project: rushProject,
-      projectOutputFolderNames,
-      additionalProjectOutputFilePaths,
-      additionalContext,
-      buildCacheConfiguration,
-      terminal,
-      configHash,
-      projectChangeAnalyzer,
-      phaseName: phase.name
-    });
+    const projectBuildCache: ProjectBuildCache | undefined =
+      await ProjectBuildCache.tryGetProjectBuildCacheAsync({
+        project: rushProject,
+        projectOutputFolderNames,
+        additionalProjectOutputFilePaths,
+        additionalContext,
+        buildCacheConfiguration,
+        terminal,
+        configHash,
+        projectChangeAnalyzer,
+        phaseName: phase.name
+      });
 
     // eslint-disable-next-line require-atomic-updates -- This is guaranteed to not be concurrent
     buildCacheContext.projectBuildCache = projectBuildCache;

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -29,10 +29,10 @@ export interface IOperationExecutionManagerOptions {
   changedProjectsOnly: boolean;
   destination?: TerminalWritable;
 
-  beforeExecuteOperation?: (operation: OperationExecutionRecord) => Promise<OperationStatus | undefined>;
-  afterExecuteOperation?: (operation: OperationExecutionRecord) => Promise<void>;
-  onOperationStatusChanged?: (record: OperationExecutionRecord) => void;
-  beforeExecuteOperations?: (records: Map<Operation, OperationExecutionRecord>) => Promise<void>;
+  beforeExecuteOperationAsync?: (operation: OperationExecutionRecord) => Promise<OperationStatus | undefined>;
+  afterExecuteOperationAsync?: (operation: OperationExecutionRecord) => Promise<void>;
+  onOperationStatusChangedAsync?: (record: OperationExecutionRecord) => void;
+  beforeExecuteOperationsAsync?: (records: Map<Operation, OperationExecutionRecord>) => Promise<void>;
 }
 
 /**
@@ -87,10 +87,10 @@ export class OperationExecutionManager {
       debugMode,
       parallelism,
       changedProjectsOnly,
-      beforeExecuteOperation,
-      afterExecuteOperation,
-      onOperationStatusChanged,
-      beforeExecuteOperations
+      beforeExecuteOperationAsync: beforeExecuteOperation,
+      afterExecuteOperationAsync: afterExecuteOperation,
+      onOperationStatusChangedAsync: onOperationStatusChanged,
+      beforeExecuteOperationsAsync: beforeExecuteOperations
     } = options;
     this._completedOperations = 0;
     this._quietMode = quietMode;
@@ -264,7 +264,7 @@ export class OperationExecutionManager {
          */
         if (operation.status === UNASSIGNED_OPERATION) {
           // Pause for a few time
-          await Async.sleep(5000);
+          await Async.sleepAsync(5000);
           record = this._executionQueue.tryGetRemoteExecutingOperation();
         } else {
           record = operation;

--- a/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/AsyncOperationQueue.test.ts
@@ -185,7 +185,7 @@ describe(AsyncOperationQueue.name, () => {
     for await (const operation of queue) {
       let record: OperationExecutionRecord | undefined;
       if (operation.status === UNASSIGNED_OPERATION) {
-        await Async.sleep(100);
+        await Async.sleepAsync(100);
         record = queue.tryGetRemoteExecutingOperation();
       } else {
         record = operation;

--- a/libraries/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -39,7 +39,7 @@ export class PnpmLinkManager extends BaseLinkManager {
   /**
    * @override
    */
-  public async createSymlinksForProjects(force: boolean): Promise<void> {
+  public async createSymlinksForProjectsAsync(force: boolean): Promise<void> {
     const useWorkspaces: boolean =
       this._rushConfiguration.pnpmOptions && this._rushConfiguration.pnpmOptions.useWorkspaces;
     if (useWorkspaces) {
@@ -53,10 +53,10 @@ export class PnpmLinkManager extends BaseLinkManager {
       throw new AlreadyReportedError();
     }
 
-    await super.createSymlinksForProjects(force);
+    await super.createSymlinksForProjectsAsync(force);
   }
 
-  protected async _linkProjects(): Promise<void> {
+  protected async _linkProjectsAsync(): Promise<void> {
     if (this._rushConfiguration.projects.length > 0) {
       // Use shrinkwrap from temp as the committed shrinkwrap may not always be up to date
       // See https://github.com/microsoft/rushstack/issues/1273#issuecomment-492779995
@@ -71,7 +71,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       }
 
       for (const rushProject of this._rushConfiguration.projects) {
-        await this._linkProject(rushProject, pnpmShrinkwrapFile);
+        await this._linkProjectAsync(rushProject, pnpmShrinkwrapFile);
       }
     } else {
       // eslint-disable-next-line no-console
@@ -89,7 +89,7 @@ export class PnpmLinkManager extends BaseLinkManager {
    * @param project             The local project that we will create symlinks for
    * @param rushLinkJson        The common/temp/rush-link.json output file
    */
-  private async _linkProject(
+  private async _linkProjectAsync(
     project: RushConfigurationProject,
     pnpmShrinkwrapFile: PnpmShrinkwrapFile
   ): Promise<void> {

--- a/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -94,7 +94,7 @@ export class SetupPackageRegistry {
    *
    * @returns - `true` if valid, `false` if not valid
    */
-  public async checkOnly(): Promise<boolean> {
+  public async checkOnlyAsync(): Promise<boolean> {
     const packageRegistry: IArtifactoryPackageRegistryJson =
       this._artifactoryConfiguration.configuration.packageRegistry;
     if (!packageRegistry.enabled) {
@@ -198,8 +198,8 @@ export class SetupPackageRegistry {
   /**
    * Test whether the NPM token is valid.  If not, prompt to update it.
    */
-  public async checkAndSetup(): Promise<void> {
-    if (await this.checkOnly()) {
+  public async checkAndSetupAsync(): Promise<void> {
+    if (await this.checkOnlyAsync()) {
       return;
     }
 
@@ -209,7 +209,7 @@ export class SetupPackageRegistry {
     const packageRegistry: IArtifactoryPackageRegistryJson =
       this._artifactoryConfiguration.configuration.packageRegistry;
 
-    const fixThisProblem: boolean = await TerminalInput.promptYesNo({
+    const fixThisProblem: boolean = await TerminalInput.promptYesNoAsync({
       message: 'Fix this problem now?',
       defaultValue: false
     });
@@ -220,7 +220,7 @@ export class SetupPackageRegistry {
 
     this._writeInstructionBlock(this._messages.introduction);
 
-    const hasArtifactoryAccount: boolean = await TerminalInput.promptYesNo({
+    const hasArtifactoryAccount: boolean = await TerminalInput.promptYesNoAsync({
       message: 'Do you already have an Artifactory user account?'
     });
     this._terminal.writeLine();
@@ -244,7 +244,7 @@ export class SetupPackageRegistry {
 
     this._writeInstructionBlock(this._messages.locateUserName);
 
-    let artifactoryUser: string = await TerminalInput.promptLine({
+    let artifactoryUser: string = await TerminalInput.promptLineAsync({
       message: this._messages.userNamePrompt
     });
     this._terminal.writeLine();
@@ -258,7 +258,7 @@ export class SetupPackageRegistry {
 
     this._writeInstructionBlock(this._messages.locateApiKey);
 
-    let artifactoryKey: string = await TerminalInput.promptPasswordLine({
+    let artifactoryKey: string = await TerminalInput.promptPasswordLineAsync({
       message: this._messages.apiKeyPrompt
     });
     this._terminal.writeLine();
@@ -270,14 +270,14 @@ export class SetupPackageRegistry {
       throw new AlreadyReportedError();
     }
 
-    await this._fetchTokenAndUpdateNpmrc(artifactoryUser, artifactoryKey, packageRegistry);
+    await this._fetchTokenAndUpdateNpmrcAsync(artifactoryUser, artifactoryKey, packageRegistry);
   }
 
   /**
    * Fetch a valid NPM token from the Artifactory service and add it to the `~/.npmrc` file,
    * preserving other settings in that file.
    */
-  private async _fetchTokenAndUpdateNpmrc(
+  private async _fetchTokenAndUpdateNpmrcAsync(
     artifactoryUser: string,
     artifactoryKey: string,
     packageRegistry: IArtifactoryPackageRegistryJson

--- a/libraries/rush-lib/src/logic/setup/TerminalInput.ts
+++ b/libraries/rush-lib/src/logic/setup/TerminalInput.ts
@@ -204,7 +204,7 @@ class PasswordKeyboardLoop extends KeyboardLoop {
 }
 
 export class TerminalInput {
-  private static async _readLine(): Promise<string> {
+  private static async _readLineAsync(): Promise<string> {
     const readlineInterface: readline.Interface = readline.createInterface({ input: process.stdin });
     try {
       return await new Promise((resolve, reject) => {
@@ -217,21 +217,21 @@ export class TerminalInput {
     }
   }
 
-  public static async promptYesNo(options: IPromptYesNoOptions): Promise<boolean> {
+  public static async promptYesNoAsync(options: IPromptYesNoOptions): Promise<boolean> {
     const keyboardLoop: YesNoKeyboardLoop = new YesNoKeyboardLoop(options);
     await keyboardLoop.startAsync();
     return keyboardLoop.result!;
   }
 
-  public static async promptLine(options: IPromptLineOptions): Promise<string> {
+  public static async promptLineAsync(options: IPromptLineOptions): Promise<string> {
     const stderr: NodeJS.WriteStream = process.stderr;
     stderr.write(Colorize.green('==>') + ' ');
     stderr.write(Colorize.bold(options.message));
     stderr.write(' ');
-    return await TerminalInput._readLine();
+    return await TerminalInput._readLineAsync();
   }
 
-  public static async promptPasswordLine(options: IPromptLineOptions): Promise<string> {
+  public static async promptPasswordLineAsync(options: IPromptLineOptions): Promise<string> {
     const keyboardLoop: PasswordKeyboardLoop = new PasswordKeyboardLoop(options);
     await keyboardLoop.startAsync();
     return keyboardLoop.result;

--- a/libraries/rush-lib/src/logic/test/CredentialCache.test.ts
+++ b/libraries/rush-lib/src/logic/test/CredentialCache.test.ts
@@ -32,7 +32,7 @@ describe(CredentialCache.name, () => {
           if (maxWaitMs === undefined) {
             await existingLock;
           } else {
-            await Promise.race([existingLock, Async.sleep(maxWaitMs)]);
+            await Promise.race([existingLock, Async.sleepAsync(maxWaitMs)]);
           }
         }
 

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -127,6 +127,8 @@ export interface IBaseCommandLineDefinitionWithArgument extends IBaseCommandLine
    * @remarks
    * This option is only used when `ICommandLineParserOptions.enableTabCompletionAction`
    * is enabled.
+   *
+   * In a future release, this will be renamed to `getCompletionsAsync`
    */
   completions?: () => Promise<string[]>;
 }

--- a/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
@@ -186,6 +186,6 @@ export class AliasCommandLineAction extends CommandLineAction {
    * Executes the target action.
    */
   protected async onExecute(): Promise<void> {
-    await this.targetAction._execute();
+    await this.targetAction._executeAsync();
   }
 }

--- a/libraries/ts-command-line/src/providers/CommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineAction.ts
@@ -109,7 +109,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
    * Invoked by CommandLineParser.onExecute().
    * @internal
    */
-  public _execute(): Promise<void> {
+  public _executeAsync(): Promise<void> {
     return this.onExecute();
   }
 
@@ -129,6 +129,9 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 
   /**
    * Your subclass should implement this hook to perform the operation.
+   *
+   * @remarks
+   * In a future release, this function will be renamed to onExecuteAsync
    */
   protected abstract onExecute(): Promise<void>;
 }

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -601,7 +601,7 @@ export abstract class CommandLineParameterProvider {
   protected abstract _getArgumentParser(): argparse.ArgumentParser;
 
   /**
-   * This is called internally by {@link CommandLineParser.execute}
+   * This is called internally by {@link CommandLineParser.executeAsync}
    * @internal
    */
   public _preParse(): void {
@@ -611,7 +611,7 @@ export abstract class CommandLineParameterProvider {
   }
 
   /**
-   * This is called internally by {@link CommandLineParser.execute} before `printUsage` is called
+   * This is called internally by {@link CommandLineParser.executeAsync} before `printUsage` is called
    * @internal
    */
   public _postParse(): void {
@@ -621,7 +621,7 @@ export abstract class CommandLineParameterProvider {
   }
 
   /**
-   * This is called internally by {@link CommandLineParser.execute}
+   * This is called internally by {@link CommandLineParser.executeAsync}
    * @internal
    */
   public _processParsedData(parserOptions: ICommandLineParserOptions, data: ICommandLineParserData): void {

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -162,10 +162,10 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
   }
 
   /**
-   * {@inheritdoc CommandLineAction._execute}
+   * {@inheritdoc CommandLineAction._executeAsync}
    * @internal
    */
-  public async _execute(): Promise<void> {
+  public async _executeAsync(): Promise<void> {
     // override
     if (!this._unscopedParserOptions || !this._scopedCommandLineParser) {
       throw new Error('The CommandLineAction parameters must be processed before execution.');
@@ -193,12 +193,12 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
     }
 
     // Call the scoped parser using only the scoped args to handle parsing
-    await this._scopedCommandLineParser.executeWithoutErrorHandling(scopedArgs);
+    await this._scopedCommandLineParser.executeWithoutErrorHandlingAsync(scopedArgs);
 
     // Only call execute if the parser reached the execute stage. This may not be true if
     // the parser exited early due to a specified '--help' parameter.
     if (this._scopedCommandLineParser.canExecute) {
-      await super._execute();
+      await super._executeAsync();
     }
 
     return;

--- a/libraries/ts-command-line/src/providers/TabCompletionAction.ts
+++ b/libraries/ts-command-line/src/providers/TabCompletionAction.ts
@@ -73,13 +73,13 @@ export class TabCompleteAction extends CommandLineAction {
     const commandLine: string = this._wordToCompleteParameter.value;
     const caretPosition: number = this._positionParameter.value || commandLine.length;
 
-    for await (const value of this.getCompletions(commandLine, caretPosition)) {
+    for await (const value of this.getCompletionsAsync(commandLine, caretPosition)) {
       // eslint-disable-next-line no-console
       console.log(value);
     }
   }
 
-  public async *getCompletions(
+  public async *getCompletionsAsync(
     commandLine: string,
     caretPosition: number = commandLine.length
   ): AsyncIterable<string> {
@@ -122,7 +122,7 @@ export class TabCompleteAction extends CommandLineAction {
           if (completePartialWord) {
             for (const parameterName of parameterNames) {
               if (parameterName === secondLastToken) {
-                const values: ReadonlyArray<string> = await this._getParameterValueCompletions(
+                const values: ReadonlyArray<string> = await this._getParameterValueCompletionsAsync(
                   parameterNameMap.get(parameterName)!
                 );
                 if (values.length > 0) {
@@ -135,7 +135,7 @@ export class TabCompleteAction extends CommandLineAction {
           } else {
             for (const parameterName of parameterNames) {
               if (parameterName === lastToken) {
-                const values: ReadonlyArray<string> = await this._getParameterValueCompletions(
+                const values: ReadonlyArray<string> = await this._getParameterValueCompletionsAsync(
                   parameterNameMap.get(parameterName)!
                 );
                 if (values.length > 0) {
@@ -172,7 +172,7 @@ export class TabCompleteAction extends CommandLineAction {
     return stringArgv(commandLine);
   }
 
-  private async _getParameterValueCompletions(
+  private async _getParameterValueCompletionsAsync(
     parameter: CommandLineParameter
   ): Promise<ReadonlyArray<string>> {
     let choiceParameterValues: ReadonlyArray<string> = [];

--- a/libraries/ts-command-line/src/test/ActionlessParser.test.ts
+++ b/libraries/ts-command-line/src/test/ActionlessParser.test.ts
@@ -32,7 +32,7 @@ describe(`Actionless ${CommandLineParser.name}`, () => {
   it('parses an empty arg list', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
-    await commandLineParser.execute([]);
+    await commandLineParser.executeAsync([]);
 
     expect(commandLineParser.done).toBe(true);
     expect(commandLineParser.selectedAction).toBeUndefined();
@@ -42,7 +42,7 @@ describe(`Actionless ${CommandLineParser.name}`, () => {
   it('parses a flag', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
-    await commandLineParser.execute(['--flag']);
+    await commandLineParser.executeAsync(['--flag']);
 
     expect(commandLineParser.done).toBe(true);
     expect(commandLineParser.selectedAction).toBeUndefined();
@@ -56,7 +56,7 @@ describe(`Actionless ${CommandLineParser.name}`, () => {
       description: 'remainder description'
     });
 
-    await commandLineParser.execute(['--flag', 'the', 'remaining', 'args']);
+    await commandLineParser.executeAsync(['--flag', 'the', 'remaining', 'args']);
 
     expect(commandLineParser.done).toBe(true);
     expect(commandLineParser.selectedAction).toBeUndefined();

--- a/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
@@ -114,7 +114,7 @@ describe(AliasCommandLineAction.name, () => {
     const aliasAction: TestAliasAction = new TestAliasAction(targetAction);
     commandLineParser.addAction(aliasAction);
 
-    await commandLineParser.execute(['alias-action', '--flag']);
+    await commandLineParser.executeAsync(['alias-action', '--flag']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
@@ -127,7 +127,7 @@ describe(AliasCommandLineAction.name, () => {
     const aliasAction: TestAliasAction = new TestAliasAction(targetAction, ['--flag']);
     commandLineParser.addAction(aliasAction);
 
-    await commandLineParser.execute(['alias-action']);
+    await commandLineParser.executeAsync(['alias-action']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
@@ -140,7 +140,7 @@ describe(AliasCommandLineAction.name, () => {
     const aliasAction: TestAliasAction = new TestAliasAction(targetAction);
     commandLineParser.addAction(aliasAction);
 
-    await commandLineParser.execute(['alias-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['alias-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
@@ -154,7 +154,7 @@ describe(AliasCommandLineAction.name, () => {
     const aliasAction: TestAliasAction = new TestAliasAction(targetAction, ['--scope', 'foo', '--']);
     commandLineParser.addAction(aliasAction);
 
-    await commandLineParser.execute(['alias-action', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['alias-action', '--scoped-foo', 'bar']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
@@ -169,7 +169,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action', '--flag']);
+    await commandLineParser.executeAsync(['alias-action', '--flag']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     const selectedAction: TestAliasAction = commandLineParser.selectedAction as TestAliasAction;
@@ -186,7 +186,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action', '--verbose']);
+    await commandLineParser.executeAsync(['alias-action', '--verbose']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     const selectedAction: TestAliasAction = commandLineParser.selectedAction as TestAliasAction;
@@ -203,7 +203,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action']);
+    await commandLineParser.executeAsync(['alias-action']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     const selectedAction: TestAliasAction = commandLineParser.selectedAction as TestAliasAction;
@@ -220,7 +220,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action', '--scope', 'foo']);
+    await commandLineParser.executeAsync(['alias-action', '--scope', 'foo']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     let selectedAction: TestAliasAction = commandLineParser.selectedAction as TestAliasAction;
@@ -238,7 +238,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['alias-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     selectedAction = commandLineParser.selectedAction as TestAliasAction;
@@ -259,7 +259,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action']);
+    await commandLineParser.executeAsync(['alias-action']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     let selectedAction: TestAliasAction = commandLineParser.selectedAction as TestAliasAction;
@@ -277,7 +277,7 @@ describe(AliasCommandLineAction.name, () => {
     commandLineParser.addAction(aliasAction);
 
     // Execute the parser in order to populate the parameters
-    await commandLineParser.execute(['alias-action', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['alias-action', '--scoped-foo', 'bar']);
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('alias-action');
     selectedAction = commandLineParser.selectedAction as TestAliasAction;

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -258,14 +258,14 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '-s'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '-s'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it('can execute the non-ambiguous scoped long names', async () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
 
-    await commandLineParser.execute([
+    await commandLineParser.executeAsync([
       'do:the-job',
       '--short1',
       'short1value',
@@ -292,7 +292,7 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--arg', 'test'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '--arg', 'test'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -304,7 +304,7 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--abbreviation-flag'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '--abbreviation-flag'])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation-flag"/);
   });
 
@@ -316,7 +316,7 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--abbreviation'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '--abbreviation'])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation"/);
   });
 
@@ -328,7 +328,7 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--abbrev'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '--abbrev'])
     ).rejects.toThrowError(/Ambiguous option: "--abbrev" could match --abbreviation-flag, --abbreviation/);
   });
 
@@ -339,7 +339,7 @@ describe(`Ambiguous ${CommandLineParser.name}`, () => {
       description: 'A flag used to test abbreviation logic'
     });
 
-    await commandLineParser.executeWithoutErrorHandling(['do:the-job', '--abbreviation-f']);
+    await commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job', '--abbreviation-f']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');
@@ -359,7 +359,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
     );
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '-s'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '-s'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -369,7 +369,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
       (commandLineParser.getAction('do:the-job-alias')! as AliasAction).targetAction
     );
 
-    await commandLineParser.execute([
+    await commandLineParser.executeAsync([
       'do:the-job-alias',
       '--short1',
       'short1value',
@@ -400,7 +400,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
     );
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '--arg', 'test'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '--arg', 'test'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -415,7 +415,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '--abbreviation-flag'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '--abbreviation-flag'])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation-flag"/);
   });
 
@@ -430,7 +430,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '--abbreviation'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '--abbreviation'])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation"/);
   });
 
@@ -445,7 +445,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '--abbrev'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '--abbrev'])
     ).rejects.toThrowError(/Ambiguous option: "--abbrev" could match --abbreviation-flag, --abbreviation/);
   });
 
@@ -459,7 +459,7 @@ describe(`Ambiguous aliased ${CommandLineParser.name}`, () => {
       description: 'A flag used to test abbreviation logic'
     });
 
-    await commandLineParser.executeWithoutErrorHandling(['do:the-job-alias', '--abbreviation-f']);
+    await commandLineParser.executeWithoutErrorHandlingAsync(['do:the-job-alias', '--abbreviation-f']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job-alias');
@@ -477,7 +477,7 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '-s'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['scoped-action', '--scoping', '--', '-s'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -485,14 +485,14 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '-a'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['scoped-action', '--scoping', '--', '-a'])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it('can execute the non-ambiguous scoped long names on the scoping action', async () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
 
-    await commandLineParser.execute([
+    await commandLineParser.executeAsync([
       'scoped-action',
       '--scoping',
       '--',
@@ -523,7 +523,13 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(AmbiguousScopedAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--arg', 'test'])
+      commandLineParser.executeWithoutErrorHandlingAsync([
+        'scoped-action',
+        '--scoping',
+        '--',
+        '--arg',
+        'test'
+      ])
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -542,7 +548,12 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--abbreviation'])
+      commandLineParser.executeWithoutErrorHandlingAsync([
+        'scoped-action',
+        '--scoping',
+        '--',
+        '--abbreviation'
+      ])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation"/);
   });
 
@@ -557,7 +568,12 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     );
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--abbreviation'])
+      commandLineParser.executeWithoutErrorHandlingAsync([
+        'scoped-action',
+        '--scoping',
+        '--',
+        '--abbreviation'
+      ])
     ).rejects.toThrowError(/Ambiguous option: "--abbreviation"/);
   });
 
@@ -576,7 +592,7 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     });
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--abbrev'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['scoped-action', '--scoping', '--', '--abbrev'])
     ).rejects.toThrowError(/Ambiguous option: "--abbrev" could match --abbreviation-flag, --abbreviation/);
   });
 
@@ -591,7 +607,7 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
     );
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['scoped-action', '--scoping', '--', '--abbrev'])
+      commandLineParser.executeWithoutErrorHandlingAsync(['scoped-action', '--scoping', '--', '--abbrev'])
     ).rejects.toThrowError(/Ambiguous option: "--abbrev" could match --abbreviation-flag, --abbreviation/);
   });
 
@@ -612,7 +628,7 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
       'scoped-action'
     ) as AbbreviationScopedAction;
 
-    await commandLineParser.executeWithoutErrorHandling([
+    await commandLineParser.executeWithoutErrorHandlingAsync([
       'scoped-action',
       '--scoping',
       '--',
@@ -639,7 +655,7 @@ describe(`Ambiguous scoping ${CommandLineParser.name}`, () => {
       'scoped-action'
     ) as AbbreviationScopedAction;
 
-    await commandLineParser.executeWithoutErrorHandling([
+    await commandLineParser.executeWithoutErrorHandlingAsync([
       'scoped-action',
       '--scoping',
       '--',

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -220,7 +220,7 @@ describe(CommandLineParameterBase.name, () => {
       'second'
     ];
 
-    await expect(commandLineParser.execute(args)).resolves.toBe(true);
+    await expect(commandLineParser.executeAsync(args)).resolves.toBe(true);
 
     expect(commandLineParser.selectedAction).toBe(action);
 
@@ -263,7 +263,7 @@ describe(CommandLineParameterBase.name, () => {
     const action: CommandLineAction = commandLineParser.getAction('do:the-job');
     const args: string[] = ['do:the-job', '--integer-required', '123', '--env-integer-required', '321'];
 
-    await expect(commandLineParser.execute(args)).resolves.toBe(true);
+    await expect(commandLineParser.executeAsync(args)).resolves.toBe(true);
 
     expect(commandLineParser.selectedAction).toBe(action);
 
@@ -327,7 +327,7 @@ describe(CommandLineParameterBase.name, () => {
     process.env.ENV_STRING_LIST = 'simple text';
     process.env.ENV_JSON_STRING_LIST = ' [ 1, true, "Hello, world!" ] ';
 
-    await expect(commandLineParser.execute(args)).resolves.toBe(true);
+    await expect(commandLineParser.executeAsync(args)).resolves.toBe(true);
 
     expect(commandLineParser.selectedAction).toBe(action);
 
@@ -353,7 +353,7 @@ describe(CommandLineParameterBase.name, () => {
       '123'
     ];
 
-    await expect(commandLineParser.execute(args)).resolves.toBe(true);
+    await expect(commandLineParser.executeAsync(args)).resolves.toBe(true);
 
     expect(commandLineParser.selectedAction).toBe(action);
 
@@ -375,7 +375,7 @@ describe(CommandLineParameterBase.name, () => {
       });
 
     const args: string[] = ['do:the-job', '--integer-required', '1'];
-    await expect(commandLineParser.executeWithoutErrorHandling(args)).rejects.toMatchSnapshot('Error');
+    await expect(commandLineParser.executeWithoutErrorHandlingAsync(args)).rejects.toMatchSnapshot('Error');
     expect(printMessageSpy).toHaveBeenCalled();
     expect(printMessageSpy.mock.calls[0][0]).toMatchSnapshot('Usage');
   });
@@ -392,7 +392,7 @@ describe(CommandLineParameterBase.name, () => {
 
       async function runWithArgsAsync(args: string[]): Promise<void> {
         const commandLineParser: CommandLineParser = createParser();
-        await expect(commandLineParser.execute(args)).resolves.toBe(false);
+        await expect(commandLineParser.executeAsync(args)).resolves.toBe(false);
       }
 
       await runWithArgsAsync(['do:the-job', '--integer-required', '1']);
@@ -442,7 +442,7 @@ describe(CommandLineParameterBase.name, () => {
 
       let error: string | undefined;
       try {
-        await commandLineParser.executeWithoutErrorHandling(args);
+        await commandLineParser.executeWithoutErrorHandlingAsync(args);
       } catch (e) {
         error = e.message;
       }
@@ -458,7 +458,7 @@ describe(CommandLineParameterBase.name, () => {
       process.env.ENV_COLOR = '[{}]';
 
       await expect(
-        commandLineParser.executeWithoutErrorHandling(args)
+        commandLineParser.executeWithoutErrorHandlingAsync(args)
       ).rejects.toThrowErrorMatchingSnapshot();
     });
 
@@ -468,7 +468,7 @@ describe(CommandLineParameterBase.name, () => {
       process.env.ENV_COLOR = 'oblong';
 
       await expect(
-        commandLineParser.executeWithoutErrorHandling(args)
+        commandLineParser.executeWithoutErrorHandlingAsync(args)
       ).rejects.toThrowErrorMatchingSnapshot();
     });
   });

--- a/libraries/ts-command-line/src/test/CommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParser.test.ts
@@ -50,7 +50,7 @@ describe(CommandLineParser.name, () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
     commandLineParser._registerDefinedParameters({ parentParameterNames: new Set() });
 
-    await commandLineParser.execute(['do:the-job', '--flag']);
+    await commandLineParser.executeAsync(['do:the-job', '--flag']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('do:the-job');

--- a/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineRemainder.test.ts
@@ -60,7 +60,7 @@ describe(CommandLineRemainder.name, () => {
     const action: CommandLineAction = commandLineParser.getAction('run');
     const args: string[] = ['run', '--title', 'The title', 'the', 'remaining', 'args'];
 
-    await commandLineParser.execute(args);
+    await commandLineParser.executeAsync(args);
 
     expect(commandLineParser.selectedAction).toBe(action);
 
@@ -81,7 +81,7 @@ describe(CommandLineRemainder.name, () => {
     const action: CommandLineAction = commandLineParser.getAction('run');
     const args: string[] = ['run', '--title', 'The title', '--', '--the', 'remaining', '--args'];
 
-    await commandLineParser.execute(args);
+    await commandLineParser.executeAsync(args);
 
     expect(commandLineParser.selectedAction).toBe(action);
 

--- a/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
@@ -129,7 +129,7 @@ describe(`Conflicting ${CommandLineParser.name}`, () => {
   it('executes an action', async () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(TestAction);
 
-    await commandLineParser.execute([
+    await commandLineParser.executeAsync([
       'do:the-job',
       '--scope1:arg',
       'scope1value',
@@ -169,7 +169,13 @@ describe(`Conflicting ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(UnscopedDuplicateArgumentTestAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--arg', 'value', '--scope:arg', 'value'])
+      commandLineParser.executeWithoutErrorHandlingAsync([
+        'do:the-job',
+        '--arg',
+        'value',
+        '--scope:arg',
+        'value'
+      ])
     ).rejects.toThrowError(/The parameter "--arg" is defined multiple times with the same long name/);
   });
 
@@ -177,7 +183,13 @@ describe(`Conflicting ${CommandLineParser.name}`, () => {
     const commandLineParser: GenericCommandLine = new GenericCommandLine(ScopedDuplicateArgumentTestAction);
 
     await expect(
-      commandLineParser.executeWithoutErrorHandling(['do:the-job', '--arg', 'value', '--scope:arg', 'value'])
+      commandLineParser.executeWithoutErrorHandlingAsync([
+        'do:the-job',
+        '--arg',
+        'value',
+        '--scope:arg',
+        'value'
+      ])
     ).rejects.toThrowError(/argument "\-\-scope:arg": Conflicting option string\(s\): \-\-scope:arg/);
   });
 });

--- a/libraries/ts-command-line/src/test/DynamicCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/DynamicCommandLineParser.test.ts
@@ -23,7 +23,7 @@ describe(DynamicCommandLineParser.name, () => {
       description: 'The flag'
     });
 
-    await commandLineParser.execute(['do:the-job', '--flag']);
+    await commandLineParser.executeAsync(['do:the-job', '--flag']);
 
     expect(commandLineParser.selectedAction).toEqual(action);
 

--- a/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
@@ -73,20 +73,24 @@ describe(CommandLineParser.name, () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
     const args: string[] = ['scoped-action', '--scope', 'foo', '--', '--scoped-bar', 'baz'];
 
-    await expect(commandLineParser.executeWithoutErrorHandling(args)).rejects.toThrowErrorMatchingSnapshot();
+    await expect(
+      commandLineParser.executeWithoutErrorHandlingAsync(args)
+    ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it('throws on missing positional arg divider with unknown positional args', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
     const args: string[] = ['scoped-action', '--scope', 'foo', 'bar'];
 
-    await expect(commandLineParser.executeWithoutErrorHandling(args)).rejects.toThrowErrorMatchingSnapshot();
+    await expect(
+      commandLineParser.executeWithoutErrorHandlingAsync(args)
+    ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it('executes a scoped action', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
 
-    await commandLineParser.execute(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
 
     expect(commandLineParser.selectedAction).toBeDefined();
     expect(commandLineParser.selectedAction!.actionName).toEqual('scoped-action');
@@ -107,7 +111,7 @@ describe(CommandLineParser.name, () => {
   it('prints the scoped action help', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
     // Execute the parser in order to populate the scoped action to populate the help text.
-    await commandLineParser.execute(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
     const scopedAction: TestScopedAction & { _getScopedCommandLineParser(): CommandLineParser } =
       commandLineParser.getAction('scoped-action') as TestScopedAction & {
         _getScopedCommandLineParser(): CommandLineParser;
@@ -120,7 +124,7 @@ describe(CommandLineParser.name, () => {
   it('prints the unscoped action parameter map', async () => {
     const commandLineParser: TestCommandLine = new TestCommandLine();
     // Execute the parser in order to populate the scoped action
-    await commandLineParser.execute(['scoped-action', '--verbose']);
+    await commandLineParser.executeAsync(['scoped-action', '--verbose']);
     const scopedAction: TestScopedAction = commandLineParser.getAction('scoped-action') as TestScopedAction;
     expect(scopedAction.done).toBe(true);
     expect(scopedAction.parameters.length).toBe(2);
@@ -131,7 +135,7 @@ describe(CommandLineParser.name, () => {
   it('prints the scoped action parameter map', async () => {
     let commandLineParser: TestCommandLine = new TestCommandLine();
     // Execute the parser in order to populate the scoped action
-    await commandLineParser.execute(['scoped-action', '--scope', 'foo']);
+    await commandLineParser.executeAsync(['scoped-action', '--scope', 'foo']);
     let scopedAction: TestScopedAction = commandLineParser.getAction('scoped-action') as TestScopedAction;
     expect(scopedAction.done).toBe(true);
     expect(scopedAction.parameters.length).toBe(3);
@@ -140,7 +144,7 @@ describe(CommandLineParser.name, () => {
 
     commandLineParser = new TestCommandLine();
     // Execute the parser in order to populate the scoped action
-    await commandLineParser.execute(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
+    await commandLineParser.executeAsync(['scoped-action', '--scope', 'foo', '--', '--scoped-foo', 'bar']);
     scopedAction = commandLineParser.getAction('scoped-action') as TestScopedAction;
     expect(scopedAction.done).toBe(true);
     expect(scopedAction.parameters.length).toBe(3);

--- a/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
+++ b/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
@@ -91,6 +91,7 @@ function getCommandLineParser(): DynamicCommandLineParser {
     parameterShortName: '-t',
     argumentName: 'PROJECT1',
     description: 'Run command in the specified project and all of its dependencies.',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     completions: async (): Promise<string[]> => {
       return ['abc', 'def', 'hij'];
     }
@@ -207,7 +208,7 @@ describe(TabCompleteAction.name, () => {
   it(`gets completion(s) for rush <tab>`, async () => {
     const commandLine: string = 'rush ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -225,7 +226,7 @@ Array [
   it(`gets completion(s) for rush a<tab>`, async () => {
     const commandLine: string = 'rush a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -238,7 +239,7 @@ Array [
   it(`gets completion(s) for rush -d a<tab>`, async () => {
     const commandLine: string = 'rush -d a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -251,7 +252,7 @@ Array [
   it(`gets completion(s) for rush build <tab>`, async () => {
     const commandLine: string = 'rush build ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -269,7 +270,7 @@ Array [
   it(`gets completion(s) for rush build -<tab>`, async () => {
     const commandLine: string = 'rush build -';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -287,7 +288,7 @@ Array [
   it(`gets completion(s) for rush build -t <tab>`, async () => {
     const commandLine: string = 'rush build -t ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -302,7 +303,7 @@ Array [
   it(`gets completion(s) for rush build -t a<tab>`, async () => {
     const commandLine: string = 'rush build -t a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -315,7 +316,7 @@ Array [
   it(`gets completion(s) for rush --debug build -t a<tab>`, async () => {
     const commandLine: string = 'rush --debug build -t a';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -328,7 +329,7 @@ Array [
   it(`gets completion(s) for rush change --bump-type <tab>`, async () => {
     const commandLine: string = 'rush change --bump-type ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -344,7 +345,7 @@ Array [
   it(`gets completion(s) for rush change --bulk <tab>`, async () => {
     const commandLine: string = 'rush change --bulk ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -366,7 +367,7 @@ Array [
   it(`gets completion(s) for rush change --bump-type m<tab>`, async () => {
     const commandLine: string = 'rush change --bump-type m';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -380,7 +381,7 @@ Array [
   it(`gets completion(s) for rush change --message <tab>`, async () => {
     const commandLine: string = 'rush change --message ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`Array []`);
@@ -389,7 +390,7 @@ Array [
   it(`gets completion(s) for rush change --message "my change log message" --bump-type <tab>`, async () => {
     const commandLine: string = 'rush change --message "my change log message" --bump-type ';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`
@@ -405,7 +406,7 @@ Array [
   it(`gets completion(s) for rush change --message "my change log message" --bump-type m<tab>`, async () => {
     const commandLine: string = 'rush change --message "my change log message" --bump-type m';
     const actual: string[] = await arrayFromAsyncIteratorAsync(
-      tc.getCompletions(commandLine, commandLine.length)
+      tc.getCompletionsAsync(commandLine, commandLine.length)
     );
 
     expect(actual.sort()).toMatchInlineSnapshot(`

--- a/libraries/typings-generator/src/TypingsGenerator.ts
+++ b/libraries/typings-generator/src/TypingsGenerator.ts
@@ -175,7 +175,7 @@ export class TypingsGenerator<TFileContents = string> {
       });
     }
 
-    await this._reprocessFiles(relativeFilePaths!, checkFilePaths);
+    await this._reprocessFilesAsync(relativeFilePaths!, checkFilePaths);
   }
 
   public async runWatcherAsync(): Promise<void> {
@@ -197,7 +197,7 @@ export class TypingsGenerator<TFileContents = string> {
 
         const toProcess: string[] = Array.from(queue);
         queue.clear();
-        this._reprocessFiles(toProcess, false)
+        this._reprocessFilesAsync(toProcess, false)
           .then(() => {
             processing = false;
             // If the timeout was invoked again, immediately reexecute with the changed files.
@@ -282,7 +282,10 @@ export class TypingsGenerator<TFileContents = string> {
     return additionalPaths ? [...typingsFilePaths, ...additionalPaths] : Array.from(typingsFilePaths);
   }
 
-  private async _reprocessFiles(relativePaths: Iterable<string>, checkFilePaths: boolean): Promise<void> {
+  private async _reprocessFilesAsync(
+    relativePaths: Iterable<string>,
+    checkFilePaths: boolean
+  ): Promise<void> {
     // Build a queue of resolved paths
     const toProcess: Set<string> = new Set();
     for (const rawPath of relativePaths) {

--- a/repo-scripts/repo-toolbox/src/start.ts
+++ b/repo-scripts/repo-toolbox/src/start.ts
@@ -8,4 +8,4 @@ console.log('repo-toolbox\n');
 
 const commandLine: ToolboxCommandLine = new ToolboxCommandLine();
 // eslint-disable-next-line no-console
-commandLine.execute().catch(console.error); // CommandLineParser.execute() should never reject the promise
+commandLine.executeAsync().catch(console.error); // CommandLineParser.executeAsync() should never reject the promise

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/AmazonS3Client.ts
@@ -112,7 +112,7 @@ export class AmazonS3Client {
 
   public async getObjectAsync(objectName: string): Promise<Buffer | undefined> {
     this._writeDebugLine('Reading object from S3');
-    return await this._sendCacheRequestWithRetries(async () => {
+    return await this._sendCacheRequestWithRetriesAsync(async () => {
       const response: fetch.Response = await this._makeRequestAsync('GET', objectName);
       if (response.ok) {
         return {
@@ -157,7 +157,7 @@ export class AmazonS3Client {
       throw new Error('Credentials are required to upload objects to S3.');
     }
 
-    await this._sendCacheRequestWithRetries(async () => {
+    await this._sendCacheRequestWithRetriesAsync(async () => {
       const response: fetch.Response = await this._makeRequestAsync('PUT', objectName, objectBuffer);
       if (!response.ok) {
         return {
@@ -351,7 +351,7 @@ export class AmazonS3Client {
     };
   }
 
-  private async _safeReadResponseText(response: fetch.Response): Promise<string | undefined> {
+  private async _safeReadResponseTextAsync(response: fetch.Response): Promise<string | undefined> {
     try {
       return await response.text();
     } catch (err) {
@@ -361,7 +361,7 @@ export class AmazonS3Client {
   }
 
   private async _getS3ErrorAsync(response: fetch.Response): Promise<Error> {
-    const text: string | undefined = await this._safeReadResponseText(response);
+    const text: string | undefined = await this._safeReadResponseTextAsync(response);
     return new Error(
       `Amazon S3 responded with status code ${response.status} (${response.statusText})${
         text ? `\n${text}` : ''
@@ -428,7 +428,7 @@ export class AmazonS3Client {
     }
   }
 
-  private async _sendCacheRequestWithRetries<T>(
+  private async _sendCacheRequestWithRetriesAsync<T>(
     sendRequest: () => Promise<RetryableRequestResponse<T>>
   ): Promise<T> {
     const response: RetryableRequestResponse<T> = await sendRequest();
@@ -447,7 +447,7 @@ export class AmazonS3Client {
           delay = Math.min(maxRetryDelayInMs, delay);
 
           log(`Will retry request in ${delay}s...`);
-          await Async.sleep(delay);
+          await Async.sleepAsync(delay);
           const retryResponse: RetryableRequestResponse<T> = await sendRequest();
 
           if (retryResponse.hasNetworkError) {

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 import { Executable } from '@rushstack/node-core-library';
-import type { AccessToken, GetTokenOptions } from '@azure/identity';
+import type { AccessToken, GetTokenOptions, TokenCredential } from '@azure/identity';
 
 interface IDecodedJwt {
   header: {
@@ -31,7 +31,8 @@ interface IDecodedJwt {
  * tokens for AAD in Codespaces.
  * https://github.com/microsoft/ado-codespaces-auth
  */
-export class AdoCodespacesAuthCredential {
+export class AdoCodespacesAuthCredential implements TokenCredential {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async getToken(scopes: string | [string], options?: GetTokenOptions): Promise<AccessToken> {
     let scope: string;
     if (Array.isArray(scopes)) {

--- a/vscode-extensions/rush-vscode-extension/src/extension.ts
+++ b/vscode-extensions/rush-vscode-extension/src/extension.ts
@@ -15,7 +15,7 @@ import { RushCommandWebViewPanel } from './logic/RushCommandWebViewPanel';
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   context.subscriptions.push(
     vscode.commands.registerCommand('rushstack.selectWorkspace', async () => {
-      await RushWorkspace.selectWorkspace();
+      await RushWorkspace.selectWorkspaceAsync();
     })
   );
   context.subscriptions.push(

--- a/vscode-extensions/rush-vscode-extension/src/logic/RushWorkspace.ts
+++ b/vscode-extensions/rush-vscode-extension/src/logic/RushWorkspace.ts
@@ -120,7 +120,7 @@ export class RushWorkspace {
     return undefined;
   }
 
-  public static async selectWorkspace(): Promise<RushWorkspace | undefined> {
+  public static async selectWorkspaceAsync(): Promise<RushWorkspace | undefined> {
     const Uris: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
       canSelectFolders: true,
       canSelectFiles: false,

--- a/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
@@ -133,7 +133,7 @@ export class RushProjectsProvider implements vscode.TreeDataProvider<RushProject
   public async runProjectScriptAsync(element: RushProjectScript): Promise<void> {
     if (element.projectFolder) {
       const { projectFolder, projectRelativeFolder, scriptName } = element;
-      await RushTaskProvider.getInstance().executeTask({
+      await RushTaskProvider.getInstance().executeTaskAsync({
         type: 'rush-project-script',
         cwd: projectFolder,
         displayName: `${scriptName} - ${projectRelativeFolder}`,

--- a/vscode-extensions/rush-vscode-extension/src/providers/TaskProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/TaskProvider.ts
@@ -45,7 +45,7 @@ export class RushTaskProvider implements vscode.TaskProvider {
     return task;
   }
 
-  public async executeTask<T extends IRushTaskDefinition>(definition: T): Promise<void> {
+  public async executeTaskAsync<T extends IRushTaskDefinition>(definition: T): Promise<void> {
     let task: vscode.Task | undefined;
     switch (definition.type) {
       case 'rush-project-script': {

--- a/webpack/webpack4-module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/webpack4-module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -421,7 +421,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
 
         // The optimizeTree hook is the last async hook that occurs before chunk rendering
         compilation.hooks.optimizeTree.tapPromise(PLUGIN_NAME, async () => {
-          minifierConnection = await minifier.connect();
+          minifierConnection = await minifier.connectAsync();
 
           submittedModules.clear();
 
@@ -583,7 +583,7 @@ export class ModuleMinifierPlugin implements webpack.Plugin {
             }
 
             // Handle any error from the minifier.
-            await minifierConnection?.disconnect();
+            await minifierConnection?.disconnectAsync();
 
             // All assets and modules have been minified, hand them off to be rehydrated
             await this.hooks.rehydrateAssets.promise(

--- a/webpack/webpack4-module-minifier-plugin/src/ParallelCompiler.ts
+++ b/webpack/webpack4-module-minifier-plugin/src/ParallelCompiler.ts
@@ -82,7 +82,7 @@ export async function runParallel(options: IParallelWebpackOptions): Promise<voi
     maxThreads: maxCompressionThreads
   });
 
-  const minifierConnection: IMinifierConnection = await minifier.connect();
+  const minifierConnection: IMinifierConnection = await minifier.connectAsync();
 
   const webpackPool: WorkerPool = new WorkerPool({
     id: 'Webpack',
@@ -139,5 +139,5 @@ export async function runParallel(options: IParallelWebpackOptions): Promise<voi
 
   await webpackPool.finishAsync();
 
-  await minifierConnection.disconnect();
+  await minifierConnection.disconnectAsync();
 }

--- a/webpack/webpack5-module-minifier-plugin/src/ModuleMinifierPlugin.ts
+++ b/webpack/webpack5-module-minifier-plugin/src/ModuleMinifierPlugin.ts
@@ -419,7 +419,7 @@ export class ModuleMinifierPlugin implements WebpackPluginInstance {
 
       // The optimizeChunkModules hook is the last async hook that occurs before chunk rendering
       compilation.hooks.optimizeChunkModules.tapPromise(PLUGIN_NAME, async () => {
-        minifierConnection = await minifier.connect();
+        minifierConnection = await minifier.connectAsync();
 
         submittedModules.clear();
       });
@@ -533,7 +533,7 @@ export class ModuleMinifierPlugin implements WebpackPluginInstance {
         }
 
         // Handle any error from the minifier.
-        await minifierConnection?.disconnect();
+        await minifierConnection?.disconnectAsync();
 
         // All assets and modules have been minified, hand them off to be rehydrated
         await this.hooks.rehydrateAssets.promise(

--- a/webpack/webpack5-module-minifier-plugin/src/test/MockMinifier.ts
+++ b/webpack/webpack5-module-minifier-plugin/src/test/MockMinifier.ts
@@ -50,12 +50,23 @@ export class MockMinifier implements IModuleMinifier {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   public async connect(): Promise<IMinifierConnection> {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public async connectAsync(): Promise<IMinifierConnection> {
     return {
       configHash: MockMinifier.name,
 
-      disconnect: async () => {
+      disconnectAsync: async () => {
         // Do nothing.
+      },
+      disconnect: () => {
+        throw new Error('Method not implemented.');
       }
     };
   }


### PR DESCRIPTION
## Summary

Updates the names of async functions to end with `Async`.

## How it was tested

Built.

## Impacted documentation

API docs will need to be updated.