### PR TITLE
[rush] Improve error reporting

### DIFF
--- a/common/changes/@microsoft/rush/fix-completed-count_2024-05-15-21-45.json
+++ b/common/changes/@microsoft/rush/fix-completed-count_2024-05-15-21-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix count of completed operations when silent operations are blocked. Add explicit message for child processes terminated by signals. Ensure that errors show up in summarized view.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-completed-count_2024-05-15-22-44.json
+++ b/common/changes/@microsoft/rush/fix-completed-count_2024-05-15-22-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Ensure that errors thrown in afterExecuteOperation show up in the summary at the end of the build.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/terminal/fix-completed-count_2024-05-15-22-44.json
+++ b/common/changes/@rushstack/terminal/fix-completed-count_2024-05-15-22-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Allow use of 'preventAutoclose' flag in StdioSummarizer.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/reviews/api/terminal.api.md
+++ b/common/reviews/api/terminal.api.md
@@ -158,7 +158,7 @@ export interface IStdioLineTransformOptions extends ITerminalTransformOptions {
 }
 
 // @beta
-export interface IStdioSummarizerOptions {
+export interface IStdioSummarizerOptions extends ITerminalWritableOptions {
     leadingLines?: number;
     trailingLines?: number;
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -93,7 +93,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
   public readonly consumers: Set<OperationExecutionRecord> = new Set();
 
   public readonly stopwatch: Stopwatch = new Stopwatch();
-  public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer();
+  public readonly stdioSummarizer: StdioSummarizer = new StdioSummarizer({
+    // Allow writing to this object after transforms have been closed. We clean it up manually in a finally block.
+    preventAutoclose: true
+  });
 
   public readonly runner: IOperationRunner;
   public readonly associatedPhase: IPhase | undefined;

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -99,10 +99,13 @@ export class ShellOperationRunner implements IOperationRunner {
 
         const status: OperationStatus = await new Promise(
           (resolve: (status: OperationStatus) => void, reject: (error: OperationError) => void) => {
-            subProcess.on('close', (code: number) => {
+            subProcess.on('close', (code: number, signal?: string) => {
               try {
-                if (code !== 0) {
-                  // Do NOT reject here immediately, give a chance for other logic to suppress the error
+                // Do NOT reject here immediately, give a chance for other logic to suppress the error
+                if (signal) {
+                  context.error = new OperationError('error', `Terminated by signal: ${signal}`);
+                  resolve(OperationStatus.Failure);
+                } else if (code !== 0) {
                   context.error = new OperationError('error', `Returned error code: ${code}`);
                   resolve(OperationStatus.Failure);
                 } else if (hasWarningOrError) {
@@ -111,6 +114,7 @@ export class ShellOperationRunner implements IOperationRunner {
                   resolve(OperationStatus.Success);
                 }
               } catch (error) {
+                context.error = error as OperationError;
                 reject(error as OperationError);
               }
             });

--- a/libraries/terminal/src/StdioSummarizer.ts
+++ b/libraries/terminal/src/StdioSummarizer.ts
@@ -2,13 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import { type ITerminalChunk, TerminalChunkKind } from './ITerminalChunk';
-import { TerminalWritable } from './TerminalWritable';
+import { type ITerminalWritableOptions, TerminalWritable } from './TerminalWritable';
 
 /**
  * Constructor options for {@link StdioSummarizer}.
  * @beta
  */
-export interface IStdioSummarizerOptions {
+export interface IStdioSummarizerOptions extends ITerminalWritableOptions {
   /**
    * Specifies the maximum number of leading lines to include in the summary.
    * @defaultValue `10`
@@ -62,7 +62,7 @@ export class StdioSummarizer extends TerminalWritable {
   private _abridgedStderr: boolean;
 
   public constructor(options?: IStdioSummarizerOptions) {
-    super();
+    super(options);
 
     if (!options) {
       options = {};


### PR DESCRIPTION
## Summary
Adds more information to Rush's error reporting in phased commands, and ensures that more error messages are included in the summary view.

## Details
- If a child operation process is killed via a signal (e.g. SIGTERM), and exits with a non-zero exit code, report the signal as well as the exit code. This comes up if, e.g., the process is killed by the OS due to lack of RAM.
- If an `afterExecuteOperation` handler throws an error, ensure that any existing error from the original process is reported to the `OperationExecutionRecord`'s `Terminal` instance and `StdioSummarizer`.
- Ensure that the final error from an `Operation` is reported to the `OperationExecutionRecord`'s Terminal instance and `StdioSummarizer`.

Unfortunately the error logging from pnpm-sync-lib still violates this contract, since it writes to the global terminal directly, but does so during `afterExecuteOperation`. See https://github.com/tiktok/pnpm-sync/issues/31 and https://github.com/tiktok/pnpm-sync/issues/32 for my suggested approach to address that case.

## How it was tested
Ran build under debugger and induced the following failure states:
- Killed a child process with SIGTERM and verified that the error message included that it failed due to being terminated with SIGTERM, and that the message appeared in the summary at the end of the build
- Threw an error during `beforeExecuteOperation` and verified that the error message appeared in the summary at the end of the build
- Threw an error during `afterExecuteOperation` and verified that the error message appeared in the summary at the end of the build

## Impacted documentation
API documentation for `StdioSummarizer`