### PR TITLE
fix(rush): don't panic when cache beforeExecute fails

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-prevent-errors-on-before-execute_2024-07-28-22-23.json
+++ b/common/changes/@microsoft/rush/sennyeya-prevent-errors-on-before-execute_2024-07-28-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a bug that caused the build cache to close its terminal writer before execution on error.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -402,13 +402,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
           }
         };
 
-        try {
-          const earlyReturnStatus: OperationStatus | undefined = await runBeforeExecute();
-          return earlyReturnStatus;
-        } catch (e) {
-          buildCacheContext.buildCacheProjectLogWritable?.close();
-          throw e;
-        }
+        return await runBeforeExecute();
       }
     );
 


### PR DESCRIPTION
## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #4831.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

This ended up being easier than I thought it would be, the issue was that `afterExecuteOperation` runs regardless of it `beforeExecuteOperation` threw. `afterExecuteOperation` expects the build cache terminal to still be open, and cleans up the terminal itself after execution. All we need to do is remove the double cleanup in `beforeExecuteOperation`

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested locally with `build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo`. 

<details><summary>Before</summary>
<p>

```
==[ FAILURE: 9 operations ]====================================================

--[ FAILURE: b (build) - shard 1/5 ]-------------------------[ 0.01 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/rush-logs/b._phase_build_shard_1.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: b (build) - shard 2/5 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/rush-logs/b._phase_build_shard_2.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: b (build) - shard 3/5 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/rush-logs/b._phase_build_shard_3.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: b (build) - shard 4/5 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/rush-logs/b._phase_build_shard_4.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: b (build) - shard 5/5 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/rush-logs/b._phase_build_shard_5.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: a (build) - shard 1/4 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/rush-logs/a._phase_build_shard_1.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: a (build) - shard 2/4 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/rush-logs/a._phase_build_shard_2.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: a (build) - shard 3/4 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/rush-logs/a._phase_build_shard_3.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.

--[ FAILURE: a (build) - shard 4/4 ]-------------------------[ 0.00 seconds ]--

Internal Error: Early return status should not be set: EXECUTING

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
Internal Error: Log writer was closed for /Users/aramis.sennyey/Projects/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/rush-logs/a._phase_build_shard_4.cache.log

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.


Operations failed.

rush cobuild (0.18 seconds)

Error: An error occurred.
    at PhasedScriptAction._executeOperationsAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:642:19)
    at async PhasedScriptAction._runInitialPhasesAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:371:9)
    at async PhasedScriptAction.runAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:335:37)
    at async RushCommandLineParser.onExecute (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:275:13)
    at async RushCommandLineParser._wrapOnExecuteAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:234:13)
    at async RushCommandLineParser.onExecute (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:182:13)
    at async RushCommandLineParser.executeWithoutErrorHandlingAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:219:13)
    at async RushCommandLineParser.executeAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:99:13)
    at async RushCommandLineParser.executeAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:168:16)
    at async RushCommandLineParser.execute (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:142:16)
```
</p>
</details>

<details><summary>After</summary>
<p>

```
==[ FAILURE: 9 operations ]====================================================

--[ FAILURE: b (build) - shard 1/5 ]-------------------------[ 0.02 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: b (build) - shard 2/5 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: b (build) - shard 3/5 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: b (build) - shard 4/5 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: b (build) - shard 5/5 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: a (build) - shard 1/4 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: a (build) - shard 2/4 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: a (build) - shard 3/4 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE

--[ FAILURE: a (build) - shard 4/4 ]-------------------------[ 0.01 seconds ]--

Early return status should not be set: FAILURE


Operations failed.

rush cobuild (0.23 seconds)

Error: An error occurred.
    at PhasedScriptAction._executeOperationsAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:642:19)
    at async PhasedScriptAction._runInitialPhasesAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:371:9)
    at async PhasedScriptAction.runAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/scriptActions/PhasedScriptAction.js:335:37)
    at async RushCommandLineParser.onExecute (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:275:13)
    at async RushCommandLineParser._wrapOnExecuteAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:234:13)
    at async RushCommandLineParser.onExecute (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:182:13)
    at async RushCommandLineParser.executeWithoutErrorHandlingAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:219:13)
    at async RushCommandLineParser.executeAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:99:13)
    at async RushCommandLineParser.executeAsync (/Users/aramis.sennyey/Projects/rushstack/libraries/rush-lib/lib-commonjs/cli/RushCommandLineParser.js:168:16)
    at async RushCommandLineParser.execute (/Users/aramis.sennyey/Projects/rushstack/libraries/ts-command-line/lib/providers/CommandLineParser.js:142:16)
```

</p>
</details> 


## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

None.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
