### PR TITLE
[heft-lint-plugin] Add ESLint and TSLint fixer support

### DIFF
--- a/common/changes/@rushstack/heft-lint-plugin/user-danade-LintFixer_2024-08-14-00-32.json
+++ b/common/changes/@rushstack/heft-lint-plugin/user-danade-LintFixer_2024-08-14-00-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "Add autofix functionality for ESLint and TSLint. Fixes can now be applied by providing the \"--fix\" command-line argument, or setting the \"alwaysFix\" plugin option to \"true\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}

--- a/heft-plugins/heft-lint-plugin/heft-plugin.json
+++ b/heft-plugins/heft-lint-plugin/heft-plugin.json
@@ -4,7 +4,17 @@
   "taskPlugins": [
     {
       "pluginName": "lint-plugin",
-      "entryPoint": "./lib/LintPlugin"
+      "entryPoint": "./lib/LintPlugin",
+      "optionsSchema": "./lib/schemas/heft-lint-plugin.schema.json",
+
+      "parameterScope": "lint",
+      "parameters": [
+        {
+          "longName": "--fix",
+          "parameterKind": "flag",
+          "description": "Fix all encountered rule violations where the violated rule provides a fixer."
+        }
+      ]
     }
   ]
 }

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -154,9 +154,7 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
     // Map the fix messages to the results. This API should only return one result per file, so we can be sure
     // that the fix messages belong to the returned result. If we somehow receive multiple results, we will
     // drop the messages on the floor, but since they are only used for logging, this should not be a problem.
-    const fixMessages: TEslint.Linter.LintMessage[] = this._currentFixMessages.splice(
-      0
-    );
+    const fixMessages: TEslint.Linter.LintMessage[] = this._currentFixMessages.splice(0);
     if (lintResults.length === 1) {
       this._fixMessagesByResult.set(lintResults[0], fixMessages);
     }

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
 import * as crypto from 'crypto';
 import * as semver from 'semver';
 import type * as TTypescript from 'typescript';
@@ -26,8 +25,10 @@ enum EslintMessageSeverity {
   error = 2
 }
 
