### PR TITLE
[rush-lib] Fix an edge case for pnpm-sync where .pnpm folder is not exist but it is still a valid pnpm install

### DIFF
--- a/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-16-00-22.json
+++ b/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-16-00-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an edge case for pnpm-sync where .pnpm folder is not exist but it is still a valid pnpm install.",
+      "comment": "Fix an edge case for pnpm-sync when the .pnpm folder is absent but still a valid installation.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-16-00-22.json
+++ b/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-16-00-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an edge case for pnpm-sync where .pnpm folder is not exist but it is still a valid pnpm install.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -522,44 +522,50 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm' && experiments?.usePnpmSyncForInjectedDependencies) {
       const pnpmLockfilePath: string = subspace.getTempShrinkwrapFilename();
       const dotPnpmFolder: string = `${subspace.getSubspaceTempFolder()}/node_modules/.pnpm`;
-      await pnpmSyncPrepareAsync({
-        lockfilePath: pnpmLockfilePath,
-        dotPnpmFolder,
-        ensureFolderAsync: FileSystem.ensureFolderAsync,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        readPnpmLockfile: async (lockfilePath: string) => {
-          const wantedPnpmLockfile: PnpmShrinkwrapFile | undefined = await PnpmShrinkwrapFile.loadFromFile(
-            lockfilePath,
-            { withCaching: true }
-          );
 
-          if (!wantedPnpmLockfile) {
-            return undefined;
-          } else {
-            const lockfilePackages: Record<string, ILockfilePackage> = Object.create(null);
-            for (const versionPath of wantedPnpmLockfile.packages.keys()) {
-              lockfilePackages[versionPath] = {
-                dependencies: wantedPnpmLockfile.packages.get(versionPath)?.dependencies as Record<
-                  string,
-                  string
-                >,
-                optionalDependencies: wantedPnpmLockfile.packages.get(versionPath)
-                  ?.optionalDependencies as Record<string, string>
+      // we have an edge case here
+      // if a package.json has no dependencies, pnpm will still generate the pnpm-lock.yaml but not .pnpm folder
+      // so we need to make sure pnpm-lock.yaml and .pnpm exists before call pnpmSync APIs
+      if ((await FileSystem.existsAsync(pnpmLockfilePath)) && (await FileSystem.existsAsync(dotPnpmFolder))) {
+        await pnpmSyncPrepareAsync({
+          lockfilePath: pnpmLockfilePath,
+          dotPnpmFolder,
+          ensureFolderAsync: FileSystem.ensureFolderAsync,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          readPnpmLockfile: async (lockfilePath: string) => {
+            const wantedPnpmLockfile: PnpmShrinkwrapFile | undefined = await PnpmShrinkwrapFile.loadFromFile(
+              lockfilePath,
+              { withCaching: true }
+            );
+
+            if (!wantedPnpmLockfile) {
+              return undefined;
+            } else {
+              const lockfilePackages: Record<string, ILockfilePackage> = Object.create(null);
+              for (const versionPath of wantedPnpmLockfile.packages.keys()) {
+                lockfilePackages[versionPath] = {
+                  dependencies: wantedPnpmLockfile.packages.get(versionPath)?.dependencies as Record<
+                    string,
+                    string
+                  >,
+                  optionalDependencies: wantedPnpmLockfile.packages.get(versionPath)
+                    ?.optionalDependencies as Record<string, string>
+                };
+              }
+
+              const result: ILockfile = {
+                lockfileVersion: wantedPnpmLockfile.shrinkwrapFileMajorVersion,
+                importers: Object.fromEntries(wantedPnpmLockfile.importers.entries()),
+                packages: lockfilePackages
               };
+
+              return result;
             }
-
-            const result: ILockfile = {
-              lockfileVersion: wantedPnpmLockfile.shrinkwrapFileMajorVersion,
-              importers: Object.fromEntries(wantedPnpmLockfile.importers.entries()),
-              packages: lockfilePackages
-            };
-
-            return result;
-          }
-        },
-        logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-          PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
-      });
+          },
+          logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
+            PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
+        });
+      }
     }
 
     // If all attempts fail we just terminate. No special handling needed.

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -525,7 +525,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
 
       // we have an edge case here
       // if a package.json has no dependencies, pnpm will still generate the pnpm-lock.yaml but not .pnpm folder
-      // so we need to make sure pnpm-lock.yaml and .pnpm exists before call pnpmSync APIs
+      // so we need to make sure pnpm-lock.yaml and .pnpm exists before calling the pnpmSync APIs
       if ((await FileSystem.existsAsync(pnpmLockfilePath)) && (await FileSystem.existsAsync(dotPnpmFolder))) {
         await pnpmSyncPrepareAsync({
           lockfilePath: pnpmLockfilePath,


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
When there is no any dependencies in a `package.json`, the `pnpm install` will only generate the `pnpm-lock.yaml`, but not `.pnpm` folder. 
Add existence check for `pnpm-lock.yaml` file and `.pnpm` folder before calling pnpm-sync APIs

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Tested with Rushstack repos manually. 
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation
N/A

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
