### PR TITLE
[rush-lib] prevent workspace dependencies in decoupledLocalDependencies

### DIFF
--- a/common/changes/@microsoft/rush/jmaher-prevent-decoupled-workspace-deps_2024-07-30-15-46.json
+++ b/common/changes/@microsoft/rush/jmaher-prevent-decoupled-workspace-deps_2024-07-30-15-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "prevent workspace deps in decoupledLocalDependencies",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "jamesmaher-dd@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/jmaher-prevent-decoupled-workspace-deps_2024-07-30-15-46.json
+++ b/common/changes/@microsoft/rush/jmaher-prevent-decoupled-workspace-deps_2024-07-30-15-46.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "prevent workspace deps in decoupledLocalDependencies",
+      "comment": "Emit an error if a `workspace:` specifier is used in a dependency that is listed in `decoupledLocalDependencies`.",
       "type": "none",
       "packageName": "@microsoft/rush"
     }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -290,7 +290,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           // eslint-disable-next-line no-console
           console.log(
             Colorize.red(
-              `"${rushProject.packageName}" depends on package ${name}@${version}, but also lists it in` +
+              `"${rushProject.packageName}" depends on package ${name}@${version}, but also lists it in ` +
                 `its "decoupledLocalDependencies" array. Either update the host project's package.json to use ` +
                 `a version from an external feed instead of "workspace:" notation, or remove the dependency from the ` +
                 `host project's "decoupledLocalDependencies" array in rush.json.`

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -279,7 +279,25 @@ export class WorkspaceInstallManager extends BaseInstallManager {
             shrinkwrapIsUpToDate = false;
             continue;
           }
-        } else if (dependencySpecifier.specifierType === DependencySpecifierType.Workspace) {
+        } else if (
+          dependencySpecifier.specifierType === DependencySpecifierType.Workspace &&
+          rushProject.decoupledLocalDependencies.has(name)
+        ) {
+          // If the dependency is a local project that is decoupled, then we need to ensure that it is not specified
+          // as a workspace project. If it is, then we need to update the package.json to remove the workspace notation.
+          // eslint-disable-next-line no-console
+          console.log();
+          // eslint-disable-next-line no-console
+          console.log(
+            Colorize.red(
+              `"${rushProject.packageName}" depends on package ${name}@${version}, but also lists it in` +
+                `its "decoupledLocalDependencies" array. Either update the host project's package.json to use ` +
+                `a version from an external feed instead of "workspace:" notation, or remove the dependency from the ` +
+                `host project's "decoupledLocalDependencies" array in rush.json.`
+            )
+          );
+          throw new AlreadyReportedError();
+        } else if (!rushProject.decoupledLocalDependencies.has(name)) {
           // Already specified as a local project. Allow the package manager to validate this
           continue;
         }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -285,16 +285,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         ) {
           // If the dependency is a local project that is decoupled, then we need to ensure that it is not specified
           // as a workspace project. If it is, then we need to update the package.json to remove the workspace notation.
-          // eslint-disable-next-line no-console
-          console.log();
-          // eslint-disable-next-line no-console
-          console.log(
-            Colorize.red(
-              `"${rushProject.packageName}" depends on package ${name}@${version}, but also lists it in ` +
-                `its "decoupledLocalDependencies" array. Either update the host project's package.json to use ` +
-                `a version from an external feed instead of "workspace:" notation, or remove the dependency from the ` +
-                `host project's "decoupledLocalDependencies" array in rush.json.`
-            )
+          this._terminal.writeWarningLine(
+            `"${rushProject.packageName}" depends on package ${name}@${version}, but also lists it in ` +
+              `its "decoupledLocalDependencies" array. Either update the host project's package.json to use ` +
+              `a version from an external feed instead of "workspace:" notation, or remove the dependency from the ` +
+              `host project's "decoupledLocalDependencies" array in rush.json.`
           );
           throw new AlreadyReportedError();
         } else if (!rushProject.decoupledLocalDependencies.has(name)) {


### PR DESCRIPTION
## Summary

Adds a check in install step to prevent a host project depending on a workspace: package version if the package is also listed in decoupledLocalDependencies.

Currently unaware of any use case that this would be intended. We came across this issue when migrating a dependency from an external feed (e.g. `"@<namespace>/packageA": "1.2.3"`) to a workspace dependency, and didn't remove the package from `decoupledLocalDependencies`. 

## Details

We came across an issue which allows a host package to depend on a package with `workspace:` notation while also listing that package in its `decoupledLocalDependencies`. Because this is currently not checked, this can result in a missing dependency in CI runs because the `package@workspace:` is not guaranteed to be built prior to the package that depends on it, so here we're adding a check for it.

## Replication steps

This is a very quick example to demonstrate how this situation occurs:
```
# hostProject1 package.json
"dependencies": {
  "@<namespace>/packageA": "workspace:*",
}
```

```
# rush.json
"projects": [
  {
    "packageName": "@<namespace>/hostProject1",
    "projectFolder": "apps/hostProject1",
    "decoupledLocalDependencies": ["@<namespace>/packageA"],
  },
```

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested with local rush against our repo by replicating with the steps above and running `rush update` or `rush install`, and no warning logged or error being thrown.

Adding this changeset against our repo with the same replication results in the error added in this PR being thrown, preventing the erroneous state.
