### PR TITLE
Bug repro: Exports which shadow built-ins are incorrectly included in non-"complete" report variants

### DIFF
--- a/build-tests/api-extractor-lib2-test/dist/api-extractor-lib2-test.d.ts
+++ b/build-tests/api-extractor-lib2-test/dist/api-extractor-lib2-test.d.ts
@@ -21,4 +21,12 @@ export declare class Lib2Class {
 export declare interface Lib2Interface {
 }
 
+/**
+ * Shadows of built-ins get aliased during rollup, which has resulted in tags being ignored when determining correct
+ * output for report variants.
+ * @internal
+ */
+declare const performance_2: Performance;
+export { performance_2 as performance }
+
 export { }

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.alpha.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.alpha.api.md
@@ -19,4 +19,7 @@ export class Lib2Class {
 export interface Lib2Interface {
 }
 
+// Warning: (ae-internal-missing-underscore) The name "performance" should be prefixed with an underscore because the declaration is marked as @internal
+export { performance_2 as performance }
+
 ```

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
@@ -19,4 +19,8 @@ export class Lib2Class {
 export interface Lib2Interface {
 }
 
+// @internal
+const performance_2: Performance;
+export { performance_2 as performance }
+
 ```

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
@@ -15,4 +15,6 @@ export class Lib2Class {
     prop: number;
 }
 
+export { performance_2 as performance }
+
 ```

--- a/build-tests/api-extractor-lib2-test/src/index.ts
+++ b/build-tests/api-extractor-lib2-test/src/index.ts
@@ -20,3 +20,10 @@ export interface Lib2Interface {}
 
 /** @public */
 export default class DefaultClass {}
+
+/**
+ * Shadows of built-ins get aliased during rollup, which has resulted in tags being ignored when determining correct
+ * output for report variants.
+ * @internal
+ */
+export const performance: Performance = globalThis.performance;


### PR DESCRIPTION
This was not an issue prior to the `reportVariants` feature, but there are now cases where exports that are aliased to avoid conflicts with built-ins result in export statements being included in reports of incorrect release variants.

I updated one of the test scenarios to include an API export called "performance", which shadows a global. It is tagged as `@internal`. Note that in the non-"complete" report variants, an export for the item still occurs, while the aliased declaration is (correctly) omitted.