### PR TITLE
[rush-lib] fix: update shrinkwrap when globalOverrides has change

### DIFF
--- a/common/changes/@microsoft/rush/kenrick-overrides-check_2024-08-22-06-49.json
+++ b/common/changes/@microsoft/rush/kenrick-overrides-check_2024-08-22-06-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Always update shrinkwrap when globalOverrides has been changed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -367,6 +367,17 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       shrinkwrapIsUpToDate = false;
     }
 
+    // Check if overrides and globalOverrides are the same
+    const overridesAreEqual: boolean = objectsAreDeepEqual<Record<string, string>>(
+      this.rushConfiguration.pnpmOptions.globalOverrides ?? {},
+      shrinkwrapFile?.overrides ? Object.fromEntries(shrinkwrapFile?.overrides) : {}
+    );
+
+    if (!overridesAreEqual) {
+      shrinkwrapWarnings.push("The overrides settings doesn't match the current shrinkwrap.");
+      shrinkwrapIsUpToDate = false;
+    }
+
     // Write the common package.json
     InstallHelpers.generateCommonPackageJson(this.rushConfiguration, subspace, undefined);
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #4820

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Add one more condition in WorkspaceInstallManager to compare the objects:

- pnpm-config.json's `globalOverrides`
- shrinkwrap's `overrides`

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

1. Run `testrush update` in a Rush repo
2. Change `globalOverrides`
3. Run `testrush update` and expect that it updates the lockfile

```
> testrush update

Rush Multi-Project Build Tool 5.132.0 (unmanaged) - https://rushjs.io
Node.js version is 18.20.4 (LTS)


Starting "rush update"

Checking Git policy for this repository.


Found files in the "common/git-hooks" folder.
Successfully installed these Git hook scripts: commit-msg, owners.json, post-checkout, pre-commit, pre-push

Trying to acquire lock for pnpm-8.15.8
Acquired lock for pnpm-8.15.8
Found pnpm version 8.15.8 in /path/to/user/.rush/node-v18.20.4/pnpm-8.15.8

Symlinking "/path/to/repo/common/temp/pnpm-local"
  --> "/path/to/user/.rush/node-v18.20.4/pnpm-8.15.8"
Transforming /path/to/repo/common/config/rush/.npmrc
  --> "/path/to/repo/common/temp/.npmrc"

Updating workspace files in /path/to/repo/common/temp
Copying "/path/to/repo/common/config/rush/pnpm-lock.yaml"
  --> "/path/to/repo/common/temp/pnpm-lock.yaml"
Copying "/path/to/repo/common/config/rush/pnpm-lock.yaml"
  --> "/path/to/repo/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file (pnpm-lock.yaml) contains the following issues:
  The overrides settings doesn't match the current shrinkwrap.


Checking installation in "/path/to/repo/common/temp"

Running "pnpm install" in /path/to/repo/common/temp
```

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

N/A

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
