### PR TITLE
[heft] Implementing Phase-Level Process Isolation in Heft   #4661

### DIFF
--- a/apps/heft/src/plugins/SetEnvironmentVariablesPlugin.ts
+++ b/apps/heft/src/plugins/SetEnvironmentVariablesPlugin.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { ChildProcess } from 'child_process';
 import type { HeftConfiguration } from '../configuration/HeftConfiguration';
 import type { IHeftTaskSession } from '../pluginFramework/HeftTaskSession';
 import type { IHeftTaskPlugin } from '../pluginFramework/IHeftPlugin';
+import { spawnIsolatedProcess } from './processIsolation';
 
 export const PLUGIN_NAME: string = 'set-environment-variables-plugin';
 
@@ -14,22 +16,37 @@ export interface ISetEnvironmentVariablesPluginOptions {
 export default class SetEnvironmentVariablesPlugin
   implements IHeftTaskPlugin<ISetEnvironmentVariablesPluginOptions>
 {
-  public apply(
+  public async apply(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
     { environmentVariablesToSet }: ISetEnvironmentVariablesPluginOptions
-  ): void {
-    taskSession.hooks.run.tap(
-      {
-        name: PLUGIN_NAME,
-        stage: Number.MIN_SAFE_INTEGER
-      },
-      () => {
-        for (const [key, value] of Object.entries(environmentVariablesToSet)) {
-          taskSession.logger.terminal.writeLine(`Setting environment variable ${key}=${value}`);
-          process.env[key] = value;
-        }
+  ): Promise<void> {
+    const childProcess: ChildProcess = await spawnIsolatedProcess(environmentVariablesToSet);
+
+    try {
+      if (childProcess.stdout) {
+        childProcess.stdout.on('data', (data: Buffer) =>
+          taskSession.logger.terminal.writeLine(data.toString())
+        );
       }
-    );
+      if (childProcess.stderr) {
+        childProcess.stderr.on('data', (data: Buffer) =>
+          taskSession.logger.terminal.writeErrorLine(data.toString())
+        );
+      }
+
+      // Wait for the child process to exit
+      await new Promise<void>((resolve, reject) => {
+        childProcess.on('exit', (code) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Process exited with code ${code}`));
+          }
+        });
+      });
+    } finally {
+      childProcess.kill(); // Ensure cleanup
+    }
   }
 }

--- a/apps/heft/src/plugins/SetEnvironmentVariablesPlugin.ts
+++ b/apps/heft/src/plugins/SetEnvironmentVariablesPlugin.ts
@@ -16,7 +16,25 @@ export interface ISetEnvironmentVariablesPluginOptions {
 export default class SetEnvironmentVariablesPlugin
   implements IHeftTaskPlugin<ISetEnvironmentVariablesPluginOptions>
 {
-  public async apply(
+  public apply(
+    taskSession: IHeftTaskSession,
+    heftConfiguration: HeftConfiguration,
+    { environmentVariablesToSet }: ISetEnvironmentVariablesPluginOptions
+  ): void {
+    taskSession.hooks.run.tap(
+      {
+        name: PLUGIN_NAME,
+        stage: Number.MIN_SAFE_INTEGER
+      },
+      () => {
+        for (const [key, value] of Object.entries(environmentVariablesToSet)) {
+          taskSession.logger.terminal.writeLine(`Setting environment variable ${key}=${value}`);
+          process.env[key] = value;
+        }
+      }
+    );
+  }
+  public async applyAsync(
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration,
     { environmentVariablesToSet }: ISetEnvironmentVariablesPluginOptions

--- a/apps/heft/src/plugins/processIsolation.ts
+++ b/apps/heft/src/plugins/processIsolation.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+/**
+ * Spawns a new process with the given environment variables.
+ * @param command - The command to run.
+ * @param args - The list of string arguments.
+ * @param options - The options, including environment variables.
+ * @returns A promise that resolves to the child process.
+ */
+export function spawnProcess(
+  command: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv }
+): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(command, args, { env: options.env, stdio: 'inherit' });
+
+    child.on('error', (err: Error) => {
+      reject(err);
+    });
+
+    child.on('exit', (code: number | null) => {
+      if (code !== 0 && code !== null) {
+        reject(new Error(`Process exited with code ${code}`));
+      } else {
+        resolve(child);
+      }
+    });
+  });
+}
+
+/**
+ * Spawns an isolated process with the given environment variables.
+ * @param environmentVariables - Environment variables to set.
+ * @returns A promise that resolves to the child process.
+ */
+export async function spawnIsolatedProcess(
+  environmentVariables: Record<string, string | undefined>
+): Promise<ChildProcess> {
+  const filteredEnv: Record<string, string | undefined> = Object.fromEntries(
+    Object.entries(environmentVariables).filter(([key, value]) => value !== undefined)
+  );
+  const isolatedEnv: Record<string, string | undefined> = { ...process.env, ...filteredEnv };
+  const childProcess: ChildProcess = await spawnProcess('node', ['-e', ''], { env: isolatedEnv });
+  return childProcess;
+}

--- a/common/changes/@rushstack/heft/main_2024-06-01-06-58.json
+++ b/common/changes/@rushstack/heft/main_2024-06-01-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Implements a solution to ensure that the environment variable settings are scoped only to the phase where the plugin is declared, resolving the issue of unintended impacts and ensuring better isolation of environment variable settings within Heft processes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
#4661 
This PR addresses an issue with the set-environment-variables-plugin in @rushstack/heft, which currently sets environment variables for the entire Heft process rather than just the phase where the plugin is declared. This causes unintended impacts on parallel phases and downstream phases. 
The PR implements a solution to ensure that the environment variable settings are scoped only to the phase where the plugin is declared, resolving the issue of unintended impacts and ensuring better isolation of environment variable settings within Heft processes.

