### PR TITLE
[rush] feat(cobuilds): allow orchestration without using the build cache

### DIFF
--- a/build-tests/rush-redis-cobuild-plugin-integration-test/README.md
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/README.md
@@ -152,6 +152,9 @@ rm -rf common/temp/build-cache
 Expected behavior: Cobuild feature is enabled, cobuild related logs out in both terminals. These two cobuild commands fail because of the failing build of project "A". And, one of them restored the failing build cache created by the other one.
 
 #### Case 5: Sharded cobuilds
+
+Enable the `allowCobuildWithoutCache` experiment in `experiments.json`.
+
 Navigate to the sandbox for sharded cobuilds,
 ```sh
 cd sandbox/sharded-repo
@@ -164,7 +167,7 @@ docker compose down && docker compose up -d
 
 Then, open 2 terminals and run this in each (changing the RUSH_COBUILD_RUNNER_ID across the 2 terminals),
 ```sh
-rm -rf common/temp/build-cache && RUSH_COBUILD_CONTEXT_ID=foo REDIS_PASS=redis123 RUSH_COBUILD_RUNNER_ID=runner1 RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED=1 node ../../lib/runRush.js cobuild -p 10 --timeline
+rm -rf common/temp/build-cache && RUSH_COBUILD_CONTEXT_ID=foo REDIS_PASS=redis123 RUSH_COBUILD_RUNNER_ID=runner1 node ../../lib/runRush.js cobuild -p 10 --timeline
 ```
 
 If all goes well, you should see a bunch of operation with `- shard xx/yy`. Operations `h (build)` and `e (build)` are both sharded heavily and should be cobuild compatible. To validate changes you're making, ensure that the timeline view for all of the shards of those 2 operations are cobuilt across both terminals. If they're not, something is wrong with your update.

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/README.md
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/README.md
@@ -150,3 +150,21 @@ rm -rf common/temp/build-cache
 5. Open command palette (Ctrl+Shift+P or Command+Shift+P) and select `Tasks: Run Task` and select `cobuild`.
 
 Expected behavior: Cobuild feature is enabled, cobuild related logs out in both terminals. These two cobuild commands fail because of the failing build of project "A". And, one of them restored the failing build cache created by the other one.
+
+#### Case 5: Sharded cobuilds
+Navigate to the sandbox for sharded cobuilds,
+```sh
+cd sandbox/sharded-repo
+```
+
+Next, start up your Redis instance,
+```sh
+docker compose down && docker compose up -d
+```
+
+Then, open 2 terminals and run this in each (changing the RUSH_COBUILD_RUNNER_ID across the 2 terminals),
+```sh
+rm -rf common/temp/build-cache && RUSH_COBUILD_CONTEXT_ID=foo REDIS_PASS=redis123 RUSH_COBUILD_RUNNER_ID=runner1 RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED=1 node ../../lib/runRush.js cobuild -p 10 --timeline
+```
+
+If all goes well, you should see a bunch of operation with `- shard xx/yy`. Operations `h (build)` and `e (build)` are both sharded heavily and should be cobuild compatible. To validate changes you're making, ensure that the timeline view for all of the shards of those 2 operations are cobuilt across both terminals. If they're not, something is wrong with your update.

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/common/config/rush/experiments.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/common/config/rush/experiments.json
@@ -3,7 +3,7 @@
  * Rush features.  More documentation is available on the Rush website: https://rushjs.io
  */
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/experiments.schema.json",
+  "$schema": "../../../../../../../libraries/rush-lib/src/schemas/experiments.schema.json",
 
   /**
    * By default, 'rush install' passes --no-prefer-frozen-lockfile to 'pnpm install'.
@@ -40,7 +40,7 @@
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */
-  "phasedCommands": true
+  "phasedCommands": true,
 
   /**
    * If true, perform a clean install after when running `rush install` or `rush update` if the
@@ -52,4 +52,6 @@
    * If true, print the outputs of shell commands defined in event hooks to the console.
    */
   // "printEventHooksOutputToConsole": true
+
+  "allowCobuildWithoutCache": true
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
@@ -1,18 +1,16 @@
 {
+  "$schema": "../../../../../../../libraries/rush-lib/src/schemas/rush-project.schema.json",
   "operationSettings": [
     {
       "operationName": "_phase:build",
       "outputFolderNames": ["dist"],
-      "sharding": {
-        "count": 75,
-        "shardOperationSettings": {
-          "weight": 10
-        }
-      }
+      "allowCobuildOrchestration": true,
+      "disableBuildCacheForOperation": true
     },
     {
       "operationName": "_phase:build:shard",
-      "weight": 1
+      "weight": 1,
+      "allowCobuildOrchestration": true
     }
   ]
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
@@ -12,7 +12,7 @@
     },
     {
       "operationName": "_phase:build:shard",
-      "weight": 1,
+      "weight": 10,
       "allowCobuildOrchestration": true
     }
   ]

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
@@ -5,7 +5,10 @@
       "operationName": "_phase:build",
       "outputFolderNames": ["dist"],
       "allowCobuildOrchestration": true,
-      "disableBuildCacheForOperation": true
+      "disableBuildCacheForOperation": true,
+      "sharding": {
+        "count": 75
+      }
     },
     {
       "operationName": "_phase:build:shard",

--- a/common/changes/@microsoft/rush/sennyeya-allow-cobuild-orchestration_2024-08-08-23-11.json
+++ b/common/changes/@microsoft/rush/sennyeya-allow-cobuild-orchestration_2024-08-08-23-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds a new experiment for cobuilds to allow uncacheable operations to benefit from cobuild orchestration without using the build cache.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/sennyeya-allow-cobuild-orchestration_2024-08-08-23-11.json
+++ b/common/changes/@microsoft/rush/sennyeya-allow-cobuild-orchestration_2024-08-08-23-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Adds a new experiment for cobuilds to allow uncacheable operations to benefit from cobuild orchestration without using the build cache.",
+      "comment": "Adds a new experiment 'allowCobuildWithoutCache' for cobuilds to allow uncacheable operations to benefit from cobuild orchestration without using the build cache.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -104,8 +104,8 @@ export class CobuildConfiguration {
     readonly cobuildContextId: string | undefined;
     readonly cobuildFeatureEnabled: boolean;
     readonly cobuildLeafProjectLogOnlyAllowed: boolean;
-    readonly cobuildOrchestrationOnlyAllowed: boolean;
     readonly cobuildRunnerId: string;
+    readonly cobuildWithoutCacheAllowed: boolean;
     // (undocumented)
     createLockProviderAsync(terminal: ITerminal): Promise<void>;
     // (undocumented)
@@ -235,8 +235,8 @@ export class EnvironmentConfiguration {
     static get buildCacheWriteAllowed(): boolean | undefined;
     static get cobuildContextId(): string | undefined;
     static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined;
-    static get cobuildOrchestrationOnlyAllowed(): boolean | undefined;
     static get cobuildRunnerId(): string | undefined;
+    static get cobuildWithoutCacheAllowed(): boolean | undefined;
     // Warning: (ae-forgotten-export) The symbol "IEnvironment" needs to be exported by the entry point index.d.ts
     //
     // @internal
@@ -271,7 +271,7 @@ export const EnvironmentVariableNames: {
     readonly RUSH_COBUILD_CONTEXT_ID: "RUSH_COBUILD_CONTEXT_ID";
     readonly RUSH_COBUILD_RUNNER_ID: "RUSH_COBUILD_RUNNER_ID";
     readonly RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: "RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED";
-    readonly RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: "RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED";
+    readonly RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: "RUSH_COBUILD_WITHOUT_CACHE_ALLOWED";
     readonly RUSH_GIT_BINARY_PATH: "RUSH_GIT_BINARY_PATH";
     readonly RUSH_TAR_BINARY_PATH: "RUSH_TAR_BINARY_PATH";
     readonly _RUSH_RECURSIVE_RUSHX_CALL: "_RUSH_RECURSIVE_RUSHX_CALL";
@@ -628,7 +628,7 @@ export interface IOperationRunnerContext {
 
 // @alpha (undocumented)
 export interface IOperationSettings {
-    allowCobuildOrchestration?: boolean;
+    allowCobuildWithoutCache?: boolean;
     dependsOnAdditionalFiles?: string[];
     dependsOnEnvVars?: string[];
     disableBuildCacheForOperation?: boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -236,7 +236,6 @@ export class EnvironmentConfiguration {
     static get cobuildContextId(): string | undefined;
     static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined;
     static get cobuildRunnerId(): string | undefined;
-    static get cobuildWithoutCacheAllowed(): boolean | undefined;
     // Warning: (ae-forgotten-export) The symbol "IEnvironment" needs to be exported by the entry point index.d.ts
     //
     // @internal
@@ -271,7 +270,6 @@ export const EnvironmentVariableNames: {
     readonly RUSH_COBUILD_CONTEXT_ID: "RUSH_COBUILD_CONTEXT_ID";
     readonly RUSH_COBUILD_RUNNER_ID: "RUSH_COBUILD_RUNNER_ID";
     readonly RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: "RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED";
-    readonly RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: "RUSH_COBUILD_WITHOUT_CACHE_ALLOWED";
     readonly RUSH_GIT_BINARY_PATH: "RUSH_GIT_BINARY_PATH";
     readonly RUSH_TAR_BINARY_PATH: "RUSH_TAR_BINARY_PATH";
     readonly _RUSH_RECURSIVE_RUSHX_CALL: "_RUSH_RECURSIVE_RUSHX_CALL";
@@ -472,6 +470,7 @@ export interface IExecutionResult {
 
 // @beta
 export interface IExperimentsJson {
+    allowCobuildWithoutCache?: boolean;
     buildCacheWithAllowWarningsInSuccessfulBuild?: boolean;
     buildSkipWithAllowWarningsInSuccessfulBuild?: boolean;
     cleanInstallAfterNpmrcChanges?: boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -104,6 +104,7 @@ export class CobuildConfiguration {
     readonly cobuildContextId: string | undefined;
     readonly cobuildFeatureEnabled: boolean;
     readonly cobuildLeafProjectLogOnlyAllowed: boolean;
+    readonly cobuildOrchestrationOnlyAllowed: boolean;
     readonly cobuildRunnerId: string;
     // (undocumented)
     createLockProviderAsync(terminal: ITerminal): Promise<void>;
@@ -234,6 +235,7 @@ export class EnvironmentConfiguration {
     static get buildCacheWriteAllowed(): boolean | undefined;
     static get cobuildContextId(): string | undefined;
     static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined;
+    static get cobuildOrchestrationOnlyAllowed(): boolean | undefined;
     static get cobuildRunnerId(): string | undefined;
     // Warning: (ae-forgotten-export) The symbol "IEnvironment" needs to be exported by the entry point index.d.ts
     //
@@ -269,6 +271,7 @@ export const EnvironmentVariableNames: {
     readonly RUSH_COBUILD_CONTEXT_ID: "RUSH_COBUILD_CONTEXT_ID";
     readonly RUSH_COBUILD_RUNNER_ID: "RUSH_COBUILD_RUNNER_ID";
     readonly RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: "RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED";
+    readonly RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: "RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED";
     readonly RUSH_GIT_BINARY_PATH: "RUSH_GIT_BINARY_PATH";
     readonly RUSH_TAR_BINARY_PATH: "RUSH_TAR_BINARY_PATH";
     readonly _RUSH_RECURSIVE_RUSHX_CALL: "_RUSH_RECURSIVE_RUSHX_CALL";
@@ -625,6 +628,7 @@ export interface IOperationRunnerContext {
 
 // @alpha (undocumented)
 export interface IOperationSettings {
+    allowCobuildOrchestration?: boolean;
     dependsOnAdditionalFiles?: string[];
     dependsOnEnvVars?: string[];
     disableBuildCacheForOperation?: boolean;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/experiments.json
@@ -96,5 +96,11 @@
    * This ensures that important notices will be seen by anyone doing active development, since people often
    * ignore normal discussion group messages or don't know to subscribe.
    */
-   /*[LINE "HYPOTHETICAL"]*/ "rushAlerts": true
+   /*[LINE "HYPOTHETICAL"]*/ "rushAlerts": true,
+
+
+  /**
+   * When using cobuilds, this experiment allows uncacheable operations to benefit from cobuild orchestration without using the build cache.
+   */
+   /*[LINE "HYPOTHETICAL"]*/ "allowCobuildWithoutCache": true
 }

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -87,7 +87,6 @@ export class CobuildConfiguration {
     this.cobuildRunnerId = EnvironmentConfiguration.cobuildRunnerId || uuidv4();
     this.cobuildLeafProjectLogOnlyAllowed =
       EnvironmentConfiguration.cobuildLeafProjectLogOnlyAllowed ?? false;
-    console.log(JSON.stringify(rushConfiguration.experimentsConfiguration.configuration));
     this.cobuildWithoutCacheAllowed =
       rushConfiguration.experimentsConfiguration.configuration.allowCobuildWithoutCache ?? false;
 

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -69,6 +69,13 @@ export class CobuildConfiguration {
    */
   public readonly cobuildLeafProjectLogOnlyAllowed: boolean;
 
+  /**
+   * If true, Rush will automatically handle the leaf project with build cache "disabled" by writing
+   * to the cache in a special "log files only mode". This is useful when you want to use Cobuilds
+   * to improve the performance in CI validations and the leaf projects have not enabled cache.
+   */
+  public readonly cobuildOrchestrationOnlyAllowed: boolean;
+
   private _cobuildLockProvider: ICobuildLockProvider | undefined;
   private readonly _cobuildLockProviderFactory: CobuildLockProviderFactory;
   private readonly _cobuildJson: ICobuildJson;
@@ -81,6 +88,7 @@ export class CobuildConfiguration {
     this.cobuildRunnerId = EnvironmentConfiguration.cobuildRunnerId || uuidv4();
     this.cobuildLeafProjectLogOnlyAllowed =
       EnvironmentConfiguration.cobuildLeafProjectLogOnlyAllowed ?? false;
+    this.cobuildOrchestrationOnlyAllowed = EnvironmentConfiguration.cobuildOrchestrationOnlyAllowed ?? false;
 
     this._cobuildLockProviderFactory = cobuildLockProviderFactory;
     this._cobuildJson = cobuildJson;

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -70,9 +70,8 @@ export class CobuildConfiguration {
   public readonly cobuildLeafProjectLogOnlyAllowed: boolean;
 
   /**
-   * If true, Rush will automatically handle the leaf project with build cache "disabled" by writing
-   * to the cache in a special "log files only mode". This is useful when you want to use Cobuilds
-   * to improve the performance in CI validations and the leaf projects have not enabled cache.
+   * If true, operations can opt into leveraging cobuild orchestration without restoring from the build cache.
+   *  Operations will need to us the allowCobuildOrchestration flag to opt into this behavior per phase.
    */
   public readonly cobuildOrchestrationOnlyAllowed: boolean;
 

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -70,10 +70,10 @@ export class CobuildConfiguration {
   public readonly cobuildLeafProjectLogOnlyAllowed: boolean;
 
   /**
-   * If true, operations can opt into leveraging cobuild orchestration without restoring from the build cache.
-   *  Operations will need to us the allowCobuildOrchestration flag to opt into this behavior per phase.
+   * If true, operations can opt into leveraging cobuilds without restoring from the build cache.
+   *  Operations will need to us the allowCobuildWithoutCache flag to opt into this behavior per phase.
    */
-  public readonly cobuildOrchestrationOnlyAllowed: boolean;
+  public readonly cobuildWithoutCacheAllowed: boolean;
 
   private _cobuildLockProvider: ICobuildLockProvider | undefined;
   private readonly _cobuildLockProviderFactory: CobuildLockProviderFactory;
@@ -87,7 +87,7 @@ export class CobuildConfiguration {
     this.cobuildRunnerId = EnvironmentConfiguration.cobuildRunnerId || uuidv4();
     this.cobuildLeafProjectLogOnlyAllowed =
       EnvironmentConfiguration.cobuildLeafProjectLogOnlyAllowed ?? false;
-    this.cobuildOrchestrationOnlyAllowed = EnvironmentConfiguration.cobuildOrchestrationOnlyAllowed ?? false;
+    this.cobuildWithoutCacheAllowed = EnvironmentConfiguration.cobuildWithoutCacheAllowed ?? false;
 
     this._cobuildLockProviderFactory = cobuildLockProviderFactory;
     this._cobuildJson = cobuildJson;

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -80,14 +80,16 @@ export class CobuildConfiguration {
   private readonly _cobuildJson: ICobuildJson;
 
   private constructor(options: ICobuildConfigurationOptions) {
-    const { cobuildJson, cobuildLockProviderFactory } = options;
+    const { cobuildJson, cobuildLockProviderFactory, rushConfiguration } = options;
 
     this.cobuildContextId = EnvironmentConfiguration.cobuildContextId;
     this.cobuildFeatureEnabled = this.cobuildContextId ? cobuildJson.cobuildFeatureEnabled : false;
     this.cobuildRunnerId = EnvironmentConfiguration.cobuildRunnerId || uuidv4();
     this.cobuildLeafProjectLogOnlyAllowed =
       EnvironmentConfiguration.cobuildLeafProjectLogOnlyAllowed ?? false;
-    this.cobuildWithoutCacheAllowed = EnvironmentConfiguration.cobuildWithoutCacheAllowed ?? false;
+    console.log(JSON.stringify(rushConfiguration.experimentsConfiguration.configuration));
+    this.cobuildWithoutCacheAllowed =
+      rushConfiguration.experimentsConfiguration.configuration.allowCobuildWithoutCache ?? false;
 
     this._cobuildLockProviderFactory = cobuildLockProviderFactory;
     this._cobuildJson = cobuildJson;

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -170,7 +170,7 @@ export const EnvironmentVariableNames = {
    * If this variable is set to "1", When getting distributed builds, Rush will allow uncacheable projects to still leverage
    * the cobuild feature. This is useful when you want to speed up operations that can't (or shouldn't) be cached.
    */
-  RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: 'RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED',
+  RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: 'RUSH_COBUILD_WITHOUT_CACHE_ALLOWED',
 
   /**
    * Explicitly specifies the path for the Git binary that is invoked by certain Rush operations.
@@ -254,7 +254,7 @@ export class EnvironmentConfiguration {
 
   private static _cobuildLeafProjectLogOnlyAllowed: boolean | undefined;
 
-  private static _cobuildOrchestrationOnlyAllowed: boolean | undefined;
+  private static _cobuildWithoutCacheAllowed: boolean | undefined;
 
   private static _gitBinaryPath: string | undefined;
 
@@ -382,11 +382,11 @@ export class EnvironmentConfiguration {
 
   /**
    * If set, enables or disables the cobuild leaf project log only feature.
-   * See {@link EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED}
+   * See {@link EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED}
    */
-  public static get cobuildOrchestrationOnlyAllowed(): boolean | undefined {
+  public static get cobuildWithoutCacheAllowed(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
-    return EnvironmentConfiguration._cobuildOrchestrationOnlyAllowed;
+    return EnvironmentConfiguration._cobuildWithoutCacheAllowed;
   }
 
   /**
@@ -538,10 +538,10 @@ export class EnvironmentConfiguration {
             break;
           }
 
-          case EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: {
-            EnvironmentConfiguration._cobuildOrchestrationOnlyAllowed =
+          case EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: {
+            EnvironmentConfiguration._cobuildWithoutCacheAllowed =
               EnvironmentConfiguration.parseBooleanEnvironmentVariable(
-                EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED,
+                EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED,
                 value
               );
             break;

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -167,12 +167,6 @@ export const EnvironmentVariableNames = {
   RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: 'RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED',
 
   /**
-   * If this variable is set to "1", When getting distributed builds, Rush will allow uncacheable projects to still leverage
-   * the cobuild feature. This is useful when you want to speed up operations that can't (or shouldn't) be cached.
-   */
-  RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: 'RUSH_COBUILD_WITHOUT_CACHE_ALLOWED',
-
-  /**
    * Explicitly specifies the path for the Git binary that is invoked by certain Rush operations.
    */
   RUSH_GIT_BINARY_PATH: 'RUSH_GIT_BINARY_PATH',
@@ -253,8 +247,6 @@ export class EnvironmentConfiguration {
   private static _cobuildRunnerId: string | undefined;
 
   private static _cobuildLeafProjectLogOnlyAllowed: boolean | undefined;
-
-  private static _cobuildWithoutCacheAllowed: boolean | undefined;
 
   private static _gitBinaryPath: string | undefined;
 
@@ -378,15 +370,6 @@ export class EnvironmentConfiguration {
   public static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._cobuildLeafProjectLogOnlyAllowed;
-  }
-
-  /**
-   * If set, enables or disables the cobuild leaf project log only feature.
-   * See {@link EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED}
-   */
-  public static get cobuildWithoutCacheAllowed(): boolean | undefined {
-    EnvironmentConfiguration._ensureValidated();
-    return EnvironmentConfiguration._cobuildWithoutCacheAllowed;
   }
 
   /**
@@ -533,15 +516,6 @@ export class EnvironmentConfiguration {
             EnvironmentConfiguration._cobuildLeafProjectLogOnlyAllowed =
               EnvironmentConfiguration.parseBooleanEnvironmentVariable(
                 EnvironmentVariableNames.RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED,
-                value
-              );
-            break;
-          }
-
-          case EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED: {
-            EnvironmentConfiguration._cobuildWithoutCacheAllowed =
-              EnvironmentConfiguration.parseBooleanEnvironmentVariable(
-                EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED,
                 value
               );
             break;

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -167,6 +167,12 @@ export const EnvironmentVariableNames = {
   RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: 'RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED',
 
   /**
+   * If this variable is set to "1", When getting distributed builds, Rush will allow uncacheable projects to still leverage
+   * the cobuild feature. This is useful when you want to speed up operations that can't (or shouldn't) be cached.
+   */
+  RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: 'RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED',
+
+  /**
    * Explicitly specifies the path for the Git binary that is invoked by certain Rush operations.
    */
   RUSH_GIT_BINARY_PATH: 'RUSH_GIT_BINARY_PATH',
@@ -247,6 +253,8 @@ export class EnvironmentConfiguration {
   private static _cobuildRunnerId: string | undefined;
 
   private static _cobuildLeafProjectLogOnlyAllowed: boolean | undefined;
+
+  private static _cobuildOrchestrationOnlyAllowed: boolean | undefined;
 
   private static _gitBinaryPath: string | undefined;
 
@@ -370,6 +378,15 @@ export class EnvironmentConfiguration {
   public static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._cobuildLeafProjectLogOnlyAllowed;
+  }
+
+  /**
+   * If set, enables or disables the cobuild leaf project log only feature.
+   * See {@link EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED}
+   */
+  public static get cobuildOrchestrationOnlyAllowed(): boolean | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._cobuildOrchestrationOnlyAllowed;
   }
 
   /**
@@ -516,6 +533,15 @@ export class EnvironmentConfiguration {
             EnvironmentConfiguration._cobuildLeafProjectLogOnlyAllowed =
               EnvironmentConfiguration.parseBooleanEnvironmentVariable(
                 EnvironmentVariableNames.RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED,
+                value
+              );
+            break;
+          }
+
+          case EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED: {
+            EnvironmentConfiguration._cobuildOrchestrationOnlyAllowed =
+              EnvironmentConfiguration.parseBooleanEnvironmentVariable(
+                EnvironmentVariableNames.RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED,
                 value
               );
             break;

--- a/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
+++ b/libraries/rush-lib/src/api/ExperimentsConfiguration.ts
@@ -106,6 +106,13 @@ export interface IExperimentsJson {
    * ignore normal discussion group messages or don't know to subscribe.
    */
   rushAlerts?: boolean;
+
+  /**
+   * Allow cobuilds without using the build cache to store previous execution info. When setting up
+   *  distributed builds, Rush will allow uncacheable projects to still leverage the cobuild feature.
+   * This is useful when you want to speed up operations that can't (or shouldn't) be cached.
+   */
+  allowCobuildWithoutCache?: boolean;
 }
 
 const _EXPERIMENTS_JSON_SCHEMA: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -134,6 +134,11 @@ export interface IOperationSettings {
    *  determined by the -p flag.
    */
   weight?: number;
+
+  /**
+   * If true, this operation can use cobuilds for orchestration without restoring build cache entries.
+   */
+  allowCobuildOrchestration?: boolean;
 }
 
 interface IOldRushProjectJson {

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -138,7 +138,7 @@ export interface IOperationSettings {
   /**
    * If true, this operation can use cobuilds for orchestration without restoring build cache entries.
    */
-  allowCobuildOrchestration?: boolean;
+  allowCobuildWithoutCache?: boolean;
 }
 
 interface IOldRushProjectJson {

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -35,6 +35,7 @@ import type { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration'
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
 import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
+import { ExperimentsConfiguration } from '../../api/ExperimentsConfiguration';
 
 const PLUGIN_NAME: 'CacheablePhasedOperationPlugin' = 'CacheablePhasedOperationPlugin';
 const PERIODIC_CALLBACK_INTERVAL_IN_SECONDS: number = 10;
@@ -106,7 +107,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
             !cobuildConfiguration?.cobuildWithoutCacheAllowed
           ) {
             throw new Error(
-              `Operation ${operation.name} is not allowed to run without the cobuild orchestration experiment enabled. You must use the ${EnvironmentVariableNames.RUSH_COBUILD_WITHOUT_CACHE_ALLOWED} environment variable to enable that mode.`
+              `Operation ${operation.name} is not allowed to run without the cobuild orchestration experiment enabled. You must enable the "allowCobuildWithoutCache" experiment in experiments.json.`
             );
           }
           if (

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -34,8 +34,6 @@ import type { OperationMetadataManager } from './OperationMetadataManager';
 import type { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
-import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
-import { ExperimentsConfiguration } from '../../api/ExperimentsConfiguration';
 
 const PLUGIN_NAME: 'CacheablePhasedOperationPlugin' = 'CacheablePhasedOperationPlugin';
 const PERIODIC_CALLBACK_INTERVAL_IN_SECONDS: number = 10;

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -66,6 +66,10 @@
       "description": "If true, when running in watch mode, Rush will check for phase scripts named `_phase:<name>:ipc` and run them instead of `_phase:<name>` if they exist. The created child process will be provided with an IPC channel and expected to persist across invocations.",
       "type": "boolean"
     },
+    "allowCobuildWithoutCache": {
+      "description": "Adds a new experiment 'allowCobuildWithoutCache' for cobuilds to allow uncacheable operations to benefit from cobuild orchestration without using the build cache.",
+      "type": "boolean"
+    },
     "rushAlerts": {
       "description": "(UNDER DEVELOPMENT) The Rush alerts feature provides a way to send announcements to engineers working in the monorepo, by printing directly in the user's shell window when they invoke Rush commands. This ensures that important notices will be seen by anyone doing active development, since people often ignore normal discussion group messages or don't know to subscribe.",
       "type": "boolean"

--- a/libraries/rush-lib/src/schemas/experiments.schema.json
+++ b/libraries/rush-lib/src/schemas/experiments.schema.json
@@ -67,7 +67,7 @@
       "type": "boolean"
     },
     "allowCobuildWithoutCache": {
-      "description": "Adds a new experiment 'allowCobuildWithoutCache' for cobuilds to allow uncacheable operations to benefit from cobuild orchestration without using the build cache.",
+      "description": "When using cobuilds, this experiment allows uncacheable operations to benefit from cobuild orchestration without using the build cache.",
       "type": "boolean"
     },
     "rushAlerts": {

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -103,7 +103,7 @@
             "type": "integer",
             "minimum": 0
           },
-          "allowCobuildOrchestration": {
+          "allowCobuildWithoutCache": {
             "type": "boolean",
             "description": "If true, this operation will not need to use the build cache to leverage cobuilds"
           }

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -102,6 +102,10 @@
             "description": "The number of concurrency units that this operation should take up. The maximum concurrency units is determined by the -p flag.",
             "type": "integer",
             "minimum": 0
+          },
+          "allowCobuildOrchestration": {
+            "type": "boolean",
+            "description": "If true, this operation will not need to use the build cache to leverage cobuilds"
           }
         }
       }


### PR DESCRIPTION
## Summary

From my thread in Zulip, [here](https://rushstack.zulipchat.com/#narrow/stream/262513-general/topic/cobuild.20support.20for.20orchestrating.20tasks.20without.20build.20cache/near/455446864). 

Currently, cobuilds rebuild un-cacheable operations across all machines. This is the expected behavior for core nodes that aren't cacheable to ensure artifacts are found for projects further up the tree. For operations like uploading/processing coverage or image building, that approach doesn't apply well and ends up in (number of machines)x more work being done. This PR attempts to add a new experiment/feature that allows users to use the cobuild orchestration engine without relying on the build cache. Inherently, this introduces risk for projects that enable this without knowing what it does as you'll be explicitly skipping build cache restoration, but I think the benefits outweigh the drawbacks here.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I tried to add this similarly to how cobuild leaf-only projects are enabled. This ends up being a pretty small change with decent impact. Shards are an interesting case here that should probably be explicitly restricted since the output needs to be shared across all agents if you have a collate step, but it was an easy way to get many events to test with.

### Before
![Screenshot 2024-08-08 at 7 05 57 PM](https://github.com/user-attachments/assets/e13ac0a3-e92d-42f0-8179-9f5c0a580f16)


### After
![Screenshot 2024-08-08 at 7 03 46 PM](https://github.com/user-attachments/assets/b4369ab1-57d9-4c74-ba0c-baa8c086d5db)

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested against the `sharded-repo` using 
```sh
rm -rf common/temp/build-cache && RUSH_COBUILD_CONTEXT_ID=foo REDIS_PASS=redis123 RUSH_COBUILD_RUNNER_ID=runner1 RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED=1 node ../../lib/runRush.js cobuild -p 10 --timeline
```
to validate that operations were being shared across the 2 machines. 

and the same command without the RUSH_COBUILD_ORCHESTRATION_ONLY_ALLOWED env var set,
```sh
rm -rf common/temp/build-cache && RUSH_COBUILD_CONTEXT_ID=foo REDIS_PASS=redis123 RUSH_COBUILD_RUNNER_ID=runner1 node ../../lib/runRush.js cobuild -p 10 --timeline
```
for the negative cases.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

It adds a new experiment that will likely need to end up on the docs and updates the rush-project JSON schema.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
