### PR TITLE
[heft] Handle errors when IPC messaging host

### DIFF
--- a/common/changes/@rushstack/operation-graph/main_2024-07-15-21-27.json
+++ b/common/changes/@rushstack/operation-graph/main_2024-07-15-21-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Handle errors when sending IPC messages to host.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}


### PR DESCRIPTION
## Summary
Adds error handling in the event that Heft, when orchestrated in IPC mode, fails to send a postmessage to the host. This condition is treated as a fatal error and rejects the watcher promise, which will cause the process to exit with a non-zero exit code and log the error, instead of hitting the unhandled error hook.

## Details

## How it was tested
Copied the version over and ran it locally to confirm that the normal code path still works. Error handling not currently separately tested.

## Impacted documentation
None.