### PR TITLE
Bump decoupled local dependencies and remove `tslint-microsoft-contrib`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ jspm_packages
 common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
-**/.rush
+**/.rush/temp/
 *.lock
 
 # Heft temporary files

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -52,8 +52,8 @@
     "typescript": "5.4.2"
   },
   "devDependencies": {
-    "@rushstack/heft-node-rig": "2.6.7",
-    "@rushstack/heft": "0.66.9",
+    "@rushstack/heft-node-rig": "2.6.14",
+    "@rushstack/heft": "0.66.16",
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",
     "@types/minimatch": "3.0.5",

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -51,8 +51,8 @@
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/watchpack": "2.4.0",

--- a/build-tests-samples/heft-node-basic-tutorial/src/index.ts
+++ b/build-tests-samples/heft-node-basic-tutorial/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests-samples/heft-node-rig-tutorial/src/index.ts
+++ b/build-tests-samples/heft-node-rig-tutorial/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests-subspace/typescript-newest-test/src/index.ts
+++ b/build-tests-subspace/typescript-newest-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests-subspace/typescript-v4-test/src/index.ts
+++ b/build-tests-subspace/typescript-v4-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-node-everything-esm-module-test/package.json
+++ b/build-tests/heft-node-everything-esm-module-test/package.json
@@ -25,7 +25,6 @@
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/heft-node-everything-esm-module-test/src/index.ts
+++ b/build-tests/heft-node-everything-esm-module-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-node-everything-esm-module-test/tslint.json
+++ b/build-tests/heft-node-everything-esm-module-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -59,9 +53,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -96,7 +88,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-node-everything-test/package.json
+++ b/build-tests/heft-node-everything-test/package.json
@@ -24,7 +24,6 @@
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/heft-node-everything-test/src/index.ts
+++ b/build-tests/heft-node-everything-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-node-everything-test/tslint.json
+++ b/build-tests/heft-node-everything-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -59,9 +53,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -96,7 +88,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-typescript-composite-test/package.json
+++ b/build-tests/heft-typescript-composite-test/package.json
@@ -20,7 +20,6 @@
     "@types/webpack-env": "1.18.0",
     "eslint": "~8.57.0",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/heft-typescript-composite-test/tslint.json
+++ b/build-tests/heft-typescript-composite-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -62,9 +56,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -99,7 +91,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-typescript-v2-test/package.json
+++ b/build-tests/heft-typescript-v2-test/package.json
@@ -20,7 +20,6 @@
     "@types/jest": "ts2.9",
     "@types/node": "ts2.9",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~2.9.2"
   }
 }

--- a/build-tests/heft-typescript-v2-test/src/index.ts
+++ b/build-tests/heft-typescript-v2-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-typescript-v2-test/tslint.json
+++ b/build-tests/heft-typescript-v2-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -59,9 +53,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -96,7 +88,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-typescript-v3-test/package.json
+++ b/build-tests/heft-typescript-v3-test/package.json
@@ -20,7 +20,6 @@
     "@types/jest": "ts3.9",
     "@types/node": "ts3.9",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~3.9.10"
   }
 }

--- a/build-tests/heft-typescript-v3-test/src/index.ts
+++ b/build-tests/heft-typescript-v3-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-typescript-v3-test/tslint.json
+++ b/build-tests/heft-typescript-v3-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -59,9 +53,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -96,7 +88,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-typescript-v4-test/package.json
+++ b/build-tests/heft-typescript-v4-test/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
-    "@rushstack/eslint-config": "3.6.10",
+    "@rushstack/eslint-config": "3.7.0",
     "@rushstack/eslint-patch": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-api-extractor-plugin": "workspace:*",

--- a/build-tests/heft-typescript-v4-test/package.json
+++ b/build-tests/heft-typescript-v4-test/package.json
@@ -23,7 +23,6 @@
     "@types/node": "ts4.9",
     "eslint": "~8.57.0",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~4.9.5"
   }
 }

--- a/build-tests/heft-typescript-v4-test/src/index.ts
+++ b/build-tests/heft-typescript-v4-test/src/index.ts
@@ -4,4 +4,4 @@
 /**
  * @public
  */
-export class TestClass {} // tslint:disable-line:export-name
+export class TestClass {}

--- a/build-tests/heft-typescript-v4-test/tslint.json
+++ b/build-tests/heft-typescript-v4-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -59,9 +53,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -96,7 +88,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-webpack4-everything-test/package.json
+++ b/build-tests/heft-webpack4-everything-test/package.json
@@ -26,7 +26,6 @@
     "file-loader": "~6.0.0",
     "source-map-loader": "~1.1.3",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.4.2",
     "webpack": "~4.47.0"
   }

--- a/build-tests/heft-webpack4-everything-test/tslint.json
+++ b/build-tests/heft-webpack4-everything-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -62,9 +56,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -99,7 +91,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -29,7 +29,6 @@
     "html-webpack-plugin": "~5.5.0",
     "source-map-loader": "~3.0.1",
     "tslint": "~5.20.1",
-    "tslint-microsoft-contrib": "~6.2.0",
     "typescript": "~5.4.2",
     "webpack": "~5.82.1",
     "@types/node": "18.17.15"

