### PR TITLE
[webpack-resolve] Fix bug caused by mutating request

### DIFF
--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/resolver-new_2024-08-23-23-41.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/resolver-new_2024-08-23-23-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "Fix bug caused by mutating resolver request object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
@@ -94,17 +94,18 @@ export class KnownDescriptionFilePlugin {
           // Store the resolver context since a WeakMap lookup is cheaper than walking the tree again
           contextForPackage.set(descriptionFileData, match.value);
 
-          // Since we don't allow any alternative processing of request, we can mutate it
-          // instead of cloning it.
-          request.descriptionFileRoot = descriptionFileRoot;
-          request.descriptionFilePath = descriptionFilePath;
-          request.descriptionFileData = descriptionFileData;
-          request.relativePath = relativePath;
+          const obj: ResolveRequest = {
+            ...request,
+            descriptionFileRoot,
+            descriptionFilePath,
+            descriptionFileData,
+            relativePath
+          };
 
           // Delegate to the resolver step at `target`.
           resolver.doResolve(
             target,
-            request,
+            obj,
             'using description file: ' + descriptionFilePath + ' (relative path: ' + relativePath + ')',
             resolveContext,
             (e: Error | undefined, result: ResolveRequest | undefined) => {


### PR DESCRIPTION
## Summary
Some plugins manage to still be impacted by mutating a `ResolveRequest` object. Stop doing so.

## Details
Removes an attempted optimization in `KnownDescriptionFilePlugin`.

## How it was tested
Unit tests.
Testing in a target repository.

## Impacted documentation
None.