### PR TITLE
[ts-command-line] Fixes a typo in the README

### DIFF
--- a/common/changes/@rushstack/ts-command-line/patch-1_2024-08-14-11-35.json
+++ b/common/changes/@rushstack/ts-command-line/patch-1_2024-08-14-11-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/ts-command-line",
-      "comment": "Typo",
+      "comment": "Fix a README typo.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/ts-command-line/patch-1_2024-08-14-11-35.json
+++ b/common/changes/@rushstack/ts-command-line/patch-1_2024-08-14-11-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Typo",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/libraries/ts-command-line/README.md
+++ b/libraries/ts-command-line/README.md
@@ -45,7 +45,7 @@ Several different kinds of parameters are supported:
 | flag | `--verbose` | `boolean` | Value is `true` if the flag was specified on the command line, `false` otherwise. |
 | integer | `--max-retry 3` | `int` | The argument is an integer number |
 | string | `--title "Hello, world"` | `string` | The argument is a text string. |
-| choice | `--color red` | `string` | The argument is must be a string from a list of allowed choices (similar to an enum). |
+| choice | `--color red` | `string` | The argument must be a string from a list of allowed choices (similar to an enum). |
 | string list | `-o file1.txt -o file2.txt` | `string[]` | The argument is a text string. The parameter can be specified multiple times to build a list. |
 
 Other parameter kinds could be implemented if requested.  That said, keeping your CLI grammar simple and systematic makes it easier for users to learn.


### PR DESCRIPTION
Fixes a typo on ts-command-line's README