### PR TITLE
Fix more instances of the child_process.on('exit') race condition

### DIFF
--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -344,6 +344,8 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
 
       childProcess.on('exit', (code: number | null, signal: string | null) => {
         try {
+          // Under normal conditions we don't reject the promise here, because 'data' events can continue
+          // to fire as data is flushed, before finally concluding with the 'close' event.
           this._logger.terminal.writeVerboseLine(
             `The service process fired its "exit" event` + this._formatCodeOrSignal(code, signal)
           );

--- a/apps/heft/src/plugins/NodeServicePlugin.ts
+++ b/apps/heft/src/plugins/NodeServicePlugin.ts
@@ -313,7 +313,7 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
         this._logger.terminal.writeError(data.toString());
       });
 
-      childProcess.on('close', (code: number, signal: string): void => {
+      childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null): void => {
         try {
           // The 'close' event is emitted after a process has ended and the stdio streams of a child process
           // have been closed. This is distinct from the 'exit' event, since multiple processes might share the
@@ -323,7 +323,7 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
           if (this._state === State.Running) {
             this._logger.terminal.writeWarningLine(
               `The service process #${childPid} terminated unexpectedly` +
-                this._formatCodeOrSignal(code, signal)
+                this._formatCodeOrSignal(exitCode, signal)
             );
             this._transitionToStopped();
             return;
@@ -332,7 +332,7 @@ export default class NodeServicePlugin implements IHeftTaskPlugin {
           if (this._state === State.Stopping || this._state === State.Killing) {
             this._logger.terminal.writeVerboseLine(
               `The service process #${childPid} terminated successfully` +
-                this._formatCodeOrSignal(code, signal)
+                this._formatCodeOrSignal(exitCode, signal)
             );
             this._transitionToStopped();
             return;

--- a/apps/heft/src/utilities/GitUtilities.ts
+++ b/apps/heft/src/utilities/GitUtilities.ts
@@ -347,11 +347,13 @@ export class GitUtilities {
       childProcess.stderr!.on('data', (chunk: Buffer) => {
         errorMessage += chunk.toString();
       });
-      childProcess.on('close', (exitCode: number) => {
-        if (exitCode !== 0) {
+      childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        if (exitCode) {
           reject(
             new Error(`git exited with error code ${exitCode}${errorMessage ? `: ${errorMessage}` : ''}`)
           );
+        } else if (signal) {
+          reject(new Error(`git terminated by signal ${signal}`));
         }
         let remainder: string = '';
         for (let chunk of stdoutBuffer) {

--- a/apps/rundown/src/Rundown.ts
+++ b/apps/rundown/src/Rundown.ts
@@ -132,9 +132,9 @@ export class Rundown {
     });
 
     await new Promise<void>((resolve, reject) => {
-      childProcess.on('close', (code: number | null, signal: string | null): void => {
-        if (code !== 0 && !ignoreExitCode) {
-          reject(new Error('Child process terminated with exit code ' + code));
+      childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null): void => {
+        if (exitCode !== 0 && !ignoreExitCode) {
+          reject(new Error('Child process terminated with exit code ' + exitCode));
         } else if (!completedNormally) {
           reject(new Error('Child process terminated without completing IPC handshake'));
         } else {

--- a/apps/rundown/src/Rundown.ts
+++ b/apps/rundown/src/Rundown.ts
@@ -132,7 +132,7 @@ export class Rundown {
     });
 
     await new Promise<void>((resolve, reject) => {
-      childProcess.on('exit', (code: number | null, signal: string | null): void => {
+      childProcess.on('close', (code: number | null, signal: string | null): void => {
         if (code !== 0 && !ignoreExitCode) {
           reject(new Error('Child process terminated with exit code ' + code));
         } else if (!completedNormally) {

--- a/apps/rundown/src/Rundown.ts
+++ b/apps/rundown/src/Rundown.ts
@@ -133,7 +133,9 @@ export class Rundown {
 
     await new Promise<void>((resolve, reject) => {
       childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null): void => {
-        if (exitCode !== 0 && !ignoreExitCode) {
+        if (signal) {
+          reject(new Error('Child process terminated by ' + signal));
+        } else if (exitCode !== 0 && !ignoreExitCode) {
           reject(new Error('Child process terminated with exit code ' + exitCode));
         } else if (!completedNormally) {
           reject(new Error('Child process terminated without completing IPC handshake'));

--- a/apps/rundown/src/launcher.ts
+++ b/apps/rundown/src/launcher.ts
@@ -106,8 +106,6 @@ class Launcher {
     moduleApi.Module.prototype.require = hookedRequire as NodeJS.Require;
     Launcher._copyProperties(hookedRequire, realRequire);
 
-    // Generally 'close' is a better event to handle for child_process cleanup, however in this case
-    // we want to send the IPC response as early as possible.
     process.on('exit', () => {
       this._sendIpcTraceBatch();
       process.send!({

--- a/apps/rundown/src/launcher.ts
+++ b/apps/rundown/src/launcher.ts
@@ -106,7 +106,9 @@ class Launcher {
     moduleApi.Module.prototype.require = hookedRequire as NodeJS.Require;
     Launcher._copyProperties(hookedRequire, realRequire);
 
-    process.on('close', () => {
+    // Generally 'close' is a better event to handle for child_process cleanup, however in this case
+    // we want to send the IPC response as early as possible.
+    process.on('exit', () => {
       this._sendIpcTraceBatch();
       process.send!({
         id: 'done'

--- a/apps/rundown/src/launcher.ts
+++ b/apps/rundown/src/launcher.ts
@@ -50,13 +50,6 @@ class Launcher {
     }
   }
 
-  /**
-   * Synchronously delay for the specified time interval.
-   */
-  private static _delayMs(milliseconds: number): void {
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
-  }
-
   public installHook(): void {
     const realRequire: NodeJS.Require = moduleApi.Module.prototype.require;
 
@@ -113,17 +106,11 @@ class Launcher {
     moduleApi.Module.prototype.require = hookedRequire as NodeJS.Require;
     Launcher._copyProperties(hookedRequire, realRequire);
 
-    process.on('exit', () => {
+    process.on('close', () => {
       this._sendIpcTraceBatch();
       process.send!({
         id: 'done'
       } as IIpcDone);
-
-      // The Node.js "exit" event is synchronous, and the process will terminate as soon as this function returns.
-      // To avoid a race condition, allow some time for IPC messages to be transmitted to the parent process.
-      // TODO: There should be a way to eliminate this delay by intercepting earlier in the shutdown sequence,
-      // but it needs to consider every way that Node.js can exit.
-      Launcher._delayMs(500);
     });
   }
 }

--- a/common/changes/@microsoft/rush/octogonz-node-exit_2024-05-17-19-20.json
+++ b/common/changes/@microsoft/rush/octogonz-node-exit_2024-05-17-19-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the build cache analysis was incorrect in rare situations due to a race condition (GitHub #4711)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/debug-certificate-manager/octogonz-node-exit_2024-05-22-00-36.json
+++ b/common/changes/@rushstack/debug-certificate-manager/octogonz-node-exit_2024-05-22-00-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix an issue where the task could report success if the subprocess was terminated by a signal",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/octogonz-node-exit_2024-05-17-19-17.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/octogonz-node-exit_2024-05-17-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Fix an edge case where the Storybook STDOUT might not be flushed completely when an error occurs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/common/changes/@rushstack/heft/octogonz-node-exit_2024-05-17-19-17.json
+++ b/common/changes/@rushstack/heft/octogonz-node-exit_2024-05-17-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/octogonz-node-exit_2024-05-17-19-17.json
+++ b/common/changes/@rushstack/node-core-library/octogonz-node-exit_2024-05-17-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix an issue where waitForExitAsync() might reject before all output was collected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/package-deps-hash/octogonz-node-exit_2024-05-17-19-17.json
+++ b/common/changes/@rushstack/package-deps-hash/octogonz-node-exit_2024-05-17-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Add a newline to an error message",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/changes/@rushstack/rundown/octogonz-node-exit_2024-05-17-19-17.json
+++ b/common/changes/@rushstack/rundown/octogonz-node-exit_2024-05-17-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "Eliminate an arbitrary 500ms delay during process shutdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rundown"
+}

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -461,7 +461,7 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
         reject(new Error(`Storybook returned error: ${error}`));
       });
 
-      forkedProcess.on('exit', (code: number | null) => {
+      forkedProcess.on('close', (code: number | null) => {
         if (processFinished) {
           return;
         }

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -461,13 +461,15 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
         reject(new Error(`Storybook returned error: ${error}`));
       });
 
-      forkedProcess.on('close', (code: number | null) => {
+      forkedProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
         if (processFinished) {
           return;
         }
         processFinished = true;
-        if (code !== 0) {
-          reject(new Error(`Storybook exited with code ${code}`));
+        if (exitCode) {
+          reject(new Error(`Storybook exited with code ${exitCode}`));
+        } else if (signal) {
+          reject(new Error(`Storybook terminated by signal ${signal}`));
         } else {
           resolve();
         }

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -273,7 +273,7 @@ export class CertificateManager {
           CA_SERIAL_NUMBER
         ]);
 
-        if (winUntrustResult.code !== 0) {
+        if (winUntrustResult.exitCode !== 0) {
           terminal.writeErrorLine(`Error: ${winUntrustResult.stderr.join(' ')}`);
           return false;
         } else {
@@ -292,7 +292,7 @@ export class CertificateManager {
           '-Z',
           MAC_KEYCHAIN
         ]);
-        if (macFindCertificateResult.code !== 0) {
+        if (macFindCertificateResult.exitCode !== 0) {
           terminal.writeErrorLine(
             `Error finding the development certificate: ${macFindCertificateResult.stderr.join(' ')}`
           );
@@ -317,7 +317,7 @@ export class CertificateManager {
           MAC_KEYCHAIN
         ]);
 
-        if (macUntrustResult.code === 0) {
+        if (macUntrustResult.exitCode === 0) {
           terminal.writeVerboseLine('Successfully untrusted development certificate.');
           return true;
         } else {
@@ -530,7 +530,7 @@ export class CertificateManager {
           certificatePath
         ]);
 
-        if (winTrustResult.code !== 0) {
+        if (winTrustResult.exitCode !== 0) {
           terminal.writeErrorLine(`Error: ${winTrustResult.stdout.toString()}`);
 
           const errorLines: string[] = winTrustResult.stdout
@@ -540,7 +540,7 @@ export class CertificateManager {
 
           // Not sure if this is always the status code for "cancelled" - should confirm.
           if (
-            winTrustResult.code === 2147943623 ||
+            winTrustResult.exitCode === 2147943623 ||
             errorLines[errorLines.length - 1].indexOf('The operation was canceled by the user.') > 0
           ) {
             terminal.writeLine('Certificate trust cancelled.');
@@ -573,7 +573,7 @@ export class CertificateManager {
           certificatePath
         ]);
 
-        if (result.code === 0) {
+        if (result.exitCode === 0) {
           terminal.writeVerboseLine('Successfully trusted development certificate.');
           return true;
         } else {
@@ -586,7 +586,7 @@ export class CertificateManager {
             return false;
           } else {
             terminal.writeErrorLine(
-              `Certificate trust failed with an unknown error. Exit code: ${result.code}. ` +
+              `Certificate trust failed with an unknown error. Exit code: ${result.exitCode}. ` +
                 `Error: ${result.stderr.join(' ')}`
             );
             return false;
@@ -614,7 +614,7 @@ export class CertificateManager {
           CA_SERIAL_NUMBER
         ]);
 
-        if (winVerifyStoreResult.code !== 0) {
+        if (winVerifyStoreResult.exitCode !== 0) {
           terminal.writeVerboseLine(
             'The development certificate was not found in the store. CertUtil error: ',
             winVerifyStoreResult.stderr.join(' ')
@@ -640,7 +640,7 @@ export class CertificateManager {
           MAC_KEYCHAIN
         ]);
 
-        if (macFindCertificateResult.code !== 0) {
+        if (macFindCertificateResult.exitCode !== 0) {
           terminal.writeVerboseLine(
             'The development certificate was not found in keychain. Find certificate error: ',
             macFindCertificateResult.stderr.join(' ')
@@ -700,7 +700,7 @@ export class CertificateManager {
         friendlyNamePath
       ]);
 
-      if (repairStoreResult.code !== 0) {
+      if (repairStoreResult.exitCode !== 0) {
         terminal.writeVerboseLine(`CertUtil Error: ${repairStoreResult.stderr.join('')}`);
         terminal.writeVerboseLine(`CertUtil: ${repairStoreResult.stdout.join('')}`);
         return false;

--- a/libraries/debug-certificate-manager/src/runCommand.ts
+++ b/libraries/debug-certificate-manager/src/runCommand.ts
@@ -7,7 +7,10 @@ import type * as child_process from 'child_process';
 export interface IRunResult {
   stdout: string[];
   stderr: string[];
-  code: number;
+  /**
+   * The exit code, or -1 if the child process was terminated by a signal
+   */
+  exitCode: number;
 }
 
 export interface ISudoOptions {
@@ -42,8 +45,9 @@ async function _handleChildProcess(childProcess: child_process.ChildProcess): Pr
       stdout.push(data.toString());
     });
 
-    childProcess.on('close', (code: number) => {
-      resolve({ code, stdout, stderr });
+    childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
+      const normalizedExitCode: number = typeof exitCode === 'number' ? exitCode : signal ? -1 : 0;
+      resolve({ exitCode: normalizedExitCode, stdout, stderr });
     });
   });
 }

--- a/libraries/node-core-library/src/Executable.ts
+++ b/libraries/node-core-library/src/Executable.ts
@@ -586,10 +586,10 @@ export class Executable {
           if (errorThrown) {
             reject(errorThrown);
           }
-          if (exitCode !== 0 && throwOnNonZeroExitCode) {
-            reject(new Error(`Process exited with code ${exitCode}`));
-          } else if (signal) {
+          if (signal) {
             reject(new Error(`Process terminated by ${signal}`));
+          } else if (exitCode !== 0 && throwOnNonZeroExitCode) {
+            reject(new Error(`Process exited with code ${exitCode}`));
           } else {
             resolve(exitCode);
           }

--- a/libraries/node-core-library/src/SubprocessTerminator.ts
+++ b/libraries/node-core-library/src/SubprocessTerminator.ts
@@ -88,7 +88,7 @@ export class SubprocessTerminator {
       return;
     }
 
-    subprocess.on('close', (code: number, signal: string): void => {
+    subprocess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null): void => {
       if (SubprocessTerminator._subprocessesByPid.delete(pid)) {
         SubprocessTerminator._logDebug(`untracking #${pid}`);
       }

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -292,7 +292,7 @@ async function spawnGitAsync(
 
   const [status] = await once(proc, 'close');
   if (status !== 0) {
-    throw new Error(`git ${args[0]} exited with code ${status}: ${stderr}`);
+    throw new Error(`git ${args[0]} exited with code ${status}:\n${stderr}`);
   }
 
   return stdout;

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -421,8 +421,13 @@ export class RushPnpmCommandLineParser {
           keepEnvironment: true
         },
         onStdoutStreamChunk,
-        (exitCode: number, signal: string) => {
-          process.exitCode = exitCode;
+        (exitCode: number | null, signal: NodeJS.Signals | null) => {
+          if (typeof exitCode === 'number') {
+            process.exitCode = exitCode;
+          } else {
+            // Terminated by a signal
+            process.exitCode = 1;
+          }
         }
       );
     } catch (e) {

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -145,12 +145,12 @@ export class IPCOperationRunner implements IOperationRunner {
 
           function onExit(exitCode: number | null, signal: NodeJS.Signals | null): void {
             try {
-              if (exitCode !== 0) {
+              if (signal) {
+                context.error = new OperationError('error', `Terminated by signal: ${signal}`);
+                resolve(OperationStatus.Failure);
+              } else if (exitCode !== 0) {
                 // Do NOT reject here immediately, give a chance for other logic to suppress the error
                 context.error = new OperationError('error', `Returned error code: ${exitCode}`);
-                resolve(OperationStatus.Failure);
-              } else if (signal) {
-                context.error = new OperationError('error', `Terminated by signal: ${signal}`);
                 resolve(OperationStatus.Failure);
               } else if (hasWarningOrError) {
                 resolve(OperationStatus.SuccessWithWarning);

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -143,11 +143,14 @@ export class IPCOperationRunner implements IOperationRunner {
             }
           }
 
-          function onExit(code: number): void {
+          function onExit(exitCode: number | null, signal: NodeJS.Signals | null): void {
             try {
-              if (code !== 0) {
+              if (exitCode !== 0) {
                 // Do NOT reject here immediately, give a chance for other logic to suppress the error
-                context.error = new OperationError('error', `Returned error code: ${code}`);
+                context.error = new OperationError('error', `Returned error code: ${exitCode}`);
+                resolve(OperationStatus.Failure);
+              } else if (signal) {
+                context.error = new OperationError('error', `Terminated by signal: ${signal}`);
                 resolve(OperationStatus.Failure);
               } else if (hasWarningOrError) {
                 resolve(OperationStatus.SuccessWithWarning);

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -99,14 +99,14 @@ export class ShellOperationRunner implements IOperationRunner {
 
         const status: OperationStatus = await new Promise(
           (resolve: (status: OperationStatus) => void, reject: (error: OperationError) => void) => {
-            subProcess.on('close', (code: number, signal?: string) => {
+            subProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
               try {
                 // Do NOT reject here immediately, give a chance for other logic to suppress the error
                 if (signal) {
                   context.error = new OperationError('error', `Terminated by signal: ${signal}`);
                   resolve(OperationStatus.Failure);
-                } else if (code !== 0) {
-                  context.error = new OperationError('error', `Returned error code: ${code}`);
+                } else if (exitCode !== 0) {
+                  context.error = new OperationError('error', `Returned error code: ${exitCode}`);
                   resolve(OperationStatus.Failure);
                 } else if (hasWarningOrError) {
                   resolve(OperationStatus.SuccessWithWarning);

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -81,7 +81,9 @@ export class BumpCyclicsAction extends CommandLineAction {
 
   private async _getLatestPublishedVersionAsync(terminal: Terminal, packageName: string): Promise<string> {
     return await new Promise((resolve: (result: string) => void, reject: (error: Error) => void) => {
-      const childProcess: ChildProcess = Executable.spawn('npm', ['view', packageName, 'version']);
+      const childProcess: ChildProcess = Executable.spawn('npm', ['view', packageName, 'version'], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
       const stdoutBuffer: string[] = [];
       childProcess.stdout!.on('data', (chunk) => stdoutBuffer.push(chunk));
       childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -84,7 +84,7 @@ export class BumpCyclicsAction extends CommandLineAction {
       const childProcess: ChildProcess = Executable.spawn('npm', ['view', packageName, 'version']);
       const stdoutBuffer: string[] = [];
       childProcess.stdout!.on('data', (chunk) => stdoutBuffer.push(chunk));
-      childProcess.on('exit', (code: number) => {
+      childProcess.on('close', (code: number) => {
         if (code) {
           reject(new Error(`Exited with ${code}`));
         } else {

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -84,9 +84,11 @@ export class BumpCyclicsAction extends CommandLineAction {
       const childProcess: ChildProcess = Executable.spawn('npm', ['view', packageName, 'version']);
       const stdoutBuffer: string[] = [];
       childProcess.stdout!.on('data', (chunk) => stdoutBuffer.push(chunk));
-      childProcess.on('close', (code: number) => {
-        if (code) {
-          reject(new Error(`Exited with ${code}`));
+      childProcess.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        if (exitCode) {
+          reject(new Error(`Exited with ${exitCode}`));
+        } else if (signal) {
+          reject(new Error(`Terminated by ${signal}`));
         } else {
           const version: string = stdoutBuffer.join('').trim();
           terminal.writeLine(`Found version "${version}" for "${packageName}"`);


### PR DESCRIPTION

## Summary

Following up from PR https://github.com/microsoft/rushstack/pull/4711, I audited the Rush Stack code base to look for any other invocations that might be affected by the same issue.

That PR did not trigger publishing of Rush, so I've also included a `rush change` file to publish a Rush release.

## Details

In this [lengthy Zulip chat](https://rushstack.zulipchat.com/#narrow/stream/262513-general/topic/.E2.9C.94.20.5Brush.5D.20.22git.20status.22.20malfunctions.20when.20using.20WSL/near/438313904) we investigated a Rush build cache failure on Windows Subsystem for Linux (WSL) that turned out to be a race condition in the way that `child_process.on('exit')` was handled.

### Background info
The sequence of events is like this:

- `child_process.on('data')` is being used to collect STDERR and STDOUT
- `child_process.on('exit')` fires indicating that the process has terminated
- `child_process.on('data')` continues to fire a few more times as STDERR/STDOUT finish flushing 👈👈👈
- `child_process.on('close')` finally fires indicating that the flush is complete, and includes the same exit code information that was available in `'exit'`

Note that `child_process.on('error')` can also fire, either up front to indicate spawning failed entirely (in which case there is no `exit` event at all), or after some `data` has been received to indicate other kinds of errors.

Therefore, `child_process.on('exit')` is redundant and does NOT normally need to be handled at all; its main value is if the parent wants to be notified as early as possible.

### The bug

The race condition bug occurs when functions are handling  `data` to collect output, but handle `exit` by rejecting immediately.  In this case, their STDERR/STDOUT can get truncated if the flushing is not complete.

This race condition is somewhat rare. In the case of https://github.com/microsoft/rushstack/pull/4711, the affected code had existed for years and years without any issues being reported.  But on Windows Subsystem for Linux, @akres encountered a situation where it caused a noticeable malfunction and was reproducible.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I did not try to reproduce the race condition in the modified code. However I did confirm that removing the 500ms delay does not break Rundown.