--- a/build-tests/heft-webpack5-everything-test/tslint.json
+++ b/build-tests/heft-webpack5-everything-test/tslint.json
@@ -1,13 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 
-  "rulesDirectory": ["tslint-microsoft-contrib"],
   "rules": {
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
-    "export-name": true,
     "forin": true,
     "indent": [true, "spaces", 2],
     "interface-name": true,
@@ -36,22 +34,18 @@
         ]
       }
     ],
-    "missing-optional-annotation": true,
     "no-arg": true,
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
-    "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,
-    "no-function-expression": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-null-keyword": true,
@@ -62,9 +56,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
@@ -99,7 +91,6 @@
       }
     ],
     "use-isnan": true,
-    "use-named-parameter": true,
     "variable-name": [true, "check-format", "allow-leading-underscore", "ban-keywords"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }

--- a/common/changes/@microsoft/api-extractor-model/main_2024-05-29-03-15.json
+++ b/common/changes/@microsoft/api-extractor-model/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor-model"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/main_2024-05-29-03-15.json
+++ b/common/changes/@microsoft/api-extractor/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-patch/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/eslint-patch/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin-packlets"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/eslint-plugin-security/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin-security"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/eslint-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/eslint-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/eslint-plugin"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-api-extractor-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-config-file/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft-config-file/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-config-file"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft-jest-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-jest-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-lint-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft-lint-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-lint-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft-typescript-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/heft/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/node-core-library/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/operation-graph/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/operation-graph/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/operation-graph"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rig-package/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/rig-package/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/rig-package"
+    }
+  ],
+  "packageName": "@rushstack/rig-package",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/terminal/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/terminal/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/terminal"
+    }
+  ],
+  "packageName": "@rushstack/terminal",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/tree-pattern/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/tree-pattern/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/tree-pattern"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/ts-command-line/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/ts-command-line/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/ts-command-line"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/main_2024-05-29-03-15.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/main_2024-05-29-03-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/webpack4-localization-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/.npmrc-publish
+++ b/common/config/rush/.npmrc-publish
@@ -22,3 +22,4 @@
 registry=https://registry.npmjs.org/
 always-auth=true
 //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+

--- a/common/config/rush/build-cache.json
+++ b/common/config/rush/build-cache.json
@@ -24,11 +24,13 @@
    * a [hash] token.
    *
    * Other available tokens:
-   *  - [projectName]
-   *  - [projectName:normalize]
-   *  - [phaseName]
-   *  - [phaseName:normalize]
-   *  - [phaseName:trimPrefix]
+   *  - [projectName]             Example: "@my-scope/my-project"
+   *  - [projectName:normalize]   Example: "my-scope+my-project"
+   *  - [phaseName]               Example: "_phase:test/api"
+   *  - [phaseName:normalize]     Example: "_phase:test+api"
+   *  - [phaseName:trimPrefix]    Example: "test/api"
+   *  - [os]                      Example: "win32"
+   *  - [arch]                    Example: "x64"
    */
   "cacheEntryNamePattern": "[projectName:normalize]-[phaseName:normalize]-[hash]",
 

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -862,10 +862,7 @@
       "name": "tslint",
       "allowedCategories": [ "libraries", "tests" ]
     },
-    {
-      "name": "tslint-microsoft-contrib",
-      "allowedCategories": [ "tests" ]
-    },
+
     {
       "name": "typescript",
       "allowedCategories": [ "libraries", "tests", "vscode-extensions" ]

--- a/common/config/subspaces/build-tests-subspace/.pnpmfile-subspace.cjs
+++ b/common/config/subspaces/build-tests-subspace/.pnpmfile-subspace.cjs
@@ -48,13 +48,6 @@ function readPackage(packageJson, context) {
       delete packageJson.dependencies['lerna'];
       break;
     }
-
-    case 'tslint-microsoft-contrib': {
-      // The `tslint-microsoft-contrib` repo is archived so it can't be updated to TS 4.4+.
-      // unmet peer typescript@"^2.1.0 || ^3.0.0": found 4.5.5
-      packageJson.peerDependencies['typescript'] = '*';
-      break;
-    }
   }
 
   return packageJson;

--- a/common/config/subspaces/default/.pnpmfile-subspace.cjs
+++ b/common/config/subspaces/default/.pnpmfile-subspace.cjs
@@ -48,13 +48,6 @@ function readPackage(packageJson, context) {
       delete packageJson.dependencies['lerna'];
       break;
     }
-
-    case 'tslint-microsoft-contrib': {
-      // The `tslint-microsoft-contrib` repo is archived so it can't be updated to TS 4.4+.
-      // unmet peer typescript@"^2.1.0 || ^3.0.0": found 4.5.5
-      packageJson.peerDependencies['typescript'] = '*';
-      break;
-    }
   }
 
   return packageJson;

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -93,11 +93,11 @@ importers:
         version: 5.4.2
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -166,11 +166,11 @@ importers:
         specifier: workspace:*
         version: link:../api-extractor
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -1519,9 +1519,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.4.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@5.4.2)
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1567,9 +1564,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.4.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@5.4.2)
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1743,9 +1737,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.4.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@5.4.2)
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1779,9 +1770,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@2.9.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@2.9.2)
       typescript:
         specifier: ~2.9.2
         version: 2.9.2
