### PR TITLE
[rush-lib] Refactor alwaysInjectDependenciesFromOtherSubspaces logic

### DIFF
--- a/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-18-05-52.json
+++ b/common/changes/@microsoft/rush/chao-fix-edge-case_2024-05-18-05-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Refactor the alwaysInjectDependenciesFromOtherSubspaces logic.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -983,6 +983,8 @@ export class PackageJsonEditor {
     protected constructor(filepath: string, data: IPackageJson);
     // (undocumented)
     addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;
+    // (undocumented)
+    addOrUpdateDependencyMeta(packageName: string, injected: boolean): void;
     get dependencyList(): ReadonlyArray<PackageJsonDependency>;
     get dependencyMetaList(): ReadonlyArray<PackageJsonDependencyMeta>;
     get devDependencyList(): ReadonlyArray<PackageJsonDependency>;

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -284,6 +284,14 @@ export class PackageJsonEditor {
     this._modified = true;
   }
 
+  public addOrUpdateDependencyMeta(packageName: string, injected: boolean): void {
+    this._dependenciesMeta.set(
+      packageName,
+      new PackageJsonDependencyMeta(packageName, injected, this._onChange.bind(this))
+    );
+    this._modified = true;
+  }
+
   public removeDependency(packageName: string, dependencyType: DependencyType): void {
     switch (dependencyType) {
       case DependencyType.Regular:
@@ -344,6 +352,7 @@ export class PackageJsonEditor {
     delete normalizedData.peerDependencies;
     delete normalizedData.devDependencies;
     delete normalizedData.resolutions;
+    delete normalizedData.dependenciesMeta;
 
     const keys: string[] = [...this._dependencies.keys()].sort();
 
@@ -385,6 +394,15 @@ export class PackageJsonEditor {
         normalizedData.devDependencies = {};
       }
       normalizedData.devDependencies[dependency.name] = dependency.version;
+    }
+
+    if (this._dependenciesMeta.size > 0) {
+      normalizedData.dependenciesMeta = {};
+      for (const [dependency, dependenciesMeta] of this._dependenciesMeta.entries()) {
+        normalizedData.dependenciesMeta[dependency] = {
+          injected: dependenciesMeta.injected
+        };
+      }
     }
 
     // (Do not sort this._resolutions because order may be significant; the RFC is unclear about that.)

--- a/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
@@ -11,7 +11,6 @@ import type { RushConfigurationProject } from '../../api/RushConfigurationProjec
 import type { PnpmPackageManager } from '../../api/packageManager/PnpmPackageManager';
 import { RushConstants } from '../RushConstants';
 import type { Subspace } from '../../api/Subspace';
-import type { PnpmOptionsConfiguration } from './PnpmOptionsConfiguration';
 
 /**
  * Loads PNPM's pnpmfile.js configuration, and invokes it to preprocess package.json files,
@@ -116,13 +115,11 @@ export class SubspacePnpmfileConfiguration {
     const processTransitiveInjectedInstallQueue: Array<RushConfigurationProject> = [];
 
     for (const subspaceProject of subspaceProjectsMap.values()) {
-      const injectedDependencySet: Set<string> = new Set();
       const dependenciesMeta: IDependenciesMetaTable | undefined =
         subspaceProject.packageJson.dependenciesMeta;
       if (dependenciesMeta) {
         for (const [dependencyName, { injected }] of Object.entries(dependenciesMeta)) {
           if (injected) {
-            injectedDependencySet.add(dependencyName);
             projectNameToInjectedDependenciesMap.get(subspaceProject.packageName)?.add(dependencyName);
 
             //if this dependency is in the same subspace, leave as it is, PNPM will handle it
@@ -131,24 +128,6 @@ export class SubspacePnpmfileConfiguration {
             if (!subspaceProjectsMap.has(dependencyName)) {
               processTransitiveInjectedInstallQueue.push(workspaceProjectsMap.get(dependencyName)!);
             }
-          }
-        }
-      }
-
-      // if alwaysInjectDependenciesFromOtherSubspaces policy is true in pnpm-config.json
-      // and the dependency is not injected yet
-      // and the dependency is in another subspace
-      // then, make this dependency as injected dependency
-      const pnpmOptions: PnpmOptionsConfiguration | undefined =
-        subspace.getPnpmOptions() || rushConfiguration.pnpmOptions;
-      if (pnpmOptions && pnpmOptions.alwaysInjectDependenciesFromOtherSubspaces) {
-        const dependencyProjects: ReadonlySet<RushConfigurationProject> = subspaceProject.dependencyProjects;
-        for (const dependencyProject of dependencyProjects) {
-          const dependencyName: string = dependencyProject.packageName;
-          if (!injectedDependencySet.has(dependencyName) && !subspaceProjectsMap.has(dependencyName)) {
-            projectNameToInjectedDependenciesMap.get(subspaceProject.packageName)?.add(dependencyName);
-            // process transitive injected installation
-            processTransitiveInjectedInstallQueue.push(workspaceProjectsMap.get(dependencyName)!);
           }
         }
       }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

We check the injected settings in the package.json to tell if a dependency is injected or not. 
However, in the current alwaysInjectDependenciesFromOtherSubspaces implementation, user no need to set injected settings in package.json for these cross subspace dependencies. This leads to inconvenience to check if a dependency is injected or not. 

The alternative we check the version representation in pnpm-lock.yaml to see if it is started with `file:`, if yes, then it is a injected dependency. But, this method also has drawback, not all dependencies started with `file:` is the injected dependency, for example , we can't treat this `file:./tarball/colors-1.4.0.tgz` as a injected dependency. 

So, we need to refactor the alwaysInjectDependenciesFromOtherSubspaces logic. Now, if user enable this logic, we write `injected:true` in the `package.json`

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
