### PR TITLE
[localization-plugin] Include webpack compilation in stats callback

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/localization-stats_2024-07-30-17-34.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/localization-stats_2024-07-30-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Include webpack compilation in localizationStats callback.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/reviews/api/webpack5-localization-plugin.api.md
+++ b/common/reviews/api/webpack5-localization-plugin.api.md
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import type { Chunk } from 'webpack';
+import type { Compilation } from 'webpack';
 import type { Compiler } from 'webpack';
 import { ILocalizationFile } from '@rushstack/localization-utilities';
 import type { IPseudolocaleOptions } from '@rushstack/localization-utilities';
@@ -77,7 +78,7 @@ export interface ILocalizationStatsEntrypoint {
 
 // @public
 export interface ILocalizationStatsOptions {
-    callback?: (stats: ILocalizationStats) => void;
+    callback?: (stats: ILocalizationStats, compilation: Compilation) => void;
     dropPath?: string;
 }
 

--- a/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
+++ b/webpack/webpack5-localization-plugin/src/LocalizationPlugin.ts
@@ -413,7 +413,7 @@ export class LocalizationPlugin implements WebpackPluginInstance {
 
             if (callback) {
               try {
-                callback(localizationStats);
+                callback(localizationStats, compilation);
               } catch (e) {
                 /* swallow errors from the callback */
               }

--- a/webpack/webpack5-localization-plugin/src/interfaces.ts
+++ b/webpack/webpack5-localization-plugin/src/interfaces.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { LoaderContext } from 'webpack';
+import type { LoaderContext, Compilation } from 'webpack';
 import type { IPseudolocaleOptions } from '@rushstack/localization-utilities';
 
 /**
@@ -97,9 +97,9 @@ export interface ILocalizationStatsOptions {
 
   /**
    * This option is used to specify a callback to be called with the stats data that would be
-   * dropped at `localizationStats.dropPath` after compilation completes.
+   * dropped at `localizationStats.dropPath` after compilation completes, and the compilation instance.
    */
-  callback?: (stats: ILocalizationStats) => void;
+  callback?: (stats: ILocalizationStats, compilation: Compilation) => void;
 }
 
 /**

--- a/webpack/webpack5-localization-plugin/src/test/LocalizedNoAsync.test.ts
+++ b/webpack/webpack5-localization-plugin/src/test/LocalizedNoAsync.test.ts
@@ -27,6 +27,7 @@ async function testLocalizedNoAsyncInner(minimize: boolean): Promise<void> {
     '/'
   );
 
+  let compilationInStats: webpack.Compilation | undefined;
   const resJsonLoader: string = resolve(__dirname, '../loaders/resjson-loader.js');
   const options: ILocalizationPluginOptions = {
     localizedData: {
@@ -53,7 +54,10 @@ async function testLocalizedNoAsyncInner(minimize: boolean): Promise<void> {
       }
     },
     localizationStats: {
-      dropPath: 'localization-stats.json'
+      dropPath: 'localization-stats.json',
+      callback: (stats, compilation) => {
+        compilationInStats = compilation;
+      }
     },
     realContentHash: true
   };
@@ -109,6 +113,9 @@ async function testLocalizedNoAsyncInner(minimize: boolean): Promise<void> {
 
   expect(errors).toHaveLength(0);
   expect(warnings).toHaveLength(0);
+
+  expect(compilationInStats).toBeDefined();
+  expect(compilationInStats).toBeInstanceOf(webpack.Compilation);
 }
 
 describe(LocalizationPlugin.name, () => {


### PR DESCRIPTION
## Summary
Adds the current webpack `Compilation` object as an additional parameter to the `localizationStats` callback. This ensures that a caller who wishes to do custom serialization of the object can use the webpack compilation to emit it.

## Details
Exactly as it says on the tin.

## How it was tested
Added unit test coverage.

## Impacted documentation
Docs on the callback.