### PR TITLE
[lockfile-explorer] fix: exit with 0 for `lockfile-explorer --help`

### DIFF
--- a/apps/lockfile-explorer/src/commandLine.test.ts
+++ b/apps/lockfile-explorer/src/commandLine.test.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { parseCommandLine } from './commandLine';
+
+describe('commandLine', () => {
+  describe('parseCommandLine()', () => {
+    it('sets showHelp when --help specified', async () => {
+      const result = parseCommandLine(['--help'])
+      expect(result).toHaveProperty('showedHelp', true);
+    });
+
+    it('sets subspace when --subspace specified', async () => {
+      const result = parseCommandLine(['--subspace', 'wallet'])
+      expect(result).toHaveProperty('subspace', 'wallet');
+    });
+
+    it('sets error when --subspace value not missing', async () => {
+      const result = parseCommandLine(['--subspace'])
+      expect(result).toHaveProperty('error', 'Expecting argument after "--subspace"');
+    });
+  });
+});
+

--- a/apps/lockfile-explorer/src/start.ts
+++ b/apps/lockfile-explorer/src/start.ts
@@ -47,13 +47,12 @@ function startApp(debugMode: boolean): void {
 
   const result: ICommandLine = parseCommandLine(process.argv.slice(2));
   if (result.showedHelp) {
-    console.error('\nFor help, use:  ' + Colorize.yellow('lockfile-explorer --help'));
-    process.exitCode = 1;
     return;
   }
 
   if (result.error) {
     console.error('\n' + Colorize.red('ERROR: ' + result.error));
+    console.error('\nFor help, use:  ' + Colorize.yellow('lockfile-explorer --help'));
     process.exitCode = 1;
     return;
   }

--- a/common/changes/@rushstack/lockfile-explorer/fix-lockfile-explorer-cli_2024-05-15-07-23.json
+++ b/common/changes/@rushstack/lockfile-explorer/fix-lockfile-explorer-cli_2024-05-15-07-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/lockfile-explorer",
-      "comment": "fix: exit with 0 for lockfile-explorer --help",
+      "comment": "Update the exit code to 0 for `lockfile-explorer --help`.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/lockfile-explorer/fix-lockfile-explorer-cli_2024-05-15-07-23.json
+++ b/common/changes/@rushstack/lockfile-explorer/fix-lockfile-explorer-cli_2024-05-15-07-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "fix: exit with 0 for lockfile-explorer --help",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This is a bugfix for `lockfile-explorer --help` not exiting with 0 code.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Added a `.test.ts` for the args parser, but not covering exitCode (it's a global status belong the `start.ts` which is harder to be tested).

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

No doc to be updated as it's a bugfix.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
