### PR TITLE
[node-core-library] Include support for parsing JSON files with object keys that are reserved words and fix an issue with JSON schema validation.

### DIFF
--- a/common/changes/@rushstack/node-core-library/fix-issue-with-json-schema_2024-05-23-22-26.json
+++ b/common/changes/@rushstack/node-core-library/fix-issue-with-json-schema_2024-05-23-22-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Update `JsonFile` to support loading JSON files that include object keys that are members of `Object.prototype`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/fix-issue-with-json-schema_2024-05-23-22-27.json
+++ b/common/changes/@rushstack/node-core-library/fix-issue-with-json-schema_2024-05-23-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix an issue with `JsonSchema` where `\"uniqueItems\": true` would throw an error if the `\"item\"` type in the schema has `\"type\": \"object\"`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -571,7 +571,10 @@ export class JsonFile {
   }
 
   private static _buildJjuParseOptions(options: IJsonFileParseOptions = {}): jju.ParseOptions {
-    const parseOptions: jju.ParseOptions = {};
+    const parseOptions: jju.ParseOptions = {
+      reserved_keys: 'replace'
+    };
+
     switch (options.jsonSyntax) {
       case JsonSyntax.Strict:
         parseOptions.mode = 'json';

--- a/libraries/node-core-library/src/test/JsonFile.test.ts
+++ b/libraries/node-core-library/src/test/JsonFile.test.ts
@@ -67,4 +67,15 @@ describe(JsonFile.name, () => {
       JsonFile.updateString(`{\n  // comment\n  a: 1,\n}`, { a: 1, b: 2, 'c-123': 3 })
     ).toMatchSnapshot();
   });
+
+  it('supports parsing keys that map to `Object` properties', () => {
+    const propertyStrings: string[] = [];
+    for (const objectKey of Object.getOwnPropertyNames(Object.prototype).sort()) {
+      propertyStrings.push(`"${objectKey}": 1`);
+    }
+
+    const jsonString: string = `{\n  ${propertyStrings.join(',\n  ')}\n}`;
+    expect(jsonString).toMatchSnapshot('JSON String');
+    expect(JsonFile.parseString(jsonString)).toMatchSnapshot('Parsed JSON Object');
+  });
 });

--- a/libraries/node-core-library/src/test/JsonSchema.test.ts
+++ b/libraries/node-core-library/src/test/JsonSchema.test.ts
@@ -95,7 +95,7 @@ describe(JsonSchema.name, () => {
     });
   });
 
