### PR TITLE
[rush] malformed package.json by explicitly setting jsonSyntax to strict

### DIFF
--- a/common/changes/@microsoft/rush/kenrick-fix-rush-add_2024-06-27-02-39.json
+++ b/common/changes/@microsoft/rush/kenrick-fix-rush-add_2024-06-27-02-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix malformed package.json by explicitly setting jsonSyntax to strict",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/kenrick-fix-rush-add_2024-06-27-02-39.json
+++ b/common/changes/@microsoft/rush/kenrick-fix-rush-add_2024-06-27-02-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix malformed package.json by explicitly setting jsonSyntax to strict",
+      "comment": "Fix an issue where running `rush add` in a project can generate a `package.json` file that uses JSON5 syntax. Package managers expect strict JSON.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/node-core-library/kenrick-fix-rush-add_2024-06-27-02-39.json
+++ b/common/changes/@rushstack/node-core-library/kenrick-fix-rush-add_2024-06-27-02-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Accept jsonSyntax option at save method to avoid malformed package.json",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/kenrick-fix-rush-add_2024-06-27-02-39.json
+++ b/common/changes/@rushstack/node-core-library/kenrick-fix-rush-add_2024-06-27-02-39.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Accept jsonSyntax option at save method to avoid malformed package.json",
-      "type": "patch"
+      "comment": "Add support for the `jsonSyntax` option to the `JsonFile.save`, `JsonFile.saveAsync`, and `JsonFile.stringify` functions.",
+      "type": "minor"
     }
   ],
   "packageName": "@rushstack/node-core-library"

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -416,7 +416,7 @@ export interface IJsonFileSaveOptions extends IJsonFileStringifyOptions {
 }
 
 // @public
-export interface IJsonFileStringifyOptions {
+export interface IJsonFileStringifyOptions extends IJsonFileParseOptions {
     headerComment?: string;
     ignoreUndefinedValues?: boolean;
     newlineConversion?: NewlineKind;

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -368,7 +368,7 @@ export class JsonFile {
       });
     } else if (options.prettyFormatting) {
       stringified = jju.stringify(newJsonObject, {
-        mode: explicitMode ? explicitMode : 'json',
+        mode: explicitMode ?? 'json',
         indent: 2
       });
 

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -363,7 +363,7 @@ export class JsonFile {
     if (previousJson !== '') {
       // NOTE: We don't use mode=json here because comments aren't allowed by strict JSON
       stringified = jju.update(previousJson, newJsonObject, {
-        mode: explicitMode ? explicitMode : JsonSyntax.Json5,
+        mode: explicitMode ?? JsonSyntax.Json5,
         indent: 2
       });
     } else if (options.prettyFormatting) {

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -128,7 +128,7 @@ export interface IJsonFileLoadAndValidateOptions extends IJsonFileParseOptions, 
  *
  * @public
  */
-export interface IJsonFileStringifyOptions {
+export interface IJsonFileStringifyOptions extends IJsonFileParseOptions {
   /**
    * If provided, the specified newline type will be used instead of the default `\r\n`.
    */
@@ -345,17 +345,30 @@ export class JsonFile {
       JsonFile.validateNoUndefinedMembers(newJsonObject);
     }
 
+    let explicitMode: 'json5' | 'json' | 'cjson' | undefined = undefined;
+    switch (options.jsonSyntax) {
+      case JsonSyntax.Strict:
+        explicitMode = 'json';
+        break;
+      case JsonSyntax.JsonWithComments:
+        explicitMode = 'cjson';
+        break;
+      case JsonSyntax.Json5:
+        explicitMode = 'json5';
+        break;
+    }
+
     let stringified: string;
 
     if (previousJson !== '') {
       // NOTE: We don't use mode=json here because comments aren't allowed by strict JSON
       stringified = jju.update(previousJson, newJsonObject, {
-        mode: JsonSyntax.Json5,
+        mode: explicitMode ? explicitMode : JsonSyntax.Json5,
         indent: 2
       });
     } else if (options.prettyFormatting) {
       stringified = jju.stringify(newJsonObject, {
-        mode: 'json',
+        mode: explicitMode ? explicitMode : 'json',
         indent: 2
       });
 

--- a/libraries/rush-lib/src/api/PackageJsonEditor.ts
+++ b/libraries/rush-lib/src/api/PackageJsonEditor.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as semver from 'semver';
-import { InternalError, type IPackageJson, JsonFile, Sort } from '@rushstack/node-core-library';
+import { InternalError, type IPackageJson, JsonFile, Sort, JsonSyntax } from '@rushstack/node-core-library';
 import { cloneDeep } from '../utilities/objectUtilities';
 
 /**
@@ -308,7 +308,10 @@ export class PackageJsonEditor {
     if (this._modified) {
       this._modified = false;
       this._sourceData = this._normalize(this._sourceData);
-      JsonFile.save(this._sourceData, this.filePath, { updateExistingFile: true });
+      JsonFile.save(this._sourceData, this.filePath, {
+        updateExistingFile: true,
+        jsonSyntax: JsonSyntax.Strict
+      });
       return true;
     }
     return false;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Attempt to fix #4811

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I investigated and found out that when saving JSON with "jju.update", it always use Json5 mode. This may cause issue when updating things that expect strict JSON like package.json.

So the fix here is to pass a `jsonSyntax` option to let `PackageJsonEditor` use that `JsonSyntax.Strict` mode.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I build locally and it works on the repro: https://github.com/kenrick95/rush-repro-rush-add-malformed-package-json

![Screenshot 2024-06-27 at 10 46 12](https://github.com/microsoft/rushstack/assets/3090380/3996cfc8-d9e3-47ae-87ab-8cf356d1dad4)

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

- IJsonFileStringifyOptions adds "jsonSyntax" as an option. Is that okay?

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
