### PR TITLE
[rush] Updates to the rush init template.

### DIFF
--- a/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-01.json
+++ b/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the `nodeSupportedVersionRange` in the `rush init` template to the LTS and current Node versions.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-02.json
+++ b/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the `pnpmVersion` in the `rush init` template to the latest version of pnpm 8.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-03.json
+++ b/common/changes/@microsoft/rush/rush-init-updates_2024-05-29-04-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update the `.gitignore` in the `rush init` template to include some common toolchain output files and folders.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/[dot]gitignore
+++ b/libraries/rush-lib/assets/rush-init/[dot]gitignore
@@ -73,3 +73,15 @@ common/autoinstallers/*/.npmrc
 # Heft temporary files
 .cache
 .heft
+
+# Common toolchain intermediate files
+temp
+lib
+lib-amd
+lib-es6
+lib-esnext
+lib-commonjs
+lib-shim
+dist
+dist-storybook
+*.tsbuildinfo

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "7.33.5",
+  "pnpmVersion": "8.15.8",
 
   /*[LINE "HYPOTHETICAL"]*/ "npmVersion": "6.14.15",
   /*[LINE "HYPOTHETICAL"]*/ "yarnVersion": "1.9.4",
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.13.0 <17.0.0 || >=18.15.0 <19.0.0",
+  "nodeSupportedVersionRange": ">=18.20.3 <19.0.0 || >=20.14.0 <21.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION
- Updates the node supported version range to the LTS and current versions
- Updates the pnpm version to the latest version of pnpm v8
- Adds some toolchain intermediate folders and files to the gitignore.