+// Patch the timer used to track rule execution time. This allows us to get access to the detailed information
+// about how long each rule took to execute, which we provide on the CLI when running in verbose mode.
 async function patchTimerAsync(eslintPackagePath: string, timingsMap: Map<string, number>): Promise<void> {
-  const timingModulePath: string = path.join(eslintPackagePath, 'lib', 'linter', 'timing');
+  const timingModulePath: string = `${eslintPackagePath}/lib/linter/timing`;
   const timing: IEslintTiming = (await import(timingModulePath)).default;
   timing.enabled = true;
   const patchedTime: (key: string, fn: (...args: unknown[]) => unknown) => (...args: unknown[]) => unknown = (

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -47,26 +47,55 @@ async function patchTimerAsync(eslintPackagePath: string, timingsMap: Map<string
   timing.time = patchedTime;
 }
 
+function getFormattedErrorMessage(lintMessage: TEslint.Linter.LintMessage): string {
+  // https://eslint.org/docs/developer-guide/nodejs-api#◆-lintmessage-type
+  return lintMessage.ruleId ? `(${lintMessage.ruleId}) ${lintMessage.message}` : lintMessage.message;
+}
+
 export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
   private readonly _eslintPackage: typeof TEslint;
   private readonly _linter: TEslint.ESLint;
   private readonly _eslintTimings: Map<string, number> = new Map();
+  private readonly _currentFixMessages: TEslint.Linter.LintMessage[] = [];
+  private readonly _fixMessagesByResult: Map<TEslint.ESLint.LintResult, TEslint.Linter.LintMessage[]> =
+    new Map();
 
   protected constructor(options: IEslintOptions) {
     super('eslint', options);
 
-    const { buildFolderPath, eslintPackage, linterConfigFilePath, tsProgram, eslintTimings } = options;
+    const { buildFolderPath, eslintPackage, linterConfigFilePath, tsProgram, eslintTimings, fix } = options;
     this._eslintPackage = eslintPackage;
-    this._linter = new eslintPackage.ESLint({
-      cwd: buildFolderPath,
-      overrideConfigFile: linterConfigFilePath,
-      // Override config takes precedence over overrideConfigFile, which allows us to provide
-      // the source TypeScript program to ESLint
-      overrideConfig: {
+
+    let overrideConfig: TEslint.Linter.Config | undefined;
+    let fixFn: Exclude<TEslint.ESLint.Options['fix'], boolean>;
+    if (fix) {
+      // We do not recieve the messages for the issues that were fixed, so we need to track them ourselves
+      // so that we can log them after the fix is applied. This array will be populated by the fix function,
+      // and subsequently mapped to the results in the ESLint.lintFileAsync method below. After the messages
+      // are mapped, the array will be cleared so that it is ready for the next fix operation.
+      fixFn = (message: TEslint.Linter.LintMessage) => {
+        this._currentFixMessages.push(message);
+        return true;
+      };
+    } else {
+      // The @typescript-eslint/parser package allows providing an existing TypeScript program to avoid needing
+      // to reparse. However, fixers in ESLint run in multiple passes against the underlying code until the
+      // fix fully succeeds. This conflicts with providing an existing program as the code no longer maps to
+      // the provided program, producing garbage fix output. To avoid this, only provide the existing program
+      // if we're not fixing.
+      overrideConfig = {
         parserOptions: {
           programs: [tsProgram]
         }
-      }
+      };
+    }
+
+    this._linter = new eslintPackage.ESLint({
+      cwd: buildFolderPath,
+      overrideConfigFile: linterConfigFilePath,
+      // Override config takes precedence over overrideConfigFile
+      overrideConfig,
+      fix: fixFn
     });
     this._eslintTimings = eslintTimings;
   }
@@ -122,9 +151,27 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
       filePath: sourceFile.fileName
     });
 
+    // Map the fix messages to the results. This API should only return one result per file, so we can be sure
+    // that the fix messages belong to the returned result. If we somehow receive multiple results, we will
+    // drop the messages on the floor, but since they are only used for logging, this should not be a problem.
+    const fixMessages: TEslint.Linter.LintMessage[] = this._currentFixMessages.splice(
+      0,
+      this._currentFixMessages.length
+    );
+    if (lintResults.length === 1) {
+      this._fixMessagesByResult.set(lintResults[0], fixMessages);
+    }
+
+    this._fixesPossible =
+      this._fixesPossible ||
+      (!this._fix &&
+        lintResults.some((lintResult: TEslint.ESLint.LintResult) => {
+          return lintResult.fixableErrorCount + lintResult.fixableWarningCount > 0;
+        }));
+
     const failures: TEslint.ESLint.LintResult[] = [];
     for (const lintResult of lintResults) {
-      if (lintResult.messages.length > 0) {
+      if (lintResult.messages.length > 0 || lintResult.output) {
         failures.push(lintResult);
       }
     }
@@ -132,7 +179,7 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
     return failures;
   }
 
-  protected lintingFinished(lintFailures: TEslint.ESLint.LintResult[]): void {
+  protected async lintingFinishedAsync(lintFailures: TEslint.ESLint.LintResult[]): Promise<void> {
     let omittedRuleCount: number = 0;
     const timings: [string, number][] = Array.from(this._eslintTimings).sort(
       (x: [string, number], y: [string, number]) => {
@@ -151,45 +198,58 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
       this._terminal.writeVerboseLine(`${omittedRuleCount} rules took 0ms`);
     }
 
-    const errors: Error[] = [];
-    const warnings: Error[] = [];
+    if (this._fix && this._fixMessagesByResult.size > 0) {
+      await this._eslintPackage.ESLint.outputFixes(lintFailures);
+    }
 
-    for (const eslintFailure of lintFailures) {
-      for (const message of eslintFailure.messages) {
-        // https://eslint.org/docs/developer-guide/nodejs-api#◆-lintmessage-type
-        const formattedMessage: string = message.ruleId
-          ? `(${message.ruleId}) ${message.message}`
-          : message.message;
-        const errorObject: FileError = new FileError(formattedMessage, {
-          absolutePath: eslintFailure.filePath,
-          projectFolder: this._buildFolderPath,
-          line: message.line,
-          column: message.column
-        });
-        switch (message.severity) {
+    for (const lintFailure of lintFailures) {
+      // Report linter fixes to the logger. These will only be returned when the underlying failure was fixed
+      const fixMessages: TEslint.Linter.LintMessage[] | undefined =
+        this._fixMessagesByResult.get(lintFailure);
+      if (fixMessages) {
+        for (const fixMessage of fixMessages) {
+          const formattedMessage: string = `[FIXED] ${getFormattedErrorMessage(fixMessage)}`;
+          const errorObject: FileError = this._getLintFileError(lintFailure, fixMessage, formattedMessage);
+          this._scopedLogger.emitWarning(errorObject);
+        }
+      }
+
+      // Report linter errors and warnings to the logger
+      for (const lintMessage of lintFailure.messages) {
+        const errorObject: FileError = this._getLintFileError(lintFailure, lintMessage);
+        switch (lintMessage.severity) {
           case EslintMessageSeverity.error: {
-            errors.push(errorObject);
+            this._scopedLogger.emitError(errorObject);
             break;
           }
 
           case EslintMessageSeverity.warning: {
-            warnings.push(errorObject);
+            this._scopedLogger.emitWarning(errorObject);
             break;
           }
         }
       }
     }
-
-    for (const error of errors) {
-      this._scopedLogger.emitError(error);
-    }
-
-    for (const warning of warnings) {
-      this._scopedLogger.emitWarning(warning);
-    }
   }
 
   protected async isFileExcludedAsync(filePath: string): Promise<boolean> {
     return await this._linter.isPathIgnored(filePath);
+  }
+
+  private _getLintFileError(
+    lintResult: TEslint.ESLint.LintResult,
+    lintMessage: TEslint.Linter.LintMessage,
+    message?: string
+  ): FileError {
+    if (!message) {
+      message = getFormattedErrorMessage(lintMessage);
+    }
+
+    return new FileError(message, {
+      absolutePath: lintResult.filePath,
+      projectFolder: this._buildFolderPath,
+      line: lintMessage.line,
+      column: lintMessage.column
+    });
   }
 }

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -155,8 +155,7 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
     // that the fix messages belong to the returned result. If we somehow receive multiple results, we will
     // drop the messages on the floor, but since they are only used for logging, this should not be a problem.
     const fixMessages: TEslint.Linter.LintMessage[] = this._currentFixMessages.splice(
-      0,
-      this._currentFixMessages.length
+      0
     );
     if (lintResults.length === 1) {
       this._fixMessagesByResult.set(lintResults[0], fixMessages);

--- a/heft-plugins/heft-lint-plugin/src/LinterBase.ts
+++ b/heft-plugins/heft-lint-plugin/src/LinterBase.ts
@@ -161,7 +161,7 @@ export abstract class LinterBase<TLintResult> {
     }
     //#endregion
 
-    this.lintingFinished(lintFailures);
+    await this.lintingFinishedAsync(lintFailures);
 
     if (!this._fix && this._fixesPossible) {
       this._terminal.writeWarningLine(
@@ -184,7 +184,7 @@ export abstract class LinterBase<TLintResult> {
 
   protected abstract lintFileAsync(sourceFile: IExtendedSourceFile): Promise<TLintResult[]>;
 
-  protected abstract lintingFinished(lintFailures: TLintResult[]): void;
+  protected abstract lintingFinishedAsync(lintFailures: TLintResult[]): Promise<void>;
 
   protected abstract isFileExcludedAsync(filePath: string): Promise<boolean>;
 }

--- a/heft-plugins/heft-lint-plugin/src/LinterBase.ts
+++ b/heft-plugins/heft-lint-plugin/src/LinterBase.ts
@@ -20,6 +20,7 @@ export interface ILinterBaseOptions {
   linterToolPath: string;
   linterConfigFilePath: string;
   tsProgram: IExtendedProgram;
+  fix?: boolean;
 }
 
 export interface IRunLinterOptions {
@@ -56,6 +57,9 @@ export abstract class LinterBase<TLintResult> {
   protected readonly _buildFolderPath: string;
   protected readonly _buildMetadataFolderPath: string;
   protected readonly _linterConfigFilePath: string;
+  protected readonly _fix: boolean;
+
+  protected _fixesPossible: boolean = false;
 
   private readonly _linterName: string;
 
@@ -66,6 +70,7 @@ export abstract class LinterBase<TLintResult> {
     this._buildMetadataFolderPath = options.buildMetadataFolderPath;
     this._linterConfigFilePath = options.linterConfigFilePath;
     this._linterName = linterName;
+    this._fix = options.fix || false;
   }
 
   public abstract printVersionHeader(): void;
@@ -157,6 +162,12 @@ export abstract class LinterBase<TLintResult> {
     //#endregion
 
     this.lintingFinished(lintFailures);
+
+    if (!this._fix && this._fixesPossible) {
+      this._terminal.writeWarningLine(
+        'The linter reported that fixes are possible. To apply fixes, run Heft with the "--fix" option.'
+      );
+    }
 
     const updatedTslintCacheData: ILinterCacheData = {
       cacheVersion: linterCacheVersion,

--- a/heft-plugins/heft-lint-plugin/src/Tslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Tslint.ts
@@ -137,7 +137,14 @@ export class Tslint extends LinterBase<TTslint.RuleFailure> {
     // Some of this code comes from here:
     // https://github.com/palantir/tslint/blob/24d29e421828348f616bf761adb3892bcdf51662/src/linter.ts#L161-L179
     // Modified to only lint files that have changed and that we care about
-    const failures: TTslint.RuleFailure[] = this._linter.getAllFailures(sourceFile, this._enabledRules);
+    let failures: TTslint.RuleFailure[] = this._linter.getAllFailures(sourceFile, this._enabledRules);
+    if (failures.some((f) => f.hasFix())) {
+      if (this._fix) {
+        failures = this._linter.applyAllFixes(this._enabledRules, failures, sourceFile, sourceFile.fileName);
+      } else {
+        this._fixesPossible = true;
+      }
+    }
 
     for (const failure of failures) {
       const severity: TTslint.RuleSeverity | undefined = this._ruleSeverityMap.get(failure.getRuleName());
@@ -154,6 +161,15 @@ export class Tslint extends LinterBase<TTslint.RuleFailure> {
   protected lintingFinished(failures: TTslint.RuleFailure[]): void {
     this._linter.failures = failures;
     const lintResult: TTslint.LintResult = this._linter.getResult();
+
+    // Report linter fixes to the logger. These will only be returned when the underlying failure was fixed
+    if (lintResult.fixes?.length) {
+      for (const fixedTslintFailure of lintResult.fixes) {
+        const formattedMessage: string = `[FIXED] ${getFormattedErrorMessage(fixedTslintFailure)}`;
+        const errorObject: FileError = this._getLintFileError(fixedTslintFailure, formattedMessage);
+        this._scopedLogger.emitWarning(errorObject);
+      }
+    }
 
     // Report linter errors and warnings to the logger
     if (lintResult.failures.length) {

--- a/heft-plugins/heft-lint-plugin/src/internalTypings/TslintInternals.ts
+++ b/heft-plugins/heft-lint-plugin/src/internalTypings/TslintInternals.ts
@@ -4,7 +4,10 @@
 import type * as TTslint from 'tslint';
 import type * as TTypescript from 'typescript';
 
-type TrimmedLinter = Omit<TTslint.Linter, 'getAllFailures' | 'getEnabledRules' | 'failures'>;
+type TrimmedLinter = Omit<
+  TTslint.Linter,
+  'getAllFailures' | 'applyAllFixes' | 'getEnabledRules' | 'failures'
+>;
 export interface IExtendedLinter extends TrimmedLinter {
   /**
    * https://github.com/palantir/tslint/blob/24d29e421828348f616bf761adb3892bcdf51662/src/linter.ts#L117
@@ -20,4 +23,14 @@ export interface IExtendedLinter extends TrimmedLinter {
    * https://github.com/palantir/tslint/blob/24d29e421828348f616bf761adb3892bcdf51662/src/linter.ts#L303-L306
    */
   getEnabledRules(configuration: TTslint.Configuration.IConfigurationFile, isJs: boolean): TTslint.IRule[];
+
+  /**
+   * https://github.com/palantir/tslint/blob/24d29e421828348f616bf761adb3892bcdf51662/src/linter.ts#L212-L241
+   */
+  applyAllFixes(
+    enabledRules: TTslint.IRule[],
+    fileFailures: TTslint.RuleFailure[],
+    sourceFile: TTypescript.SourceFile,
+    sourceFileName: string
+  ): TTslint.RuleFailure[];
 }

--- a/heft-plugins/heft-lint-plugin/src/schemas/heft-lint-plugin.schema.json
+++ b/heft-plugins/heft-lint-plugin/src/schemas/heft-lint-plugin.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Heft Lint Plugin Options Configuration",
+  "description": "This schema describes the \"options\" field that can be specified in heft.json when loading \"@rushstack/heft-lint-plugin\".",
+  "type": "object",
+
+  "additionalProperties": false,
+
+  "properties": {
+    "alwaysFix": {
+      "title": "Always Fix",
+      "description": "If set to true, fix all encountered rule violations where the violated rule provides a fixer, regardless of if the \"--fix\" command-line argument is provided.",
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add fixer support for ESLint and TSLint.

Fixes #2769.

## Details

Fixes can now be automatically applied when the `--fix` CLI flag is provided, or the `alwaysFix` plugin option is provided in heft.json. 

## How it was tested

- Validated in-repo via TSLint- and ESLint-enabled projects
