### PR TITLE
[rush-lib] Fix an issue where rush-pnpm patch is not working for the subspace scenario

### DIFF
--- a/common/changes/@microsoft/rush/chao-fix-rush-pnpm-patch_2024-06-12-23-51.json
+++ b/common/changes/@microsoft/rush/chao-fix-rush-pnpm-patch_2024-06-12-23-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where rush-pnpm patch is not working for the subspace scenario",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -404,7 +404,10 @@ export class RushPnpmCommandLineParser {
         // Replace `pnpm patch-commit` with `rush-pnpm patch-commit` when running
         // `pnpm patch` to avoid the `pnpm patch` command being suggested in the output
         onStdoutStreamChunk = (stdoutChunk: string) => {
-          return stdoutChunk.replace(/pnpm patch-commit/g, 'rush-pnpm patch-commit');
+          return stdoutChunk.replace(
+            /pnpm patch-commit/g,
+            `rush-pnpm --subspace ${this._subspace.subspaceName} patch-commit`
+          );
         };
 
         break;
@@ -483,11 +486,6 @@ export class RushPnpmCommandLineParser {
   }
 
   private async _doRushUpdateAsync(): Promise<void> {
-    if (this._rushConfiguration.subspacesFeatureEnabled) {
-      this._terminal.writeLine(Colorize.red('The rush-pnpm command is not yet supported for subspaces.'));
-      throw new AlreadyReportedError();
-    }
-
     this._terminal.writeLine();
     this._terminal.writeLine(Colorize.green('Running "rush update"'));
     this._terminal.writeLine();
@@ -508,8 +506,7 @@ export class RushPnpmCommandLineParser {
       pnpmFilterArgumentValues: [],
       selectedProjects: new Set(this._rushConfiguration.projects),
       checkOnly: false,
-      // TODO: Support subspaces
-      subspace: this._rushConfiguration.defaultSubspace,
+      subspace: this._subspace,
       terminal: this._terminal
     };
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
Support `rush-pnpm patch` for subspace scenario.
## Details
In the [PR 4662](https://github.com/microsoft/rushstack/pull/4662) , we already support to pass a subspace name when run `rush-pnpm` command, so all need to do here is to pass the subspace name to the patch action. 

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually tested with rushstack repo locally.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
