### PR TITLE
[rush] Put pnpm patches back in common/pnpm-patches when subspaces are not enabled.

### DIFF
--- a/apps/lockfile-explorer/src/utils/init.ts
+++ b/apps/lockfile-explorer/src/utils/init.ts
@@ -31,7 +31,7 @@ export const init = (options: {
 
       const rushConfiguration: RushConfiguration = RushConfiguration.tryLoadFromDefaultLocation()!;
       const subspace: Subspace = rushConfiguration.getSubspace(subspaceName);
-      const workspaceFolder: string = subspace.getSubspaceTempFolder();
+      const workspaceFolder: string = subspace.getSubspaceTempFolderPath();
 
       const projectsByProjectFolder: Map<string, IRushProjectDetails> = new Map();
       for (const project of rushConfiguration.projects) {

--- a/common/changes/@microsoft/rush/fix-patches-subspace-folder_2024-08-11-02-27.json
+++ b/common/changes/@microsoft/rush/fix-patches-subspace-folder_2024-08-11-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Revert a breaking change in Rush 5.131.3 where pnpm patches were moved from `common/pnpm-patches` to `common/config/rush/pnpm-patches`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/lockfile-explorer/fix-patches-subspace-folder_2024-08-11-03-11.json
+++ b/common/changes/@rushstack/lockfile-explorer/fix-patches-subspace-folder_2024-08-11-03-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/lockfile-explorer"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1466,9 +1466,11 @@ export class Subspace {
     // @beta
     getRepoStateFilePath(): string;
     // @beta
-    getSubspaceConfigFolder(): string;
+    getSubspaceConfigFolderPath(): string;
     // @beta
-    getSubspaceTempFolder(): string;
+    getSubspacePnpmPatchesFolderPath(): string;
+    // @beta
+    getSubspaceTempFolderPath(): string;
     // @beta
     getTempShrinkwrapFilename(): string;
     // @beta

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -210,5 +210,5 @@ export function getCommonTempFlag(
     }
   }
 
-  return new LastInstallFlag(subspace.getSubspaceTempFolder(), currentState);
+  return new LastInstallFlag(subspace.getSubspaceTempFolderPath(), currentState);
 }

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -31,6 +31,7 @@ import type { IInstallManagerOptions } from '../logic/base/BaseInstallManagerTyp
 import { objectsAreDeepEqual } from '../utilities/objectUtilities';
 import { Utilities } from '../utilities/Utilities';
 import type { Subspace } from '../api/Subspace';
+import type { PnpmOptionsConfiguration } from '../logic/pnpm/PnpmOptionsConfiguration';
 
 const RUSH_SKIP_CHECKS_PARAMETER: string = '--rush-skip-checks';
 
@@ -135,7 +136,7 @@ export class RushPnpmCommandLineParser {
     const subspace: Subspace = rushConfiguration.getSubspace(subspaceName);
     this._subspace = subspace;
 
-    const workspaceFolder: string = subspace.getSubspaceTempFolder();
+    const workspaceFolder: string = subspace.getSubspaceTempFolderPath();
     const workspaceFilePath: string = path.join(workspaceFolder, 'pnpm-workspace.yaml');
 
     if (!FileSystem.exists(workspaceFilePath)) {
@@ -374,7 +375,7 @@ export class RushPnpmCommandLineParser {
 
   private async _executeAsync(): Promise<void> {
     const rushConfiguration: RushConfiguration = this._rushConfiguration;
-    const workspaceFolder: string = this._subspace.getSubspaceTempFolder();
+    const workspaceFolder: string = this._subspace.getSubspaceTempFolderPath();
     const pnpmEnvironmentMap: EnvironmentMap = new EnvironmentMap(process.env);
     pnpmEnvironmentMap.set('NPM_CONFIG_WORKSPACE_DIR', workspaceFolder);
 
@@ -442,8 +443,8 @@ export class RushPnpmCommandLineParser {
       return;
     }
 
-    const subspaceTempFolder: string = this._subspace.getSubspaceTempFolder();
-    const subspaceConfigFolder: string = this._subspace.getSubspaceConfigFolder();
+    const subspaceTempFolder: string = this._subspace.getSubspaceTempFolderPath();
+    const subspaceConfigFolder: string = this._subspace.getSubspaceConfigFolderPath();
 
     switch (commandName) {
       case 'patch-commit': {
@@ -454,7 +455,7 @@ export class RushPnpmCommandLineParser {
         if (this._subspace.getPnpmOptions() === undefined) {
           this._terminal.writeErrorLine(
             `The "rush-pnpm patch-commit" command cannot proceed without a pnpm-config.json file.` +
-              `  Create one in this folder: ${this._subspace.getSubspaceConfigFolder()}`
+              `  Create one in this folder: ${subspaceConfigFolder}`
           );
           break;
         }
@@ -464,13 +465,15 @@ export class RushPnpmCommandLineParser {
         const commonPackageJson: JsonObject = JsonFile.load(commonPackageJsonFilename);
         const newGlobalPatchedDependencies: Record<string, string> | undefined =
           commonPackageJson?.pnpm?.patchedDependencies;
+        const pnpmOptions: PnpmOptionsConfiguration | undefined = this._subspace.getPnpmOptions();
         const currentGlobalPatchedDependencies: Record<string, string> | undefined =
-          this._subspace.getPnpmOptions()?.globalPatchedDependencies;
+          pnpmOptions?.globalPatchedDependencies;
 
         if (!objectsAreDeepEqual(currentGlobalPatchedDependencies, newGlobalPatchedDependencies)) {
           const commonTempPnpmPatchesFolder: string = `${subspaceTempFolder}/${RushConstants.pnpmPatchesFolderName}`;
-          const rushPnpmPatchesFolder: string = `${subspaceConfigFolder}/${RushConstants.pnpmPatchesCommonFolderName}`;
-          // Copy (or delete) common\temp\subspace\patches\ --> subspace\pnpm-patches\
+          const rushPnpmPatchesFolder: string = this._subspace.getSubspacePnpmPatchesFolderPath();
+
+          // Copy (or delete) common\temp\subspace\patches\ --> common\config\pnpm-patches\ OR common\config\rush\pnpm-patches\
           if (FileSystem.exists(commonTempPnpmPatchesFolder)) {
             FileSystem.ensureEmptyFolder(rushPnpmPatchesFolder);
             // eslint-disable-next-line no-console
@@ -490,7 +493,7 @@ export class RushPnpmCommandLineParser {
           }
 
           // Update patchedDependencies to pnpm configuration file
-          this._subspace.getPnpmOptions()?.updateGlobalPatchedDependencies(newGlobalPatchedDependencies);
+          pnpmOptions?.updateGlobalPatchedDependencies(newGlobalPatchedDependencies);
 
           // Rerun installation to update
           await this._doRushUpdateAsync();

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -175,7 +175,7 @@ export class DeployAction extends BaseRushAction {
         }
 
         if (!scenarioConfiguration.json.omitPnpmWorkaroundLinks) {
-          subspace.pnpmInstallFolder = project.subspace.getSubspaceTempFolder();
+          subspace.pnpmInstallFolder = project.subspace.getSubspaceTempFolderPath();
         }
         subspaces.set(subspace.subspaceName, subspace);
       }

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -304,7 +304,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     if (!this._runsBeforeInstall) {
       // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are removed
       const lastLinkFlag: FlagFile = new FlagFile(
-        this.rushConfiguration.defaultSubspace.getSubspaceTempFolder(),
+        this.rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
         RushConstants.lastLinkFlagFilename,
         {}
       );

--- a/libraries/rush-lib/src/cli/test/TestUtils.ts
+++ b/libraries/rush-lib/src/cli/test/TestUtils.ts
@@ -82,7 +82,7 @@ export async function getCommandLineParserInstanceAsync(
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid
   await new FlagFile(
-    parser.rushConfiguration.defaultSubspace.getSubspaceTempFolder(),
+    parser.rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
     RushConstants.lastLinkFlagFilename,
     {}
   ).createAsync();

--- a/libraries/rush-lib/src/logic/TempProjectHelper.ts
+++ b/libraries/rush-lib/src/logic/TempProjectHelper.ts
@@ -26,7 +26,7 @@ export class TempProjectHelper {
    * Deletes the existing tarball and creates a tarball for the given rush project
    */
   public createTempProjectTarball(rushProject: RushConfigurationProject): void {
-    FileSystem.ensureFolder(path.resolve(this._subspace.getSubspaceTempFolder(), 'projects'));
+    FileSystem.ensureFolder(path.resolve(this._subspace.getSubspaceTempFolderPath(), 'projects'));
     const tarballFile: string = this.getTarballFilePath(rushProject);
     const tempProjectFolder: string = this.getTempProjectFolder(rushProject);
 
@@ -64,7 +64,7 @@ export class TempProjectHelper {
    */
   public getTarballFilePath(project: RushConfigurationProject): string {
     return path.join(
-      this._subspace.getSubspaceTempFolder(),
+      this._subspace.getSubspaceTempFolderPath(),
       RushConstants.rushTempProjectsFolderName,
       `${project.unscopedTempProjectName}.tgz`
     );
@@ -73,7 +73,7 @@ export class TempProjectHelper {
   public getTempProjectFolder(rushProject: RushConfigurationProject): string {
     const unscopedTempProjectName: string = rushProject.unscopedTempProjectName;
     return path.join(
-      this._subspace.getSubspaceTempFolder(),
+      this._subspace.getSubspaceTempFolderPath(),
       RushConstants.rushTempProjectsFolderName,
       unscopedTempProjectName
     );

--- a/libraries/rush-lib/src/logic/UnlinkManager.ts
+++ b/libraries/rush-lib/src/logic/UnlinkManager.ts
@@ -42,7 +42,7 @@ export class UnlinkManager {
     }
 
     await new FlagFile(
-      this._rushConfiguration.defaultSubspace.getSubspaceTempFolder(),
+      this._rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
       RushConstants.lastLinkFlagFilename,
       {}
     ).clearAsync();

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -100,7 +100,7 @@ export abstract class BaseInstallManager {
     this.options = options;
 
     this._commonTempLinkFlag = new FlagFile(
-      options.subspace.getSubspaceTempFolder(),
+      options.subspace.getSubspaceTempFolderPath(),
       RushConstants.lastLinkFlagFilename,
       {}
     );
@@ -165,7 +165,7 @@ export abstract class BaseInstallManager {
     }
 
     // eslint-disable-next-line no-console
-    console.log('\n' + Colorize.bold(`Checking installation in "${subspace.getSubspaceTempFolder()}"`));
+    console.log('\n' + Colorize.bold(`Checking installation in "${subspace.getSubspaceTempFolderPath()}"`));
 
     // This marker file indicates that the last "rush install" completed successfully.
     // Always perform a clean install if filter flags were provided. Additionally, if
@@ -276,7 +276,7 @@ export abstract class BaseInstallManager {
     // the pnpm-sync will generate the pnpm-sync.json based on lockfile
     if (this.rushConfiguration.packageManager === 'pnpm' && experiments?.usePnpmSyncForInjectedDependencies) {
       const pnpmLockfilePath: string = subspace.getTempShrinkwrapFilename();
-      const dotPnpmFolder: string = `${subspace.getSubspaceTempFolder()}/node_modules/.pnpm`;
+      const dotPnpmFolder: string = `${subspace.getSubspaceTempFolderPath()}/node_modules/.pnpm`;
 
       // we have an edge case here
       // if a package.json has no dependencies, pnpm will still generate the pnpm-lock.yaml but not .pnpm folder
@@ -367,7 +367,7 @@ export abstract class BaseInstallManager {
     // Consider the timestamp on the node_modules folder; if someone tampered with it
     // or deleted it entirely, then we can't skip this install
     potentiallyChangedFiles.push(
-      path.join(subspace.getSubspaceTempFolder(), RushConstants.nodeModulesFolderName)
+      path.join(subspace.getSubspaceTempFolderPath(), RushConstants.nodeModulesFolderName)
     );
 
     // Additionally, if they pulled an updated shrinkwrap file from Git,
@@ -472,7 +472,7 @@ export abstract class BaseInstallManager {
       }
 
       extraNpmrcLines.push(
-        `global-pnpmfile=${subspace.getSubspaceTempFolder()}/${RushConstants.pnpmfileGlobalFilename}`
+        `global-pnpmfile=${subspace.getSubspaceTempFolderPath()}/${RushConstants.pnpmfileGlobalFilename}`
       );
     }
 
@@ -480,8 +480,8 @@ export abstract class BaseInstallManager {
     // "common\config\rush\.npmrc" --> "common\temp\.npmrc"
     // Also ensure that we remove any old one that may be hanging around
     const npmrcText: string | undefined = Utilities.syncNpmrc({
-      sourceNpmrcFolder: subspace.getSubspaceConfigFolder(),
-      targetNpmrcFolder: subspace.getSubspaceTempFolder(),
+      sourceNpmrcFolder: subspace.getSubspaceConfigFolderPath(),
+      targetNpmrcFolder: subspace.getSubspaceTempFolderPath(),
       linesToPrepend: extraNpmrcLines,
       createIfMissing: this.rushConfiguration.subspacesFeatureEnabled
     });
@@ -493,10 +493,10 @@ export abstract class BaseInstallManager {
 
     if (this.rushConfiguration.packageManager === 'pnpm') {
       // Copy the committed patches folder if using pnpm
-      const commonTempPnpmPatchesFolder: string = `${subspace.getSubspaceTempFolder()}/${
+      const commonTempPnpmPatchesFolder: string = `${subspace.getSubspaceTempFolderPath()}/${
         RushConstants.pnpmPatchesFolderName
       }`;
-      const rushPnpmPatchesFolder: string = `${subspace.getSubspaceConfigFolder()}/${RushConstants.pnpmPatchesCommonFolderName}`;
+      const rushPnpmPatchesFolder: string = subspace.getSubspacePnpmPatchesFolderPath();
       let rushPnpmPatches: FolderItem[] | undefined;
       try {
         rushPnpmPatches = await FileSystem.readFolderItemsAsync(rushPnpmPatchesFolder);
@@ -549,7 +549,7 @@ export abstract class BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm') {
       await PnpmfileConfiguration.writeCommonTempPnpmfileShimAsync(
         this.rushConfiguration,
-        subspace.getSubspaceTempFolder(),
+        subspace.getSubspaceTempFolderPath(),
         subspace
       );
 
@@ -849,7 +849,7 @@ ${gitLfsHookHandling}
         If user does not set auto-install-peers in both pnpm-config.json and .npmrc, rush will default it to "false"
       */
       const isAutoInstallPeersInNpmrc: boolean = isVariableSetInNpmrcFile(
-        subspace.getSubspaceConfigFolder(),
+        subspace.getSubspaceConfigFolderPath(),
         'auto-install-peers'
       );
 
@@ -877,7 +877,7 @@ ${gitLfsHookHandling}
         If user does not set resolution-mode in pnpm-config.json and .npmrc, rush will default it to "highest"
       */
       const isResolutionModeInNpmrc: boolean = isVariableSetInNpmrcFile(
-        subspace.getSubspaceConfigFolder(),
+        subspace.getSubspaceConfigFolderPath(),
         'resolution-mode'
       );
 
@@ -1059,7 +1059,7 @@ ${gitLfsHookHandling}
           .packageManagerWrapper as PnpmPackageManager;
 
         FileSystem.deleteFile(
-          path.join(subspace.getSubspaceTempFolder(), pnpmPackageManager.internalShrinkwrapRelativePath)
+          path.join(subspace.getSubspaceTempFolderPath(), pnpmPackageManager.internalShrinkwrapRelativePath)
         );
       }
     }

--- a/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -199,7 +199,7 @@ export abstract class BaseLinkManager {
 
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
     await new FlagFile(
-      this._rushConfiguration.defaultSubspace.getSubspaceTempFolder(),
+      this._rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
       RushConstants.lastLinkFlagFilename,
       {}
     ).createAsync();

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -90,7 +90,7 @@ export class InstallHelpers {
 
     // Example: "C:\MyRepo\common\temp\package.json"
     const commonPackageJsonFilename: string = path.join(
-      subspace.getSubspaceTempFolder(),
+      subspace.getSubspaceTempFolderPath(),
       FileConstants.PackageJson
     );
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -89,7 +89,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
 
     // eslint-disable-next-line no-console
-    console.log('\n' + Colorize.bold('Updating workspace files in ' + subspace.getSubspaceTempFolder()));
+    console.log('\n' + Colorize.bold('Updating workspace files in ' + subspace.getSubspaceTempFolderPath()));
 
     const shrinkwrapWarnings: string[] = [];
 
@@ -181,7 +181,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
 
     // To generate the workspace file, we will add each project to the file as we loop through and validate
     const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(
-      path.join(subspace.getSubspaceTempFolder(), 'pnpm-workspace.yaml')
+      path.join(subspace.getSubspaceTempFolderPath(), 'pnpm-workspace.yaml')
     );
 
     // For pnpm package manager, we need to handle dependenciesMeta changes in package.json. See more: https://pnpm.io/package_json#dependenciesmeta
@@ -189,7 +189,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // Build a object for dependenciesMeta settings in projects' package.json
     // key is the package path, value is the dependenciesMeta info for that package
     const expectedDependenciesMetaByProjectRelativePath: Record<string, IDependenciesMetaTable> = {};
-    const commonTempFolder: string = subspace.getSubspaceTempFolder();
+    const commonTempFolder: string = subspace.getSubspaceTempFolderPath();
     const rushJsonFolder: string = this.rushConfiguration.rushJsonFolder;
     // get the relative path from common temp folder to repo root folder
     const relativeFromTempFolderToRootFolder: string = path.relative(commonTempFolder, rushJsonFolder);
@@ -374,7 +374,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     if (this.rushConfiguration.packageManager === 'pnpm') {
       // Add workspace file. This file is only modified when workspace packages change.
       const pnpmWorkspaceFilename: string = path.join(
-        subspace.getSubspaceTempFolder(),
+        subspace.getSubspaceTempFolderPath(),
         'pnpm-workspace.yaml'
       );
 
@@ -416,7 +416,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
 
     const commonNodeModulesFolder: string = path.join(
-      subspace.getSubspaceTempFolder(),
+      subspace.getSubspaceTempFolderPath(),
       RushConstants.nodeModulesFolderName
     );
 
@@ -448,7 +448,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
         '\n' +
           Colorize.bold(
             `Running "${this.rushConfiguration.packageManager} install" in` +
-              ` ${subspace.getSubspaceTempFolder()}`
+              ` ${subspace.getSubspaceTempFolderPath()}`
           ) +
           '\n'
       );
@@ -501,7 +501,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           {
             command: packageManagerFilename,
             args: installArgs,
-            workingDirectory: subspace.getSubspaceTempFolder(),
+            workingDirectory: subspace.getSubspaceTempFolderPath(),
             environment: packageManagerEnv,
             suppressOutput: false,
             onStdoutStreamChunk: onPnpmStdoutChunk
@@ -556,7 +556,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // Ensure that node_modules folders exist after install, since the timestamps on these folders are used
     // to determine if the install can be skipped
     const projectNodeModulesFolders: string[] = [
-      path.join(subspace.getSubspaceTempFolder(), RushConstants.nodeModulesFolderName),
+      path.join(subspace.getSubspaceTempFolderPath(), RushConstants.nodeModulesFolderName),
       ...this.rushConfiguration.projects.map((project) => {
         return path.join(project.projectFolder, RushConstants.nodeModulesFolderName);
       })
@@ -622,7 +622,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       this.rushConfiguration.subspacesFeatureEnabled &&
       this.rushConfiguration.subspacesConfiguration?.splitWorkspaceCompatibility
     ) {
-      const tempNodeModulesPath: string = `${subspace.getSubspaceTempFolder()}/node_modules`;
+      const tempNodeModulesPath: string = `${subspace.getSubspaceTempFolderPath()}/node_modules`;
       const modulesFilePath: string = `${tempNodeModulesPath}/${RushConstants.pnpmModulesFilename}`;
       if (
         subspace.subspaceName.startsWith('split_') &&
@@ -676,7 +676,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
     await new FlagFile(
-      subspace.getSubspaceTempFolder(),
+      subspace.getSubspaceTempFolderPath(),
       RushConstants.lastLinkFlagFilename,
       {}
     ).createAsync();

--- a/libraries/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
@@ -76,7 +76,7 @@ export class PnpmProjectShrinkwrapFile extends BaseProjectShrinkwrapFile<PnpmShr
     const subspace: Subspace = this.project.subspace;
 
     const importerKey: string = this.shrinkwrapFile.getImporterKeyByPath(
-      subspace.getSubspaceTempFolder(),
+      subspace.getSubspaceTempFolderPath(),
       this.project.projectFolder
     );
 

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -713,7 +713,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const orphanedProjectPaths: string[] = [];
     for (const importerKey of this.getImporterKeys()) {
       // PNPM importer keys are relative paths from the workspace root, which is the common temp folder
-      const rushProjectPath: string = path.resolve(subspace.getSubspaceTempFolder(), importerKey);
+      const rushProjectPath: string = path.resolve(subspace.getSubspaceTempFolderPath(), importerKey);
       if (!rushConfiguration.tryGetProjectForPath(rushProjectPath)) {
         orphanedProjectPaths.push(rushProjectPath);
       }
@@ -794,7 +794,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     subspace: Subspace
   ): Promise<boolean> {
     const importerKey: string = this.getImporterKeyByPath(
-      subspace.getSubspaceTempFolder(),
+      subspace.getSubspaceTempFolderPath(),
       project.projectFolder
     );
 
@@ -820,7 +820,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     if (project.rushConfiguration.subspacesFeatureEnabled) {
       // Get the pnpmfile
       const subspacePnpmfilePath: string = path.join(
-        subspace.getSubspaceTempFolder(),
+        subspace.getSubspaceTempFolderPath(),
         RushConstants.pnpmfileGlobalFilename
       );
 

--- a/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
@@ -33,7 +33,7 @@ export class SubspacePnpmfileConfiguration {
       );
     }
 
-    const targetDir: string = subspace.getSubspaceTempFolder();
+    const targetDir: string = subspace.getSubspaceTempFolderPath();
     const subspaceGlobalPnpmfilePath: string = path.join(targetDir, RushConstants.pnpmfileGlobalFilename);
 
     // Write the shim itself
@@ -85,7 +85,7 @@ export class SubspacePnpmfileConfiguration {
 
     // common/config/subspaces/<subspace_name>/.pnpmfile.cjs
     const userPnpmfilePath: string = path.join(
-      subspace.getSubspaceConfigFolder(),
+      subspace.getSubspaceConfigFolderPath(),
       (rushConfiguration.packageManagerWrapper as PnpmPackageManager).pnpmfileFilename
     );
     if (FileSystem.exists(userPnpmfilePath)) {

--- a/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
@@ -157,7 +157,7 @@ describe(PnpmShrinkwrapFile.name, () => {
               commonTempFolder: 'common/temp'
             },
             subspace: {
-              getSubspaceTempFolder: () => 'common/temp'
+              getSubspaceTempFolderPath: () => 'common/temp'
             }
           } as RushConfigurationProject;
 


### PR DESCRIPTION
## Summary

https://github.com/microsoft/rushstack/pull/4874 inadvertently moved the pnpm-patches folder from `common/pnpm-patches` to `common/config/rush/pnpm-patches` when subspaces are disabled. This PR restores the previous location for the non-subspaces case.

## How it was tested

Tested on a non-subspaces repo and in this repo (which is using subspaces).