### PR TITLE
[node-core-library] [api-extractor] Include typings for the package.json 'exports' and 'typesVersions' fields support for resolving the tsdoc-metadata.json field referenced by 'exports' and 'typesVersions'.

### DIFF
--- a/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
@@ -93,8 +93,19 @@ export class PackageMetadataManager {
       // 3. If package.json contains a field such as "main": "./path1/path2/index.js", then we look for
       // the file under "./path1/path2/tsdoc-metadata.json"
       tsdocMetadataRelativePath = path.join(path.dirname(packageJson.main), tsdocMetadataFilename);
+    } else if (
+      typeof packageJson.exports === 'object' &&
+      !Array.isArray(packageJson.exports) &&
+      packageJson.exports?.['.']?.types
+    ) {
+      // 4. If package.json contains a field such as "exports": { ".": { "types": "./path1/path2/index.d.ts" } },
+      // then we look for the file under "./path1/path2/tsdoc-metadata.json"
+      tsdocMetadataRelativePath = path.join(
+        path.dirname(packageJson.exports['.'].types),
+        tsdocMetadataFilename
+      );
     } else {
-      // 4. If none of the above rules apply, then by default we look for the file under "./tsdoc-metadata.json"
+      // 5. If none of the above rules apply, then by default we look for the file under "./tsdoc-metadata.json"
       // since the default entry point is "./index.js"
       tsdocMetadataRelativePath = tsdocMetadataFilename;
     }

--- a/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/analyzer/PackageMetadataManager.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
+import path from 'path';
+import semver from 'semver';
 
 import {
   type PackageJsonLookup,
@@ -9,7 +10,8 @@ import {
   JsonFile,
   type NewlineKind,
   type INodePackageJson,
-  type JsonObject
+  type JsonObject,
+  type IPackageJsonExports
 } from '@rushstack/node-core-library';
 import { Extractor } from '../api/Extractor';
 import type { MessageRouter } from '../collector/MessageRouter';
@@ -42,6 +44,125 @@ export class PackageMetadata {
   }
 }
 
