### PR TITLE
[rush] Clean up and refactor operation logging.

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-05-29-07-33.json
+++ b/common/changes/@microsoft/rush/main_2024-05-29-07-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Move logs into the project `rush-logs` folder regardless of whether or not the `\"phasedCommands\"` experiment is enabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -197,12 +197,12 @@ export class OperationExecutionRecord implements IOperationRunnerContext {
     const { createLogFile, logFileSuffix = '' } = options;
     const projectLogWritable: ProjectLogWritable | undefined =
       createLogFile && associatedProject && associatedPhase && this._operationMetadataManager
-        ? new ProjectLogWritable(
-            associatedProject,
-            this.collatedWriter.terminal,
-            `${this._operationMetadataManager.logFilenameIdentifier}${logFileSuffix}`,
-            { enableChunkedOutput: true }
-          )
+        ? await ProjectLogWritable.initializeAsync({
+            project: associatedProject,
+            terminal: this.collatedWriter.terminal,
+            logFilenameIdentifier: `${this._operationMetadataManager.logFilenameIdentifier}${logFileSuffix}`,
+            enableChunkedOutput: true
+          })
         : undefined;
 
     try {


### PR DESCRIPTION
## Summary

This PR includes a general refactor of how log files are generated. In addition to that, it changes a few things: 
- The "legacy" logs that were placed in the root of the project folder are no longer deleted.
- All `.log` files are now dropped in the project `rush-logs` folder.
- The chunked log files are now dropped in the project `.rush/temp/chunked-rush-logs` folder.

## How it was tested

Ran in this repo.

## Impacted documentation

None.