### PR TITLE
[node-core-library] Clean up a few things from node-core-library in preparation for a major bump.

### DIFF
--- a/common/changes/@rushstack/node-core-library/main_2024-05-21-02-47.json
+++ b/common/changes/@rushstack/node-core-library/main_2024-05-21-02-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Remove the deprecated `Async.sleep` function.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/remove-Async.sleep_2024-05-21-03-05.json
+++ b/common/changes/@rushstack/node-core-library/remove-Async.sleep_2024-05-21-03-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Convert `FileConstants` and `FolderConstants` from enums to const objects.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -39,8 +39,6 @@ export class Async {
         weighted: true;
     }): Promise<TRetVal[]>;
     static runWithRetriesAsync<TResult>({ action, maxRetries, retryDelayMs }: IRunWithRetriesOptions<TResult>): Promise<TResult>;
-    // @deprecated (undocumented)
-    static sleep(ms: number): Promise<void>;
     static sleepAsync(ms: number): Promise<void>;
     static validateWeightedIterable(operation: IWeighted): void;
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -116,9 +116,9 @@ export type ExecutableStdioMapping = 'pipe' | 'ignore' | 'inherit' | ExecutableS
 export type ExecutableStdioStreamMapping = 'pipe' | 'ignore' | 'inherit' | NodeJS.WritableStream | NodeJS.ReadableStream | number | undefined;
 
 // @public
-export enum FileConstants {
-    PackageJson = "package.json"
-}
+export const FileConstants: {
+    readonly PackageJson: "package.json";
+};
 
 // @public
 export class FileError extends Error {
@@ -225,10 +225,10 @@ export class FileWriter {
 }
 
 // @public
-export enum FolderConstants {
-    Git = ".git",
-    NodeModules = "node_modules"
-}
+export const FolderConstants: {
+    readonly Git: ".git";
+    readonly NodeModules: "node_modules";
+};
 
 // @public
 export type FolderItem = fs.Dirent;

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -306,14 +306,6 @@ export class Async {
   }
 
   /**
-   * @deprecated Use {@link Async.sleepAsync} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  public static async sleep(ms: number): Promise<void> {
-    await Async.sleepAsync(ms);
-  }
-
-  /**
    * Executes an async function and optionally retries it if it fails.
    */
   public static async runWithRetriesAsync<TResult>({

--- a/libraries/node-core-library/src/Constants.ts
+++ b/libraries/node-core-library/src/Constants.ts
@@ -6,26 +6,28 @@
  *
  * @public
  */
-export enum FileConstants {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const FileConstants = {
   /**
    * "package.json" - the configuration file that defines an NPM package
    */
-  PackageJson = 'package.json'
-}
+  PackageJson: 'package.json'
+} as const;
 
 /**
  * String constants for common folder names.
  *
  * @public
  */
-export enum FolderConstants {
+// eslint-disable-next-line @typescript-eslint/typedef
+export const FolderConstants = {
   /**
    * ".git" - the data storage for a Git working folder
    */
-  Git = '.git',
+  Git: '.git',
 
   /**
    * "node_modules" - the folder where package managers install their files
    */
-  NodeModules = 'node_modules'
-}
+  NodeModules: 'node_modules'
+} as const;


### PR DESCRIPTION
## Summary

Removes `Async.sleep`, which is deprecated, for the upcoming major bump.

## How it was tested

N/A

## Impacted documentation

API docs will need to be updated.