+const TSDOC_METADATA_FILENAME: 'tsdoc-metadata.json' = 'tsdoc-metadata.json';
+
+const TSDOC_METADATA_RESOLUTION_FUNCTIONS: [
+  ...((packageJson: INodePackageJson) => string | undefined)[],
+  (packageJson: INodePackageJson) => string
+] = [
+  /**
+   * 1. If package.json a `"tsdocMetadata": "./path1/path2/tsdoc-metadata.json"` field
+   * then that takes precedence. This convention will be rarely needed, since the other rules below generally
+   * produce a good result.
+   */
+  ({ tsdocMetadata }) => tsdocMetadata,
+  /**
+   * 2. If package.json contains a `"exports": { ".": { "types": "./path1/path2/index.d.ts" } }` field,
+   * then we look for the file under "./path1/path2/tsdoc-metadata.json"
+   *
+   * This always looks for a "." and then a "*" entry in the exports field, and then evaluates for
+   * a "types" field in that entry.
+   */
+  ({ exports }) => {
+    switch (typeof exports) {
+      case 'string': {
+        return `${path.dirname(exports)}/${TSDOC_METADATA_FILENAME}`;
+      }
+
+      case 'object': {
+        if (Array.isArray(exports)) {
+          const [firstExport] = exports;
+          // Take the first entry in the array
+          if (firstExport) {
+            return `${path.dirname(exports[0])}/${TSDOC_METADATA_FILENAME}`;
+          }
+        } else {
+          const rootExport: IPackageJsonExports | string | null | undefined = exports['.'] ?? exports['*'];
+          switch (typeof rootExport) {
+            case 'string': {
+              return `${path.dirname(rootExport)}/${TSDOC_METADATA_FILENAME}`;
+            }
+
+            case 'object': {
+              let typesExport: IPackageJsonExports | string | undefined = rootExport?.types;
+              while (typesExport) {
+                switch (typeof typesExport) {
+                  case 'string': {
+                    return `${path.dirname(typesExport)}/${TSDOC_METADATA_FILENAME}`;
+                  }
+
+                  case 'object': {
+                    typesExport = typesExport?.types;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+        break;
+      }
+    }
+  },
+  /**
+   * 3. If package.json contains a `typesVersions` field, look for the version
+   * matching the highest minimum version that either includes a "." or "*" entry.
+   */
+  ({ typesVersions }) => {
+    if (typesVersions) {
+      let highestMinimumMatchingSemver: semver.SemVer | undefined;
+      let latestMatchingPath: string | undefined;
+      for (const [version, paths] of Object.entries(typesVersions)) {
+        let range: semver.Range;
+        try {
+          range = new semver.Range(version);
+        } catch {
+          continue;
+        }
+
+        const minimumMatchingSemver: semver.SemVer | null = semver.minVersion(range);
+        if (
+          minimumMatchingSemver &&
+          (!highestMinimumMatchingSemver || semver.gt(minimumMatchingSemver, highestMinimumMatchingSemver))
+        ) {
+          const pathEntry: string[] | undefined = paths['.'] ?? paths['*'];
+          const firstPath: string | undefined = pathEntry?.[0];
+          if (firstPath) {
+            highestMinimumMatchingSemver = minimumMatchingSemver;
+            latestMatchingPath = firstPath;
+          }
+        }
+      }
+
+      if (latestMatchingPath) {
+        return `${path.dirname(latestMatchingPath)}/${TSDOC_METADATA_FILENAME}`;
+      }
+    }
+  },
+  /**
+   * 4. If package.json contains a `"types": "./path1/path2/index.d.ts"` or a `"typings": "./path1/path2/index.d.ts"`
+   * field, then we look for the file under "./path1/path2/tsdoc-metadata.json".
+   *
+   * @remarks
+   * `types` takes precedence over `typings`.
+   */
+  ({ typings, types }) => {
+    const typesField: string | undefined = types ?? typings;
+    if (typesField) {
+      return `${path.dirname(typesField)}/${TSDOC_METADATA_FILENAME}`;
+    }
+  },
+  ({ main }) => {
+    if (main) {
+      return `${path.dirname(main)}/${TSDOC_METADATA_FILENAME}`;
+    }
+  },
+  /**
+   * As a final fallback, place the file in the root of the package.
+   */
+  () => TSDOC_METADATA_FILENAME
+];
+
 /**
  * This class maintains a cache of analyzed information obtained from package.json
  * files.  It is built on top of the PackageJsonLookup class.
@@ -56,7 +177,7 @@ export class PackageMetadata {
  * Use ts.program.isSourceFileFromExternalLibrary() to test source files before passing the to PackageMetadataManager.
  */
 export class PackageMetadataManager {
-  public static tsdocMetadataFilename: string = 'tsdoc-metadata.json';
+  public static tsdocMetadataFilename: string = TSDOC_METADATA_FILENAME;
 
   private readonly _packageJsonLookup: PackageJsonLookup;
   private readonly _messageRouter: MessageRouter;
@@ -70,48 +191,31 @@ export class PackageMetadataManager {
     this._messageRouter = messageRouter;
   }
 
-  // This feature is still being standardized: https://github.com/microsoft/tsdoc/issues/7
-  // In the future we will use the @microsoft/tsdoc library to read this file.
-  private static _resolveTsdocMetadataPathFromPackageJson(
+  /**
+   * This feature is still being standardized: https://github.com/microsoft/tsdoc/issues/7
+   * In the future we will use the @microsoft/tsdoc library to read this file.
+   *
+   * @internal
+   */
+  public static _resolveTsdocMetadataPathFromPackageJson(
     packageFolder: string,
     packageJson: INodePackageJson
   ): string {
-    const tsdocMetadataFilename: string = PackageMetadataManager.tsdocMetadataFilename;
-
-    let tsdocMetadataRelativePath: string;
-
-    if (packageJson.tsdocMetadata) {
-      // 1. If package.json contains a field such as "tsdocMetadata": "./path1/path2/tsdoc-metadata.json",
-      // then that takes precedence.  This convention will be rarely needed, since the other rules below generally
-      // produce a good result.
-      tsdocMetadataRelativePath = packageJson.tsdocMetadata;
-    } else if (packageJson.typings) {
-      // 2. If package.json contains a field such as "typings": "./path1/path2/index.d.ts", then we look
-      // for the file under "./path1/path2/tsdoc-metadata.json"
-      tsdocMetadataRelativePath = path.join(path.dirname(packageJson.typings), tsdocMetadataFilename);
-    } else if (packageJson.main) {
-      // 3. If package.json contains a field such as "main": "./path1/path2/index.js", then we look for
-      // the file under "./path1/path2/tsdoc-metadata.json"
-      tsdocMetadataRelativePath = path.join(path.dirname(packageJson.main), tsdocMetadataFilename);
-    } else if (
-      typeof packageJson.exports === 'object' &&
-      !Array.isArray(packageJson.exports) &&
-      packageJson.exports?.['.']?.types
-    ) {
-      // 4. If package.json contains a field such as "exports": { ".": { "types": "./path1/path2/index.d.ts" } },
-      // then we look for the file under "./path1/path2/tsdoc-metadata.json"
-      tsdocMetadataRelativePath = path.join(
-        path.dirname(packageJson.exports['.'].types),
-        tsdocMetadataFilename
-      );
-    } else {
-      // 5. If none of the above rules apply, then by default we look for the file under "./tsdoc-metadata.json"
-      // since the default entry point is "./index.js"
-      tsdocMetadataRelativePath = tsdocMetadataFilename;
+    let tsdocMetadataRelativePath: string | undefined;
+    for (const tsdocMetadataResolutionFunction of TSDOC_METADATA_RESOLUTION_FUNCTIONS) {
+      tsdocMetadataRelativePath = tsdocMetadataResolutionFunction(packageJson);
+      if (tsdocMetadataRelativePath) {
+        break;
+      }
     }
 
     // Always resolve relative to the package folder.
-    const tsdocMetadataPath: string = path.resolve(packageFolder, tsdocMetadataRelativePath);
+    const tsdocMetadataPath: string = path.resolve(
+      packageFolder,
+      // This non-null assertion is safe because the last entry in TSDOC_METADATA_RESOLUTION_FUNCTIONS
+      // returns a non-undefined value.
+      tsdocMetadataRelativePath!
+    );
     return tsdocMetadataPath;
   }
 
@@ -128,6 +232,7 @@ export class PackageMetadataManager {
     if (tsdocMetadataPath) {
       return path.resolve(packageFolder, tsdocMetadataPath);
     }
+
     return PackageMetadataManager._resolveTsdocMetadataPathFromPackageJson(packageFolder, packageJson);
   }
 

--- a/apps/api-extractor/src/analyzer/test/PackageMetadataManager.test.ts
+++ b/apps/api-extractor/src/analyzer/test/PackageMetadataManager.test.ts
@@ -1,39 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
+jest.mock('path', () => {
+  const actualPath: typeof import('path') = jest.requireActual('path');
+  return {
+    ...actualPath,
+    resolve: actualPath.posix.resolve
+  };
+});
+
 import { PackageMetadataManager } from '../PackageMetadataManager';
-import {
-  FileSystem,
-  PackageJsonLookup,
-  type INodePackageJson,
-  NewlineKind
-} from '@rushstack/node-core-library';
-
-const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
-
-function resolveInTestPackage(testPackageName: string, ...args: string[]): string {
-  return path.resolve(__dirname, 'test-data/tsdoc-metadata-path-inference', testPackageName, ...args);
-}
-
-function getPackageMetadata(testPackageName: string): {
-  packageFolder: string;
-  packageJson: INodePackageJson;
-} {
-  const packageFolder: string = resolveInTestPackage(testPackageName);
-  const packageJson: INodePackageJson | undefined = packageJsonLookup.tryLoadPackageJsonFor(packageFolder);
-  if (!packageJson) {
-    throw new Error('There should be a package.json file in the test package');
-  }
-  return { packageFolder, packageJson };
-}
+import { FileSystem, type INodePackageJson, NewlineKind } from '@rushstack/node-core-library';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function firstArgument(mockFn: jest.Mock): any {
   return mockFn.mock.calls[0][0];
 }
 
-/* eslint-disable @typescript-eslint/typedef */
+const PACKAGE_FOLDER: '/pkg' = '/pkg';
 
 describe(PackageMetadataManager.name, () => {
   describe(PackageMetadataManager.writeTsdocMetadataFile.name, () => {
@@ -42,9 +26,11 @@ describe(PackageMetadataManager.name, () => {
     beforeAll(() => {
       FileSystem.writeFile = mockWriteFile;
     });
+
     afterEach(() => {
       mockWriteFile.mockClear();
     });
+
     afterAll(() => {
       FileSystem.writeFile = originalWriteFile;
     });
@@ -56,77 +42,325 @@ describe(PackageMetadataManager.name, () => {
   });
 
   describe(PackageMetadataManager.resolveTsdocMetadataPath.name, () => {
-    describe('when an empty tsdocMetadataPath is provided', () => {
-      const tsdocMetadataPath: string = '';
+    describe.each([
+      {
+        tsdocMetadataPath: '',
+        label: 'when an empty tsdocMetadataPath is provided'
+      },
+      {
+        tsdocMetadataPath: 'path/to/custom-tsdoc-metadata.json',
+        label: 'when a non-empty tsdocMetadataPath is provided',
+        itValue:
+          'outputs the tsdoc metadata file at the provided path in the folder where package.json is located',
+        overrideExpected: `${PACKAGE_FOLDER}/path/to/custom-tsdoc-metadata.json`
+      }
+    ])('$label', ({ tsdocMetadataPath, itValue, overrideExpected }) => {
+      function testForPackageJson(
+        packageJson: INodePackageJson,
+        options:
+          | { expectsPackageRoot: true }
+          | {
+              expectedPathInsidePackage: string;
+            }
+      ): void {
+        const { expectsPackageRoot, expectedPathInsidePackage } = options as {
+          expectsPackageRoot: true;
+        } & {
+          expectedPathInsidePackage: string;
+        };
+        const resolvedTsdocMetadataPath: string = PackageMetadataManager.resolveTsdocMetadataPath(
+          PACKAGE_FOLDER,
+          packageJson,
+          tsdocMetadataPath
+        );
+        if (overrideExpected) {
+          expect(resolvedTsdocMetadataPath).toBe(overrideExpected);
+        } else if (expectsPackageRoot) {
+          expect(resolvedTsdocMetadataPath).toBe(`${PACKAGE_FOLDER}/tsdoc-metadata.json`);
+        } else {
+          expect(resolvedTsdocMetadataPath).toBe(
+            `${PACKAGE_FOLDER}/${expectedPathInsidePackage}/tsdoc-metadata.json`
+          );
+        }
+      }
+
       describe('given a package.json where the field "tsdocMetadata" is defined', () => {
-        it('outputs the tsdoc metadata path as given by "tsdocMetadata" relative to the folder of package.json', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-tsdoc-metadata');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, packageJson.tsdocMetadata as string));
+        it(
+          itValue ??
+            'outputs the tsdoc metadata path as given by "tsdocMetadata" relative to the folder of package.json',
+          () => {
+            testForPackageJson(
+              {
+                name: 'package-inferred-from-tsdoc-metadata',
+                version: '1.0.0',
+                main: 'path/to/main.js',
+                typings: 'path/to/typings/typings.d.ts',
+                tsdocMetadata: 'path/to/tsdoc-metadata/tsdoc-metadata.json'
+              },
+              {
+                expectedPathInsidePackage: 'path/to/tsdoc-metadata'
+              }
+            );
+          }
+        );
+      });
+
+      describe('given a package.json where the field "exports" is defined and "tsdocMetadata" is not defined', () => {
+        describe.each(['.', '*'])('with an exports field that contains a "%s" key', (exportsKey) => {
+          describe('with a string value', () => {
+            it(
+              itValue ??
+                `outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "${exportsKey}"`,
+              () => {
+                testForPackageJson(
+                  {
+                    name: 'package-inferred-from-exports',
+                    version: '1.0.0',
+                    exports: {
+                      [exportsKey]: 'path/to/exports/exports.js'
+                    }
+                  },
+                  { expectedPathInsidePackage: 'path/to/exports' }
+                );
+              }
+            );
+          });
+
+          describe('with an object value that does not include a "types" key', () => {
+            it(itValue ?? 'outputs the tsdoc metadata file "tsdoc-metadata.json" in the package root', () => {
+              testForPackageJson(
+                {
+                  name: 'package-inferred-from-exports',
+                  version: '1.0.0',
+                  exports: {
+                    [exportsKey]: {
+                      import: 'path/to/exports/exports.js'
+                    }
+                  }
+                },
+                { expectsPackageRoot: true }
+              );
+            });
+          });
+
+          describe('with an object value that does include a "types" key', () => {
+            it(
+              itValue ??
+                `outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "${exportsKey}"`,
+              () => {
+                testForPackageJson(
+                  {
+                    name: 'package-inferred-from-exports',
+                    version: '1.0.0',
+                    exports: {
+                      [exportsKey]: {
+                        types: 'path/to/types-exports/exports.d.ts'
+                      }
+                    }
+                  },
+                  { expectedPathInsidePackage: 'path/to/types-exports' }
+                );
+              }
+            );
+          });
+
+          describe('that nests into an object that doesn\'t contain a "types" key', () => {
+            it(itValue ?? 'outputs the tsdoc metadata file "tsdoc-metadata.json" package root', () => {
+              testForPackageJson(
+                {
+                  name: 'package-inferred-from-exports',
+                  version: '1.0.0',
+                  exports: {
+                    [exportsKey]: {
+                      types: {
+                        import: 'path/to/types-exports/exports.js'
+                      }
+                    }
+                  }
+                },
+                { expectsPackageRoot: true }
+              );
+            });
+          });
+
+          describe('that nests into an object that contains a "types" key', () => {
+            it(itValue ?? 'outputs the tsdoc metadata file "tsdoc-metadata.json" package root', () => {
+              testForPackageJson(
+                {
+                  name: 'package-inferred-from-exports',
+                  version: '1.0.0',
+                  exports: {
+                    [exportsKey]: {
+                      types: {
+                        types: 'path/to/types-exports/exports.d.ts'
+                      }
+                    }
+                  }
+                },
+                { expectedPathInsidePackage: 'path/to/types-exports' }
+              );
+            });
+          });
         });
       });
-      describe('given a package.json where the field "typings" is defined and "tsdocMetadata" is not defined', () => {
-        it('outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "typings"', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-typings');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, path.dirname(packageJson.typings!), 'tsdoc-metadata.json'));
+
+      describe('given a package.json where the field "typesVersions" is defined and "exports" and "tsdocMetadata" are not defined', () => {
+        describe('with an exports field that contains a "%s" key', () => {
+          describe('with no selectors', () => {
+            it(itValue ?? 'outputs the tsdoc metadata file "tsdoc-metadata.json" in the package root', () => {
+              testForPackageJson(
+                {
+                  name: 'package-inferred-from-typesVersions',
+                  version: '1.0.0',
+                  typesVersions: {}
+                },
+                { expectsPackageRoot: true }
+              );
+            });
+          });
+
+          describe.each(['.', '*'])('with a %s selector', (pathSelector) => {
+            it(
+              itValue ?? 'outputs the tsdoc metadata file "tsdoc-metadata.json" in the path selected',
+              () => {
+                testForPackageJson(
+                  {
+                    name: 'package-inferred-from-typesVersions',
+                    version: '1.0.0',
+                    typesVersions: {
+                      '>=3.0': {
+                        [pathSelector]: ['path/to/types-exports/exports.d.ts']
+                      }
+                    }
+                  },
+                  { expectedPathInsidePackage: 'path/to/types-exports' }
+                );
+              }
+            );
+          });
+
+          describe('with multiple TypeScript versions', () => {
+            describe.each(['.', '*'])('with a %s selector', (pathSelector) => {
+              it(
+                itValue ??
+                  'outputs the tsdoc metadata file "tsdoc-metadata.json" in the path selected for the latest TypeScript version',
+                () => {
+                  testForPackageJson(
+                    {
+                      name: 'package-inferred-from-typesVersions',
+                      version: '1.0.0',
+                      typesVersions: {
+                        '>=3.6': {
+                          [pathSelector]: ['path/to/types-exports-3.6/exports.d.ts']
+                        },
+                        '>=3.0': {
+                          [pathSelector]: ['path/to/types-exports-3.0/exports.d.ts']
+                        },
+                        '~4.0': {
+                          [pathSelector]: ['path/to/types-exports-4.0/exports.d.ts']
+                        }
+                      }
+                    },
+                    { expectedPathInsidePackage: 'path/to/types-exports-4.0' }
+                  );
+                }
+              );
+            });
+          });
         });
       });
-      describe('given a package.json where the field "main" is defined but not "typings" nor "tsdocMetadata"', () => {
-        it('outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "main"', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-main');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, path.dirname(packageJson.main!), 'tsdoc-metadata.json'));
-        });
+
+      describe('given a package.json where the field "types" is defined and "typings", "exports", "typesVersions", and "tsdocMetadata" is not defined', () => {
+        it(
+          itValue ??
+            'outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "types"',
+          () => {
+            testForPackageJson(
+              {
+                name: 'package-inferred-from-types',
+                version: '1.0.0',
+                main: 'path/to/main.js',
+                types: 'path/to/types/types.d.ts'
+              },
+              { expectedPathInsidePackage: 'path/to/types' }
+            );
+          }
+        );
       });
-      describe('given a package.json where the fields "main", "typings" and "tsdocMetadata" are not defined', () => {
-        it('outputs the tsdoc metadata file "tsdoc-metadata.json" in the folder where package.json is located', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-default');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, 'tsdoc-metadata.json'));
-        });
+
+      describe('given a package.json where the field "types" and "typing " are defined "exports", "typesVersions", and "tsdocMetadata" is not defined', () => {
+        it(
+          itValue ??
+            'outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "types"',
+          () => {
+            testForPackageJson(
+              {
+                name: 'package-inferred-from-types',
+                version: '1.0.0',
+                main: 'path/to/main.js',
+                types: 'path/to/types/types.d.ts',
+                typings: 'path/to/typings/typings.d.ts'
+              },
+              { expectedPathInsidePackage: 'path/to/types' }
+            );
+          }
+        );
       });
-    });
-    describe('when a non-empty tsdocMetadataPath is provided', () => {
-      const tsdocMetadataPath: string = 'path/to/custom-tsdoc-metadata.json';
-      describe('given a package.json where the field "tsdocMetadata" is defined', () => {
-        it('outputs the tsdoc metadata file at the provided path in the folder where package.json is located', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-tsdocMetadata');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, tsdocMetadataPath));
-        });
+
+      describe('given a package.json where the field "typings" is defined and "types", "exports", "typesVersions", and "tsdocMetadata" is not defined', () => {
+        it(
+          itValue ??
+            'outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "typings"',
+          () => {
+            testForPackageJson(
+              {
+                name: 'package-inferred-from-typings',
+                version: '1.0.0',
+                main: 'path/to/main.js',
+                typings: 'path/to/typings/typings.d.ts'
+              },
+              { expectedPathInsidePackage: 'path/to/typings' }
+            );
+          }
+        );
       });
-      describe('given a package.json where the field "typings" is defined and "tsdocMetadata" is not defined', () => {
-        it('outputs the tsdoc metadata file at the provided path in the folder where package.json is located', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-typings');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, tsdocMetadataPath));
-        });
+
+      describe('given a package.json where the field "main" is defined but not and "types", "typings", "exports", "typesVersions", and "tsdocMetadata" is not defined', () => {
+        it(
+          itValue ??
+            'outputs the tsdoc metadata file "tsdoc-metadata.json" in the same folder as the path of "main"',
+          () => {
+            testForPackageJson(
+              {
+                name: 'package-inferred-from-main',
+                version: '1.0.0',
+                main: 'path/to/main/main.js'
+              },
+              { expectedPathInsidePackage: 'path/to/main' }
+            );
+          }
+        );
       });
-      describe('given a package.json where the field "main" is defined but not "typings" nor "tsdocMetadata"', () => {
-        it('outputs the tsdoc metadata file at the provided path in the folder where package.json is located', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-inferred-from-main');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, tsdocMetadataPath));
-        });
-      });
-      describe('given a package.json where the fields "main", "typings" and "tsdocMetadata" are not defined', () => {
-        it('outputs the tsdoc metadata file at the provided path in the folder where package.json is located', () => {
-          const { packageFolder, packageJson } = getPackageMetadata('package-default');
-          expect(
-            PackageMetadataManager.resolveTsdocMetadataPath(packageFolder, packageJson, tsdocMetadataPath)
-          ).toBe(path.resolve(packageFolder, tsdocMetadataPath));
-        });
-      });
+
+      describe(
+        'given a package.json where the fields "exports", "typesVersions", "types", "main", "typings" ' +
+          'and "tsdocMetadata" are not defined',
+        () => {
+          it(
+            itValue ??
+              'outputs the tsdoc metadata file "tsdoc-metadata.json" in the folder where package.json is located',
+            () => {
+              testForPackageJson(
+                {
+                  name: 'package-default',
+                  version: '1.0.0'
+                },
+                { expectsPackageRoot: true }
+              );
+            }
+          );
+        }
+      );
     });
   });
 });
-
-/* eslint-enable @typescript-eslint/typedef */

--- a/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-default/package.json
+++ b/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-default/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "package-default",
-  "version": "1.0.0"
-}

--- a/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-main/package.json
+++ b/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-main/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "package-inferred-from-main",
-  "version": "1.0.0",
-  "main": "path/to/main.js"
-}

--- a/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-tsdoc-metadata/package.json
+++ b/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-tsdoc-metadata/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "package-inferred-from-tsdoc-metadata",
-  "version": "1.0.0",
-  "main": "path/to/main.js",
-  "typings": "path/to/typings.d.ts",
-  "tsdocMetadata": "path/to/tsdoc-metadata.json"
-}

--- a/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-typings/package.json
+++ b/apps/api-extractor/src/analyzer/test/test-data/tsdoc-metadata-path-inference/package-inferred-from-typings/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "package-inferred-from-typings",
-  "version": "1.0.0",
-  "main": "path/to/main.js",
-  "typings": "path/to/typings.d.ts"
-}

--- a/common/changes/@microsoft/api-extractor/add-support-for-exports-types_2024-05-26-00-41.json
+++ b/common/changes/@microsoft/api-extractor/add-support-for-exports-types_2024-05-26-00-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improve support for resolving the `tsdoc-metadata.json` to include the folder referenced by a `types` field in an `\"exports\"` field and an `\"typesVersions\"` field in addition to `\"types\"`, `\"typings\"`, and `\"tsdocMetadata\"` fields.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/node-core-library/add-support-for-exports-types_2024-05-26-00-41.json
+++ b/common/changes/@rushstack/node-core-library/add-support-for-exports-types_2024-05-26-00-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "\"Include typings for the `\"exports\"` and `\"typesVersions\"` fields in `IPackageJson`.\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -461,6 +461,7 @@ export interface INodePackageJson {
     dependenciesMeta?: IDependenciesMetaTable;
     description?: string;
     devDependencies?: IPackageJsonDependencyTable;
+    exports?: string | string[] | Record<string, null | string | IPackageJsonExports>;
     homepage?: string;
     license?: string;
     main?: string;
@@ -496,6 +497,19 @@ export interface IPackageJson extends INodePackageJson {
 // @public
 export interface IPackageJsonDependencyTable {
     [dependencyName: string]: string;
+}
+
+// @public
+export interface IPackageJsonExports {
+    'node-addons'?: string | IPackageJsonExports;
+    browser?: string | IPackageJsonExports;
+    default?: string | IPackageJsonExports;
+    development?: string | IPackageJsonExports;
+    import?: string | IPackageJsonExports;
+    node?: string | IPackageJsonExports;
+    production?: string | IPackageJsonExports;
+    require?: string | IPackageJsonExports;
+    types?: string | IPackageJsonExports;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -476,6 +476,7 @@ export interface INodePackageJson {
     // @beta
     tsdocMetadata?: string;
     types?: string;
+    typesVersions?: Record<string, Record<string, [string, ...string[]]>>;
     typings?: string;
     version?: string;
 }

--- a/libraries/node-core-library/src/IPackageJson.ts
+++ b/libraries/node-core-library/src/IPackageJson.ts
@@ -266,6 +266,43 @@ export interface INodePackageJson {
   resolutions?: Record<string, string>;
 
   /**
+   * A table of TypeScript *.d.ts file paths that are compatible with specific TypeScript version
+   * selectors. This data take a form similar to that of the {@link INodePackageJson.exports} field,
+   * with fallbacks listed in order in the value array for example:
+   *
+   * ```JSON
+   * "typesVersions": {
+   *   ">=3.1": {
+   *     "*": ["./types-3.1/*", "./types-3.1-fallback/*"]
+   *   },
+   *   ">=3.0": {
+   *     "*": ["./types-legacy/*"]
+   *   }
+   * }
+   * ```
+   *
+   * or
+   *
+   * ```JSON
+   * "typesVersions": {
+   *   ">=3.1": {
+   *     "app/*": ["./app/types-3.1/*"],
+   *     "lib/*": ["./lib/types-3.1/*"]
+   *   },
+   *   ">=3.0": {
+   *     "app/*": ["./app/types-legacy/*"],
+   *     "lib/*": ["./lib/types-legacy/*"]
+   *   }
+   * }
+   * ```
+   *
+   * See the
+   * {@link https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
+   * | TypeScript documentation} for details.
+   */
+  typesVersions?: Record<string, Record<string, [string, ...string[]]>>;
+
+  /**
    * The "exports" field is used to specify the entry points for a package.
    * See {@link https://nodejs.org/api/packages.html#exports | Node.js documentation}
    */

--- a/libraries/node-core-library/src/IPackageJson.ts
+++ b/libraries/node-core-library/src/IPackageJson.ts
@@ -72,6 +72,69 @@ export interface IDependenciesMetaTable {
 }
 
 /**
+ * This interface is part of the {@link IPackageJson} file format. It is used for the values
+ * of the "exports" field.
+ *
+ * See {@link https://nodejs.org/api/packages.html#conditional-exports | Node.js documentation on Conditional Exports} and
+ * {@link https://nodejs.org/api/packages.html#community-conditions-definitions | Node.js documentation on Community Conditional Exports}.
+ *
+ * @public
+ */
+export interface IPackageJsonExports {
+  /**
+   * This export is like {@link IPackageJsonExports.node} in that it matches for any NodeJS environment.
+   * This export is specifically for native C++ addons.
+   */
+  'node-addons'?: string | IPackageJsonExports;
+
+  /**
+   * This export matches for any NodeJS environment.
+   */
+  node?: string | IPackageJsonExports;
+
+  /**
+   * This export matches when loaded via ESM syntax (i.e. - `import '...'` or `import('...')`).
+   * This is always mutually exclusive with {@link IPackageJsonExports.require}.
+   */
+  import?: string | IPackageJsonExports;
+
+  /**
+   * This export matches when loaded via `require()`.
+   * This is always mutually exclusive with {@link IPackageJsonExports.import}.
+   */
+  require?: string | IPackageJsonExports;
+
+  /**
+   * This export matches as a fallback when no other conditions match. Because exports are evaluated in
+   * the order that they are specified in the `package.json` file, this condition should always come last
+   * as no later exports will match if this one does.
+   */
+  default?: string | IPackageJsonExports;
+
+  /**
+   * This export matches when loaded by the typing system (i.e. - the TypeScript compiler).
+   */
+  types?: string | IPackageJsonExports;
+
+  /**
+   * Any web browser environment.
+   */
+  browser?: string | IPackageJsonExports;
+
+  /**
+   * This export matches in development-only environments.
+   * This is always mutually exclusive with {@link IPackageJsonExports.production}.
+   */
+  development?: string | IPackageJsonExports;
+
+  /**
+   * This export matches in production-only environments.
+   * This is always mutually exclusive with {@link IPackageJsonExports.development}.
+   */
+  production?: string | IPackageJsonExports;
+}
+
+/**
  * An interface for accessing common fields from a package.json file whose version field may be missing.
  *
  * @remarks
@@ -201,6 +264,13 @@ export interface INodePackageJson {
    * | 0000-selective-versions-resolutions.md RFC} for details.
    */
   resolutions?: Record<string, string>;
+
+  /**
+   * The "exports" field is used to specify the entry points for a package.
+   * See {@link https://nodejs.org/api/packages.html#exports | Node.js documentation}
+   */
+  // eslint-disable-next-line @rushstack/no-new-null
+  exports?: string | string[] | Record<string, null | string | IPackageJsonExports>;
 }
 
 /**

--- a/libraries/node-core-library/src/PackageJsonLookup.ts
+++ b/libraries/node-core-library/src/PackageJsonLookup.ts
@@ -346,6 +346,7 @@ export class PackageJsonLookup {
         packageJson.dependencies = loadedPackageJson.dependencies;
         packageJson.description = loadedPackageJson.description;
         packageJson.devDependencies = loadedPackageJson.devDependencies;
+        packageJson.exports = loadedPackageJson.exports;
         packageJson.homepage = loadedPackageJson.homepage;
         packageJson.license = loadedPackageJson.license;
         packageJson.main = loadedPackageJson.main;
@@ -354,8 +355,8 @@ export class PackageJsonLookup {
         packageJson.peerDependencies = loadedPackageJson.peerDependencies;
         packageJson.private = loadedPackageJson.private;
         packageJson.scripts = loadedPackageJson.scripts;
-        packageJson.typings = loadedPackageJson.typings || loadedPackageJson.types;
         packageJson.tsdocMetadata = loadedPackageJson.tsdocMetadata;
+        packageJson.typings = loadedPackageJson.typings || loadedPackageJson.types;
         packageJson.version = loadedPackageJson.version;
       }
 

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -34,7 +34,8 @@ export {
   IPackageJsonScriptTable,
   IPackageJsonRepository,
   IPeerDependenciesMetaTable,
-  IDependenciesMetaTable
+  IDependenciesMetaTable,
+  IPackageJsonExports
 } from './IPackageJson';
 export {
   Import,


### PR DESCRIPTION
## Summary

This is necessary for allowing the `exports` field in `package.json`s to define the default typings location.

## How it was tested

Tested in a branch that moves `node-core-library` to use `exports` and added unit tests.

## Impacted documentation

This will probably require updates to the API Extractor and/or tsdoc docs.