@@ -1815,9 +1803,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@3.9.10)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@3.9.10)
       typescript:
         specifier: ~3.9.10
         version: 3.9.10
@@ -1828,8 +1813,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/api-extractor
       '@rushstack/eslint-config':
-        specifier: 3.6.10
-        version: 3.6.10(eslint@8.57.0)(typescript@4.9.5)
+        specifier: 3.7.0
+        version: 3.7.0(eslint@8.57.0)(typescript@4.9.5)
       '@rushstack/eslint-patch':
         specifier: workspace:*
         version: link:../../eslint/eslint-patch
@@ -1860,9 +1845,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@4.9.5)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@4.9.5)
       typescript:
         specifier: ~4.9.5
         version: 4.9.5
@@ -1926,9 +1908,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.4.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@5.4.2)
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1992,9 +1971,6 @@ importers:
       tslint:
         specifier: ~5.20.1
         version: 5.20.1(typescript@5.4.2)
-      tslint-microsoft-contrib:
-        specifier: ~6.2.0
-        version: 6.2.0(tslint@5.20.1)(typescript@5.4.2)
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -2376,11 +2352,11 @@ importers:
   ../../../eslint/eslint-patch:
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2413,11 +2389,11 @@ importers:
         specifier: ~3.0.0
         version: 3.0.2
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2459,11 +2435,11 @@ importers:
         version: 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2505,11 +2481,11 @@ importers:
         specifier: ~3.0.0
         version: 3.0.2
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.2.0
         version: 8.2.0
@@ -2594,8 +2570,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
@@ -2677,8 +2653,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -2720,8 +2696,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/heft-typescript-plugin':
         specifier: workspace:*
         version: link:../heft-typescript-plugin
@@ -2850,8 +2826,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
@@ -2958,11 +2934,11 @@ importers:
         version: link:../node-core-library
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3014,11 +2990,11 @@ importers:
         version: 4.0.0
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3119,11 +3095,11 @@ importers:
         version: 7.5.4
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/fs-extra':
         specifier: 7.0.0
         version: 7.0.0
