### PR TITLE
[rush] Remove unnecessary condition in the logic for skipping operations when build cache is disabled

### DIFF
--- a/common/changes/@microsoft/rush/remove-unnecessary-condition_2024-06-06-18-39.json
+++ b/common/changes/@microsoft/rush/remove-unnecessary-condition_2024-06-06-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove an unnecessary condition in the logic for skipping operations when build cache is disabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -76,8 +76,8 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
         await Async.forEachAsync(operations.values(), async (record: IOperationExecutionResult) => {
           const { operation } = record;
-          const { associatedProject, associatedPhase, runner, logFilenameIdentifier } = operation;
-          if (!associatedProject || !associatedPhase || !runner) {
+          const { associatedProject, runner, logFilenameIdentifier } = operation;
+          if (!associatedProject || !runner) {
             return;
           }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/rushstack/pull/4763#discussion_r1628476617