### PR TITLE
Upgrade to PNPM 8.15.9

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "8.15.8",
+  "pnpmVersion": "8.15.9",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",


### PR DESCRIPTION
PNPM 8.15.9 includes a [backport](https://github.com/pnpm/pnpm/releases/tag/v8.15.9) of PR https://github.com/pnpm/pnpm/pull/8126 which fixed issue https://github.com/pnpm/pnpm/issues/7833.  It is a race condition that was causing Rush Stack CI pipelines to fail `rush install` occasionally with various error messages such as:

- `PERM: operation not permitted`
- `'nt.js" --config .eslintrc.js' is not recognized as an internal or external command`

🏆 Thank you @KSXGitHub for the fix.