### PR TITLE
[heft-sass-plugin] Upgrade sass-embedded and fix indirect dependency resolution in import and use rules.

### DIFF
--- a/common/changes/@rushstack/heft-sass-plugin/main_2024-05-20-08-33.json
+++ b/common/changes/@rushstack/heft-sass-plugin/main_2024-05-20-08-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Bump `sass-embedded` to 1.77.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/main_2024-05-20-08-35.json
+++ b/common/changes/@rushstack/heft-sass-plugin/main_2024-05-20-08-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Fix an issue where `@import` and `@use` rules that referenced dependency packages that are not direct dependencies of the project being built were not correctly resolved.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2771,8 +2771,8 @@ importers:
         specifier: ~6.0.0
         version: 6.0.0(postcss@8.4.36)
       sass-embedded:
-        specifier: ~1.62.0
-        version: 1.62.0
+        specifier: ~1.77.2
+        version: 1.77.2
     devDependencies:
       '@microsoft/api-extractor':
         specifier: workspace:*
@@ -24433,26 +24433,98 @@ packages:
       walker: 1.0.8
     dev: true
 
-  /sass-embedded-darwin-arm64@1.62.0:
-    resolution: {integrity: sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==}
+  /sass-embedded-android-arm64@1.77.2:
+    resolution: {integrity: sha512-7DiFMros5iRYrkPlNqUBfzZ/DCgsI199pRF8xuBsPf9yuB8SLDOqvNk3QOnUCMAbpjW5VW1JgdfGFFlHTCnJQA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [android]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-android-arm@1.77.2:
+    resolution: {integrity: sha512-rMuIMZ/FstMrT9Y23LDgQGpCyfe3i10dJnmW+DVJ9Gqz4dR7qpysEBIQXU35mHVq8ppNZ0yGiFlFZTSiiVMdzQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [android]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-android-ia32@1.77.2:
+    resolution: {integrity: sha512-qN0laKrAjuvBLFdUogGz8jQlbHs6tgH91tKQeE7ZE4AO9zzDRlXtaEJP1x6B6AGVc8UOEkvQyR3Nej4qwWprhA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [android]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-android-x64@1.77.2:
+    resolution: {integrity: sha512-HByqtC5g5hOaJenWs4Klx6gFEIZYx+IEFh5K56U+wB+jd6EU32Lrnbdxy1+i/p/kZrd+23HrVHQPv8zpmxucaw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [android]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-darwin-arm64@1.77.2:
+    resolution: {integrity: sha512-0jkL/FwbAStqqxFSjHfhElEAWrKRRvFz2JeXOxskUdzMehDMv5LaewqSRCijyeKBO3KgurvndmSfrOizdU6WAw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
+    hasBin: true
     requiresBuild: true
     dev: false
     optional: true
 
-  /sass-embedded-darwin-x64@1.62.0:
-    resolution: {integrity: sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==}
+  /sass-embedded-darwin-x64@1.77.2:
+    resolution: {integrity: sha512-8Sy36IxOOFPWA5TdhC87SvOkrXUSis51CGKlIsM8yZISQiY9y8b+wrNJM1f3oHvs641xZBaeIuwibJXaY6hNBg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [darwin]
+    hasBin: true
     requiresBuild: true
     dev: false
     optional: true
 
-  /sass-embedded-linux-arm64@1.62.0:
-    resolution: {integrity: sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==}
+  /sass-embedded-linux-arm64@1.77.2:
+    resolution: {integrity: sha512-hlfNFu1IWHI0cOsbpFWPrJlx7IFZfXuI3iEhwa4oljM21y72E6tETUFmTr4f9Ka9qDLXkUxUoYaTH2SqGU9dDA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-linux-arm@1.77.2:
+    resolution: {integrity: sha512-/gtCseBkGCBw61p6MG2BqeYy8rblffw2KXUzMKjo9Hlqj/KajWDk7j1B+mVnqrHOPB/KBbm8Ym/2ooCYpnMIkQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-linux-ia32@1.77.2:
+    resolution: {integrity: sha512-JSIqGIeAKlrMw/oMFFFxZ10F3QUJVdjeGVI83h6mwNHTYgrX6PuOngcAYleIpYR5XicQgfueC5pPVPbP5CArBQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [linux]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-linux-musl-arm64@1.77.2:
+    resolution: {integrity: sha512-JQZuONuhIurKjc/qE9cTiJXSLixL8hGkalWN3LJHasYHVAU92QA/t8rv0T51vIzf/I2F59He3bapkPme60dwSw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -24460,8 +24532,8 @@ packages:
     dev: false
     optional: true
 
-  /sass-embedded-linux-arm@1.62.0:
-    resolution: {integrity: sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==}
+  /sass-embedded-linux-musl-arm@1.77.2:
+    resolution: {integrity: sha512-LZTSnfHPlfvkdQ8orpnEUCEx40qhKpMjxN3Ggi8kgQqv5jvtqn0ECdWl0n4WI5CrlkmtdS3VeFcsf078bt/f8Q==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
@@ -24469,8 +24541,8 @@ packages:
     dev: false
     optional: true
 
-  /sass-embedded-linux-ia32@1.62.0:
-    resolution: {integrity: sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==}
+  /sass-embedded-linux-musl-ia32@1.77.2:
+    resolution: {integrity: sha512-6F1GHBgPkcTXtfM0MK3PofozagNF8IawdfIG4RNzGeSZRhGBRgZLOS+vdre4xubTLSaa6xjbI47YfaD43z8URQ==}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [linux]
@@ -24478,8 +24550,8 @@ packages:
     dev: false
     optional: true
 
-  /sass-embedded-linux-x64@1.62.0:
-    resolution: {integrity: sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==}
+  /sass-embedded-linux-musl-x64@1.77.2:
+    resolution: {integrity: sha512-8BiqLA1NJeN3rCaX6t747GWMMdH5YUFYuytXU8waDC/u+FSGoOHRxfrsB8BEWHVgSPDxhwZklanPCXXzbzB2lw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
@@ -24487,42 +24559,74 @@ packages:
     dev: false
     optional: true
 
-  /sass-embedded-win32-ia32@1.62.0:
-    resolution: {integrity: sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==}
+  /sass-embedded-linux-x64@1.77.2:
+    resolution: {integrity: sha512-czQOxGOX4U47jW9k+cbFBgSt/6FVx2WGLPqPvrgDiEToLJdZyvzUqrkpqQYfJ6hN1koqatCPEpDrUZBcTPGUGg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-win32-arm64@1.77.2:
+    resolution: {integrity: sha512-NA+4Y5PO04YQGtKNCyLrUjQU2nijskVA3Er/UYGtx66BBlWZ/ttbnlk+dU05SF5Jhjb3HtThGGH1meb7pKA+OQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /sass-embedded-win32-ia32@1.77.2:
+    resolution: {integrity: sha512-/3hGz4GefhVuuUu2gSOdsxBYym5Di0co0tZbtiokCU/8VhYhcAQ3v2Lni49VV6OnsyJLb1nUx+rbpd8cKO1U4w==}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [win32]
+    hasBin: true
     requiresBuild: true
     dev: false
     optional: true
 
-  /sass-embedded-win32-x64@1.62.0:
-    resolution: {integrity: sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==}
+  /sass-embedded-win32-x64@1.77.2:
+    resolution: {integrity: sha512-joHLDICWmnR9Ca+LT9B+Fp85sCvV9F3gdtHtXLSuQAEulG5Ip1Z9euB3FUw+Z0s0Vz4MjNea+JD+TwO9eMrpyw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
+    hasBin: true
     requiresBuild: true
     dev: false
     optional: true
 
-  /sass-embedded@1.62.0:
-    resolution: {integrity: sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==}
-    engines: {node: '>=14.0.0'}
+  /sass-embedded@1.77.2:
+    resolution: {integrity: sha512-luiDeWNZ0tKs1jCiSFbuz8wFVQxYqN+vh+yfm9v7kW42yPtwEF8+z2ROaDJluSUZ7vhFmsXuqoKg9qBxc7SCnw==}
+    engines: {node: '>=16.0.0'}
     dependencies:
       '@bufbuild/protobuf': 1.8.0
       buffer-builder: 0.2.0
       immutable: 4.3.5
       rxjs: 7.8.1
       supports-color: 8.1.1
+      varint: 6.0.0
     optionalDependencies:
-      sass-embedded-darwin-arm64: 1.62.0
-      sass-embedded-darwin-x64: 1.62.0
-      sass-embedded-linux-arm: 1.62.0
-      sass-embedded-linux-arm64: 1.62.0
-      sass-embedded-linux-ia32: 1.62.0
-      sass-embedded-linux-x64: 1.62.0
-      sass-embedded-win32-ia32: 1.62.0
-      sass-embedded-win32-x64: 1.62.0
+      sass-embedded-android-arm: 1.77.2
+      sass-embedded-android-arm64: 1.77.2
+      sass-embedded-android-ia32: 1.77.2
+      sass-embedded-android-x64: 1.77.2
+      sass-embedded-darwin-arm64: 1.77.2
+      sass-embedded-darwin-x64: 1.77.2
+      sass-embedded-linux-arm: 1.77.2
+      sass-embedded-linux-arm64: 1.77.2
+      sass-embedded-linux-ia32: 1.77.2
+      sass-embedded-linux-musl-arm: 1.77.2
+      sass-embedded-linux-musl-arm64: 1.77.2
+      sass-embedded-linux-musl-ia32: 1.77.2
+      sass-embedded-linux-musl-x64: 1.77.2
+      sass-embedded-linux-x64: 1.77.2
+      sass-embedded-win32-arm64: 1.77.2
+      sass-embedded-win32-ia32: 1.77.2
+      sass-embedded-win32-x64: 1.77.2
     dev: false
 
   /sass-loader@10.0.5(sass@1.3.2)(webpack@4.47.0):
@@ -26777,6 +26881,10 @@ packages:
   /validator@13.11.0:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
+
+  /varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "2dc21c60f11c299657b860cd5b046de59f8081e7",
+  "pnpmShrinkwrapHash": "06e94d45eef30c2d1b95197865251383fc263592",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648"
 }

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -22,7 +22,7 @@
     "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/typings-generator": "workspace:*",
-    "sass-embedded": "~1.62.0",
+    "sass-embedded": "~1.77.2",
     "postcss": "~8.4.6",
     "postcss-modules": "~6.0.0"
   },

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -5,10 +5,16 @@
 
 import * as path from 'path';
 import { URL, pathToFileURL, fileURLToPath } from 'url';
-import { type CompileResult, type Syntax, type Exception, compileStringAsync } from 'sass-embedded';
+import {
+  type CompileResult,
+  type Syntax,
+  type Exception,
+  compileStringAsync,
+  type CanonicalizeContext
+} from 'sass-embedded';
 import * as postcss from 'postcss';
 import cssModules from 'postcss-modules';
-import { FileSystem, Sort } from '@rushstack/node-core-library';
+import { FileSystem, Import, Sort } from '@rushstack/node-core-library';
 import { type IStringValueTypings, StringValuesTypingsGenerator } from '@rushstack/typings-generator';
 
 /**
@@ -235,8 +241,33 @@ export class SassProcessor extends StringValuesTypingsGenerator {
       result = await compileStringAsync(fileContents, {
         importers: [
           {
-            findFileUrl: (url: string): URL | null => {
-              return this._patchSassUrl(url, nodeModulesUrl);
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            findFileUrl: async (url: string, context: CanonicalizeContext): Promise<URL | null> => {
+              if (url[0] === '~') {
+                const packagePath: string = url.slice(1);
+                const { containingUrl } = context;
+                if (containingUrl) {
+                  let packageNameDelimiter: number = packagePath.indexOf('/');
+                  if (packagePath[0] === '@') {
+                    packageNameDelimiter = packagePath.indexOf('/', packageNameDelimiter + 1);
+                  }
+
+                  const packageName: string = packagePath.slice(0, packageNameDelimiter);
+                  const modulePath: string = packagePath.slice(packageNameDelimiter + 1);
+
+                  const baseFolderPath: string = path.dirname(fileURLToPath(containingUrl));
+                  const resolvedPackagePath: string = await Import.resolvePackageAsync({
+                    packageName,
+                    baseFolderPath
+                  });
+                  const resolvedPath: string = `${resolvedPackagePath}/${modulePath}`;
+                  return pathToFileURL(resolvedPath);
+                } else {
+                  return new URL(packagePath, nodeModulesUrl);
+                }
+              } else {
+                return null;
+              }
             }
           }
         ],
@@ -261,14 +292,6 @@ export class SassProcessor extends StringValuesTypingsGenerator {
     }
 
     return result.css.toString();
-  }
-
-  private _patchSassUrl(url: string, nodeModulesUrl: URL): URL | null {
-    if (url[0] !== '~') {
-      return null;
-    }
-
-    return new URL(url.slice(1), nodeModulesUrl);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR bumps `sass-embedded` to make use of a new parameter provided to the `findFileUrl` callback. This parameter provides the context from which a file is being resolved, allowing a correct resolution algorithm to be employed. This PR also implements that algorithm. With this change, `@import` and `@use` rules in dependency scss files work correctly, even if the project being built doesn't have a direct dependency on the package that the rule resolves to.

## How it was tested

Tested in a large repo that previously had this issue.

## Impacted documentation

None.