### PR TITLE
[rush] Graduate the 'phasedCommands' experiment.

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-06-07-19-17.json
+++ b/common/changes/@microsoft/rush/main_2024-06-07-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Graduate the `phasedCommands` experiment to a standard feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.127.1",
-    "nextBump": "patch",
+    "nextBump": "minor",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -297,7 +297,7 @@ export class EventHooks {
 // @public
 export class ExperimentsConfiguration {
     // @internal
-    constructor(jsonFileName: string);
+    constructor(jsonFilePath: string);
     // @beta
     readonly configuration: Readonly<IExperimentsJson>;
 }
@@ -473,7 +473,6 @@ export interface IExperimentsJson {
     generateProjectImpactGraphDuringRushUpdate?: boolean;
     noChmodFieldInTarHeaderNormalization?: boolean;
     omitImportersFromPreventManualShrinkwrapChanges?: boolean;
-    phasedCommands?: boolean;
     printEventHooksOutputToConsole?: boolean;
     useIPCScriptsInWatchMode?: boolean;
     usePnpmFrozenLockfileForRushInstall?: boolean;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -50,12 +50,6 @@
   /*[LINE "HYPOTHETICAL"]*/ "buildSkipWithAllowWarningsInSuccessfulBuild": true,
 
   /**
-   * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
-   * in common/config/rush/command-line.json.
-   */
-  /*[LINE "HYPOTHETICAL"]*/ "phasedCommands": true,
-
-  /**
    * If true, perform a clean install after when running `rush install` or `rush update` if the
    * `.npmrc` file has changed since the last install.
    */

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -2,8 +2,11 @@
 // See LICENSE in the project root for license information.
 
 import { JsonFile, JsonSchema, FileSystem } from '@rushstack/node-core-library';
+import { Colorize } from '@rushstack/terminal';
 
 import schemaJson from '../schemas/experiments.schema.json';
+
+const GRADUATED_EXPERIMENTS: Set<string> = new Set(['phasedCommands']);
 
 /**
  * This interface represents the raw experiments.json file which allows repo
@@ -56,12 +59,6 @@ export interface IExperimentsJson {
   buildSkipWithAllowWarningsInSuccessfulBuild?: boolean;
 
   /**
-   * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
-   * in common/config/rush/command-line.json.
-   */
-  phasedCommands?: boolean;
-
-  /**
    * If true, perform a clean install after when running `rush install` or `rush update` if the
    * `.npmrc` file has changed since the last install.
    */
@@ -103,16 +100,14 @@ export interface IExperimentsJson {
   useIPCScriptsInWatchMode?: boolean;
 }
 
+const _EXPERIMENTS_JSON_SCHEMA: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
+
 /**
  * Use this class to load the "common/config/rush/experiments.json" config file.
  * This file allows repo maintainers to enable and disable experimental Rush features.
  * @public
  */
 export class ExperimentsConfiguration {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
-
-  private _jsonFileName: string;
-
   /**
    * Get the experiments configuration.
    * @beta
@@ -122,14 +117,27 @@ export class ExperimentsConfiguration {
   /**
    * @internal
    */
-  public constructor(jsonFileName: string) {
-    this._jsonFileName = jsonFileName;
-    this.configuration = {};
+  public constructor(jsonFilePath: string) {
+    try {
+      this.configuration = JsonFile.loadAndValidate(jsonFilePath, _EXPERIMENTS_JSON_SCHEMA);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e)) {
+        this.configuration = {};
+      } else {
+        throw e;
+      }
+    }
 
-    if (!FileSystem.exists(this._jsonFileName)) {
-      this.configuration = {};
-    } else {
-      this.configuration = JsonFile.loadAndValidate(this._jsonFileName, ExperimentsConfiguration._jsonSchema);
+    for (const experimentName of Object.getOwnPropertyNames(this.configuration)) {
+      if (GRADUATED_EXPERIMENTS.has(experimentName)) {
+        // eslint-disable-next-line no-console
+        console.log(
+          Colorize.yellow(
+            `The experiment "${experimentName}" has graduated to a standard feature. Remove this experiment from ` +
+              `"${jsonFilePath}".`
+          )
+        );
+      }
     }
   }
 }

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -325,18 +325,6 @@ export class RushCommandLineParser extends CommandLineParser {
       }
 
       case RushConstants.phasedCommandKind: {
-        if (
-          !command.isSynthetic && // synthetic commands come from bulk commands
-          !this.rushConfiguration.experimentsConfiguration.configuration.phasedCommands
-        ) {
-          throw new Error(
-            `${RushConstants.commandLineFilename} defines a command "${command.name}" ` +
-              `that uses the "${RushConstants.phasedCommandKind}" command kind. To use this command kind, ` +
-              'the "phasedCommands" experiment must be enabled. Note that this feature is not complete ' +
-              'and will not work as expected.'
-          );
-        }
-
         this._addPhasedCommandLineConfigAction(commandLineConfiguration, command);
         break;
       }

--- a/libraries/rush-lib/src/logic/test/workspaceRepo/common/config/rush/experiments.json
+++ b/libraries/rush-lib/src/logic/test/workspaceRepo/common/config/rush/experiments.json
@@ -1,3 +1,0 @@
-{
-  "phasedCommands": true
-}

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -39,7 +39,7 @@
       "type": "boolean"
     },
     "phasedCommands": {
-      "description": "If true, the phased commands feature is enabled. To use this feature, create a \"phased\" command in common/config/rush/command-line.json.",
+      "description": "THIS EXPERIMENT HAS BEEN GRADUATED TO A STANDARD FEATURE. THIS PROPERTY SHOULD BE REMOVED.",
       "type": "boolean"
     },
     "cleanInstallAfterNpmrcChanges": {


### PR DESCRIPTION
## Summary

The `phasedCommands` feature has been out for a very long time and is stable at this point. It makes sense to remove the experiment flag at this point.

## How it was tested

Ran `rush build` in a repo without the experiment flag.

## Impacted documentation

https://rushjs.io/pages/configs/experiments_json/ needs to be updated.