### PR TITLE
[rush] Fix an issue where the 'rush-pnpm ...' command always terminates with an exit code of 1.

### DIFF
--- a/common/changes/@microsoft/rush/rush-pnpm-exit-code_2024-06-19-21-22.json
+++ b/common/changes/@microsoft/rush/rush-pnpm-exit-code_2024-06-19-21-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the `rush pnpm ...` command always terminates with an exit code of 1.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "c040a0d59aada7e1f9bdf0916df7079547de3a85",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "25b153582664854d3f0080a8d4fb2ce9dd409aed"
+  "packageJsonInjectedDependenciesHash": "faf9f64843602dd4f48cdea4308e7b00fe222387"
 }

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -415,14 +415,22 @@ export class RushPnpmCommandLineParser {
     }
 
     try {
-      await Utilities.executeCommandAsync({
+      const { exitCode } = await Utilities.executeCommandAsync({
         command: rushConfiguration.packageManagerToolFilename,
         args: this._pnpmArgs,
         workingDirectory: process.cwd(),
         environment: pnpmEnvironmentMap.toObject(),
         keepEnvironment: true,
-        onStdoutStreamChunk
+        onStdoutStreamChunk,
+        captureExitCodeAndSignal: true
       });
+
+      if (typeof exitCode === 'number') {
+        process.exitCode = exitCode;
+      } else {
+        // If the exit code is not a number, the process was terminated by a signal
+        process.exitCode = 1;
+      }
     } catch (e) {
       this._terminal.writeDebugLine(`Error: ${e}`);
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/rushstack/issues/4795

## Details

This was accidentally broken by https://github.com/microsoft/rushstack/pull/4350.

Tested in the repro repo in https://github.com/microsoft/rushstack/issues/4795

## Impacted documentation

None.