### PR TITLE
fix(rush,sharding): add back clustering based on operation name

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-clustering-by-operation-name_2024-06-17-19-57.json
+++ b/common/changes/@microsoft/rush/sennyeya-clustering-by-operation-name_2024-06-17-19-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fixed a key collision for cobuild clustering for operations that share the same phase name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/sennyeya-clustering-by-operation-name_2024-06-17-19-57.json
+++ b/common/changes/@microsoft/rush/sennyeya-clustering-by-operation-name_2024-06-17-19-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fixed a key collision for cobuild clustering for operations that share the same phase name.",
+      "comment": "Fix a key collision for cobuild clustering for operations that share the same phase name.",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -170,14 +170,14 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
                 return operation.name;
               });
 
-              // Generates cluster id, cluster id comes from the project folder and phase name of all operations in the same cluster.
+              // Generates cluster id, cluster id comes from the project folder and operation name of all operations in the same cluster.
               const hash: crypto.Hash = crypto.createHash('sha1');
               for (const operation of groupedOperations) {
                 const { associatedPhase: phase, associatedProject: project } = operation;
                 if (project && phase) {
                   hash.update(project.projectRelativeFolder);
                   hash.update(RushConstants.hashDelimiter);
-                  hash.update(phase.name);
+                  hash.update(operation.name ?? phase.name);
                   hash.update(RushConstants.hashDelimiter);
                 }
               }


### PR DESCRIPTION
## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Followup to #4750, this was accidentally reverted in https://github.com/microsoft/rushstack/pull/4750/commits/86c54bb24ed557506093607c01e26eb6240155a0. We need to use operation name instead of phase name to cluster by since shards have the same phase but different operation names. I found this while trying to support clustering in our local instance.


## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested on the `build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo`. You can see in the below screenshot that shards for package a and b are cobuilt across both machines.
<img width="1033" alt="Screenshot 2024-06-17 at 3 55 47 PM" src="https://github.com/microsoft/rushstack/assets/159921952/c5e833b4-9adb-4d66-9f02-f478ea429e4c">

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

None.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
