### PR TITLE
[heft-localization-typings-plugin] Fix a few issues with the typings generator plugin.

### DIFF
--- a/common/changes/@rushstack/heft-localization-typings-plugin/fix-a-few-issues_2024-08-21-07-21.json
+++ b/common/changes/@rushstack/heft-localization-typings-plugin/fix-a-few-issues_2024-08-21-07-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-localization-typings-plugin",
+      "comment": "Fix an issue where the `stringNamesToIgnore` option was ignored.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-localization-typings-plugin"
+}

--- a/common/changes/@rushstack/localization-utilities/fix-a-few-issues_2024-08-21-07-21.json
+++ b/common/changes/@rushstack/localization-utilities/fix-a-few-issues_2024-08-21-07-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Fix an issue where `inferDefaultExportInterfaceNameFromFilename` did not apply.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2798,9 +2798,6 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/localization-utilities
     devDependencies:
-      '@microsoft/api-extractor':
-        specifier: workspace:*
-        version: link:../../apps/api-extractor
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft

--- a/heft-plugins/heft-localization-typings-plugin/package.json
+++ b/heft-plugins/heft-localization-typings-plugin/package.json
@@ -19,7 +19,6 @@
     "@rushstack/heft": "^0.67.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "local-node-rig": "workspace:*",
     "eslint": "~8.57.0"

--- a/heft-plugins/heft-localization-typings-plugin/src/LocalizationTypingsPlugin.ts
+++ b/heft-plugins/heft-localization-typings-plugin/src/LocalizationTypingsPlugin.ts
@@ -71,7 +71,7 @@ export default class LocalizationTypingsPlugin implements IHeftTaskPlugin<ILocal
       generatedTsFolder: `${slashNormalizedBuildFolderPath}/${generatedTsFolder ?? 'temp/loc-ts'}`,
       terminal: logger.terminal,
       ignoreString: stringNamesToIgnoreSet
-        ? (stringName: string) => stringNamesToIgnoreSet.has(stringName)
+        ? (filePath: string, stringName: string) => stringNamesToIgnoreSet.has(stringName)
         : undefined,
       secondaryGeneratedTsFolders
     });

--- a/libraries/localization-utilities/src/TypingsGenerator.ts
+++ b/libraries/localization-utilities/src/TypingsGenerator.ts
@@ -3,6 +3,7 @@
 
 import {
   StringValuesTypingsGenerator,
+  type IStringValueTypings,
   type IExportAsDefaultOptions,
   type IStringValueTyping,
   type ITypingsGeneratorBaseOptions
@@ -64,7 +65,11 @@ export class TypingsGenerator extends StringValuesTypingsGenerator {
     super({
       ...options,
       fileExtensions: ['.resx', '.resx.json', '.loc.json', '.resjson'],
-      parseAndGenerateTypings: (content: string, filePath: string, relativeFilePath: string) => {
+      parseAndGenerateTypings: (
+        content: string,
+        filePath: string,
+        relativeFilePath: string
+      ): IStringValueTypings => {
         const locFileData: ILocalizationFile = parseLocFile({
           filePath,
           content,
@@ -89,7 +94,6 @@ export class TypingsGenerator extends StringValuesTypingsGenerator {
           });
         }
 
-        let exportAsDefaultInterfaceName: string | undefined;
         if (inferDefaultExportInterfaceNameFromFilename) {
           const lastSlashIndex: number = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
           let extensionIndex: number = filePath.lastIndexOf('.');
@@ -100,20 +104,23 @@ export class TypingsGenerator extends StringValuesTypingsGenerator {
           const fileNameWithoutExtension: string = filePath.substring(lastSlashIndex + 1, extensionIndex);
           const normalizedFileName: string = fileNameWithoutExtension.replace(/[^a-zA-Z0-9$_]/g, '');
           const firstCharUpperCased: string = normalizedFileName.charAt(0).toUpperCase();
-          exportAsDefaultInterfaceName = `I${firstCharUpperCased}${normalizedFileName.slice(1)}`;
+          let interfaceName: string | undefined = `I${firstCharUpperCased}${normalizedFileName.slice(1)}`;
 
-          if (
-            !exportAsDefaultInterfaceName.endsWith('strings') &&
-            !exportAsDefaultInterfaceName.endsWith('Strings')
-          ) {
-            exportAsDefaultInterfaceName += 'Strings';
+          if (!interfaceName.endsWith('strings') && !interfaceName.endsWith('Strings')) {
+            interfaceName += 'Strings';
           }
-        }
 
-        return {
-          typings,
-          exportAsDefaultInterfaceName
-        };
+          return {
+            typings,
+            exportAsDefault: {
+              interfaceName
+            }
+          };
+        } else {
+          return {
+            typings
+          };
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

This PR fixes two minor issues with the heft-localization-typings-plugin:
- The `stringNamesToIgnore` option didn't work because the `ignoreString` function was used incorrectly.
- The `inferInterfaceNameFromFilename` option didn't work because it was returned as the wrong property.

## How it was tested

Tested in a repo that is using the plugin.

## Impacted documentation

None.