-  describe('validateObjectWithCallback', () => {
+  describe(JsonSchema.prototype.validateObjectWithCallback.name, () => {
     test('successfully reports a compound validation error schema errors', () => {
       const jsonPath: string = `${__dirname}/test-data/test-invalid-additional.json`;
       const jsonObject: JsonObject = JsonFile.load(jsonPath);

--- a/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
@@ -43,7 +43,22 @@ exports[`JsonFile supports parsing keys that map to \`Object\` properties: JSON 
 }"
 `;
 
-exports[`JsonFile supports parsing keys that map to \`Object\` properties: Parsed JSON Object 1`] = `Object {}`;
+exports[`JsonFile supports parsing keys that map to \`Object\` properties: Parsed JSON Object 1`] = `
+Object {
+  "__defineGetter__": 1,
+  "__defineSetter__": 1,
+  "__lookupGetter__": 1,
+  "__lookupSetter__": 1,
+  "__proto__": 1,
+  "constructor": 1,
+  "hasOwnProperty": 1,
+  "isPrototypeOf": 1,
+  "propertyIsEnumerable": 1,
+  "toLocaleString": 1,
+  "toString": 1,
+  "valueOf": 1,
+}
+`;
 
 exports[`JsonFile supports updating a simple file 1`] = `
 "{\\"a\\": 1,\\"b\\": 2}

--- a/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/JsonFile.test.ts.snap
@@ -26,6 +26,25 @@ exports[`JsonFile allows undefined values when asked 2`] = `
 "
 `;
 
+exports[`JsonFile supports parsing keys that map to \`Object\` properties: JSON String 1`] = `
+"{
+  \\"__defineGetter__\\": 1,
+  \\"__defineSetter__\\": 1,
+  \\"__lookupGetter__\\": 1,
+  \\"__lookupSetter__\\": 1,
+  \\"__proto__\\": 1,
+  \\"constructor\\": 1,
+  \\"hasOwnProperty\\": 1,
+  \\"isPrototypeOf\\": 1,
+  \\"propertyIsEnumerable\\": 1,
+  \\"toLocaleString\\": 1,
+  \\"toString\\": 1,
+  \\"valueOf\\": 1
+}"
+`;
+
+exports[`JsonFile supports parsing keys that map to \`Object\` properties: Parsed JSON Object 1`] = `Object {}`;
+
 exports[`JsonFile supports updating a simple file 1`] = `
 "{\\"a\\": 1,\\"b\\": 2}
 "

--- a/libraries/node-core-library/src/test/test-data/test-schema-draft-04.json
+++ b/libraries/node-core-library/src/test/test-data/test-schema-draft-04.json
@@ -52,6 +52,22 @@
       "description": "Description for exampleOneOf - this is a very long description to show in an error message",
       "type": "object",
       "oneOf": [{ "$ref": "#/definitions/type1" }, { "$ref": "#/definitions/type2" }]
+    },
+    "exampleUniqueObjectArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "field2": {
+            "type": "string"
+          },
+          "field3": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/libraries/node-core-library/src/test/test-data/test-schema-draft-07.json
+++ b/libraries/node-core-library/src/test/test-data/test-schema-draft-07.json
@@ -52,6 +52,22 @@
       "description": "Description for exampleOneOf - this is a very long description to show in an error message",
       "type": "object",
       "oneOf": [{ "$ref": "#/definitions/type1" }, { "$ref": "#/definitions/type2" }]
+    },
+    "exampleUniqueObjectArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "field2": {
+            "type": "string"
+          },
+          "field3": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/libraries/node-core-library/src/test/test-data/test-schema-nested.json
+++ b/libraries/node-core-library/src/test/test-data/test-schema-nested.json
@@ -24,6 +24,11 @@
         { "$ref": "test-schema-nested-child.json#/definitions/type1" },
         { "$ref": "test-schema-nested-child.json#/definitions/type2" }
       ]
+    },
+    "exampleUniqueObjectArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "test-schema-nested-child.json#/definitions/type2" }
     }
   },
   "additionalProperties": false,

--- a/libraries/node-core-library/src/test/test-data/test-schema.json
+++ b/libraries/node-core-library/src/test/test-data/test-schema.json
@@ -51,6 +51,22 @@
       "description": "Description for exampleOneOf - this is a very long description to show in an error message",
       "type": "object",
       "oneOf": [{ "$ref": "#/definitions/type1" }, { "$ref": "#/definitions/type2" }]
+    },
+    "exampleUniqueObjectArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "field2": {
+            "type": "string"
+          },
+          "field3": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/libraries/node-core-library/src/test/test-data/test-valid.json
+++ b/libraries/node-core-library/src/test/test-data/test-valid.json
@@ -1,5 +1,15 @@
 {
   "exampleString": "This is a string",
   "exampleLink": "http://example.com",
-  "exampleArray": ["apple", "banana", "coconut"]
+  "exampleArray": ["apple", "banana", "coconut"],
+  "exampleUniqueObjectArray": [
+    {
+      "field2": "a",
+      "field3": "b"
+    },
+    {
+      "field2": "c",
+      "field3": "d"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

With the upgrade to use `ajv` for JSON schema validation, we accidentally introduced a regression where using the `"uniqueItems": true` option in a schema for an array with items that are objects causes an exception to be thrown when calling `JsonFile.loadAndValidate`. This is because the `jju` parses JSON files by default does not populate the functions from `Object.prototype` on parsed JSON objects and `ajv` uses `a.valueOf() === b.valueOf()` as part of its deep comparison of objects (via the `fast-deep-equal` package). The `valueOf` function isn't populated on objects, so this function call fails.

This PR adds the `reserved_keys: 'replace'` `jju` parse option to populate these functions. This also allows parsing of objects with these properties. This introduces an edge case where a JSON object with a `"valueOf"` key will fail with a similar error in a similar scenario, but this is a much less common case than the currently-broken functionality.

## How it was tested

Introduced tests for these scenarios.