### PR TITLE
[webpack5] Add onGetWatchOptions hook

### DIFF
--- a/common/changes/@rushstack/heft-webpack5-plugin/webpack5-watch-options_2024-06-07-01-16.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/webpack5-watch-options_2024-06-07-01-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Add `onGetWatchOptions` accessor hook to allow cooperating plugins to, for example, configure a list of globs for the file watcher to ignore.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/common/reviews/api/heft-webpack5-plugin.api.md
+++ b/common/reviews/api/heft-webpack5-plugin.api.md
@@ -7,6 +7,7 @@
 import type { AsyncParallelHook } from 'tapable';
 import type { AsyncSeriesBailHook } from 'tapable';
 import type { AsyncSeriesHook } from 'tapable';
+import type { AsyncSeriesWaterfallHook } from 'tapable';
 import type { Configuration } from 'webpack-dev-server';
 import type { HeftConfiguration } from '@rushstack/heft';
 import type { IHeftTaskSession } from '@rushstack/heft';
@@ -41,6 +42,7 @@ export interface IWebpackPluginAccessorHooks {
     readonly onAfterConfigure: AsyncParallelHook<IWebpackConfiguration, never, never>;
     readonly onConfigure: AsyncSeriesHook<IWebpackConfiguration, never, never>;
     readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats, never, never>;
+    readonly onGetWatchOptions: AsyncSeriesWaterfallHook<Parameters<TWebpack.Compiler['watch']>[0], Readonly<IWebpackConfiguration>, never>;
     readonly onLoadConfiguration: AsyncSeriesBailHook<never, never, never, IWebpackConfiguration | false>;
 }
 

--- a/heft-plugins/heft-webpack5-plugin/src/shared.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/shared.ts
@@ -3,7 +3,12 @@
 
 import type * as TWebpack from 'webpack';
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-import type { AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook } from 'tapable';
+import type {
+  AsyncParallelHook,
+  AsyncSeriesBailHook,
+  AsyncSeriesHook,
+  AsyncSeriesWaterfallHook
+} from 'tapable';
 import type { IHeftTaskSession, HeftConfiguration } from '@rushstack/heft';
 
 /**
@@ -82,6 +87,14 @@ export interface IWebpackPluginAccessorHooks {
    * this hook will not be called.
    */
   readonly onEmitStats: AsyncParallelHook<TWebpack.Stats | TWebpack.MultiStats, never, never>;
+  /**
+   * A hook that allows for customization of the file watcher options. If not running in watch mode, this hook will not be called.
+   */
+  readonly onGetWatchOptions: AsyncSeriesWaterfallHook<
+    Parameters<TWebpack.Compiler['watch']>[0],
+    Readonly<IWebpackConfiguration>,
+    never
+  >;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a new accessor hook `onGetWatchOptions` to the `heft-webpack5-plugin`. The motivation is to give users of the plugin an avenue to specify watch exclusions to Webpack's watcher.

## Details
Default options value is `{}`.

## How it was tested
Ran the `heft-webpack5-everything-test` project in watch mode.

## Impacted documentation
Documentation for the accessor.