### PR TITLE
[localization-plugin] Improve localized asset construction performance by 50%

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/localization-plugin-perf_2024-08-06-01-24.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/localization-plugin-perf_2024-08-06-01-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Improve performance of localized asset reconstruction.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/webpack/webpack5-localization-plugin/src/AssetProcessor.ts
+++ b/webpack/webpack5-localization-plugin/src/AssetProcessor.ts
@@ -208,7 +208,8 @@ function _reconstructLocalized(
 ): ILocalizedReconstructionResult {
   const issues: string[] = [];
 
-  for (const element of reconstructionSeries) {
+  for (let i: number = reconstructionSeries.length - 1; i >= 0; i--) {
+    const element: IReconstructionElement = reconstructionSeries[i];
     switch (element.kind) {
       case 'localized': {
         const { data } = element;
@@ -228,19 +229,25 @@ function _reconstructLocalized(
 
         const escapedBackslash: string = element.escapedBackslash || '\\';
 
-        // Replace backslashes with the properly escaped backslash
-        BACKSLASH_REGEX.lastIndex = -1;
-        newValue = newValue.replace(BACKSLASH_REGEX, escapedBackslash);
-
-        // @todo: look into using JSON.parse(...) to get the escaping characters
-        const escapingCharacterSequence: string = escapedBackslash.slice(escapedBackslash.length / 2);
+        if (newValue.includes('\\')) {
+          // The vast majority of localized strings do not contain `\\`, so this check avoids an allocation.
+          // Replace backslashes with the properly escaped backslash
+          BACKSLASH_REGEX.lastIndex = -1;
+          newValue = newValue.replace(BACKSLASH_REGEX, escapedBackslash);
+        }
 
         // Ensure the the quotemark, apostrophe, tab, and newline characters are properly escaped
         ESCAPE_REGEX.lastIndex = -1;
-        newValue = newValue.replace(
-          ESCAPE_REGEX,
-          (match) => `${escapingCharacterSequence}${ESCAPE_MAP.get(match)}`
-        );
+        if (ESCAPE_REGEX.test(newValue)) {
+          // The majority of localized strings do not contain the characters that need to be escaped,
+          // so this check avoids an allocation.
+          // @todo: look into using JSON.parse(...) to get the escaping characters
+          const escapingCharacterSequence: string = escapedBackslash.slice(escapedBackslash.length / 2);
+          newValue = newValue.replace(
+            ESCAPE_REGEX,
+            (match) => `${escapingCharacterSequence}${ESCAPE_MAP.get(match)}`
+          );
+        }
 
         result.replace(element.start, element.end - 1, newValue);
         break;
@@ -267,7 +274,8 @@ function _reconstructNonLocalized(
 ): INonLocalizedReconstructionResult {
   const issues: string[] = [];
 
-  for (const element of reconstructionSeries) {
+  for (let i: number = reconstructionSeries.length - 1; i >= 0; i--) {
+    const element: IReconstructionElement = reconstructionSeries[i];
     switch (element.kind) {
       case 'localized': {
         issues.push(
@@ -305,9 +313,7 @@ function _parseStringToReconstructionSequence(
   const jsonStringifyFormatLocaleForFilenameFn: FormatLocaleForFilenameFn = (locale: string) =>
     JSON.stringify(formatLocaleForFilenameFn(locale));
 
-  let regexResult: RegExpExecArray | null;
-  PLACEHOLDER_REGEX.lastIndex = -1;
-  while ((regexResult = PLACEHOLDER_REGEX.exec(source))) {
+  for (const regexResult of source.matchAll(PLACEHOLDER_REGEX)) {
     const [placeholder, escapedBackslash, elementLabel, placeholderSerialNumber] = regexResult;
     const start: number = regexResult.index;
     const end: number = start + placeholder.length;

--- a/webpack/webpack5-localization-plugin/src/AssetProcessor.ts
+++ b/webpack/webpack5-localization-plugin/src/AssetProcessor.ts
@@ -208,8 +208,7 @@ function _reconstructLocalized(
 ): ILocalizedReconstructionResult {
   const issues: string[] = [];
 
-  for (let i: number = reconstructionSeries.length - 1; i >= 0; i--) {
-    const element: IReconstructionElement = reconstructionSeries[i];
+  for (const element of reconstructionSeries) {
     switch (element.kind) {
       case 'localized': {
         const { data } = element;
@@ -274,8 +273,7 @@ function _reconstructNonLocalized(
 ): INonLocalizedReconstructionResult {
   const issues: string[] = [];
 
-  for (let i: number = reconstructionSeries.length - 1; i >= 0; i--) {
-    const element: IReconstructionElement = reconstructionSeries[i];
+  for (const element of reconstructionSeries) {
     switch (element.kind) {
       case 'localized': {
         issues.push(


### PR DESCRIPTION
## Summary
Applies some preliminary checks to localized replacement strings before invoking `string.replace` to avoid allocating unnecessary strings when there are no characters that need escaping.

## Details
The calls to `string.replace` are expensive and most localized strings don't contain `\`, `"`, `'`, `\t`, `\n` or `\r`.

## How it was tested
Unit tests for behavior.

Before:
![image](https://github.com/user-attachments/assets/361ea65d-3746-4464-9370-eff3c684941b)

After:
![image](https://github.com/user-attachments/assets/53459a71-f8a2-4ab3-84bb-e5c64f9938dd)


## Impacted documentation
None.