### PR TITLE
[rush-lib] Fix rush install failed when user didn't configure git user.email and didn't configure allow email regexp

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-06-11-02-39.json
+++ b/common/changes/@microsoft/rush/main_2024-06-11-02-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix check git email on install even user didn't set up allowedEmailRegExps",
+      "comment": "Fix an issue where an error is thrown if a Git email address isn't configured and email validation isn't configured in `rush.json` via `allowedEmailRegExps`.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/main_2024-06-11-02-39.json
+++ b/common/changes/@microsoft/rush/main_2024-06-11-02-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix check git email on install even user didn't set up allowedEmailRegExps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/test/Git.test.ts
+++ b/libraries/rush-lib/src/logic/test/Git.test.ts
@@ -227,9 +227,9 @@ describe(Git.name, () => {
   describe(Git.prototype.tryGetGitEmailAsync.name, () => {
     async function getMockGitEmail(hasGitPath: boolean, output: string | Error): Promise<string | undefined> {
       const gitInstance: Git = new Git({ rushJsonFolder: '/repo/root' } as RushConfiguration);
-      jest.spyOn(gitInstance, 'getGitPathOrThrow').mockImplementation(() => {
+      jest.spyOn(gitInstance, 'gitPath', 'get').mockImplementation(() => {
         if (hasGitPath) return '/git/bin/path';
-        else throw new Error('Git is not present');
+        else return undefined;
       });
 
       jest
@@ -244,16 +244,20 @@ describe(Git.name, () => {
       return await gitInstance.tryGetGitEmailAsync();
     }
 
-    it('Throw exception when cannot find git path', () => {
-      expect(() => getMockGitEmail(false, 'user@example.com')).toThrow('Git is not present');
+    it('Throw exception when cannot find git path', async () => {
+      await expect(getMockGitEmail(false, 'user@example.com')).rejects.toBeInstanceOf(Error);
     });
 
-    it('Returns result when git user.email has been found', () => {
-      expect(getMockGitEmail(true, 'user@example.com')).toEqual('user@example.com');
+    it('Returns result when git user.email has been found', async () => {
+      await expect(getMockGitEmail(true, 'user@example.com')).resolves.toEqual('user@example.com');
     });
 
-    it('Returns undefined when git user.email not configure', () => {
-      expect(getMockGitEmail(true, '')).toEqual(undefined);
+    it('Returns empty email when git user.email return empty string', async () => {
+      await expect(getMockGitEmail(true, '')).resolves.toEqual('');
+    });
+
+    it('Returns undefined when git user.email not configure', async () => {
+      await expect(getMockGitEmail(true, new Error('Email is missing'))).resolves.toEqual(undefined);
     });
   });
 });


### PR DESCRIPTION
## Summary

The problem is rush install always check user.email on git configuration and throws error if user didn't configure email address EVEN user didn't configure `allowedEmailRegExps` settings on rush.json. ([Example](https://github.com/kc-workspace/kcws-js/actions/runs/9451572312/job/26032839959#step:3:150))

![CleanShot 2024-06-10 at 23 51 28@2x](https://github.com/microsoft/rushstack/assets/14089557/64d6b83f-2c9f-45c0-bd13-2ecbe4b86271)

## Details

This is because `tryGetGitEmailAsync` function will always throw error first if it cannot fetch  email successfully. Therefore email will never by undefined in the first place and the if email equals undefined will never catch.

https://github.com/microsoft/rushstack/blob/dbaebcd68f5195872dae95545decb2d26d81d273/libraries/rush-lib/src/logic/policy/GitEmailPolicy.ts#L37-L47

## How it was tested

I add some tests to ensure the function can return both string (email) and undefined.

## Impacted documentation

This should not impact any public apis
