### PR TITLE
[rush]: fix operation clustering for shards and no-ops

### DIFF
--- a/common/changes/@microsoft/rush/clustering-fixes_2024-05-29-16-51.json
+++ b/common/changes/@microsoft/rush/clustering-fixes_2024-05-29-16-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes build cache no-op and sharded operation clustering.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1398,12 +1398,12 @@ export class RushLifecycleHooks {
 export class RushProjectConfiguration {
     readonly disableBuildCacheForProject: boolean;
     getCacheDisabledReason(trackedFileNames: Iterable<string>, phaseName: string, isNoOp: boolean): string | undefined;
-    static getCacheDisabledReasonForProjectAsync(project: RushConfigurationProject, options: {
-        terminal: ITerminal;
+    static getCacheDisabledReasonForProject(options: {
+        projectConfiguration: RushProjectConfiguration | undefined;
         trackedFileNames: Iterable<string>;
         phaseName: string;
         isNoOp: boolean;
-    }): Promise<string | undefined>;
+    }): string | undefined;
     readonly incrementalBuildIgnoredGlobs: ReadonlyArray<string>;
     // (undocumented)
     readonly operationSettingsByOperationName: ReadonlyMap<string, Readonly<IOperationSettings>>;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1398,6 +1398,13 @@ export class RushLifecycleHooks {
 export class RushProjectConfiguration {
     readonly disableBuildCacheForProject: boolean;
     getCacheDisabledReason(trackedFileNames: Iterable<string>, phaseName: string, isNoOp: boolean): string | undefined;
+    // (undocumented)
+    static getCacheDisabledReasonForProjectAsync(project: RushConfigurationProject, options: {
+        terminal: ITerminal;
+        trackedFileNames: Iterable<string>;
+        phaseName: string;
+        isNoOp: boolean;
+    }): Promise<string | undefined>;
     readonly incrementalBuildIgnoredGlobs: ReadonlyArray<string>;
     // (undocumented)
     readonly operationSettingsByOperationName: ReadonlyMap<string, Readonly<IOperationSettings>>;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1398,7 +1398,6 @@ export class RushLifecycleHooks {
 export class RushProjectConfiguration {
     readonly disableBuildCacheForProject: boolean;
     getCacheDisabledReason(trackedFileNames: Iterable<string>, phaseName: string, isNoOp: boolean): string | undefined;
-    // (undocumented)
     static getCacheDisabledReasonForProjectAsync(project: RushConfigurationProject, options: {
         terminal: ITerminal;
         trackedFileNames: Iterable<string>;

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -397,24 +397,24 @@ export class RushProjectConfiguration {
    *  we'll want to ignore those completely.
    */
   public static getCacheDisabledReasonForProject(options: {
-    config: RushProjectConfiguration | undefined;
+    projectConfiguration: RushProjectConfiguration | undefined;
     trackedFileNames: Iterable<string>;
     phaseName: string;
     isNoOp: boolean;
   }): string | undefined {
-    const { config, trackedFileNames, phaseName, isNoOp } = options;
+    const { projectConfiguration, trackedFileNames, phaseName, isNoOp } = options;
     if (isNoOp) {
       return undefined;
     }
 
-    if (!config) {
+    if (!projectConfiguration) {
       return (
         `Project does not have a ${RushConstants.rushProjectConfigFilename} configuration file, ` +
         'or one provided by a rig, so it does not support caching.'
       );
     }
 
-    return config.getCacheDisabledReason(trackedFileNames, phaseName, isNoOp);
+    return projectConfiguration.getCacheDisabledReason(trackedFileNames, phaseName, isNoOp);
   }
 
   /**

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -406,12 +406,12 @@ export class RushProjectConfiguration {
     }
   ): Promise<string | undefined> {
     const { terminal, trackedFileNames, phaseName, isNoOp } = options;
-    const config: RushProjectConfiguration | undefined =
-      await RushProjectConfiguration.tryLoadForProjectAsync(project, terminal);
-
     if (isNoOp) {
       return undefined;
     }
+
+    const config: RushProjectConfiguration | undefined =
+      await RushProjectConfiguration.tryLoadForProjectAsync(project, terminal);
 
     if (!config) {
       return (

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -396,22 +396,16 @@ export class RushProjectConfiguration {
    * As some operations may not have a rush-project.json file defined at all, but may be no-op operations
    *  we'll want to ignore those completely.
    */
-  public static async getCacheDisabledReasonForProjectAsync(
-    project: RushConfigurationProject,
-    options: {
-      terminal: ITerminal;
-      trackedFileNames: Iterable<string>;
-      phaseName: string;
-      isNoOp: boolean;
-    }
-  ): Promise<string | undefined> {
-    const { terminal, trackedFileNames, phaseName, isNoOp } = options;
+  public static getCacheDisabledReasonForProject(options: {
+    config: RushProjectConfiguration | undefined;
+    trackedFileNames: Iterable<string>;
+    phaseName: string;
+    isNoOp: boolean;
+  }): string | undefined {
+    const { config, trackedFileNames, phaseName, isNoOp } = options;
     if (isNoOp) {
       return undefined;
     }
-
-    const config: RushProjectConfiguration | undefined =
-      await RushProjectConfiguration.tryLoadForProjectAsync(project, terminal);
 
     if (!config) {
       return (

--- a/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
@@ -46,7 +46,7 @@ export class BuildPlanPlugin implements IPhasedCommandPlugin {
       recordByOperation: Map<Operation, IOperationExecutionResult>,
       context: IExecuteOperationsContext
     ): Promise<void> {
-      const { projectConfigurations, projectChangeAnalyzer } = context;
+      const { projectChangeAnalyzer } = context;
       const disjointSet: DisjointSet<Operation> = new DisjointSet<Operation>();
       const operations: Operation[] = [...recordByOperation.keys()];
       for (const operation of operations) {

--- a/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
@@ -69,7 +69,7 @@ export class BuildPlanPlugin implements IPhasedCommandPlugin {
           }
           const cacheDisabledReason: string | undefined =
             RushProjectConfiguration.getCacheDisabledReasonForProject({
-              config: projectConfiguration,
+              projectConfiguration,
               trackedFileNames: fileHashes.keys(),
               isNoOp: operation.isNoOp,
               phaseName: associatedPhase.name

--- a/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
@@ -11,7 +11,6 @@ import type { Operation } from './Operation';
 import { clusterOperations, type IOperationBuildCacheContext } from './CacheableOperationPlugin';
 import { DisjointSet } from '../cobuild/DisjointSet';
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
-import { RushConstants } from '../RushConstants';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 
 const PLUGIN_NAME: 'BuildPlanPlugin' = 'BuildPlanPlugin';

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -92,8 +92,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
         recordByOperation: Map<Operation, IOperationExecutionResult>,
         context: IExecuteOperationsContext
       ): Promise<void> => {
-        const { isIncrementalBuildAllowed, projectChangeAnalyzer, projectConfigurations, isInitial } =
-          context;
+        const { isIncrementalBuildAllowed, projectChangeAnalyzer, isInitial } = context;
 
         const disjointSet: DisjointSet<Operation> | undefined = cobuildConfiguration?.cobuildFeatureEnabled
           ? new DisjointSet()
@@ -165,14 +164,14 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
                 return operation.name;
               });
 
-              // Generates cluster id, cluster id comes from the project folder and phase name of all operations in the same cluster.
+              // Generates cluster id, cluster id comes from the project folder and operation name of all operations in the same cluster.
               const hash: crypto.Hash = crypto.createHash('sha1');
               for (const operation of groupedOperations) {
-                const { associatedPhase: phase, associatedProject: project } = operation;
-                if (project && phase) {
+                const { associatedProject: project } = operation;
+                if (project && operation.name) {
                   hash.update(project.projectRelativeFolder);
                   hash.update(RushConstants.hashDelimiter);
-                  hash.update(phase.name);
+                  hash.update(operation.name);
                   hash.update(RushConstants.hashDelimiter);
                 }
               }

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -125,7 +125,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
 
             const cacheDisabledReason: string | undefined =
               RushProjectConfiguration.getCacheDisabledReasonForProject({
-                config: projectConfiguration,
+                projectConfiguration,
                 phaseName: phaseName,
                 isNoOp: operation.isNoOp,
                 trackedFileNames: fileHashes.keys()

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -12,7 +12,7 @@ import { OperationStatus } from './OperationStatus';
 import { CobuildLock, type ICobuildCompletedState } from '../cobuild/CobuildLock';
 import { ProjectBuildCache } from '../buildCache/ProjectBuildCache';
 import { RushConstants } from '../RushConstants';
-import { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import { type IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { getHashesForGlobsAsync } from '../buildCache/getHashesForGlobsAsync';
 import { ProjectLogWritable } from './ProjectLogWritable';
 import type { CobuildConfiguration } from '../../api/CobuildConfiguration';


### PR DESCRIPTION
## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

This PR is a followup to #4652 and #4660.

1. It addresses the case where a no-op operation may not have a `rush-project.json` file (and may not want one in order to prevent build cache clustering).
2. It fixes the cluster ID to use operation name instead of phase name, which is important for sharding and other operations that may use the same phase name for multiple operations.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested in the sharded-repo for cobuilds and in my company's monorepo. 

For sharding clustering, before this change all sharded operations are built on the same machine, and after it, they are able to be picked up. For operations that are _not_ no-ops, it performs the same checks (has `rush-project.json`, `disableBuildCacheForOperation`, etc).

### Before

<img width="1087" alt="Screenshot 2024-05-29 at 12 02 46 PM" src="https://github.com/microsoft/rushstack/assets/159921952/bba82d4e-d3d3-4895-a472-f3e63f65b55e">


### After
<img width="1087" alt="Screenshot 2024-05-29 at 11 59 31 AM" src="https://github.com/microsoft/rushstack/assets/159921952/ad679219-1311-4e35-884e-6e0a9d9315ce">

## Impacted documentation

None.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
