### PR TITLE
[rush] Fix an issue where if `missingScriptBehavior` is set to `"error"` and a script is present and empty, an error would be thrown.

### DIFF
--- a/common/changes/@microsoft/rush/fix-missing-script-behavior_2024-05-29-05-08.json
+++ b/common/changes/@microsoft/rush/fix-missing-script-behavior_2024-05-29-05-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where if `missingScriptBehavior` is set to `\"error\"` and a script is present and empty, an error would be thrown.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -47,9 +47,8 @@ function createShellOperations(
 
       const rawCommandToRun: string | undefined = getScriptToRun(project, phase.name, phase.shellCommand);
 
-      const commandToRun: string | undefined = rawCommandToRun
-        ? formatCommand(rawCommandToRun, customParameterValues)
-        : undefined;
+      const commandToRun: string | undefined =
+        rawCommandToRun !== undefined ? formatCommand(rawCommandToRun, customParameterValues) : undefined;
 
       operation.runner = initializeShellOperationRunner({
         phase,


### PR DESCRIPTION
## Summary

This regression was introduced by https://github.com/microsoft/rushstack/pull/4652. After that change, a missing and an empty script are both treated as a missing script. This PR fixes that.

## How it was tested

Tested in a repo with a repro.

## Impacted documentation

None.