### PR TITLE
[jest] Update the test reporter to report unchecked snapshots.

### DIFF
--- a/common/changes/@microsoft/rush/report-obsolete-snapshots_2024-06-10-23-46.json
+++ b/common/changes/@microsoft/rush/report-obsolete-snapshots_2024-06-10-23-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/main_2024-06-10-23-03.json
+++ b/common/changes/@rushstack/heft-jest-plugin/main_2024-06-10-23-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Update the test reporter to report unchecked snapshots.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/package-deps-hash/report-obsolete-snapshots_2024-06-10-23-46.json
+++ b/common/changes/@rushstack/package-deps-hash/report-obsolete-snapshots_2024-06-10-23-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/package-deps-hash"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
+++ b/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
@@ -83,18 +83,6 @@ Object {
 }
 `;
 
-exports[`getRepoStateAsync handles requests for additional files 2`] = `
-Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/log.log": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-}
-`;
-
 exports[`parseGitHashObject can parse multiple entries 1`] = `
 Map {
   "a" => "11",

--- a/rush-plugins/rush-redis-cobuild-plugin/src/test/__snapshots__/RedisCobuildLockProvider.test.ts.snap
+++ b/rush-plugins/rush-redis-cobuild-plugin/src/test/__snapshots__/RedisCobuildLockProvider.test.ts.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RedisCobuildLockProvider getCompletedStateKey works 1`] = `"cobuild:v1:123:abc:completed"`;
-
-exports[`RedisCobuildLockProvider getLockKey works 1`] = `"cobuild:v1:123:abc:lock"`;
-
 exports[`RedisCobuildLockProvider throws error with missing environment variables 1`] = `
 "The \\"RedisCobuildLockProvider\\" tries to access missing environment variable: REDIS_PASS
 Please check the configuration in rush-redis-cobuild-plugin.json file"


### PR DESCRIPTION
## Summary

Heft's Jest plugin currently doesn't report obsolete snapshots. This PR updates the reporter to print a warning if a snapshot is unchecked.

## How it was tested

Introduced an unchecked snapshot and ran `heft test`.

## Impacted documentation

None.