### PR TITLE
[rush-lib] Fix edge cases where Rush does not update the lockfile

### DIFF
--- a/common/changes/@microsoft/rush/fix-edge-case_2024-07-18-06-38.json
+++ b/common/changes/@microsoft/rush/fix-edge-case_2024-07-18-06-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix edge cases where Rush does not update the lockfile",
+      "comment": "Fix an issue where Rush does not detect an outdated lockfile if the `dependenciesMeta` `package.json` field is edited.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-edge-case_2024-07-18-06-38.json
+++ b/common/changes/@microsoft/rush/fix-edge-case_2024-07-18-06-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix edge cases where Rush does not update the lockfile",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -872,7 +872,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
     // Use a new PackageJsonEditor since it will classify each dependency type, making tracking the
     // found versions much simpler.
-    const { dependencyList, devDependencyList } = PackageJsonEditor.fromObject(
+    const { dependencyList, devDependencyList, dependencyMetaList } = PackageJsonEditor.fromObject(
       this._pnpmfileConfiguration.transform(transformedPackageJson),
       project.packageJsonEditor.filePath
     );
@@ -960,6 +960,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       );
       const importerDependencies: Set<string> = new Set(Object.keys(importer.dependencies ?? {}));
       const importerDevDependencies: Set<string> = new Set(Object.keys(importer.devDependencies ?? {}));
+      const importerDependenciesMeta: Set<string> = new Set(Object.keys(importer.dependenciesMeta ?? {}));
 
       for (const { dependencyType, name, version } of allDependencies) {
         let isOptional: boolean = false;
@@ -1019,11 +1020,18 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         }
       }
 
+      for (const { name, injected } of dependencyMetaList) {
+        if (importer.dependenciesMeta?.[name]?.injected === injected) {
+          importerDependenciesMeta.delete(name);
+        }
+      }
+
       // Finally, validate that all values in the importer are also present in the dependency list.
       if (
         importerOptionalDependencies.size > 0 ||
         importerDependencies.size > 0 ||
-        importerDevDependencies.size > 0
+        importerDevDependencies.size > 0 ||
+        importerDependenciesMeta.size > 0
       ) {
         return true;
       }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

After removing `dependenciesMeta` from `package.json` and running `rush update`, the pnpm lockfile isn't updated because Rush doesn't consider the update of `dependenciesMeta`.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->



<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

![image](https://github.com/user-attachments/assets/9f731c3e-a9d6-4cc2-bc34-0cc31e0f799e)

After removing `dependenciesMeta` and running `rush update`, it can update the lockfile normally.

![image](https://github.com/user-attachments/assets/957e5c52-0978-4afa-9a6f-eb9d71003d39)


<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

None.

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
