### PR TITLE
[rush] Fix an edge case for workspace peer dependencies when calculating packageJsonInjectedDependenciesHash to improve its accuracy

### DIFF
--- a/common/changes/@microsoft/rush/chao-improve-getPackageJsonInjectedDependenciesHash_2024-06-26-04-40.json
+++ b/common/changes/@microsoft/rush/chao-improve-getPackageJsonInjectedDependenciesHash_2024-06-26-04-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Normalize workspace dependencies' version when calculating packageJsonInjectedDependenciesHash to improve its accuracy ",
+      "comment": "Fix an edge case for workspace peer dependencies when calculating packageJsonInjectedDependenciesHash to improve its accuracy ",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/chao-improve-getPackageJsonInjectedDependenciesHash_2024-06-26-04-40.json
+++ b/common/changes/@microsoft/rush/chao-improve-getPackageJsonInjectedDependenciesHash_2024-06-26-04-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Normalize workspace dependencies' version when calculating packageJsonInjectedDependenciesHash to improve its accuracy ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "c040a0d59aada7e1f9bdf0916df7079547de3a85",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "f3a12861197ad52c4c30bdaceed213a8dfe77a23"
+  "packageJsonInjectedDependenciesHash": "5ae59c4febdaa2b4d21f7e19b0d7a8a5b56f4e60"
 }

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -443,7 +443,12 @@ export class Subspace {
     return packageJsonInjectedDependenciesHash;
   }
 
-  /** @internal */
+  /** @internal
+   *
+   * No need to recognize workspace dependencies' version field when calculating packageJsonInjectedDependenciesHash.
+   * It is because we always using the whatever latest version in the Monorepo when PNPM installs them.
+   *
+   */
   private _handleWorkspaceDependencyForPackageJsonInjectedDependenciesHash(
     allWorkspaceProjectSet: Set<string>,
     dependencies: IPackageJsonDependencyTable | undefined

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.129.3",
+  "rushVersion": "5.129.5",
 
   /**
    * The next field selects which package manager should be installed and determines its version.


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
If you declare a workspace package in peerDependencies, though you put the version range there, PNPM does not respect it. Below is an example: 
peerDependencies section in `@rushstack/heft-api-extractor-plugin` project package.json
```
"peerDependencies": {
    "@rushstack/heft": "0.66.18"
  },
```
The actual `pnpm-lock.yaml`
![img_v3_02c8_154f1501-0d30-4138-a2ce-b5e78bf2775h](https://github.com/microsoft/rushstack/assets/10736839/681d7c50-7fe8-49af-828e-f76233a5a591)

So, we don't need to take these packages into consideration when calculating packageJsonInjectedDependenciesHash.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
Manually tested with Monorepo locally.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
