### PR TITLE
[rush-lib] Don't interrupt the installation process if the user hasn't enabled the inject dependencies feature.

### DIFF
--- a/common/changes/@microsoft/rush/chore-inject-deps_2024-07-11-06-27.json
+++ b/common/changes/@microsoft/rush/chore-inject-deps_2024-07-11-06-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Don't interrupt the installation process if the user hasn't enabled the inject dependencies feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/RepoStateFile.ts
+++ b/libraries/rush-lib/src/logic/RepoStateFile.ts
@@ -208,6 +208,12 @@ export class RepoStateFile {
       ) {
         this._packageJsonInjectedDependenciesHash = packageJsonInjectedDependenciesHash;
         this._modified = true;
+      } else if (!packageJsonInjectedDependenciesHash && this._packageJsonInjectedDependenciesHash) {
+        // if packageJsonInjectedDependenciesHash is undefined, but this._packageJsonInjectedDependenciesHash is not
+        // means users may turn off the injected installation
+        // so we will need to remove unused fields in repo-state.json as well
+        this._packageJsonInjectedDependenciesHash = undefined;
+        this._modified = true
       }
     }
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -170,8 +170,10 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         // there is a situation that the subspace previously has injected dependencies but removed
         // so we can check if the repoState up to date
         if (repoState.packageJsonInjectedDependenciesHash !== undefined) {
-          shrinkwrapWarnings.push(`Some injected dependencies' package.json might have been modified.`);
-          shrinkwrapIsUpToDate = false;
+          shrinkwrapWarnings.push(
+            'It was detected that the repo-state.json contains packageJsonInjectedDependenciesHash, ' +
+              'but the inject dependencies feature is not enabled.'
+          );
         }
       }
     }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -172,8 +172,8 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         if (repoState.packageJsonInjectedDependenciesHash !== undefined) {
           shrinkwrapWarnings.push(
             `It was detected that ${repoState.filePath} contains packageJsonInjectedDependenciesHash` +
-              ' but the injected dependencies feature is not enabled. You can delete this file' +
-              ' and rerun the rush update command to generate the correct repo-state.json file.'
+              ' but the injected dependencies feature is not enabled. You can manually remove this field in repo-state.json.' +
+              ' Or run rush update command to update the repo-state.json file.'
           );
         }
       }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -171,8 +171,9 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         // so we can check if the repoState up to date
         if (repoState.packageJsonInjectedDependenciesHash !== undefined) {
           shrinkwrapWarnings.push(
-            'It was detected that the repo-state.json contains packageJsonInjectedDependenciesHash, ' +
-              'but the inject dependencies feature is not enabled.'
+            `It was detected that ${repoState.filePath} contains packageJsonInjectedDependenciesHash` +
+              ' but the injected dependencies feature is not enabled. You can delete this file' +
+              ' and rerun the rush update command to generate the correct repo-state.json file.'
           );
         }
       }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Yesterday, we received an on-call stating that a user experienced a failure in the CI installation process, even after executing `rush update`.

![img_v3_02cm_acf52fae-7ae9-4f2c-9e6e-f5273b45c7hu](https://github.com/microsoft/rushstack/assets/68707557/603bd5eb-86f9-4822-b870-3d7329cab2a9)


After investigating, we discovered that the `repo-state.json` file includes the `packageJsonInjectedDependenciesHash`, but `alwaysInjectDependenciesFromOtherSubspaces` is not enabled. 

![img_v3_02cm_4b8fd515-ab1f-4803-9dc1-22bc7bc19ehu](https://github.com/microsoft/rushstack/assets/68707557/ce289f6f-d40c-45ab-92ee-49ce2b5775d8)


We believe this error negatively impacts the user experience. Users do not know how to resolve the issue after receiving the error message. So, we made a small modification to the source code:

I think a better way is to give a warning without interrupting the installation process.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

1. Remove `alwaysInjectDependenciesFromOtherSubspaces` from  the`pnpm-config.json` file.
2. Run `rush update`.
3. Run `rush install`.
4. Installion successful.



<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

None.

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