@@ -3156,11 +3132,11 @@ importers:
         version: link:../terminal
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3252,11 +3228,11 @@ importers:
         version: 3.1.1
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3496,7 +3472,7 @@ importers:
         version: 1.0.4(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@radix-ui/react-icons':
         specifier: ~1.1.1
-        version: 1.1.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+        version: 1.1.1(react@17.0.2)
       '@radix-ui/react-scroll-area':
         specifier: ~1.0.2
         version: 1.0.5(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -3555,11 +3531,11 @@ importers:
         version: 8.1.1
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3576,14 +3552,14 @@ importers:
   ../../../libraries/tree-pattern:
     devDependencies:
       '@rushstack/eslint-config':
-        specifier: 3.6.10
-        version: 3.6.10(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: 3.7.0
+        version: 3.7.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3613,11 +3589,11 @@ importers:
         version: 0.3.2
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.66.9
-        version: 0.66.9(@types/node@18.17.15)
+        specifier: 0.66.16
+        version: 0.66.16(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.7
-        version: 2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.14
+        version: 2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -9343,27 +9319,27 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: true
 
-  /@microsoft/api-extractor-model@7.28.17(@types/node@18.17.15):
-    resolution: {integrity: sha512-b2AfLP33oEVtWLeNavSBRdyDa8sKlXjN4pdhBnC4HLontOtjILhL1ERAmZObF4PWSyChnnC2vjb47C9WKCFRGg==}
+  /@microsoft/api-extractor-model@7.29.1(@types/node@18.17.15):
+    resolution: {integrity: sha512-nPiAbD1lBx4imlIwpHxEnQbMPVOvZ7RmopC5WeTUQ4oA9KBeRe6fq0gI+FCzSPBhMeQhDzC40XpkfaNEAhR1Aw==}
     dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.43.7(@types/node@18.17.15):
-    resolution: {integrity: sha512-t5M8BdnS+TmroUA/Z9HJXExS9iL4pK9I3yGu9PsXVTXPmcVXlBlA1CVI7TjRa1jwm+vusG/+sbX1/t5UkJhQMg==}
+  /@microsoft/api-extractor@7.46.1(@types/node@18.17.15):
+    resolution: {integrity: sha512-rp/fGAWszN+Mlyt7QAtD4qoAj7Tu19fmkyFVl3oUNCPAfpMzfttS84QKBqAkwODkfn8MmOrSOjY6zBtJ626c1Q==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.17(@types/node@18.17.15)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@microsoft/api-extractor-model': 7.29.1(@types/node@18.17.15)
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
-      '@rushstack/ts-command-line': 4.21.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
+      '@rushstack/ts-command-line': 4.21.5(@types/node@18.17.15)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -9382,15 +9358,6 @@ packages:
     resolution: {integrity: sha512-AxDfMpiVqh3hsqTxMEYtQoz866WB/sw/Jl0pgTLh6sMHHmIBNMd+E0pVcP9WNk8zTkr9LCphJ5SziU1C8BgZMA==}
     dev: true
 
-  /@microsoft/tsdoc-config@0.16.2:
-    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      ajv: 6.12.6
-      jju: 1.4.0
-      resolve: 1.19.0
-    dev: true
-
   /@microsoft/tsdoc-config@0.17.0:
     resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
     dependencies:
@@ -9398,15 +9365,9 @@ packages:
       ajv: 8.12.0
       jju: 1.4.0
       resolve: 1.22.8
-    dev: false
-
-  /@microsoft/tsdoc@0.14.2:
-    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
-    dev: true
 
   /@microsoft/tsdoc@0.15.0:
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
-    dev: false
 
   /@mrmlnc/readdir-enhanced@2.2.1:
     resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}
@@ -9685,13 +9646,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-context': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@radix-ui/react-presence': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-use-size': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
@@ -9712,21 +9673,20 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-context': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-slot': 1.0.2(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-slot': 1.0.2(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@radix-ui/react-compose-refs@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -9734,15 +9694,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-context@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-context@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -9750,15 +9708,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-direction@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-direction@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -9766,36 +9722,29 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-icons@1.1.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-icons@1.1.1(react@17.0.2):
     resolution: {integrity: sha512-xc3wQC59rsFylVbSusQCrrM+6695ppF730Q6yqzhRdqDcRNWIm2R6ngpzBoSOQMcwnq4p805F+Gr7xo4fmtN1A==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.x || ^17.x || ^18.x
     dependencies:
-      '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-id@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-id@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
@@ -9813,8 +9762,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
@@ -9835,7 +9784,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-slot': 1.0.2(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-slot': 1.0.2(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
@@ -9858,13 +9807,13 @@ packages:
       '@babel/runtime': 7.24.0
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-context': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-direction': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-id': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-id': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
@@ -9887,33 +9836,31 @@ packages:
       '@babel/runtime': 7.24.0
       '@radix-ui/number': 1.0.1
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-context': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-direction': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@radix-ui/react-presence': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@radix-ui/react-slot@1.0.2(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-slot@1.0.2(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
@@ -9932,24 +9879,23 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-context': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-direction': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
-      '@radix-ui/react-id': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-id': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@radix-ui/react-presence': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@17.0.25)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@radix-ui/react-use-callback-ref@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -9957,32 +9903,28 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-use-controllable-state@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-use-layout-effect@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -9990,15 +9932,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-use-previous@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-use-previous@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -10006,24 +9946,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
-  /@radix-ui/react-use-size@1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2):
+  /@radix-ui/react-use-size@1.0.1(@types/react@17.0.74)(react@17.0.2):
     resolution: {integrity: sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==}
     peerDependencies:
       '@types/react': '*'
-      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
       '@babel/runtime': 7.24.0
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react-dom@17.0.25)(@types/react@17.0.74)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@17.0.74)(react@17.0.2)
       '@types/react': 17.0.74
-      '@types/react-dom': 17.0.25
       react: 17.0.2
     dev: true
 
@@ -10060,8 +9997,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@rushstack/eslint-config@3.6.10(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
-    resolution: {integrity: sha512-Q0g5j0RuvLghsfRxczyyZXROMCZ4Gn994GGZoDeBJD/+MR2SACakmj3fw8WkG4gXUSrFPZoLlLPakRW4sYKHLg==}
+  /@rushstack/eslint-config@3.7.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+    resolution: {integrity: sha512-9AWc0eIElbrTm9VTfdjaXeqrS7gGoZJ7oMmUdUX0dtPzYrWBHLCuR4eOgLo3pQIC+HyLFt/AzX1ontQTJlWjtQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
@@ -10077,14 +10014,14 @@ packages:
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
-      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-tsdoc: 0.3.0
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@3.6.10(eslint@8.57.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-Q0g5j0RuvLghsfRxczyyZXROMCZ4Gn994GGZoDeBJD/+MR2SACakmj3fw8WkG4gXUSrFPZoLlLPakRW4sYKHLg==}
+  /@rushstack/eslint-config@3.7.0(eslint@8.57.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-9AWc0eIElbrTm9VTfdjaXeqrS7gGoZJ7oMmUdUX0dtPzYrWBHLCuR4eOgLo3pQIC+HyLFt/AzX1ontQTJlWjtQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
@@ -10100,7 +10037,7 @@ packages:
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
-      eslint-plugin-tsdoc: 0.2.17
+      eslint-plugin-tsdoc: 0.3.0
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -10188,46 +10125,46 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/heft-api-extractor-plugin@0.3.29(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-cHS+h07+W1/2kTo1eIwG2ybWx0D6uVLiV6fN4Q2JPPeUOC+WdZSYWdWll5DHk8UyNd/axCggERtrYYyd9WMd0w==}
+  /@rushstack/heft-api-extractor-plugin@0.3.36(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-ZJtBIJhD0jr73UL7YNWIXvu7mwD1qs2Ar2MnoGeBgLDFacEGx9K/7YE5UHWLYD7FxS5im9odiweC2VLIz6jViA==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-api-extractor-plugin@0.3.29(@rushstack/heft@0.66.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-cHS+h07+W1/2kTo1eIwG2ybWx0D6uVLiV6fN4Q2JPPeUOC+WdZSYWdWll5DHk8UyNd/axCggERtrYYyd9WMd0w==}
+  /@rushstack/heft-api-extractor-plugin@0.3.36(@rushstack/heft@0.66.16)(@types/node@18.17.15):
+    resolution: {integrity: sha512-ZJtBIJhD0jr73UL7YNWIXvu7mwD1qs2Ar2MnoGeBgLDFacEGx9K/7YE5UHWLYD7FxS5im9odiweC2VLIz6jViA==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.66.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.66.16(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-config-file@0.14.19(@types/node@18.17.15):
-    resolution: {integrity: sha512-XLrq3gY6M7SzY2HRtmI/frCNURdqNdH557mXoULIfUEBj61lpngMKdBhEpzyekilEowTnHSmHpi0/JCyE61kbA==}
+  /@rushstack/heft-config-file@0.14.24(@types/node@18.17.15):
+    resolution: {integrity: sha512-eik6YDV7spA6pEqA877lDxxjUxbFGmKlN8Mnrh5U+v1prX4J5HL3cSIOQdEFBneWQVbLYhk85DTKC62qBjViZg==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
       jsonpath-plus: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.11.30(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0):
-    resolution: {integrity: sha512-KJkrYM00HS9klQ2cOxNhHcSZhRpgyBhNSblU7H4GdsAv0aHVbHOPJFlzGN5x/yj3AiF0nLAQZ6SAzCV2srFQSw==}
+  /@rushstack/heft-jest-plugin@0.11.37(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0):
+    resolution: {integrity: sha512-wCTw5x4M1+7ZpmPWLjXmHx1lbQCvz5oBQUWhAb3AJK3bw6CZBScHa/gaYO3L2qSV4RwsiBpUBj0aDIc/J8y29g==}
     peerDependencies:
       '@rushstack/heft': '*'
       jest-environment-jsdom: ^29.5.0
@@ -10242,9 +10179,9 @@ packages:
       '@jest/reporters': 29.5.0(supports-color@8.1.1)
       '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
       jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-environment-jsdom: 29.5.0
       jest-environment-node: 29.5.0
@@ -10259,8 +10196,8 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.11.30(@rushstack/heft@0.66.9)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1):
-    resolution: {integrity: sha512-KJkrYM00HS9klQ2cOxNhHcSZhRpgyBhNSblU7H4GdsAv0aHVbHOPJFlzGN5x/yj3AiF0nLAQZ6SAzCV2srFQSw==}
+  /@rushstack/heft-jest-plugin@0.11.37(@rushstack/heft@0.66.16)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1):
+    resolution: {integrity: sha512-wCTw5x4M1+7ZpmPWLjXmHx1lbQCvz5oBQUWhAb3AJK3bw6CZBScHa/gaYO3L2qSV4RwsiBpUBj0aDIc/J8y29g==}
     peerDependencies:
       '@rushstack/heft': '*'
       jest-environment-jsdom: ^29.5.0
@@ -10274,10 +10211,10 @@ packages:
       '@jest/core': 29.5.0(supports-color@8.1.1)
       '@jest/reporters': 29.5.0(supports-color@8.1.1)
       '@jest/transform': 29.5.0(supports-color@8.1.1)
-      '@rushstack/heft': 0.66.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.66.16(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
       jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
       jest-environment-node: 29.5.0
       jest-resolve: 29.5.0
@@ -10291,42 +10228,42 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-lint-plugin@0.3.30(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-Tu7+UcVpzJb3FcgiaFNwuO+Afdj5FzpbeTCYuRBf+AUH4uRV/tWyjy++hrvzev6ZY4Jten4Q7/YVFXPLlboQow==}
+  /@rushstack/heft-lint-plugin@0.3.37(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-YJyjly9H+oVqAUPeFcPryYZA+YfwWxutcdFf2I/V5PCGMdB/NoC27ohf4JHtG5Bvsj1D8Ztm3BlhPLrlrVJr3g==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-lint-plugin@0.3.30(@rushstack/heft@0.66.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-Tu7+UcVpzJb3FcgiaFNwuO+Afdj5FzpbeTCYuRBf+AUH4uRV/tWyjy++hrvzev6ZY4Jten4Q7/YVFXPLlboQow==}
+  /@rushstack/heft-lint-plugin@0.3.37(@rushstack/heft@0.66.16)(@types/node@18.17.15):
+    resolution: {integrity: sha512-YJyjly9H+oVqAUPeFcPryYZA+YfwWxutcdFf2I/V5PCGMdB/NoC27ohf4JHtG5Bvsj1D8Ztm3BlhPLrlrVJr3g==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.66.9(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.66.16(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-node-rig@2.6.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0):
-    resolution: {integrity: sha512-LW8yE82Y6bIMZCpV9ANyG6oQT4h5ziHJGpzNl194LqLOwuvWn/0y4nzEOb5xGEgTMqyW0exPc1KQJsQo7BC9pA==}
+  /@rushstack/heft-node-rig@2.6.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0):
+    resolution: {integrity: sha512-taNs51oc9Qw3vFoi4V7rhivHwYQ5o5aPb6uKVQLEJzK2C8Jbd0dh4hNYLhJs4UfXFD47CQn34AgTTbRDsiFBSg==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@microsoft/api-extractor': 7.43.7(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.10(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@microsoft/api-extractor': 7.46.1(@types/node@18.17.15)
+      '@rushstack/eslint-config': 3.7.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-api-extractor-plugin': 0.3.29(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.11.30(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': 0.3.30(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': 0.5.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': 0.3.36(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': 0.11.37(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
+      '@rushstack/heft-lint-plugin': 0.3.37(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': 0.5.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
@@ -10340,18 +10277,18 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-node-rig@2.6.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)(supports-color@8.1.1):
-    resolution: {integrity: sha512-LW8yE82Y6bIMZCpV9ANyG6oQT4h5ziHJGpzNl194LqLOwuvWn/0y4nzEOb5xGEgTMqyW0exPc1KQJsQo7BC9pA==}
+  /@rushstack/heft-node-rig@2.6.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)(supports-color@8.1.1):
+    resolution: {integrity: sha512-taNs51oc9Qw3vFoi4V7rhivHwYQ5o5aPb6uKVQLEJzK2C8Jbd0dh4hNYLhJs4UfXFD47CQn34AgTTbRDsiFBSg==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@microsoft/api-extractor': 7.43.7(@types/node@18.17.15)
-      '@rushstack/eslint-config': 3.6.10(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@rushstack/heft': 0.66.9(@types/node@18.17.15)
-      '@rushstack/heft-api-extractor-plugin': 0.3.29(@rushstack/heft@0.66.9)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.11.30(@rushstack/heft@0.66.9)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1)
-      '@rushstack/heft-lint-plugin': 0.3.30(@rushstack/heft@0.66.9)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': 0.5.7(@rushstack/heft@0.66.9)(@types/node@18.17.15)
+      '@microsoft/api-extractor': 7.46.1(@types/node@18.17.15)
+      '@rushstack/eslint-config': 3.7.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@rushstack/heft': 0.66.16(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': 0.3.36(@rushstack/heft@0.66.16)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': 0.11.37(@rushstack/heft@0.66.16)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1)
+      '@rushstack/heft-lint-plugin': 0.3.37(@rushstack/heft@0.66.16)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': 0.5.14(@rushstack/heft@0.66.16)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
@@ -10365,14 +10302,14 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-typescript-plugin@0.5.7(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-Pe1C0466nWRfSV/x1L9dClp0TWr53RB3r6wfODDaNkOHgDnmWuec8J+9CEJyEZ+VBBN/zhlZdr9/yGWAjmxYkw==}
+  /@rushstack/heft-typescript-plugin@0.5.14(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-BsmuELK9rJmgnz8TAKpZz/nh3/7YWW1qhts2EYXfHlBvA90gr580wyKUjY7jozLaDFMMfOzLhclD87YFgxFJvQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       semver: 7.5.4
       tapable: 1.1.3
@@ -10380,14 +10317,14 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-typescript-plugin@0.5.7(@rushstack/heft@0.66.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-Pe1C0466nWRfSV/x1L9dClp0TWr53RB3r6wfODDaNkOHgDnmWuec8J+9CEJyEZ+VBBN/zhlZdr9/yGWAjmxYkw==}
+  /@rushstack/heft-typescript-plugin@0.5.14(@rushstack/heft@0.66.16)(@types/node@18.17.15):
+    resolution: {integrity: sha512-BsmuELK9rJmgnz8TAKpZz/nh3/7YWW1qhts2EYXfHlBvA90gr580wyKUjY7jozLaDFMMfOzLhclD87YFgxFJvQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.66.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.66.16(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       semver: 7.5.4
       tapable: 1.1.3
@@ -10395,17 +10332,17 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft@0.66.9(@types/node@18.17.15):
-    resolution: {integrity: sha512-nTdLS7ATkELK4dYQORQRt+TkW7+Jur4MSQIi76+sxbWxhS1nW9BN2Cz6+DFg/EWqTcxEIjqONFG0J3yHTDQZWQ==}
+  /@rushstack/heft@0.66.16(@types/node@18.17.15):
+    resolution: {integrity: sha512-GYw7VNSKoJyELjj8uR7nPPtk9ebzuWuy1GIXc6HHDfLbgH03mKKnF+7pPtFnLqXGm9cOgf/6QgSpJrRZjFp74A==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': 0.14.19(@types/node@18.17.15)
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
-      '@rushstack/operation-graph': 0.2.19(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.14.24(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
+      '@rushstack/operation-graph': 0.2.24(@types/node@18.17.15)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
-      '@rushstack/ts-command-line': 4.21.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
+      '@rushstack/ts-command-line': 4.21.5(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       fast-glob: 3.3.2
       git-repo-info: 2.1.1
@@ -10434,8 +10371,8 @@ packages:
       semver: 7.5.4
       z-schema: 5.0.6
 
-  /@rushstack/node-core-library@4.3.0(@types/node@18.17.15):
-    resolution: {integrity: sha512-JuNZ7lwaYQ4R1TugpryyWBn4lIxK+L7fF+muibFp0by5WklG22nsvH868fuBoZMLo5FqAs6WFOifNos4PJjWSA==}
+  /@rushstack/node-core-library@5.4.0(@types/node@18.17.15):
+    resolution: {integrity: sha512-AORYbEZUgEj8w4vGGWMkrdMkWPE9+wMor5Z0H6vyVBQn4Y+iNuV2OA7ozKF7f4KqHrh6ZmmKnSxLzYp/kcF0Gg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -10443,24 +10380,26 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.17.15
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
-      z-schema: 5.0.6
     dev: true
 
-  /@rushstack/operation-graph@0.2.19(@types/node@18.17.15):
-    resolution: {integrity: sha512-yGxy5WfuR+uzR5AuwIYSayJsWb/Xa/mZvGlWI3A1CsJlOu9xBS2JFAGO9YAGURWY2QuUd64gGokYHKej2oa3Ew==}
+  /@rushstack/operation-graph@0.2.24(@types/node@18.17.15):
+    resolution: {integrity: sha512-T0MENiWPBu92Bblw5bENsgcF+g3CV7lbFrl4P3v8sADLgb4vZvdPKwCaGMVzq03/4jNlukiFiR6rZOPrDCYBtw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
       '@types/node': 18.17.15
     dev: true
 
@@ -10486,15 +10425,15 @@ packages:
       - '@types/node'
       - webpack
 
-  /@rushstack/terminal@0.11.0(@types/node@18.17.15):
-    resolution: {integrity: sha512-LKz7pv0G9Py5uULahNSixK1pTqIIKd103pAGhDW51YfzPojvmO5wfITe0PEUNAJZjuufN/KgeRW83dJo1gL2rQ==}
+  /@rushstack/terminal@0.12.3(@types/node@18.17.15):
+    resolution: {integrity: sha512-J8sDqJiRpXM8QyfYP7ywlueFNzuxVG9P2rZiy5vvgqCtp/6ds7mhjK8mMP6qplTjqn9Dft9bRij2SDPwIAx5NA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.3.0(@types/node@18.17.15)
+      '@rushstack/node-core-library': 5.4.0(@types/node@18.17.15)
       '@types/node': 18.17.15
       supports-color: 8.1.1
     dev: true
@@ -10503,10 +10442,10 @@ packages:
     resolution: {integrity: sha512-IBsPzcdZhzlMfYWEZxK87Zuqzu7gEOY5eB6KkkD9HfMHLXP2l/54jKI0Tmo5OcbrVa8aivwy0AlVcaPlobLwaQ==}
     dev: true
 
-  /@rushstack/ts-command-line@4.21.0(@types/node@18.17.15):
-    resolution: {integrity: sha512-z38FLUCn8M9FQf19gJ9eltdwkvc47PxvJmVZS6aKwbBAa3Pis3r3A+ZcBCVPNb9h/Tbga+i0tHdzoSGUoji9GQ==}
+  /@rushstack/ts-command-line@4.21.5(@types/node@18.17.15):
+    resolution: {integrity: sha512-5+pltcINLviII2Fdy/EuJxkq+B0XdqWBswI8lUVlKiUlf7YnfpeSqTK9aLETF6ykjqpmTrHDQjRDENulmGiMzg==}
     dependencies:
-      '@rushstack/terminal': 0.11.0(@types/node@18.17.15)
+      '@rushstack/terminal': 0.12.3(@types/node@18.17.15)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -13775,7 +13714,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.13.0
-    dev: false
 
   /ajv-errors@1.0.1(ajv@6.12.6):
     resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}
@@ -13786,9 +13724,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.13.0
 
@@ -13801,7 +13736,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.13.0
-    dev: false
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -13834,7 +13768,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: false
 
   /ajv@8.13.0:
     resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
@@ -17310,19 +17243,11 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
 
-  /eslint-plugin-tsdoc@0.2.17:
-    resolution: {integrity: sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==}
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-    dev: true
-
   /eslint-plugin-tsdoc@0.3.0:
     resolution: {integrity: sha512-0MuFdBrrJVBjT/gyhkP2BqpD0np1NxNLfQ38xXDlSs/KVVpKI2A6vN7jx2Rve/CyUsvOsMGwp9KKrinv7q9g3A==}
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-    dev: false
 
   /eslint-scope@4.0.3:
     resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
@@ -19237,9 +19162,6 @@ packages:
   /http-proxy-middleware@2.0.6:
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
     engines: {node: '>=12.0.0'}
-    peerDependenciesMeta:
-      '@types/express':
-        optional: true
     dependencies:
       '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
@@ -24308,13 +24230,6 @@ packages:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
 
-  /resolve@1.19.0:
-    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
-    dependencies:
-      is-core-module: 2.13.1
-      path-parse: 1.0.7
-    dev: true
-
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -26152,54 +26067,6 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tslint-microsoft-contrib@6.2.0(tslint@5.20.1)(typescript@2.9.2):
-    resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
-    deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
-    peerDependencies:
-      tslint: ^5.1.0
-      typescript: '*'
-    dependencies:
-      tslint: 5.20.1(typescript@2.9.2)
-      tsutils: 2.28.0(typescript@2.9.2)
-      typescript: 2.9.2
-    dev: true
-
-  /tslint-microsoft-contrib@6.2.0(tslint@5.20.1)(typescript@3.9.10):
-    resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
-    deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
-    peerDependencies:
-      tslint: ^5.1.0
-      typescript: '*'
-    dependencies:
-      tslint: 5.20.1(typescript@3.9.10)
-      tsutils: 2.28.0(typescript@3.9.10)
-      typescript: 3.9.10
-    dev: true
-
-  /tslint-microsoft-contrib@6.2.0(tslint@5.20.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
-    deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
-    peerDependencies:
-      tslint: ^5.1.0
-      typescript: '*'
-    dependencies:
-      tslint: 5.20.1(typescript@4.9.5)
-      tsutils: 2.28.0(typescript@4.9.5)
-      typescript: 4.9.5
-    dev: true
-
-  /tslint-microsoft-contrib@6.2.0(tslint@5.20.1)(typescript@5.4.2):
-    resolution: {integrity: sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==}
-    deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
-    peerDependencies:
-      tslint: ^5.1.0
-      typescript: '*'
-    dependencies:
-      tslint: 5.20.1(typescript@5.4.2)
-      tsutils: 2.28.0(typescript@5.4.2)
-      typescript: 5.4.2
-    dev: true
-
   /tslint@5.20.1(typescript@2.9.2):
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
     engines: {node: '>=4.8.0'}
@@ -26289,42 +26156,6 @@ packages:
       semver: 5.7.2
       tslib: 1.14.1
       tsutils: 2.29.0(typescript@5.4.2)
-      typescript: 5.4.2
-    dev: true
-
-  /tsutils@2.28.0(typescript@2.9.2):
-    resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 2.9.2
-    dev: true
-
-  /tsutils@2.28.0(typescript@3.9.10):
-    resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 3.9.10
-    dev: true
-
-  /tsutils@2.28.0(typescript@4.9.5):
-    resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.9.5
-    dev: true
-
-  /tsutils@2.28.0(typescript@5.4.2):
-    resolution: {integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==}
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    dependencies:
-      tslib: 1.14.1
       typescript: 5.4.2
     dev: true
 

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8b49a5c17573043a3c86a32f5f8e906e90adfea1",
+  "pnpmShrinkwrapHash": "3d66b078837f98d400ae37c78fdcd1fdfcb10a4c",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648"
 }

--- a/eslint/eslint-patch/package.json
+++ b/eslint/eslint-patch/package.json
@@ -30,8 +30,8 @@
     "patch"
   ],
   "devDependencies": {
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/eslint": "8.2.0",
     "@types/node": "18.17.15",
     "@typescript-eslint/types": "~5.59.2",

--- a/eslint/eslint-plugin-packlets/package.json
+++ b/eslint/eslint-plugin-packlets/package.json
@@ -30,8 +30,8 @@
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/eslint": "8.2.0",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/eslint/eslint-plugin-security/package.json
+++ b/eslint/eslint-plugin-security/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "~3.0.0",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/eslint": "8.2.0",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/eslint/eslint-plugin/package.json
+++ b/eslint/eslint-plugin/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "~3.0.0",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/eslint": "8.2.0",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/heft-plugins/heft-api-extractor-plugin/package.json
+++ b/heft-plugins/heft-api-extractor-plugin/package.json
@@ -26,7 +26,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@rushstack/terminal": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@jest/types": "29.5.0",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@rushstack/heft": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",

--- a/heft-plugins/heft-lint-plugin/package.json
+++ b/heft-plugins/heft-lint-plugin/package.json
@@ -25,7 +25,7 @@
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-typescript-plugin": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@rushstack/terminal": "workspace:*",
     "@types/eslint": "8.2.0",
     "@types/heft-jest": "1.0.1",

--- a/heft-plugins/heft-typescript-plugin/package.json
+++ b/heft-plugins/heft-typescript-plugin/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@rushstack/terminal": "workspace:*",
     "@types/node": "18.17.15",
     "@types/semver": "7.5.0",

--- a/libraries/api-extractor-model/package.json
+++ b/libraries/api-extractor-model/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/fs-extra": "7.0.0",
     "@types/heft-jest": "1.0.1",
     "@types/jju": "1.4.1",

--- a/libraries/operation-graph/package.json
+++ b/libraries/operation-graph/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   },

--- a/libraries/rig-package/package.json
+++ b/libraries/rig-package/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.7",
-    "@rushstack/heft": "0.66.9",
+    "@rushstack/heft-node-rig": "2.6.14",
+    "@rushstack/heft": "0.66.16",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/resolve": "1.20.2",

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -20,8 +20,8 @@
     "supports-color": "~8.1.1"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/supports-color": "8.1.3",

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -16,9 +16,9 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "3.6.10",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/eslint-config": "3.7.0",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "eslint": "~8.57.0",

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.66.9",
-    "@rushstack/heft-node-rig": "2.6.7",
+    "@rushstack/heft": "0.66.16",
+    "@rushstack/heft-node-rig": "2.6.14",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.124.6",
+  "rushVersion": "5.125.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "8.7.6",
+  "pnpmVersion": "8.15.8",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",


### PR DESCRIPTION
Bumps decoupled local dependencies and removes `tslint-microsoft-contrib`, as that package is no longer supported and has a mismatched peerDependency on an older version of TypeScript.
