### PR TITLE
[rush] Fix an issue about dependency using NPM alias with workspace protocol is not selected by selectors (eg: --to .)

### DIFF
--- a/common/changes/@microsoft/rush/fix-alias-workspace-protocol-selector_2024-05-24-07-55.json
+++ b/common/changes/@microsoft/rush/fix-alias-workspace-protocol-selector_2024-05-24-07-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix missing selection when declaring dependency using `workspace:alias@1.2.3`",
+      "comment": "Fix an issue where selection syntax (like `--to` or `--from`) misses project dependencies declared using workspace alias syntax (i.e. - `workspace:alias@1.2.3`).",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-alias-workspace-protocol-selector_2024-05-24-07-55.json
+++ b/common/changes/@microsoft/rush/fix-alias-workspace-protocol-selector_2024-05-24-07-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix missing selection when declaring dependency using `workspace:alias@1.2.3`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -412,7 +412,7 @@ export class RushConfigurationProject {
         if (dependencySet) {
           for (const [dependency, version] of Object.entries(dependencySet)) {
             const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
-            const dependencyName = dependencySpecifier.aliasTarget
+            const dependencyName: string = dependencySpecifier.aliasTarget
               ? dependencySpecifier.aliasTarget.packageName
               : dependencySpecifier.packageName;
             // Skip if we can't find the local project or it's a cyclic dependency

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -412,9 +412,8 @@ export class RushConfigurationProject {
         if (dependencySet) {
           for (const [dependency, version] of Object.entries(dependencySet)) {
             const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
-            const dependencyName: string = dependencySpecifier.aliasTarget
-              ? dependencySpecifier.aliasTarget.packageName
-              : dependencySpecifier.packageName;
+            const dependencyName: string =
+              dependencySpecifier.aliasTarget?.packageName ?? dependencySpecifier.packageName;
             // Skip if we can't find the local project or it's a cyclic dependency
             const localProject: RushConfigurationProject | undefined =
               this.rushConfiguration.getProjectByName(dependencyName);

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -411,12 +411,15 @@ export class RushConfigurationProject {
       ]) {
         if (dependencySet) {
           for (const [dependency, version] of Object.entries(dependencySet)) {
+            const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
+            const dependencyName = dependencySpecifier.aliasTarget
+              ? dependencySpecifier.aliasTarget.packageName
+              : dependencySpecifier.packageName;
             // Skip if we can't find the local project or it's a cyclic dependency
             const localProject: RushConfigurationProject | undefined =
-              this.rushConfiguration.getProjectByName(dependency);
+              this.rushConfiguration.getProjectByName(dependencyName);
             if (localProject && !this.decoupledLocalDependencies.has(dependency)) {
               // Set the value if it's a workspace project, or if we have a local project and the semver is satisfied
-              const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
               switch (dependencySpecifier.specifierType) {
                 case DependencySpecifierType.Version:
                 case DependencySpecifierType.Range:

--- a/libraries/rush-lib/src/logic/DependencySpecifier.ts
+++ b/libraries/rush-lib/src/logic/DependencySpecifier.ts
@@ -10,30 +10,32 @@ import { InternalError } from '@rushstack/node-core-library';
  * `"workspace:*"`
  * `"workspace:alias@1.2.3"`
  */
-const WORKSPACE_PREF_REGEX: RegExp = /^workspace:((?<alias>[^._/][^@]*)@)?(?<version>.*)$/;
+const WORKSPACE_PREFIX_REGEX: RegExp = /^workspace:((?<alias>[^._/][^@]*)@)?(?<version>.*)$/;
 
 /**
  * resolve workspace protocol(from `@pnpm/workspace.spec-parser`).
  * used by pnpm. see [pkgs-graph](https://github.com/pnpm/pnpm/blob/27c33f0319f86c45c1645d064cd9c28aada80780/workspace/pkgs-graph/src/index.ts#L49)
  */
 class WorkspaceSpec {
-  public alias?: string;
-  public version: string;
+  public readonly alias?: string;
+  public readonly version: string;
+  public readonly versionSpecifier: string;
 
   public constructor(version: string, alias?: string) {
     this.version = version;
     this.alias = alias;
+    this.versionSpecifier = alias ? `${alias}@${version}` : version;
   }
 
-  public static parse(pref: string): WorkspaceSpec | undefined {
-    const parts: RegExpExecArray | null = WORKSPACE_PREF_REGEX.exec(pref);
-    if (!parts?.groups) return undefined;
-    return new WorkspaceSpec(parts.groups.version, parts.groups.alias);
+  public static tryParse(pref: string): WorkspaceSpec | undefined {
+    const parts: RegExpExecArray | null = WORKSPACE_PREFIX_REGEX.exec(pref);
+    if (parts?.groups) {
+      return new WorkspaceSpec(parts.groups.version, parts.groups.alias);
+    }
   }
 
   public toString(): `workspace:${string}` {
-    const { alias, version } = this;
-    return alias ? `workspace:${alias}@${version}` : `workspace:${version}`;
+    return `workspace:${this.versionSpecifier}`;
   }
 }
 
@@ -122,17 +124,18 @@ export class DependencySpecifier {
 
     // Workspace ranges are a feature from PNPM and Yarn. Set the version specifier
     // to the trimmed version range.
-    if (versionSpecifier.startsWith('workspace:')) {
+    const workspaceSpecResult: WorkspaceSpec | undefined = WorkspaceSpec.tryParse(versionSpecifier);
+    if (workspaceSpecResult) {
       this.specifierType = DependencySpecifierType.Workspace;
-      this.versionSpecifier = versionSpecifier.slice(this.specifierType.length + 1).trim();
+      this.versionSpecifier = workspaceSpecResult.versionSpecifier;
 
-      const workspaceSpecResult: WorkspaceSpec | undefined = WorkspaceSpec.parse(versionSpecifier);
-      if (workspaceSpecResult?.alias) {
+      if (workspaceSpecResult.alias) {
         // "workspace:some-package@^1.2.3" should be resolved as alias
         this.aliasTarget = new DependencySpecifier(workspaceSpecResult.alias, workspaceSpecResult.version);
       } else {
         this.aliasTarget = undefined;
       }
+
       return;
     }
 

--- a/libraries/rush-lib/src/logic/DependencySpecifier.ts
+++ b/libraries/rush-lib/src/logic/DependencySpecifier.ts
@@ -92,6 +92,7 @@ export class DependencySpecifier {
     if (versionSpecifier.startsWith('workspace:')) {
       this.specifierType = DependencySpecifierType.Workspace;
       this.versionSpecifier = versionSpecifier.slice(this.specifierType.length + 1).trim();
+      // "workspace:some-package@^1.2.3" should be resolved as alias
       this.aliasTarget = undefined;
       return;
     }

--- a/libraries/rush-lib/src/logic/DependencySpecifier.ts
+++ b/libraries/rush-lib/src/logic/DependencySpecifier.ts
@@ -4,28 +4,34 @@
 import npmPackageArg from 'npm-package-arg';
 import { InternalError } from '@rushstack/node-core-library';
 
-const WORKSPACE_PREF_REGEX = /^workspace:((?<alias>[^._/][^@]*)@)?(?<version>.*)$/;
+/**
+ * match workspace protocol in dependencies value declaration in `package.json`
+ * example:
+ * `"workspace:*"`
+ * `"workspace:alias@1.2.3"`
+ */
+const WORKSPACE_PREF_REGEX: RegExp = /^workspace:((?<alias>[^._/][^@]*)@)?(?<version>.*)$/;
 
 /**
  * resolve workspace protocol(from `@pnpm/workspace.spec-parser`).
  * used by pnpm. see [pkgs-graph](https://github.com/pnpm/pnpm/blob/27c33f0319f86c45c1645d064cd9c28aada80780/workspace/pkgs-graph/src/index.ts#L49)
  */
 class WorkspaceSpec {
-  alias?: string;
-  version: string;
+  public alias?: string;
+  public version: string;
 
-  constructor(version: string, alias?: string) {
+  public constructor(version: string, alias?: string) {
     this.version = version;
     this.alias = alias;
   }
 
-  static parse(pref: string): WorkspaceSpec | null {
-    const parts = WORKSPACE_PREF_REGEX.exec(pref);
-    if (!parts?.groups) return null;
+  public static parse(pref: string): WorkspaceSpec | undefined {
+    const parts: RegExpExecArray | null = WORKSPACE_PREF_REGEX.exec(pref);
+    if (!parts?.groups) return undefined;
     return new WorkspaceSpec(parts.groups.version, parts.groups.alias);
   }
 
-  toString(): `workspace:${string}` {
+  public toString(): `workspace:${string}` {
     const { alias, version } = this;
     return alias ? `workspace:${alias}@${version}` : `workspace:${version}`;
   }
@@ -120,7 +126,7 @@ export class DependencySpecifier {
       this.specifierType = DependencySpecifierType.Workspace;
       this.versionSpecifier = versionSpecifier.slice(this.specifierType.length + 1).trim();
 
-      const workspaceSpecResult = WorkspaceSpec.parse(versionSpecifier);
+      const workspaceSpecResult: WorkspaceSpec | undefined = WorkspaceSpec.parse(versionSpecifier);
       if (workspaceSpecResult?.alias) {
         // "workspace:some-package@^1.2.3" should be resolved as alias
         this.aliasTarget = new DependencySpecifier(workspaceSpecResult.alias, workspaceSpecResult.version);

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -1,0 +1,18 @@
+import { DependencySpecifier } from '../DependencySpecifier';
+
+describe(DependencySpecifier.name, () => {
+  it('correctly parses workspace protocol in package.json', () => {
+    const specifier = new DependencySpecifier('dep', 'workspace:*');
+    expect(specifier.versionSpecifier).toBe('*');
+    expect(specifier.aliasTarget).toBeUndefined();
+
+    const specifier2 = new DependencySpecifier('dep', 'workspace:^1.0.0');
+    expect(specifier2.versionSpecifier).toBe('^1.0.0');
+    expect(specifier2.aliasTarget).toBeUndefined();
+
+    const specifier3 = new DependencySpecifier('dep', 'workspace:alias-target@*');
+    expect(specifier3.versionSpecifier).toBe('*');
+    expect(specifier3.aliasTarget?.packageName).toBe('alias-target');
+    expect(specifier3.aliasTarget?.versionSpecifier).toBe('*');
+  });
+});

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import { DependencySpecifier } from '../DependencySpecifier';
 
 describe(DependencySpecifier.name, () => {
@@ -11,7 +14,7 @@ describe(DependencySpecifier.name, () => {
     expect(specifier2.aliasTarget).toBeUndefined();
 
     const specifier3 = new DependencySpecifier('dep', 'workspace:alias-target@*');
-    expect(specifier3.versionSpecifier).toBe('*');
+    expect(specifier3.versionSpecifier).toBe('alias-target@*');
     expect(specifier3.aliasTarget?.packageName).toBe('alias-target');
     expect(specifier3.aliasTarget?.versionSpecifier).toBe('*');
   });

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -1,21 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { DependencySpecifier } from '../DependencySpecifier';
+import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
 
 describe(DependencySpecifier.name, () => {
   it('correctly parses workspace protocol in package.json', () => {
     const specifier = new DependencySpecifier('dep', 'workspace:*');
     expect(specifier.versionSpecifier).toBe('*');
     expect(specifier.aliasTarget).toBeUndefined();
+    expect(specifier.specifierType).toBe(DependencySpecifierType.Workspace);
 
     const specifier2 = new DependencySpecifier('dep', 'workspace:^1.0.0');
     expect(specifier2.versionSpecifier).toBe('^1.0.0');
     expect(specifier2.aliasTarget).toBeUndefined();
+    expect(specifier2.specifierType).toBe(DependencySpecifierType.Workspace);
 
     const specifier3 = new DependencySpecifier('dep', 'workspace:alias-target@*');
     expect(specifier3.versionSpecifier).toBe('alias-target@*');
     expect(specifier3.aliasTarget?.packageName).toBe('alias-target');
     expect(specifier3.aliasTarget?.versionSpecifier).toBe('*');
+    expect(specifier3.specifierType).toBe(DependencySpecifierType.Workspace);
   });
 });

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -1,24 +1,138 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { DependencySpecifier, DependencySpecifierType } from '../DependencySpecifier';
+import { DependencySpecifier } from '../DependencySpecifier';
 
 describe(DependencySpecifier.name, () => {
-  it('correctly parses workspace protocol in package.json', () => {
-    const specifier = new DependencySpecifier('dep', 'workspace:*');
-    expect(specifier.versionSpecifier).toBe('*');
-    expect(specifier.aliasTarget).toBeUndefined();
-    expect(specifier.specifierType).toBe(DependencySpecifierType.Workspace);
+  it('parses a simple version', () => {
+    const specifier = new DependencySpecifier('dep', '1.2.3');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Version",
+  "versionSpecifier": "1.2.3",
+}
+`);
+  });
 
-    const specifier2 = new DependencySpecifier('dep', 'workspace:^1.0.0');
-    expect(specifier2.versionSpecifier).toBe('^1.0.0');
-    expect(specifier2.aliasTarget).toBeUndefined();
-    expect(specifier2.specifierType).toBe(DependencySpecifierType.Workspace);
+  it('parses a range version', () => {
+    const specifier = new DependencySpecifier('dep', '^1.2.3');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Range",
+  "versionSpecifier": "^1.2.3",
+}
+`);
+  });
 
-    const specifier3 = new DependencySpecifier('dep', 'workspace:alias-target@*');
-    expect(specifier3.versionSpecifier).toBe('alias-target@*');
-    expect(specifier3.aliasTarget?.packageName).toBe('alias-target');
-    expect(specifier3.aliasTarget?.versionSpecifier).toBe('*');
-    expect(specifier3.specifierType).toBe(DependencySpecifierType.Workspace);
+  it('parses an alias version', () => {
+    const specifier = new DependencySpecifier('dep', 'npm:alias-target@1.2.3');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "alias-target",
+    "specifierType": "Version",
+    "versionSpecifier": "1.2.3",
+  },
+  "packageName": "dep",
+  "specifierType": "Alias",
+  "versionSpecifier": "npm:alias-target@1.2.3",
+}
+`);
+  });
+
+  it('parses a git version', () => {
+    const specifier = new DependencySpecifier('dep', 'git+https://github.com/user/foo');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Git",
+  "versionSpecifier": "git+https://github.com/user/foo",
+}
+`);
+  });
+
+  it('parses a file version', () => {
+    const specifier = new DependencySpecifier('dep', 'file:foo.tar.gz');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "File",
+  "versionSpecifier": "file:foo.tar.gz",
+}
+`);
+  });
+
+  it('parses a directory version', () => {
+    const specifier = new DependencySpecifier('dep', 'file:../foo/bar/');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Directory",
+  "versionSpecifier": "file:../foo/bar/",
+}
+`);
+  });
+
+  it('parses a remote version', () => {
+    const specifier = new DependencySpecifier('dep', 'https://example.com/foo.tgz');
+    expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Remote",
+  "versionSpecifier": "https://example.com/foo.tgz",
+}
+`);
+  });
+
+  describe('Workspace protocol', () => {
+    it('correctly parses a "workspace:*" version', () => {
+      const specifier = new DependencySpecifier('dep', 'workspace:*');
+      expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Workspace",
+  "versionSpecifier": "*",
+}
+`);
+    });
+
+    it('correctly parses a "workspace:^1.0.0" version', () => {
+      const specifier = new DependencySpecifier('dep', 'workspace:^1.0.0');
+      expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": undefined,
+  "packageName": "dep",
+  "specifierType": "Workspace",
+  "versionSpecifier": "^1.0.0",
+}
+`);
+    });
+
+    it('correctly parses a "workspace:alias@1.2.3" version', () => {
+      const specifier = new DependencySpecifier('dep', 'workspace:alias-target@*');
+      expect(specifier).toMatchInlineSnapshot(`
+DependencySpecifier {
+  "aliasTarget": DependencySpecifier {
+    "aliasTarget": undefined,
+    "packageName": "alias-target",
+    "specifierType": "Range",
+    "versionSpecifier": "*",
+  },
+  "packageName": "dep",
+  "specifierType": "Workspace",
+  "versionSpecifier": "alias-target@*",
+}
+`);
+    });
   });
 });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

currently, when declaring dependency with `NPM` alias with workspace protocol `workspace:`, the dependency won't be picked up by selectors (eg: --to-except)

eg: `"alias-for-my-controls": "workspace:my-controls@^1.0.0"`

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->


2 dependencies added in package.json: 
```
  "name": "my-app",
  "dependencies": {
    "my-toolchain": "workspace:^1.0.0",
    "alias-for-my-controls": "workspace:my-controls@^1.0.0"
  },
  ... 
```

when running `rush list --to-except my-app`
the output will only print `my-toolchain`, while `my-controls` is absent.

```
Starting "rush list"

my-toolchain
```

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

TODO

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
