### PR TITLE
[rush] Add option to suppress hardcoded npmjs.org registry call

### DIFF
--- a/common/changes/@microsoft/rush/user-dmichon-suppress-registry-call_2024-08-22-21-46.json
+++ b/common/changes/@microsoft/rush/user-dmichon-suppress-registry-call_2024-08-22-21-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add rush.json option \"suppressRushIsPublicVersionCheck\" to allow suppressing hardcoded calls to the npmjs.org registry.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/rush.json
+++ b/libraries/rush-lib/assets/rush-init/rush.json
@@ -66,6 +66,13 @@
   /*[LINE "HYPOTHETICAL"]*/ "suppressNodeLtsWarning": false,
 
   /**
+   * Rush normally prints a warning if it detects that the current version is not one published to the
+   * public npmjs.org registry. If you need to block calls to the npm registry, you can use this setting to disable
+   * Rush's check.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "suppressRushIsPublicVersionCheck": false,
+
+  /**
    * Large monorepos can become intimidating for newcomers if project folder paths don't follow
    * a consistent and recognizable pattern.  When the system allows nested folder trees,
    * we've found that teams will often use subfolders to create islands that isolate

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -158,6 +158,7 @@ export interface IRushConfigurationJson {
   nodeSupportedVersionRange?: string;
   nodeSupportedVersionInstructions?: string;
   suppressNodeLtsWarning?: boolean;
+  suppressRushIsPublicVersionCheck?: boolean;
   projectFolderMinDepth?: number;
   projectFolderMaxDepth?: number;
   allowMostlyStandardPackageNames?: boolean;

--- a/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -17,7 +17,7 @@ import { PrintUtilities, Colorize, ConsoleTerminalProvider, Terminal } from '@ru
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import { Utilities } from '../../utilities/Utilities';
 import { type IArtifactoryPackageRegistryJson, ArtifactoryConfiguration } from './ArtifactoryConfiguration';
-import { WebClient, type WebClientResponse } from '../../utilities/WebClient';
+import type { WebClient as WebClientType, WebClientResponse } from '../../utilities/WebClient';
 import { TerminalInput } from './TerminalInput';
 
 interface IArtifactoryCustomizableMessages {
@@ -284,7 +284,9 @@ export class SetupPackageRegistry {
   ): Promise<void> {
     this._terminal.writeLine('\nFetching an NPM token from the Artifactory service...');
 
-    const webClient: WebClient = new WebClient();
+    // Defer this import since it is conditionally needed.
+    const { WebClient } = await import('../../utilities/WebClient');
+    const webClient: WebClientType = new WebClient();
 
     webClient.addBasicAuthHeader(artifactoryUser, artifactoryKey);
 

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -64,6 +64,10 @@
       "description": "Rush normally prints a warning if it detects a pre-LTS Node.js version. If you are testing pre-LTS versions in preparation for supporting the first LTS version, you can use this setting to disable Rush's warning.",
       "type": "boolean"
     },
+    "suppressRushIsPublicVersionCheck": {
+      "description": "Rush normally prints a warning if it detects that the current version is not one published to the public npmjs.org registry. If you need to block calls to the npm registry, you can use this setting to disable Rush's check.",
+      "type": "boolean"
+    },
     "projectFolderMinDepth": {
       "description": "The minimum folder depth for the projectFolder field.  The default value is 1, i.e. no slashes in the path name.",
       "type": "number"


### PR DESCRIPTION
## Summary
Add a new option to rush.json `"suppressRushIsPublicVersionCheck"` that disables a hardcoded call to the public npmjs.org registry to validate that the executing version of Rush (according to `package.json`) matches one that has been published to the public registry.

This feature is to support enterprises that run Rush on machines that they are denying access to npmjs.org.

## Details
Also defer loads the `WebClient` wrapper around `node-fetch` to reduce startup time.

Updated `rush-init` template to include the setting.

## How it was tested
Walked through `rush install` under debugger and validated that the condition hit both branches depending on the setting in `rush.json`.

## Impacted documentation
Docs for `rush.json`