### PR TITLE
[rush]: fix JSON schema definition for `deploy.json`

### DIFF
--- a/common/changes/@microsoft/rush/fix-ajv-warning_2024-05-29-19-03.json
+++ b/common/changes/@microsoft/rush/fix-ajv-warning_2024-05-29-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixes a string schema validation warning message when running `rush deploy`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/schemas/deploy-scenario.schema.json
+++ b/libraries/rush-lib/src/schemas/deploy-scenario.schema.json
@@ -14,9 +14,9 @@
       "description": "The \"rush deploy\" command prepares a deployment folder, starting from the main project and collecting all of its dependencies (both NPM packages and other Rush projects).  The main project is specified using the \"--project\" parameter.  The \"deploymentProjectNames\" setting lists the allowable choices for the \"--project\" parameter; this documents the intended deployments for your monorepo and helps validate that \"rush deploy\" is invoked correctly.  If there is only one item in the \"deploymentProjectNames\" array, then \"--project\" can be omitted.  The names should be complete package names as declared in rush.json.\n\nIf the main project should include other unrelated Rush projects, add it to the \"projectSettings\" section, and then specify those projects in the \"additionalProjectsToInclude\" list.",
       "type": "array",
       "items": {
-        "type": "string",
-        "minItems": 1
-      }
+        "type": "string"
+      },
+      "minItems": 1
     },
 
     "includeDevDependencies": {


### PR DESCRIPTION
## Summary

I think this crept in with the AJV refactor #4714. The schema was invalid, setting `minItems` on a string is a no-op. I'm assuming it was intended to sit on the array itself.

## Details

We started seeing this in CI after upgrading to 5.125.0 when running `rush deploy`.

## How it was tested

I created a new empty`deploy.json` file in this repo. It will fail validation, but the string mode error checking is what I'm looking for.

### Before
Using `rush deploy`
```
Loading deployment scenario: /Users/aramis.sennyey/Projects/rushstack/common/config/rush/deploy.json
strict mode: missing type "array" for keyword "minItems" at "#/properties/deploymentProjectNames/items" (strictTypes)

ERROR: JSON validation failed:
/Users/aramis.sennyey/Projects/rushstack/common/config/rush/deploy.json

Error: #
       must have required property 'deploymentProjectNames'
```

### After
Using ` node apps/rush/lib/start-dev deploy`,
```
Loading deployment scenario: /Users/aramis.sennyey/Projects/rushstack/common/config/rush/deploy.json

ERROR: JSON validation failed:
/Users/aramis.sennyey/Projects/rushstack/common/config/rush/deploy.json

Error: #
       must have required property 'deploymentProjectNames'
```

## Impacted documentation

The schema file should be changed on the website.


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
