### PR TITLE
[rush] Fix bundling of rush-sdk.

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-sdk-bundling_2024-08-08-21-07.json
+++ b/common/changes/@microsoft/rush/fix-rush-sdk-bundling_2024-08-08-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where rush-sdk can't be bundled by a consuming package.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.131.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/rush-sdk/.npmignore
+++ b/libraries/rush-sdk/.npmignore
@@ -30,5 +30,5 @@
 # ---------------------------------------------------------------------------
 # DO NOT MODIFY ABOVE THIS LINE!  Add any project-specific overrides below.
 # ---------------------------------------------------------------------------
-/lib-shim/generate-stubs*
-
+/lib-commonjs/**
+/lib-esnext/**

--- a/libraries/rush-sdk/webpack.config.js
+++ b/libraries/rush-sdk/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env es6 */
 'use strict';
 
-const webpack = require('webpack');
 const { PackageJsonLookup } = require('@rushstack/node-core-library');
 const { PreserveDynamicRequireWebpackPlugin } = require('@rushstack/webpack-preserve-dynamic-require-plugin');
 
@@ -54,18 +53,6 @@ module.exports = () => {
           callback();
         }
       }
-    ],
-    optimization: {
-      splitChunks: {
-        chunks: 'all',
-        minChunks: 1,
-        cacheGroups: {
-          commons: {
-            name: 'commons',
-            chunks: 'initial'
-          }
-        }
-      }
-    }
+    ]
   };
 };


### PR DESCRIPTION
## Summary

Currently when `@rushstack/rush-sdk` is bundled by a dependent project, calling into it won't work because a shared chunk is generated and isn't consumed by the bundler. This PR removes the commons chunk.

## How it was tested

Tested in a project that has an issue.